### PR TITLE
Add S3 export for experiment runs (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2026-03-07
+
+### Added
+
+- S3 export for experiment run data — `aptl runs export` packages runs as tar.gz with SHA-256 checksums, optional S3 upload via `--s3-bucket` with metadata tags (#157)
+- `aptl[s3]` optional dependency group for boto3
+
 ## [4.1.0] - 2026-03-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
 aptl = "aptl.cli.main:app"
 
 [project.optional-dependencies]
+s3 = [
+    "boto3>=1.28.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-mock>=3.12.0",

--- a/src/aptl/cli/runs.py
+++ b/src/aptl/cli/runs.py
@@ -186,3 +186,60 @@ def run_path(
         raise typer.Exit(code=1)
 
     typer.echo(str(store.get_run_path(matches[0])))
+
+
+def _resolve_run_id(store: LocalRunStore, run_id: str) -> str:
+    """Resolve a run ID prefix to a full run ID."""
+    all_runs = store.list_runs()
+    matches = [r for r in all_runs if r.startswith(run_id)]
+    if not matches:
+        typer.echo(f"No run found matching '{run_id}'")
+        raise typer.Exit(code=1)
+    if len(matches) > 1:
+        typer.echo(f"Ambiguous run ID '{run_id}', matches: {', '.join(matches[:5])}")
+        raise typer.Exit(code=1)
+    return matches[0]
+
+
+@app.command("export")
+def export_run(
+    run_id: str = typer.Argument(help="Run UUID (full or prefix)."),
+    project_dir: Path = typer.Option(
+        Path("."),
+        "--project-dir",
+        "-d",
+        help="Path to the APTL project directory.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("./exports"),
+        "--output-dir",
+        "-o",
+        help="Directory to write the export archive to.",
+    ),
+    s3_bucket: str = typer.Option(
+        None,
+        "--s3-bucket",
+        help="S3 bucket for remote export.",
+    ),
+    s3_prefix: str = typer.Option(
+        "runs/",
+        "--s3-prefix",
+        help="S3 key prefix for remote export.",
+    ),
+) -> None:
+    """Export a run as a tar.gz archive, optionally to S3."""
+    store = _get_store(project_dir)
+    resolved_id = _resolve_run_id(store, run_id)
+
+    from aptl.core.exporter import export_local, export_s3
+
+    if s3_bucket:
+        try:
+            uri = export_s3(store, resolved_id, s3_bucket, s3_prefix, output_dir)
+            typer.echo(f"Exported to S3: {uri}")
+        except ImportError as e:
+            typer.echo(f"Error: {e}")
+            raise typer.Exit(code=1)
+    else:
+        archive = export_local(store, resolved_id, output_dir)
+        typer.echo(f"Exported to: {archive}")

--- a/src/aptl/core/exporter.py
+++ b/src/aptl/core/exporter.py
@@ -1,0 +1,152 @@
+"""Run export to local archive and S3.
+
+Packages experiment run directories into tar.gz archives with
+SHA-256 checksums, and optionally uploads to S3.
+"""
+
+import hashlib
+import json
+import tarfile
+from pathlib import Path
+
+from aptl.utils.logging import get_logger
+
+log = get_logger("exporter")
+
+try:
+    import boto3 as boto3
+except ImportError:
+    boto3 = None  # type: ignore[assignment]
+
+
+def _sha256_file(path: Path) -> str:
+    """Compute SHA-256 hex digest for a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def export_local(
+    store: "LocalRunStore",
+    run_id: str,
+    output_dir: Path,
+) -> Path:
+    """Export a run as a tar.gz archive with SHA-256 checksums.
+
+    Args:
+        store: The run store containing the run data.
+        run_id: The run identifier.
+        output_dir: Directory to write the archive to.
+
+    Returns:
+        Path to the created tar.gz archive.
+
+    Raises:
+        FileNotFoundError: If the run directory does not exist.
+    """
+    from aptl.core.runstore import LocalRunStore
+
+    run_path = store.get_run_path(run_id)
+    if not run_path.exists():
+        raise FileNotFoundError(f"Run directory not found: {run_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Compute checksums for all files in the run
+    checksums = {}
+    for item in sorted(run_path.rglob("*")):
+        if item.is_file():
+            rel = str(item.relative_to(run_path))
+            checksums[rel] = _sha256_file(item)
+
+    # Write checksums file into the run directory
+    checksums_path = run_path / "checksums.sha256"
+    lines = [f"{digest}  {name}\n" for name, digest in sorted(checksums.items())]
+    checksums_path.write_text("".join(lines))
+
+    # Create tar.gz archive
+    archive_name = f"{run_id}.tar.gz"
+    archive_path = output_dir / archive_name
+
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(run_path, arcname=run_id)
+
+    log.info("Exported run %s to %s (%d files)", run_id, archive_path, len(checksums))
+    return archive_path
+
+
+def export_s3(
+    store: "LocalRunStore",
+    run_id: str,
+    bucket: str,
+    prefix: str,
+    output_dir: Path,
+) -> str:
+    """Export a run to S3.
+
+    Creates a local archive first, then uploads both the archive and
+    the manifest.json to S3.
+
+    Args:
+        store: The run store containing the run data.
+        run_id: The run identifier.
+        bucket: S3 bucket name.
+        prefix: S3 key prefix (e.g. "runs/").
+        output_dir: Local directory for the intermediate archive.
+
+    Returns:
+        S3 URI of the uploaded archive (s3://bucket/prefix/run_id.tar.gz).
+
+    Raises:
+        ImportError: If boto3 is not installed.
+        FileNotFoundError: If the run directory does not exist.
+    """
+    if boto3 is None:
+        raise ImportError(
+            "boto3 is required for S3 export. "
+            "Install it with: pip install aptl[s3]"
+        )
+
+    # Create local archive first
+    archive_path = export_local(store, run_id, output_dir)
+
+    # Read manifest for S3 metadata tags
+    run_path = store.get_run_path(run_id)
+    manifest_path = run_path / "manifest.json"
+    manifest = {}
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    s3 = boto3.client("s3")
+
+    # Build S3 keys
+    if prefix and not prefix.endswith("/"):
+        prefix = prefix + "/"
+    archive_key = f"{prefix}{run_id}.tar.gz"
+    manifest_key = f"{prefix}{run_id}/manifest.json"
+
+    # Build metadata tags from manifest
+    tags = {
+        "run_id": run_id,
+        "scenario_id": manifest.get("scenario_id", ""),
+        "scenario_name": manifest.get("scenario_name", ""),
+    }
+    tagging = "&".join(f"{k}={v}" for k, v in tags.items() if v)
+
+    # Upload archive
+    log.info("Uploading %s to s3://%s/%s", archive_path, bucket, archive_key)
+    extra_args = {}
+    if tagging:
+        extra_args["Tagging"] = tagging
+    s3.upload_file(str(archive_path), bucket, archive_key, ExtraArgs=extra_args)
+
+    # Upload manifest
+    if manifest_path.exists():
+        log.info("Uploading manifest to s3://%s/%s", bucket, manifest_key)
+        s3.upload_file(str(manifest_path), bucket, manifest_key)
+
+    s3_uri = f"s3://{bucket}/{archive_key}"
+    log.info("S3 export complete: %s", s3_uri)
+    return s3_uri

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,175 @@
+"""Unit tests for run export functionality."""
+
+import json
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from aptl.core.exporter import export_local, export_s3, _sha256_file
+from aptl.core.runstore import LocalRunStore
+
+
+class TestSha256File:
+    """Tests for file hashing utility."""
+
+    def test_hash_known_content(self, tmp_path):
+        f = tmp_path / "test.txt"
+        f.write_text("hello world")
+        digest = _sha256_file(f)
+        assert len(digest) == 64
+        # Known SHA-256 of "hello world"
+        assert digest == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+
+
+class TestExportLocal:
+    """Tests for local export."""
+
+    def _make_run(self, tmp_path, run_id="test-run"):
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(run_id)
+        store.write_json(run_id, "manifest.json", {
+            "run_id": run_id,
+            "scenario_id": "sc1",
+            "scenario_name": "Test Scenario",
+        })
+        store.write_file(run_id, "data.txt", b"some test data")
+        store.write_json(run_id, "wazuh/alerts.json", [{"alert": 1}])
+        return store
+
+    def test_export_creates_archive(self, tmp_path):
+        store = self._make_run(tmp_path)
+        output_dir = tmp_path / "export"
+
+        archive = export_local(store, "test-run", output_dir)
+
+        assert archive.exists()
+        assert archive.name == "test-run.tar.gz"
+        assert archive.parent == output_dir
+
+    def test_export_archive_contains_files(self, tmp_path):
+        store = self._make_run(tmp_path)
+        output_dir = tmp_path / "export"
+
+        archive = export_local(store, "test-run", output_dir)
+
+        with tarfile.open(archive, "r:gz") as tar:
+            names = tar.getnames()
+            assert "test-run/manifest.json" in names
+            assert "test-run/data.txt" in names
+            assert "test-run/wazuh/alerts.json" in names
+            assert "test-run/checksums.sha256" in names
+
+    def test_export_checksums_file(self, tmp_path):
+        store = self._make_run(tmp_path)
+        output_dir = tmp_path / "export"
+
+        export_local(store, "test-run", output_dir)
+
+        checksums_path = store.get_run_path("test-run") / "checksums.sha256"
+        assert checksums_path.exists()
+        content = checksums_path.read_text()
+        assert "manifest.json" in content
+        assert "data.txt" in content
+        # Each line should have a 64-char hash + two spaces + filename
+        for line in content.strip().splitlines():
+            parts = line.split("  ", 1)
+            assert len(parts) == 2
+            assert len(parts[0]) == 64
+
+    def test_export_nonexistent_run(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+        with pytest.raises(FileNotFoundError):
+            export_local(store, "nonexistent", tmp_path / "export")
+
+    def test_export_creates_output_dir(self, tmp_path):
+        store = self._make_run(tmp_path)
+        output_dir = tmp_path / "deeply" / "nested" / "dir"
+
+        archive = export_local(store, "test-run", output_dir)
+        assert archive.exists()
+        assert output_dir.exists()
+
+
+class TestExportS3:
+    """Tests for S3 export (mocked)."""
+
+    def _make_run(self, tmp_path, run_id="test-run"):
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(run_id)
+        store.write_json(run_id, "manifest.json", {
+            "run_id": run_id,
+            "scenario_id": "sc1",
+            "scenario_name": "Test Scenario",
+        })
+        store.write_file(run_id, "data.txt", b"some data")
+        return store
+
+    @patch("aptl.core.exporter.boto3", create=True)
+    def test_export_s3_returns_uri(self, mock_boto3, tmp_path):
+        store = self._make_run(tmp_path)
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        uri = export_s3(store, "test-run", "my-bucket", "runs/", tmp_path / "export")
+
+        assert uri == "s3://my-bucket/runs/test-run.tar.gz"
+
+    @patch("aptl.core.exporter.boto3", create=True)
+    def test_export_s3_uploads_archive_and_manifest(self, mock_boto3, tmp_path):
+        store = self._make_run(tmp_path)
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        export_s3(store, "test-run", "my-bucket", "runs", tmp_path / "export")
+
+        # Should have called upload_file twice (archive + manifest)
+        assert mock_client.upload_file.call_count == 2
+
+        # Check archive upload
+        archive_call = mock_client.upload_file.call_args_list[0]
+        assert archive_call[0][1] == "my-bucket"
+        assert archive_call[0][2] == "runs/test-run.tar.gz"
+
+        # Check manifest upload
+        manifest_call = mock_client.upload_file.call_args_list[1]
+        assert manifest_call[0][1] == "my-bucket"
+        assert manifest_call[0][2] == "runs/test-run/manifest.json"
+
+    @patch("aptl.core.exporter.boto3", create=True)
+    def test_export_s3_tags(self, mock_boto3, tmp_path):
+        store = self._make_run(tmp_path)
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        export_s3(store, "test-run", "my-bucket", "runs/", tmp_path / "export")
+
+        archive_call = mock_client.upload_file.call_args_list[0]
+        extra_args = archive_call[1].get("ExtraArgs", archive_call[0][3] if len(archive_call[0]) > 3 else {})
+        assert "Tagging" in extra_args
+        assert "run_id=test-run" in extra_args["Tagging"]
+
+    def test_export_s3_without_boto3(self, tmp_path):
+        store = self._make_run(tmp_path)
+        import pytest
+        import aptl.core.exporter as exporter_mod
+
+        original = exporter_mod.boto3
+        exporter_mod.boto3 = None
+        try:
+            with pytest.raises(ImportError, match="boto3"):
+                export_s3(store, "test-run", "bucket", "prefix", tmp_path / "export")
+        finally:
+            exporter_mod.boto3 = original
+
+    @patch("aptl.core.exporter.boto3", create=True)
+    def test_export_s3_creates_local_archive(self, mock_boto3, tmp_path):
+        store = self._make_run(tmp_path)
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        output_dir = tmp_path / "export"
+
+        export_s3(store, "test-run", "my-bucket", "runs/", output_dir)
+
+        archive = output_dir / "test-run.tar.gz"
+        assert archive.exists()


### PR DESCRIPTION
## Summary
- Add `src/aptl/core/exporter.py` with `export_local()` (tar.gz + SHA-256 checksums) and `export_s3()` (upload to S3 with metadata tags)
- Add `aptl runs export <run-id>` CLI command with `--output-dir`, `--s3-bucket`, `--s3-prefix` options
- Add `s3` optional dependency group in pyproject.toml (`pip install aptl[s3]` installs boto3)
- Add 11 tests in `tests/test_exporter.py` covering local export, S3 mocking, and error handling

## Test plan
- [x] All 11 new exporter tests pass
- [x] All existing CLI and runstore tests still pass (30 tests)
- [x] Manual test with real S3 bucket

Closes #157