### PR TITLE
Fix Kali Dockerfile: replace curl-pipe-bash with verified GPG key install

### DIFF
--- a/containers/kali/Dockerfile
+++ b/containers/kali/Dockerfile
@@ -51,8 +51,14 @@ RUN mkdir -p /home/kali/operations && \
     chmod 755 /usr/bin/dumpcap && \
     setcap cap_net_raw,cap_net_admin+eip /usr/bin/dumpcap
 
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN sudo -u kali ssh-keygen -t rsa -b 2048 -f /home/kali/.ssh/id_rsa -N "" && \
     chown -R kali:kali /home/kali/.ssh/


### PR DESCRIPTION
## Summary
- Replaces insecure `curl | bash` NodeSource install with explicit GPG key verification and signed apt repository
- Closes #32

## Test plan
Per issue #32 resolution steps:
- [x] 1. Verify base image integrity — uses official `kalilinux/kali-last-release:latest`
- [x] 2. Fix GPG keys properly — keyring installed before package operations (already done in prior commit)
- [x] 5. Remove insecure flags — no `--allow-unauthenticated` or `--force-yes` present
- [x] Verify `docker build` succeeds for `containers/kali/`
- [x] Verify Node.js is available inside the container (`node --version` → v20.20.1)

### Not addressed (nice-to-have, not security-critical)
- Step 3: Multi-stage build — would reduce image size but doesn't affect security
- Step 4: Pin package versions — improves reproducibility but Kali is a rolling release