### PR TITLE
feat: restrict internet access for Kali and victim instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2025-07-27
+
+### Security
+
+- **Network Isolation**: Removed internet access from Kali and victim instances to prevent AI
+  red team accidents
+- **Internal Communication**: Lab instances can only communicate within VPC using security
+  group references
+- **SIEM Access**: Preserved internet access for SIEM updates and licensing
+
+### Fixed
+
+- Circular dependency between Kali and victim security groups using separate rule resources
+
 ## [1.1.4] - 2025-07-27
 
 ### Added


### PR DESCRIPTION
  - Remove 0.0.0.0/0 egress from Kali and victim security groups
  - Use security group references for internal lab communication only
  - Preserve SIEM internet access and admin SSH access
  - Fix circular dependency with separate security group rules
