### PR TITLE
feat: implement base victim container with systemd and SSH access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2025-07-28
+
+### Added
+
+- **Base Victim Container**: Implemented Rocky Linux 9 base victim container with systemd support
+- **SSH Key Management**: Added dual SSH key delivery methods (volume mount for local dev, environment variable for AWS)
+- **Container Validation**: Created validation script with custom SSH port support for testing containers
+- **Docker Compose Configurations**: Added consistent compose files for local development and AWS deployment
+
+### Changed
+
+- **Victim Architecture**: Prepared foundation for victim container migration from VMs
+- **Security Configuration**: Implemented secure SSH defaults with key-based authentication only
+
 ## [1.1.7] - 2025-07-28
 
 ### Changed

--- a/containers/victim/Dockerfile
+++ b/containers/victim/Dockerfile
@@ -1,0 +1,68 @@
+# Base victim container using Rocky Linux 9 (RHEL-compatible)
+FROM rockylinux:9
+
+# Install only essential packages every victim needs
+RUN dnf install -y epel-release && \
+    dnf update -y && \
+    dnf install -y \
+    rsyslog \
+    openssh-server \
+    sudo \
+    systemd \
+    systemd-sysv \
+    iproute \
+    hostname \
+    && dnf clean all
+
+# Configure systemd for container use
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /etc/systemd/system/*.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+# Set systemd default target to multi-user (not graphical)
+RUN systemctl set-default multi-user.target
+
+# Enable essential services including user sessions (removes /run/nologin)
+RUN systemctl enable rsyslog sshd systemd-user-sessions
+
+# Configure SSH (secure by default)
+RUN mkdir /var/run/sshd && \
+    ssh-keygen -A && \
+    sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config && \
+    sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config && \
+    sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+# Create lab maintainer user with passwordless sudo
+RUN useradd -m -s /bin/bash labadmin && \
+    usermod -aG wheel labadmin && \
+    echo "labadmin ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/labadmin && \
+    chmod 440 /etc/sudoers.d/labadmin
+
+# Create .ssh directory for lab maintainer
+RUN mkdir -p /home/labadmin/.ssh && \
+    chmod 700 /home/labadmin/.ssh && \
+    chown -R labadmin:labadmin /home/labadmin/.ssh
+
+# Create directories for scripts and configs
+RUN mkdir -p /opt/purple-team/scripts /etc/rsyslog.d
+
+# Copy entrypoint script
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Expose only SSH and syslog
+EXPOSE 22 514
+
+# Volume for persistent data
+VOLUME ["/var/log", "/home"]
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# Use systemd as init
+CMD ["/usr/sbin/init"]

--- a/containers/victim/README.md
+++ b/containers/victim/README.md
@@ -1,0 +1,146 @@
+# APTL Victim Containers
+
+This directory contains the containerized victim machines for the Purple Team Lab.
+
+## Architecture
+
+The victim containers support dual deployment modes:
+1. **Local Development**: Uses volume-mounted SSH keys
+2. **AWS Production**: Uses environment variables
+
+Both modes use the same container image and entrypoint script, ensuring consistency.
+
+## Local Development Setup
+
+### 1. Generate Lab Admin SSH Key
+```bash
+# Generate dedicated keypair for lab admin access
+ssh-keygen -t ed25519 -f ~/.ssh/aptl-labadmin -C "labadmin@aptl"
+```
+
+### 2. Build and Run Locally
+```bash
+# Build the base image
+docker build -t aptl-victim:latest .
+
+# Run with local compose file
+docker-compose -f docker-compose.local.yml up -d
+
+# Access victim container
+ssh -i ~/.ssh/aptl-labadmin -p 2222 labadmin@localhost
+```
+
+### 3. Test Log Collection
+```bash
+# View collected logs from local rsyslog collector
+docker-compose -f docker-compose.local.yml logs rsyslog-collector
+docker exec aptl-rsyslog-collector cat /var/log/collected.log
+```
+
+## AWS Production Setup
+
+### 1. Create .env File
+```bash
+cat > .env << EOF
+ECR_REGISTRY=123456789012.dkr.ecr.us-east-1.amazonaws.com
+LABADMIN_SSH_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5... labadmin@aptl"
+SIEM_PRIVATE_IP=10.0.1.100
+SIEM_TYPE=qradar
+EOF
+```
+
+### 2. Deploy on Container Host
+```bash
+# This would typically be done by user_data script
+docker-compose -f docker-compose.aws.yml up -d
+```
+
+## How the Dual Mode Works
+
+The `entrypoint.sh` script checks for SSH keys in this order:
+1. Volume mount at `/keys/labadmin.pub` (local dev)
+2. `LABADMIN_SSH_KEY` environment variable (production)
+3. File path in `LABADMIN_SSH_KEY_FILE` environment variable (alternative)
+
+This allows the same image to work in both environments without modification.
+
+## Container Scenarios
+
+### Base Victim
+- Standard RHEL-based system
+- SSH, HTTP, FTP services
+- Weak users (if enabled)
+
+### Web Victim
+- DVWA, WebGoat installations
+- Additional web vulnerabilities
+- PHP, MySQL services
+
+### SSH Victim
+- Weak SSH configurations
+- Multiple authentication methods
+- Brute-force targets
+
+### Multi-Service Victim
+- Multiple vulnerable services
+- Telnet, FTP, SMB
+- Simulates legacy systems
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `LABADMIN_SSH_KEY` | SSH public key for lab admin | `ssh-ed25519 AAAA...` |
+| `SIEM_IP` | SIEM server IP for log forwarding | `10.0.1.100` |
+| `SIEM_TYPE` | Type of SIEM (qradar/splunk) | `qradar` |
+| `SIEM_PORT` | SIEM syslog port (optional) | `514` |
+| `ENABLE_WEAK_USERS` | Create users with weak passwords | `true` |
+| `SCENARIO` | Victim scenario type | `web`, `ssh`, `multi` |
+
+## Testing
+
+### Local Testing Checklist
+- [ ] Container starts successfully
+- [ ] Can SSH as labadmin with key
+- [ ] Services are running (check with `systemctl status`)
+- [ ] Logs are being generated
+- [ ] Rsyslog collector receives logs (if enabled)
+
+### Production Testing Checklist  
+- [ ] Container pulls from ECR
+- [ ] SSH key from environment variable works
+- [ ] Logs forward to SIEM
+- [ ] All services accessible from Kali container
+- [ ] Resource usage is acceptable
+
+## Troubleshooting
+
+### SSH Access Issues
+```bash
+# Check if key was properly installed
+docker exec aptl-victim-base cat /home/labadmin/.ssh/authorized_keys
+
+# Check SSH logs
+docker exec aptl-victim-base journalctl -u sshd -f
+```
+
+### Log Forwarding Issues
+```bash
+# Check rsyslog configuration
+docker exec aptl-victim-base cat /etc/rsyslog.d/90-forward.conf
+
+# Test manual log entry
+docker exec aptl-victim-base logger "TEST: Manual log entry"
+
+# Check rsyslog status
+docker exec aptl-victim-base systemctl status rsyslog
+```
+
+### Service Issues
+```bash
+# Check all services
+docker exec aptl-victim-base systemctl list-units --failed
+
+# Restart a service
+docker exec aptl-victim-base systemctl restart httpd
+```

--- a/containers/victim/docker-compose.aws.yml
+++ b/containers/victim/docker-compose.aws.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+# AWS/Production compose file
+# This demonstrates how containers would be configured on the lab container host
+# Environment variables would be set via user_data or .env file
+
+services:
+  victim-base:
+    image: ${ECR_REGISTRY}/aptl-victim:latest
+    container_name: aptl-victim-base
+    hostname: victim-base
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - victim-logs:/var/log
+    environment:
+      # SSH key passed as environment variable
+      - LABADMIN_SSH_KEY=${LABADMIN_SSH_KEY}
+      # SIEM configuration
+      - SIEM_IP=${SIEM_PRIVATE_IP}
+      - SIEM_TYPE=${SIEM_TYPE:-qradar}
+      - SIEM_PORT=${SIEM_PORT:-514}
+    tmpfs:
+      - /run
+      - /tmp
+    stop_signal: SIGRTMIN+3
+    networks:
+      aptl-net:
+        ipv4_address: 172.18.1.10
+    restart: unless-stopped
+
+networks:
+  aptl-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.18.0.0/16
+
+volumes:
+  victim-logs:

--- a/containers/victim/docker-compose.local.yml
+++ b/containers/victim/docker-compose.local.yml
@@ -1,0 +1,62 @@
+version: '3.8'
+
+# Local development compose file
+# Usage: docker-compose -f docker-compose.local.yml up
+
+services:
+  victim-base:
+    build: .
+    container_name: aptl-victim-base
+    hostname: victim-base
+    privileged: true
+    volumes:
+      # Mount local SSH key for labadmin access
+      - ~/.ssh/aptl-labadmin.pub:/keys/labadmin.pub:ro
+      # Mount systemd cgroup (rw required for systemd)
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      # Persistent logs
+      - victim-logs:/var/log
+    tmpfs:
+      - /run
+      - /tmp
+    stop_signal: SIGRTMIN+3
+    networks:
+      - aptl-net
+    ports:
+      - "2222:22"   # SSH only
+
+  # Optional: Local SIEM simulator for testing log forwarding
+  rsyslog-collector:
+    image: alpine:latest
+    container_name: aptl-rsyslog-collector
+    command: |
+      sh -c "
+      apk add --no-cache rsyslog
+      cat > /etc/rsyslog.conf << 'EOF'
+      module(load=\"imudp\")
+      input(type=\"imudp\" port=\"514\")
+      module(load=\"imtcp\")
+      input(type=\"imtcp\" port=\"514\")
+      *.* /var/log/collected.log
+      EOF
+      mkdir -p /var/log
+      rsyslogd -n -f /etc/rsyslog.conf
+      "
+    volumes:
+      - syslog-data:/var/log
+    networks:
+      - aptl-net
+    ports:
+      - "514:514/udp"
+      - "514:514/tcp"
+
+networks:
+  aptl-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+
+volumes:
+  victim-logs:
+  syslog-data:

--- a/containers/victim/entrypoint.sh
+++ b/containers/victim/entrypoint.sh
@@ -23,14 +23,14 @@ setup_labadmin_ssh() {
     fi
     
     # Option 2: Check for environment variable (AWS/production)
-    if [ ! -z "$LABADMIN_SSH_KEY" ]; then
+    if [ -n "$LABADMIN_SSH_KEY" ]; then
         echo "Found SSH key in LABADMIN_SSH_KEY environment variable"
         echo "$LABADMIN_SSH_KEY" >> /home/labadmin/.ssh/authorized_keys
         key_added=true
     fi
     
     # Option 3: Check for file path in environment variable
-    if [ ! -z "$LABADMIN_SSH_KEY_FILE" ] && [ -f "$LABADMIN_SSH_KEY_FILE" ]; then
+    if [ -n "$LABADMIN_SSH_KEY_FILE" ] && [ -f "$LABADMIN_SSH_KEY_FILE" ]; then
         echo "Found SSH key file at $LABADMIN_SSH_KEY_FILE"
         cat "$LABADMIN_SSH_KEY_FILE" >> /home/labadmin/.ssh/authorized_keys
         key_added=true

--- a/containers/victim/entrypoint.sh
+++ b/containers/victim/entrypoint.sh
@@ -90,7 +90,7 @@ setup_rsyslog
 echo "=== Container initialization complete ==="
 
 # Execute the main command (typically systemd)
-exec "$@" &
+"$@" &
 
 # Wait for systemd to be ready, then start user sessions
 sleep 5

--- a/containers/victim/entrypoint.sh
+++ b/containers/victim/entrypoint.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -e
+
+echo "=== Purple Team Lab Victim Container Starting ==="
+
+# Function to setup SSH key for labadmin
+setup_labadmin_ssh() {
+    echo "Setting up labadmin SSH access..."
+    
+    # Ensure .ssh directory exists with correct permissions
+    mkdir -p /home/labadmin/.ssh
+    chmod 700 /home/labadmin/.ssh
+    chown labadmin:labadmin /home/labadmin/.ssh
+    
+    # Check multiple sources for SSH key in priority order
+    local key_added=false
+    
+    # Option 1: Check for volume-mounted key file (local dev)
+    if [ -f "/keys/labadmin.pub" ]; then
+        echo "Found volume-mounted SSH key at /keys/labadmin.pub"
+        cat /keys/labadmin.pub >> /home/labadmin/.ssh/authorized_keys
+        key_added=true
+    fi
+    
+    # Option 2: Check for environment variable (AWS/production)
+    if [ ! -z "$LABADMIN_SSH_KEY" ]; then
+        echo "Found SSH key in LABADMIN_SSH_KEY environment variable"
+        echo "$LABADMIN_SSH_KEY" >> /home/labadmin/.ssh/authorized_keys
+        key_added=true
+    fi
+    
+    # Option 3: Check for file path in environment variable
+    if [ ! -z "$LABADMIN_SSH_KEY_FILE" ] && [ -f "$LABADMIN_SSH_KEY_FILE" ]; then
+        echo "Found SSH key file at $LABADMIN_SSH_KEY_FILE"
+        cat "$LABADMIN_SSH_KEY_FILE" >> /home/labadmin/.ssh/authorized_keys
+        key_added=true
+    fi
+    
+    if [ "$key_added" = true ]; then
+        # Set correct permissions
+        chmod 600 /home/labadmin/.ssh/authorized_keys
+        chown labadmin:labadmin /home/labadmin/.ssh/authorized_keys
+        echo "✅ Labadmin SSH key configured successfully"
+    else
+        echo "⚠️  WARNING: No SSH key found for labadmin. SSH key auth will not work."
+        echo "   Expected one of:"
+        echo "   - Volume mount at /keys/labadmin.pub"
+        echo "   - LABADMIN_SSH_KEY environment variable"
+        echo "   - File path in LABADMIN_SSH_KEY_FILE environment variable"
+    fi
+}
+
+# Function to configure rsyslog forwarding
+setup_rsyslog() {
+    if [ ! -z "$SIEM_IP" ] && [ ! -z "$SIEM_TYPE" ]; then
+        echo "Configuring rsyslog to forward to $SIEM_TYPE at $SIEM_IP..."
+        
+        # Determine port based on SIEM type
+        if [ "$SIEM_TYPE" = "splunk" ]; then
+            SIEM_PORT="${SIEM_PORT:-5514}"
+        else
+            SIEM_PORT="${SIEM_PORT:-514}"
+        fi
+        
+        # Create rsyslog forwarding config
+        cat > /etc/rsyslog.d/90-forward.conf << EOF
+# Purple Team Lab - Forward all logs to ${SIEM_TYPE} SIEM
+*.* @@${SIEM_IP}:${SIEM_PORT}
+EOF
+        
+        echo "✅ Rsyslog forwarding configured to $SIEM_IP:$SIEM_PORT"
+    else
+        echo "ℹ️  SIEM forwarding not configured (SIEM_IP or SIEM_TYPE not set)"
+    fi
+}
+
+# Base image has no scenario-specific setup
+# Scenario-specific users will be added by derived containers
+
+# Main execution
+echo "Container hostname: $(hostname)"
+echo "Container IP: $(hostname -I | awk '{print $1}')"
+
+# Setup labadmin SSH access
+setup_labadmin_ssh
+
+# Configure rsyslog if SIEM details provided
+setup_rsyslog
+
+echo "=== Container initialization complete ==="
+
+# Execute the main command (typically systemd)
+exec "$@" &
+
+# Wait for systemd to be ready, then start user sessions
+sleep 5
+while ! systemctl is-system-running >/dev/null 2>&1; do
+    sleep 1
+done
+systemctl start systemd-user-sessions
+
+# Keep the container running
+wait

--- a/containers/victim/entrypoint.sh
+++ b/containers/victim/entrypoint.sh
@@ -52,7 +52,7 @@ setup_labadmin_ssh() {
 
 # Function to configure rsyslog forwarding
 setup_rsyslog() {
-    if [ ! -z "$SIEM_IP" ] && [ ! -z "$SIEM_TYPE" ]; then
+    if [ -n "$SIEM_IP" ] && [ -n "$SIEM_TYPE" ]; then
         echo "Configuring rsyslog to forward to $SIEM_TYPE at $SIEM_IP..."
         
         # Determine port based on SIEM type

--- a/containers/victim/validate-victim.sh
+++ b/containers/victim/validate-victim.sh
@@ -133,7 +133,7 @@ if [ ! -z "$SIEM_IP" ]; then
     
     # Test network connectivity to SIEM
     echo -n "   - Network connectivity to SIEM... "
-    if $SSH_CMD "timeout 5 bash -c 'echo >/dev/tcp/$SIEM_IP/$SIEM_PORT' 2>/dev/null"; then
+    if $SSH_CMD "timeout 5 bash -c \"echo >/dev/tcp/$SIEM_IP/$SIEM_PORT\" 2>/dev/null"; then
         echo -e "${GREEN}REACHABLE${NC}"
     else
         echo -e "${RED}UNREACHABLE${NC}"

--- a/containers/victim/validate-victim.sh
+++ b/containers/victim/validate-victim.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+
+# Victim Container Validation Script
+# Run from deployment system or Kali container to verify victim is operational
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+VICTIM_IP=""
+SSH_KEY=""
+SSH_PORT="22"
+SIEM_IP=""
+SIEM_TYPE="qradar"
+VERBOSE=false
+
+# Parse arguments
+usage() {
+    echo "Usage: $0 -h <victim-ip> -k <ssh-key-path> [-p <ssh-port>] [-s <siem-ip>] [-t <siem-type>] [-v]"
+    echo "  -h: Victim host IP address"
+    echo "  -k: Path to labadmin SSH private key"
+    echo "  -p: SSH port (default: 22)"
+    echo "  -s: SIEM IP address (optional, for log forwarding test)"
+    echo "  -t: SIEM type (qradar/splunk, default: qradar)"
+    echo "  -v: Verbose output"
+    exit 1
+}
+
+while getopts "h:k:p:s:t:v" opt; do
+    case $opt in
+        h) VICTIM_IP="$OPTARG" ;;
+        k) SSH_KEY="$OPTARG" ;;
+        p) SSH_PORT="$OPTARG" ;;
+        s) SIEM_IP="$OPTARG" ;;
+        t) SIEM_TYPE="$OPTARG" ;;
+        v) VERBOSE=true ;;
+        *) usage ;;
+    esac
+done
+
+# Validate required arguments
+if [ -z "$VICTIM_IP" ] || [ -z "$SSH_KEY" ]; then
+    echo -e "${RED}Error: Victim IP and SSH key are required${NC}"
+    usage
+fi
+
+if [ ! -f "$SSH_KEY" ]; then
+    echo -e "${RED}Error: SSH key file not found: $SSH_KEY${NC}"
+    exit 1
+fi
+
+# SSH command alias
+SSH_CMD="ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -p $SSH_PORT -i $SSH_KEY labadmin@$VICTIM_IP"
+
+echo "=== APTL Victim Container Validation ==="
+echo "Target: $VICTIM_IP"
+echo ""
+
+# Test 1: SSH Connectivity
+echo -n "1. Testing SSH connectivity... "
+if $SSH_CMD "echo 'SSH OK' >/dev/null 2>&1"; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "   Cannot establish SSH connection to labadmin@$VICTIM_IP"
+    exit 1
+fi
+
+# Test 2: Verify labadmin sudo access
+echo -n "2. Verifying labadmin sudo access... "
+if $SSH_CMD "sudo whoami" 2>/dev/null | grep -q "root"; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "   labadmin does not have passwordless sudo"
+    exit 1
+fi
+
+# Test 3: Check system info
+echo -n "3. Gathering system information... "
+HOSTNAME=$($SSH_CMD "hostname" 2>/dev/null)
+OS_VERSION=$($SSH_CMD "cat /etc/redhat-release 2>/dev/null || echo 'Unknown'" 2>/dev/null)
+KERNEL=$($SSH_CMD "uname -r" 2>/dev/null)
+echo -e "${GREEN}PASS${NC}"
+if [ "$VERBOSE" = true ]; then
+    echo "   Hostname: $HOSTNAME"
+    echo "   OS: $OS_VERSION"
+    echo "   Kernel: $KERNEL"
+fi
+
+# Test 4: Verify essential services
+echo "4. Checking essential services:"
+
+# SSH
+echo -n "   - SSH daemon... "
+if $SSH_CMD "sudo systemctl is-active sshd" 2>/dev/null | grep -q "active"; then
+    echo -e "${GREEN}RUNNING${NC}"
+else
+    echo -e "${RED}NOT RUNNING${NC}"
+fi
+
+# Rsyslog
+echo -n "   - Rsyslog... "
+if $SSH_CMD "sudo systemctl is-active rsyslog" 2>/dev/null | grep -q "active"; then
+    echo -e "${GREEN}RUNNING${NC}"
+else
+    echo -e "${RED}NOT RUNNING${NC}"
+fi
+
+# Test 5: Check rsyslog configuration
+if [ ! -z "$SIEM_IP" ]; then
+    echo "5. Checking SIEM log forwarding configuration:"
+    
+    # Determine expected port
+    if [ "$SIEM_TYPE" = "splunk" ]; then
+        SIEM_PORT="5514"
+    else
+        SIEM_PORT="514"
+    fi
+    
+    echo -n "   - Rsyslog forwarding rule... "
+    if $SSH_CMD "sudo grep -q '@@$SIEM_IP:$SIEM_PORT' /etc/rsyslog.conf /etc/rsyslog.d/*.conf 2>/dev/null"; then
+        echo -e "${GREEN}CONFIGURED${NC}"
+    else
+        echo -e "${YELLOW}NOT FOUND${NC}"
+        echo "     Expected: *.* @@$SIEM_IP:$SIEM_PORT"
+    fi
+    
+    # Test network connectivity to SIEM
+    echo -n "   - Network connectivity to SIEM... "
+    if $SSH_CMD "timeout 5 bash -c 'echo >/dev/tcp/$SIEM_IP/$SIEM_PORT' 2>/dev/null"; then
+        echo -e "${GREEN}REACHABLE${NC}"
+    else
+        echo -e "${RED}UNREACHABLE${NC}"
+        echo "     Cannot connect to $SIEM_IP:$SIEM_PORT"
+    fi
+    
+    # Send test log
+    echo -n "   - Sending test log entry... "
+    TEST_MSG="VICTIM_VALIDATION: Test from $HOSTNAME at $(date +%s)"
+    $SSH_CMD "logger -p auth.info '$TEST_MSG'" 2>/dev/null
+    echo -e "${GREEN}SENT${NC}"
+    if [ "$VERBOSE" = true ]; then
+        echo "     Message: $TEST_MSG"
+    fi
+else
+    echo "5. Skipping SIEM tests (no SIEM IP provided)"
+fi
+
+# Test 6: Security checks
+echo "6. Security configuration checks:"
+
+# SSH root login
+echo -n "   - SSH root login disabled... "
+if $SSH_CMD "sudo grep -E '^PermitRootLogin no' /etc/ssh/sshd_config" >/dev/null 2>&1; then
+    echo -e "${GREEN}SECURE${NC}"
+else
+    echo -e "${YELLOW}WARNING${NC} (root login may be enabled)"
+fi
+
+# SSH password auth
+echo -n "   - SSH password auth disabled... "
+if $SSH_CMD "sudo grep -E '^PasswordAuthentication no' /etc/ssh/sshd_config" >/dev/null 2>&1; then
+    echo -e "${GREEN}SECURE${NC}"
+else
+    echo -e "${YELLOW}WARNING${NC} (password auth may be enabled)"
+fi
+
+# Test 7: Container-specific checks (if applicable)
+echo -n "7. Checking if running in container... "
+if $SSH_CMD "grep -q docker /proc/1/cgroup 2>/dev/null || [ -f /.dockerenv ]" 2>/dev/null; then
+    echo -e "${GREEN}YES${NC}"
+    
+    # Check for systemd
+    echo -n "   - Systemd as init... "
+    if $SSH_CMD "ps -p 1 -o comm=" 2>/dev/null | grep -q "systemd"; then
+        echo -e "${GREEN}YES${NC}"
+    else
+        echo -e "${YELLOW}NO${NC} (may cause issues)"
+    fi
+else
+    echo "NO (running on VM/bare metal)"
+fi
+
+# Summary
+echo ""
+echo "=== Validation Summary ==="
+echo -e "${GREEN}✓${NC} SSH connectivity verified"
+echo -e "${GREEN}✓${NC} labadmin access confirmed"
+echo -e "${GREEN}✓${NC} System information retrieved"
+
+if [ ! -z "$SIEM_IP" ]; then
+    echo -e "${YELLOW}!${NC} SIEM log forwarding should be verified in $SIEM_TYPE console"
+fi
+
+echo ""
+echo "Victim container at $VICTIM_IP is operational"

--- a/containers/victim/validate-victim.sh
+++ b/containers/victim/validate-victim.sh
@@ -63,7 +63,7 @@ echo ""
 
 # Test 1: SSH Connectivity
 echo -n "1. Testing SSH connectivity... "
-if $SSH_CMD "echo 'SSH OK' >/dev/null 2>&1"; then
+if $SSH_CMD "echo 'SSH OK'"; then
     echo -e "${GREEN}PASS${NC}"
 else
     echo -e "${RED}FAIL${NC}"

--- a/containers/victim/validate-victim.sh
+++ b/containers/victim/validate-victim.sh
@@ -124,7 +124,7 @@ if [ ! -z "$SIEM_IP" ]; then
     fi
     
     echo -n "   - Rsyslog forwarding rule... "
-    if $SSH_CMD "sudo grep -q '@@$SIEM_IP:$SIEM_PORT' /etc/rsyslog.conf /etc/rsyslog.d/*.conf 2>/dev/null"; then
+    if $SSH_CMD "sudo grep -q \"@@$SIEM_IP:$SIEM_PORT\" /etc/rsyslog.conf /etc/rsyslog.d/*.conf 2>/dev/null"; then
         echo -e "${GREEN}CONFIGURED${NC}"
     else
         echo -e "${YELLOW}NOT FOUND${NC}"


### PR DESCRIPTION
  - Add Rocky Linux 9 base victim Dockerfile with minimal secure configuration
  - Configure systemd for container use with multi-user target
  - Enable SSH access via labadmin user with key-based authentication
  - Implement dual SSH key delivery: volume mount (local) and env var (AWS)
  - Add rsyslog forwarding configuration for qRadar/Splunk integration
  - Create entrypoint script with automatic systemd-user-sessions startup
  - Add validation script with custom SSH port support for testing
  - Provide consistent docker-compose files for local dev and AWS deployment
  - Fix systemd nologin issue preventing SSH login during container boot
