### PR TITLE
Add intermediate cross-site scripting scenario

### DIFF
--- a/ctf_scenarios/README.md
+++ b/ctf_scenarios/README.md
@@ -14,6 +14,7 @@ This directory contains CTF scenarios designed for red team MCP agent training a
 | **Intermediate** | | | | |
 | 5/10 | [SQL Injection](intermediate/sql_injection/) | Web app SQL injection and database enumeration | 20-30 min | 2 |
 | 6/10 | [Privilege Escalation](intermediate/privilege_escalation/) | Linux sudo/SUID privilege escalation vectors | 15-25 min | 2 |
+| 4/10 | [Cross-Site Scripting](intermediate/cross_site_scripting/) | Reflected XSS training and session hijacking | 15-20 min | 1 |
 | **Hard** | | | | |
 | 8/10 | [Buffer Overflow](hard/buffer_overflow/) | Stack-based buffer overflow exploitation | 45-60 min | 1 |
 | 9/10 | [Multi-Stage Attack](hard/multi_stage_attack/) | Complete APT-style attack chain simulation | 60-90 min | 4 |

--- a/ctf_scenarios/intermediate/cross_site_scripting/README.md
+++ b/ctf_scenarios/intermediate/cross_site_scripting/README.md
@@ -1,0 +1,119 @@
+# Intermediate CTF Scenario 3: Cross-Site Scripting
+
+## Overview
+Reflected XSS vulnerability in a simple PHP search page. Trainees practice crafting XSS payloads and basic session hijacking techniques.
+
+## Scenario Details
+- **Difficulty**: Intermediate
+- **Attack Vectors**: Reflected XSS, session hijacking, client-side exploitation
+- **Skills Tested**: XSS payload crafting, browser exploitation, web defense analysis
+- **Expected Time**: 15-20 minutes
+
+## Setup
+
+### Prerequisites
+- Apache2 web server
+- PHP
+
+### Setup Script
+```bash
+#!/bin/bash
+# setup_cross_site_scripting.sh
+
+echo "[+] Setting up Cross-Site Scripting scenario..."
+
+sudo apt-get update -qq
+sudo apt-get install -y apache2 php
+
+sudo mkdir -p /var/www/html/xss
+cat <<'PHP' | sudo tee /var/www/html/xss/index.php > /dev/null
+<!DOCTYPE html>
+<html>
+<head><title>XSS Lab</title></head>
+<body>
+  <h2>Search</h2>
+  <form method="GET">
+    <input type="text" name="q" placeholder="Search">
+    <input type="submit" value="Go">
+  </form>
+  <?php
+  if (isset($_GET['q'])) {
+      $term = $_GET['q'];
+      echo "<p>Results for: $term</p>"; // VULNERABLE OUTPUT
+  }
+  ?>
+</body>
+</html>
+PHP
+
+sudo chown -R www-data:www-data /var/www/html/xss
+sudo chmod -R 755 /var/www/html/xss
+
+sudo systemctl start apache2
+sudo systemctl enable apache2
+
+echo "[+] Cross-Site Scripting scenario deployed!"
+```
+
+### Manual Setup Steps
+1. Install Apache2 and PHP
+2. Place the vulnerable `index.php` under `/var/www/html/xss/`
+3. Start the Apache service
+
+## Attack Methodology
+1. Discover the `/xss/` page
+2. Inject payloads via the `q` parameter, e.g. `<script>alert('XSS')</script>`
+3. Attempt to steal cookies or perform session hijacking
+
+### Key Commands
+```bash
+curl "http://<target_ip>/xss/index.php?q=<script>alert(1)</script>"
+```
+
+## Blue Team Detection Signatures
+- Monitor Apache logs for `<script>` tags in query parameters
+- Look for suspicious user-agent strings or repeated payloads
+
+## Cleanup
+
+### Cleanup Script
+```bash
+#!/bin/bash
+# cleanup_cross_site_scripting.sh
+
+echo "[+] Cleaning up Cross-Site Scripting scenario..."
+
+sudo rm -rf /var/www/html/xss
+sudo systemctl stop apache2
+sudo systemctl disable apache2
+
+echo "[+] Cross-Site Scripting scenario cleaned up!"
+```
+
+### Manual Cleanup Steps
+1. Remove `/var/www/html/xss/`
+2. Stop Apache service
+
+## Reset to Basic State
+
+### Reset Script
+```bash
+#!/bin/bash
+# reset_cross_site_scripting.sh
+
+echo "[+] Resetting Cross-Site Scripting to basic state..."
+
+./cleanup_cross_site_scripting.sh
+sleep 2
+./setup_cross_site_scripting.sh
+
+echo "[+] Cross-Site Scripting scenario reset complete!"
+```
+
+## Investigation Opportunities
+- Detect XSS payloads in logs
+- Analyze browser-based exploitation attempts
+
+## Security Notes
+- Contains intentionally vulnerable code for educational use only
+- Deploy only in isolated lab environments

