### PR TITLE
Add range snapshot capture (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2026-03-07
+
+### Added
+
+- Range snapshot capture in experiment runs — records software versions, container state, Wazuh rules inventory, network config, and config file hashes as `snapshot.json` (#156)
+
 ## [4.1.0] - 2026-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Range snapshot capture in experiment runs — records software versions, container state, Wazuh rules inventory, network config, and config file hashes as `snapshot.json` (#156)
 
+### Fixed
+
+- Snapshot used wrong container names (`aptl-wazuh-manager` → `aptl-wazuh.manager-1`) causing all Wazuh data to be empty
+- Snapshot indexer version read from non-existent file; now extracted from opensearch jar filename
+
 ## [4.1.0] - 2026-03-02
 
 ### Added

--- a/docs/reference/experiment-runs.md
+++ b/docs/reference/experiment-runs.md
@@ -1,0 +1,79 @@
+# Experiment Runs
+
+The experiment run system captures data from each scenario execution for reproducibility and post-run analysis.
+
+## Run Directory Structure
+
+Each run is stored under `<project_dir>/runs/<run_id>/` with:
+
+```
+<run_id>/
+  manifest.json          # Run metadata (scenario, timing, flags)
+  snapshot.json          # Range snapshot (software, containers, rules, networks, config hashes)
+  flags.json             # Captured flags
+  scenario/
+    definition.yaml      # Scenario YAML copy
+    events.jsonl         # Scenario events timeline
+  wazuh/
+    alerts.jsonl         # Wazuh alerts from the run window
+  suricata/
+    eve.jsonl            # Suricata IDS events (if available)
+  soc/
+    thehive-cases.json   # TheHive cases (if available)
+    misp-correlations.json  # MISP events (if available)
+    shuffle-executions.json # Shuffle SOAR executions (if available)
+  containers/
+    <name>.log           # Container logs for each aptl- container
+  agents/
+    traces.jsonl         # MCP agent traces (if available)
+```
+
+## Range Snapshot (`snapshot.json`)
+
+Captured at the start of each run for reproducibility. Contains:
+
+| Field | Description |
+|-------|-------------|
+| `timestamp` | ISO 8601 capture time |
+| `software.python_version` | Python interpreter version |
+| `software.docker_version` | Docker Engine version |
+| `software.compose_version` | Docker Compose version |
+| `software.wazuh_manager_version` | Wazuh manager version (from `/var/ossec/bin/wazuh-control`) |
+| `software.wazuh_indexer_version` | OpenSearch version on the Wazuh indexer |
+| `software.aptl_version` | APTL package version |
+| `containers[]` | Name, image, image ID, status, health, labels for each `aptl-*` container |
+| `wazuh_rules.total_rules` | Total Wazuh rules loaded |
+| `wazuh_rules.custom_rules` | Custom rules in `/var/ossec/etc/rules/` |
+| `wazuh_rules.custom_rule_files` | List of custom rule XML filenames |
+| `wazuh_rules.total_decoders` | Total decoders loaded |
+| `wazuh_rules.custom_decoders` | Custom decoders count |
+| `networks[]` | Docker network name, subnet, gateway, connected containers |
+| `config_hashes` | SHA-256 of `aptl.json`, `docker-compose.yml`, `.env` |
+
+## CLI Commands
+
+```bash
+# List recent runs
+aptl runs list
+
+# Show run details
+aptl runs show <run-id>
+
+# Print run directory path
+aptl runs path <run-id>
+
+# Export run as tar.gz archive
+aptl runs export <run-id>
+
+# Export to S3 (requires pip install aptl[s3])
+aptl runs export <run-id> --s3-bucket my-bucket --s3-prefix runs/
+```
+
+## Key Source Files
+
+- `src/aptl/core/runstore.py` — Storage backend protocol and local filesystem implementation
+- `src/aptl/core/run_assembler.py` — Orchestrates data collection after scenario stop
+- `src/aptl/core/snapshot.py` — Range snapshot dataclasses and capture logic
+- `src/aptl/core/exporter.py` — Local tar.gz and S3 export
+- `src/aptl/core/collectors.py` — Individual data collectors (Wazuh, Suricata, TheHive, etc.)
+- `src/aptl/cli/runs.py` — CLI commands (`aptl runs list|show|path|export`)

--- a/src/aptl/core/run_assembler.py
+++ b/src/aptl/core/run_assembler.py
@@ -23,6 +23,7 @@ from aptl.core.events import Event
 from aptl.core.runstore import LocalRunStore, RunManifest
 from aptl.core.scenarios import ScenarioDefinition
 from aptl.core.session import ActiveSession
+from aptl.core.snapshot import capture_snapshot
 from aptl.utils.logging import get_logger
 
 log = get_logger("run_assembler")
@@ -77,6 +78,13 @@ def assemble_run(
     # 1. Create run directory
     run_dir = store.create_run(run_id)
     log.info("Assembling run %s at %s", run_id, run_dir)
+
+    # 1b. Capture range snapshot
+    try:
+        snapshot = capture_snapshot(config_dir=scenario_path.parent)
+        store.write_json(run_id, "snapshot.json", snapshot.to_dict())
+    except Exception:
+        log.exception("Failed to capture range snapshot")
 
     # 2. Write flags
     store.write_json(run_id, "flags.json", session.flags)

--- a/src/aptl/core/snapshot.py
+++ b/src/aptl/core/snapshot.py
@@ -1,0 +1,328 @@
+"""Range snapshot capture.
+
+Captures the current state of the lab environment including software
+versions, container status, Wazuh rules, network topology, and
+configuration file hashes.
+"""
+
+import hashlib
+import subprocess
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+from aptl.utils.logging import get_logger
+
+log = get_logger("snapshot")
+
+
+@dataclass
+class SoftwareVersions:
+    """Versions of key software components."""
+
+    python_version: str = ""
+    docker_version: str = ""
+    compose_version: str = ""
+    wazuh_manager_version: str = ""
+    wazuh_indexer_version: str = ""
+    aptl_version: str = ""
+
+
+@dataclass
+class ContainerSnapshot:
+    """State of a single Docker container."""
+
+    name: str = ""
+    image: str = ""
+    image_id: str = ""
+    status: str = ""
+    health: str = ""
+    labels: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class WazuhRulesSnapshot:
+    """Summary of Wazuh rule configuration."""
+
+    total_rules: int = 0
+    custom_rules: int = 0
+    custom_rule_files: list[str] = field(default_factory=list)
+    total_decoders: int = 0
+    custom_decoders: int = 0
+
+
+@dataclass
+class NetworkSnapshot:
+    """State of a Docker network."""
+
+    name: str = ""
+    subnet: str = ""
+    gateway: str = ""
+    containers: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RangeSnapshot:
+    """Complete point-in-time snapshot of the lab range."""
+
+    timestamp: str = ""
+    software: SoftwareVersions = field(default_factory=SoftwareVersions)
+    containers: list[ContainerSnapshot] = field(default_factory=list)
+    wazuh_rules: WazuhRulesSnapshot = field(default_factory=WazuhRulesSnapshot)
+    networks: list[NetworkSnapshot] = field(default_factory=list)
+    config_hashes: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Convert to a JSON-serializable dictionary."""
+        return asdict(self)
+
+
+def _run_cmd(args: list[str], timeout: int = 15) -> str:
+    """Run a command and return stdout, or empty string on failure."""
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError, FileNotFoundError) as e:
+        log.debug("Command %s failed: %s", args, e)
+    return ""
+
+
+def _get_software_versions() -> SoftwareVersions:
+    """Collect software version information."""
+    versions = SoftwareVersions()
+
+    versions.python_version = sys.version.split()[0]
+
+    docker_out = _run_cmd(["docker", "version", "--format", "{{.Server.Version}}"])
+    if docker_out:
+        versions.docker_version = docker_out
+
+    compose_out = _run_cmd(["docker", "compose", "version", "--short"])
+    if compose_out:
+        versions.compose_version = compose_out
+
+    # Wazuh manager version from container
+    wm_out = _run_cmd([
+        "docker", "exec", "aptl-wazuh-manager",
+        "/var/ossec/bin/wazuh-control", "info", "-v",
+    ])
+    if wm_out:
+        versions.wazuh_manager_version = wm_out.strip().lstrip("v")
+
+    # Wazuh indexer version
+    wi_out = _run_cmd([
+        "docker", "exec", "aptl-wazuh-indexer",
+        "cat", "/usr/share/wazuh-indexer/VERSION",
+    ])
+    if wi_out:
+        versions.wazuh_indexer_version = wi_out.strip()
+
+    # APTL version from package metadata
+    try:
+        from importlib.metadata import version
+
+        versions.aptl_version = version("aptl")
+    except Exception:
+        versions.aptl_version = "dev"
+
+    return versions
+
+
+def _get_container_snapshots() -> list[ContainerSnapshot]:
+    """Snapshot all aptl- containers."""
+    fmt = "{{.Names}}\t{{.Image}}\t{{.ID}}\t{{.Status}}\t{{.Labels}}"
+    out = _run_cmd([
+        "docker", "ps", "-a", "--filter", "name=aptl-", "--format", fmt,
+    ])
+    if not out:
+        return []
+
+    snapshots = []
+    for line in out.splitlines():
+        parts = line.split("\t", 4)
+        if len(parts) < 5:
+            continue
+
+        name, image, image_id, status, labels_str = parts
+
+        # Parse health from status string
+        health = ""
+        if "(healthy)" in status:
+            health = "healthy"
+        elif "(unhealthy)" in status:
+            health = "unhealthy"
+        elif "(health: starting)" in status:
+            health = "starting"
+
+        # Parse labels
+        labels = {}
+        if labels_str:
+            for pair in labels_str.split(","):
+                if "=" in pair:
+                    k, v = pair.split("=", 1)
+                    labels[k.strip()] = v.strip()
+
+        snapshots.append(ContainerSnapshot(
+            name=name,
+            image=image,
+            image_id=image_id,
+            status=status,
+            health=health,
+            labels=labels,
+        ))
+
+    return snapshots
+
+
+def _get_wazuh_rules_snapshot() -> WazuhRulesSnapshot:
+    """Snapshot Wazuh rule/decoder counts."""
+    snap = WazuhRulesSnapshot()
+
+    # Count total rules
+    rule_count = _run_cmd([
+        "docker", "exec", "aptl-wazuh-manager",
+        "bash", "-c",
+        "find /var/ossec/ruleset/rules -name '*.xml' -exec grep -c '<rule ' {} + 2>/dev/null | awk -F: '{s+=$NF} END {print s}'",
+    ])
+    if rule_count and rule_count.isdigit():
+        snap.total_rules = int(rule_count)
+
+    # Count custom rules
+    custom_count = _run_cmd([
+        "docker", "exec", "aptl-wazuh-manager",
+        "bash", "-c",
+        "find /var/ossec/etc/rules -name '*.xml' -exec grep -c '<rule ' {} + 2>/dev/null | awk -F: '{s+=$NF} END {print s}'",
+    ])
+    if custom_count and custom_count.isdigit():
+        snap.custom_rules = int(custom_count)
+
+    # List custom rule files
+    custom_files = _run_cmd([
+        "docker", "exec", "aptl-wazuh-manager",
+        "bash", "-c",
+        "ls /var/ossec/etc/rules/*.xml 2>/dev/null",
+    ])
+    if custom_files:
+        snap.custom_rule_files = [
+            Path(f).name for f in custom_files.splitlines() if f.strip()
+        ]
+
+    # Count total decoders
+    decoder_count = _run_cmd([
+        "docker", "exec", "aptl-wazuh-manager",
+        "bash", "-c",
+        "find /var/ossec/ruleset/decoders -name '*.xml' -exec grep -c '<decoder ' {} + 2>/dev/null | awk -F: '{s+=$NF} END {print s}'",
+    ])
+    if decoder_count and decoder_count.isdigit():
+        snap.total_decoders = int(decoder_count)
+
+    # Count custom decoders
+    custom_dec = _run_cmd([
+        "docker", "exec", "aptl-wazuh-manager",
+        "bash", "-c",
+        "find /var/ossec/etc/decoders -name '*.xml' -exec grep -c '<decoder ' {} + 2>/dev/null | awk -F: '{s+=$NF} END {print s}'",
+    ])
+    if custom_dec and custom_dec.isdigit():
+        snap.custom_decoders = int(custom_dec)
+
+    return snap
+
+
+def _get_network_snapshots() -> list[NetworkSnapshot]:
+    """Snapshot Docker networks with aptl prefix."""
+    import json as _json
+
+    out = _run_cmd(["docker", "network", "ls", "--filter", "name=aptl", "--format", "{{.Name}}"])
+    if not out:
+        return []
+
+    snapshots = []
+    for net_name in out.splitlines():
+        net_name = net_name.strip()
+        if not net_name:
+            continue
+
+        inspect_out = _run_cmd(["docker", "network", "inspect", net_name])
+        if not inspect_out:
+            snapshots.append(NetworkSnapshot(name=net_name))
+            continue
+
+        try:
+            info = _json.loads(inspect_out)
+            if isinstance(info, list) and info:
+                info = info[0]
+
+            subnet = ""
+            gateway = ""
+            ipam_configs = info.get("IPAM", {}).get("Config", [])
+            if ipam_configs:
+                subnet = ipam_configs[0].get("Subnet", "")
+                gateway = ipam_configs[0].get("Gateway", "")
+
+            containers_map = info.get("Containers", {})
+            container_names = [
+                c.get("Name", "") for c in containers_map.values()
+            ]
+
+            snapshots.append(NetworkSnapshot(
+                name=net_name,
+                subnet=subnet,
+                gateway=gateway,
+                containers=sorted(container_names),
+            ))
+        except (_json.JSONDecodeError, KeyError, IndexError) as e:
+            log.debug("Failed to parse network inspect for %s: %s", net_name, e)
+            snapshots.append(NetworkSnapshot(name=net_name))
+
+    return snapshots
+
+
+def _hash_config_files(config_dir: Path | None = None) -> dict[str, str]:
+    """Compute SHA-256 hashes for config files in the project."""
+    hashes = {}
+
+    if config_dir is None:
+        config_dir = Path(".")
+
+    patterns = ["aptl.json", "docker-compose*.yml", "docker-compose*.yaml", ".env"]
+    for pattern in patterns:
+        for f in sorted(config_dir.glob(pattern)):
+            if f.is_file():
+                digest = hashlib.sha256(f.read_bytes()).hexdigest()
+                hashes[f.name] = digest
+
+    return hashes
+
+
+def capture_snapshot(config_dir: Path | None = None) -> RangeSnapshot:
+    """Capture a complete snapshot of the current lab state.
+
+    Args:
+        config_dir: Directory containing config files to hash.
+                    Defaults to current working directory.
+
+    Returns:
+        A RangeSnapshot with all collected data.
+    """
+    from datetime import datetime, timezone
+
+    log.info("Capturing range snapshot")
+
+    snapshot = RangeSnapshot(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        software=_get_software_versions(),
+        containers=_get_container_snapshots(),
+        wazuh_rules=_get_wazuh_rules_snapshot(),
+        networks=_get_network_snapshots(),
+        config_hashes=_hash_config_files(config_dir),
+    )
+
+    log.info(
+        "Snapshot captured: %d containers, %d networks",
+        len(snapshot.containers),
+        len(snapshot.networks),
+    )
+    return snapshot

--- a/src/aptl/core/snapshot.py
+++ b/src/aptl/core/snapshot.py
@@ -106,19 +106,24 @@ def _get_software_versions() -> SoftwareVersions:
 
     # Wazuh manager version from container
     wm_out = _run_cmd([
-        "docker", "exec", "aptl-wazuh-manager",
+        "docker", "exec", "aptl-wazuh.manager-1",
         "/var/ossec/bin/wazuh-control", "info", "-v",
     ])
     if wm_out:
         versions.wazuh_manager_version = wm_out.strip().lstrip("v")
 
-    # Wazuh indexer version
+    # Wazuh indexer version (extract from opensearch jar filename)
     wi_out = _run_cmd([
-        "docker", "exec", "aptl-wazuh-indexer",
-        "cat", "/usr/share/wazuh-indexer/VERSION",
+        "docker", "exec", "aptl-wazuh.indexer-1",
+        "bash", "-c",
+        "ls /usr/share/wazuh-indexer/lib/opensearch-[0-9]*.jar 2>/dev/null | head -1",
     ])
     if wi_out:
-        versions.wazuh_indexer_version = wi_out.strip()
+        # Extract version from e.g. "opensearch-2.19.1.jar"
+        jar_name = Path(wi_out.strip()).name
+        ver = jar_name.removeprefix("opensearch-").removesuffix(".jar")
+        if ver:
+            versions.wazuh_indexer_version = ver
 
     # APTL version from package metadata
     try:
@@ -183,7 +188,7 @@ def _get_wazuh_rules_snapshot() -> WazuhRulesSnapshot:
 
     # Count total rules
     rule_count = _run_cmd([
-        "docker", "exec", "aptl-wazuh-manager",
+        "docker", "exec", "aptl-wazuh.manager-1",
         "bash", "-c",
         "find /var/ossec/ruleset/rules -name '*.xml' -exec grep -c '<rule ' {} + 2>/dev/null | awk -F: '{s+=$NF} END {print s}'",
     ])
@@ -192,7 +197,7 @@ def _get_wazuh_rules_snapshot() -> WazuhRulesSnapshot:
 
     # Count custom rules
     custom_count = _run_cmd([
-        "docker", "exec", "aptl-wazuh-manager",
+        "docker", "exec", "aptl-wazuh.manager-1",
         "bash", "-c",
         "find /var/ossec/etc/rules -name '*.xml' -exec grep -c '<rule ' {} + 2>/dev/null | awk -F: '{s+=$NF} END {print s}'",
     ])
@@ -201,7 +206,7 @@ def _get_wazuh_rules_snapshot() -> WazuhRulesSnapshot:
 
     # List custom rule files
     custom_files = _run_cmd([
-        "docker", "exec", "aptl-wazuh-manager",
+        "docker", "exec", "aptl-wazuh.manager-1",
         "bash", "-c",
         "ls /var/ossec/etc/rules/*.xml 2>/dev/null",
     ])
@@ -212,7 +217,7 @@ def _get_wazuh_rules_snapshot() -> WazuhRulesSnapshot:
 
     # Count total decoders
     decoder_count = _run_cmd([
-        "docker", "exec", "aptl-wazuh-manager",
+        "docker", "exec", "aptl-wazuh.manager-1",
         "bash", "-c",
         "find /var/ossec/ruleset/decoders -name '*.xml' -exec grep -c '<decoder ' {} + 2>/dev/null | awk -F: '{s+=$NF} END {print s}'",
     ])
@@ -221,7 +226,7 @@ def _get_wazuh_rules_snapshot() -> WazuhRulesSnapshot:
 
     # Count custom decoders
     custom_dec = _run_cmd([
-        "docker", "exec", "aptl-wazuh-manager",
+        "docker", "exec", "aptl-wazuh.manager-1",
         "bash", "-c",
         "find /var/ossec/etc/decoders -name '*.xml' -exec grep -c '<decoder ' {} + 2>/dev/null | awk -F: '{s+=$NF} END {print s}'",
     ])

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,190 @@
+"""Unit tests for range snapshot capture."""
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from unittest.mock import patch
+
+from aptl.core.snapshot import (
+    SoftwareVersions,
+    ContainerSnapshot,
+    WazuhRulesSnapshot,
+    NetworkSnapshot,
+    RangeSnapshot,
+    capture_snapshot,
+    _hash_config_files,
+)
+
+
+class TestDataclasses:
+    """Tests for snapshot dataclass creation and serialization."""
+
+    def test_software_versions_defaults(self):
+        sv = SoftwareVersions()
+        assert sv.python_version == ""
+        assert sv.docker_version == ""
+        assert sv.aptl_version == ""
+
+    def test_software_versions_values(self):
+        sv = SoftwareVersions(
+            python_version="3.11.5",
+            docker_version="24.0.7",
+            compose_version="2.23.0",
+            wazuh_manager_version="4.7.0",
+            wazuh_indexer_version="4.7.0",
+            aptl_version="0.1.0",
+        )
+        d = asdict(sv)
+        assert d["python_version"] == "3.11.5"
+        assert d["docker_version"] == "24.0.7"
+        assert d["aptl_version"] == "0.1.0"
+
+    def test_container_snapshot(self):
+        cs = ContainerSnapshot(
+            name="aptl-victim",
+            image="aptl/victim:latest",
+            image_id="sha256:abc123",
+            status="Up 5 minutes (healthy)",
+            health="healthy",
+            labels={"com.docker.compose.service": "victim"},
+        )
+        d = asdict(cs)
+        assert d["name"] == "aptl-victim"
+        assert d["health"] == "healthy"
+        assert d["labels"]["com.docker.compose.service"] == "victim"
+
+    def test_container_snapshot_defaults(self):
+        cs = ContainerSnapshot()
+        assert cs.labels == {}
+        assert cs.name == ""
+
+    def test_wazuh_rules_snapshot(self):
+        wr = WazuhRulesSnapshot(
+            total_rules=3500,
+            custom_rules=15,
+            custom_rule_files=["local_rules.xml", "ssh_rules.xml"],
+            total_decoders=800,
+            custom_decoders=3,
+        )
+        d = asdict(wr)
+        assert d["total_rules"] == 3500
+        assert d["custom_rules"] == 15
+        assert len(d["custom_rule_files"]) == 2
+
+    def test_network_snapshot(self):
+        ns = NetworkSnapshot(
+            name="aptl_default",
+            subnet="172.20.0.0/16",
+            gateway="172.20.0.1",
+            containers=["aptl-victim", "aptl-wazuh-manager"],
+        )
+        d = asdict(ns)
+        assert d["subnet"] == "172.20.0.0/16"
+        assert len(d["containers"]) == 2
+
+    def test_range_snapshot_to_dict(self):
+        snap = RangeSnapshot(
+            timestamp="2026-03-07T12:00:00+00:00",
+            software=SoftwareVersions(python_version="3.11.5"),
+            containers=[
+                ContainerSnapshot(name="aptl-victim", image="aptl/victim:latest"),
+            ],
+            wazuh_rules=WazuhRulesSnapshot(total_rules=100),
+            networks=[
+                NetworkSnapshot(name="aptl_default", subnet="172.20.0.0/16"),
+            ],
+            config_hashes={"aptl.json": "abc123def456"},
+        )
+        d = snap.to_dict()
+        assert d["timestamp"] == "2026-03-07T12:00:00+00:00"
+        assert d["software"]["python_version"] == "3.11.5"
+        assert len(d["containers"]) == 1
+        assert d["containers"][0]["name"] == "aptl-victim"
+        assert d["wazuh_rules"]["total_rules"] == 100
+        assert d["networks"][0]["subnet"] == "172.20.0.0/16"
+        assert d["config_hashes"]["aptl.json"] == "abc123def456"
+
+    def test_range_snapshot_json_roundtrip(self):
+        snap = RangeSnapshot(
+            timestamp="2026-03-07T12:00:00+00:00",
+            software=SoftwareVersions(python_version="3.11"),
+            containers=[ContainerSnapshot(name="test")],
+            wazuh_rules=WazuhRulesSnapshot(),
+            networks=[],
+            config_hashes={"f.json": "deadbeef"},
+        )
+        serialized = json.dumps(snap.to_dict())
+        loaded = json.loads(serialized)
+        assert loaded["timestamp"] == "2026-03-07T12:00:00+00:00"
+        assert loaded["containers"][0]["name"] == "test"
+        assert loaded["config_hashes"]["f.json"] == "deadbeef"
+
+
+class TestHashConfigFiles:
+    """Tests for config file hashing."""
+
+    def test_hash_config_files(self, tmp_path):
+        (tmp_path / "aptl.json").write_text('{"lab": {"name": "test"}}')
+        (tmp_path / "docker-compose.yml").write_text("version: '3'\n")
+        (tmp_path / "unrelated.txt").write_text("ignored")
+
+        hashes = _hash_config_files(tmp_path)
+        assert "aptl.json" in hashes
+        assert "docker-compose.yml" in hashes
+        assert "unrelated.txt" not in hashes
+        assert len(hashes["aptl.json"]) == 64  # SHA-256 hex digest length
+
+    def test_hash_config_empty_dir(self, tmp_path):
+        hashes = _hash_config_files(tmp_path)
+        assert hashes == {}
+
+
+class TestCaptureSnapshot:
+    """Tests for the capture_snapshot function."""
+
+    @patch("aptl.core.snapshot._get_network_snapshots")
+    @patch("aptl.core.snapshot._get_wazuh_rules_snapshot")
+    @patch("aptl.core.snapshot._get_container_snapshots")
+    @patch("aptl.core.snapshot._get_software_versions")
+    def test_capture_snapshot_structure(
+        self, mock_sw, mock_containers, mock_wazuh, mock_networks, tmp_path
+    ):
+        mock_sw.return_value = SoftwareVersions(python_version="3.11.5")
+        mock_containers.return_value = [
+            ContainerSnapshot(name="aptl-victim", image="aptl/victim:latest"),
+        ]
+        mock_wazuh.return_value = WazuhRulesSnapshot(total_rules=100)
+        mock_networks.return_value = [
+            NetworkSnapshot(name="aptl_default", subnet="172.20.0.0/16"),
+        ]
+
+        (tmp_path / "aptl.json").write_text("{}")
+
+        snap = capture_snapshot(config_dir=tmp_path)
+
+        assert snap.timestamp  # non-empty
+        assert snap.software.python_version == "3.11.5"
+        assert len(snap.containers) == 1
+        assert snap.containers[0].name == "aptl-victim"
+        assert snap.wazuh_rules.total_rules == 100
+        assert len(snap.networks) == 1
+        assert "aptl.json" in snap.config_hashes
+
+    @patch("aptl.core.snapshot._get_network_snapshots")
+    @patch("aptl.core.snapshot._get_wazuh_rules_snapshot")
+    @patch("aptl.core.snapshot._get_container_snapshots")
+    @patch("aptl.core.snapshot._get_software_versions")
+    def test_capture_snapshot_serializable(
+        self, mock_sw, mock_containers, mock_wazuh, mock_networks, tmp_path
+    ):
+        mock_sw.return_value = SoftwareVersions()
+        mock_containers.return_value = []
+        mock_wazuh.return_value = WazuhRulesSnapshot()
+        mock_networks.return_value = []
+
+        snap = capture_snapshot(config_dir=tmp_path)
+        serialized = json.dumps(snap.to_dict())
+        loaded = json.loads(serialized)
+        assert "timestamp" in loaded
+        assert "software" in loaded
+        assert "containers" in loaded


### PR DESCRIPTION
## Summary
- Add `src/aptl/core/snapshot.py` with dataclasses (`SoftwareVersions`, `ContainerSnapshot`, `WazuhRulesSnapshot`, `NetworkSnapshot`, `RangeSnapshot`) and `capture_snapshot()` function
- Integrate snapshot capture into `assemble_run()` in `run_assembler.py` — writes `snapshot.json` to each run directory
- Add 12 tests in `tests/test_snapshot.py` covering dataclass creation, serialization, config hashing, and full capture

## Test plan
- [x] All 12 new snapshot tests pass
- [x] All 3 existing run_assembler tests still pass
- [x] Manual verification with live lab containers

Closes #156