### PR TITLE
docs: add config management architecture

### DIFF
--- a/aptl.config.example
+++ b/aptl.config.example
@@ -1,0 +1,11 @@
+version: 1
+paths:
+  data_dir: ${APT_DATA_DIR:-./data}
+
+wazuh:
+  api_port: ${WAZUH_API_PORT:-55000}
+  dashboard_port: ${WAZUH_DASHBOARD_PORT:-443}
+
+kali:
+  ssh_port: ${KALI_SSH_PORT:-2023}
+

--- a/docs/architecture/config-management.md
+++ b/docs/architecture/config-management.md
@@ -1,0 +1,73 @@
+# Configuration Management Architecture
+
+Centralized environment and runtime configuration for APTL.
+
+## Goals
+
+- Single source of truth for ports, paths, and secrets
+- Consistent configuration loading across languages and services
+- Simple overrides for local development or CI
+
+## Structure
+
+```
+aptl/
+├── .env                 # Environment variable definitions
+├── aptl.config          # YAML configuration with defaults
+└── ...                  # Code and documentation
+```
+
+## .env File
+
+Defines environment variables for all services. Example:
+
+```bash
+APT_ENV=development
+WAZUH_API_PORT=55000
+KALI_SSH_PORT=2023
+```
+
+Values can be overridden per-developer or per-environment without modifying source files.
+
+## aptl.config
+
+YAML file containing structured settings that reference environment variables:
+
+```yaml
+version: 1
+paths:
+  data_dir: ${APT_DATA_DIR:-./data}
+wazuh:
+  api_port: ${WAZUH_API_PORT}
+  dashboard_port: ${WAZUH_DASHBOARD_PORT:-443}
+```
+
+The config loader resolves `${VAR}` entries using the values loaded from `.env`.
+
+## Loading Order
+
+1. Load `.env` using language-specific dotenv libraries
+2. Parse `aptl.config`
+3. Resolve `${VAR}` placeholders from the environment
+4. Expose resulting config object to application code
+
+## Component Integration
+
+- **Node.js**: use `dotenv` and `js-yaml` to load config in each MCP service
+- **Python**: use `python-dotenv` and `pyyaml` for auxiliary scripts
+- **Shell scripts**: source `.env` and use `yq` to read `aptl.config`
+
+## Example Usage
+
+```javascript
+// Node.js loader example
+import dotenv from 'dotenv';
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+dotenv.config();
+const config = yaml.load(fs.readFileSync('aptl.config', 'utf8'));
+```
+
+Applications import the shared loader to ensure consistent configuration across the lab.
+

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,5 +1,7 @@
 # Lab Architecture
 
+See [Configuration Management](./config-management.md) for how environment variables and runtime settings are managed across the lab.
+
 ## Network Topology
 
 ```mermaid

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
     - Overview: architecture/index.md
     - Docker Compose: architecture/docker-compose.md
     - Networking: architecture/networking.md
+    - Config Management: architecture/config-management.md
   - Deployment:
     - Overview: deployment/index.md
     - Local Setup: deployment/local-setup.md


### PR DESCRIPTION
## Summary
- document cross-repo configuration approach using `.env` and `aptl.config`
- add sample `aptl.config.example`
- reference the new architecture in docs navigation

## Testing
- `mkdocs build` *(fails: mkdocs not installed and installation blocked by network proxy)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b37ef8b5fc832c8a6efa6d0793585f