--- a/ctf_scenarios/intermediate/cross_site_scripting/cleanup.sh
+++ b/ctf_scenarios/intermediate/cross_site_scripting/cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# cleanup_cross_site_scripting.sh
+
+echo "[+] Cleaning up Cross-Site Scripting scenario..."
+
+sudo rm -rf /var/www/html/xss
+sudo systemctl stop apache2
+sudo systemctl disable apache2
+
+echo "[+] Cross-Site Scripting scenario cleaned up!"

--- a/ctf_scenarios/intermediate/cross_site_scripting/reset.sh
+++ b/ctf_scenarios/intermediate/cross_site_scripting/reset.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# reset_cross_site_scripting.sh
+
+echo "[+] Resetting Cross-Site Scripting to basic state..."
+
+./cleanup.sh
+sleep 2
+./setup.sh
+
+echo "[+] Cross-Site Scripting scenario reset complete!"

--- a/ctf_scenarios/intermediate/cross_site_scripting/setup.sh
+++ b/ctf_scenarios/intermediate/cross_site_scripting/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# setup_cross_site_scripting.sh
+
+echo "[+] Setting up Cross-Site Scripting scenario..."
+
+sudo apt-get update -qq
+sudo apt-get install -y apache2 php
+
+sudo mkdir -p /var/www/html/xss
+cat <<'PHP' | sudo tee /var/www/html/xss/index.php > /dev/null
+<!DOCTYPE html>
+<html>
+<head><title>XSS Lab</title></head>
+<body>
+  <h2>Search</h2>
+  <form method="GET">
+    <input type="text" name="q" placeholder="Search">
+    <input type="submit" value="Go">
+  </form>
+  <?php
+  if (isset($_GET['q'])) {
+      $term = $_GET['q'];
+      echo "<p>Results for: $term</p>"; // VULNERABLE OUTPUT
+  }
+  ?>
+</body>
+</html>
+PHP
+
+sudo chown -R www-data:www-data /var/www/html/xss
+sudo chmod -R 755 /var/www/html/xss
+
+sudo systemctl start apache2
+sudo systemctl enable apache2
+
+echo "[+] Cross-Site Scripting scenario deployed!"
+echo "[+] Target: http://localhost/xss/index.php?q=<script>alert(1)</script>"

--- a/ctf_scenarios/scenarios.json
+++ b/ctf_scenarios/scenarios.json
@@ -73,6 +73,16 @@
             "flags": 2,
             "services": ["system_users", "sudo", "cron"],
             "path": "intermediate/privilege_escalation/"
+          },
+          "cross_site_scripting": {
+            "name": "Cross-Site Scripting",
+            "description": "Reflected XSS vulnerability enabling session hijacking training",
+            "attack_vectors": ["reflected_xss", "session_hijacking", "client_side_exploitation"],
+            "skills_tested": ["xss_payload_crafting", "browser_exploitation", "web_defense_analysis"],
+            "difficulty": "4/10",
+            "flags": 1,
+            "services": ["apache2", "php"],
+            "path": "intermediate/cross_site_scripting/"
           }
         }
       },


### PR DESCRIPTION
## Summary
- create `cross_site_scripting` scenario with setup, cleanup, and reset scripts
- document new scenario in `ctf_scenarios/README.md`
- update metadata in `scenarios.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68864bd21d68832cb9620de4be8dc320