### PR TITLE
fix(redaction): preserve wrapper quote around Cookie / sensitive_kv values (follow-up to #275)

### DIFF
--- a/mcp/aptl-mcp-common/src/redaction.ts
+++ b/mcp/aptl-mcp-common/src/redaction.ts
@@ -85,9 +85,12 @@ const KEY_LB = String.raw`(?<![a-zA-Z0-9])`;
 const KEY_RB = String.raw`(?![a-zA-Z0-9])`;
 // `key=value` or `key: value` for any sensitive token. Stops at common
 // delimiters so URL query strings and shell key/value pairs mask only
-// the value, not the surrounding context.
+// the value, not the surrounding context. Capture leading and trailing
+// quotes as separate groups so the replacement preserves them
+// (otherwise wrapping `'<value>'` / `"<value>"` loses the closing
+// quote, corrupting downstream diagnostic structure).
 const SENSITIVE_KV_PATTERN = new RegExp(
-  String.raw`(${KEY_LB}${SENSITIVE_KEY_PATTERN}${KEY_RB}\s*[=:]\s*)['"]?[^'"&\s,;|]+['"]?`,
+  String.raw`(${KEY_LB}${SENSITIVE_KEY_PATTERN}${KEY_RB}\s*[=:]\s*['"]?)([^'"&\s,;|]+)(['"]?)`,
   'gi',
 );
 // Bare `Bearer <token>` (no Authorization: prefix).
@@ -104,9 +107,12 @@ const CLI_FLAG_PATTERN = new RegExp(
 );
 // Cookie / Set-Cookie header: redact the entire body so multi-segment
 // cookies like `Cookie: lang=en; connect.sid=SECRET` are masked in one
-// pass instead of leaving later segments intact.
+// pass instead of leaving later segments intact. Capture the leading
+// and trailing quotes (when present) as separate groups so the
+// replacement can put them back — otherwise a wrapping `'...'` loses
+// its closing quote.
 const COOKIE_HEADER_PATTERN =
-  /(set-cookie\s*[:=]\s*|cookie\s*[:=]\s*)['"]?[^'"\r\n]+['"]?/gi;
+  /((?:set-cookie|cookie)\s*[:=]\s*['"]?)([^'"\r\n]+)(['"]?)/gi;
 // URL userinfo: `scheme://user:password@host/path`. Preserve user (often
 // useful for diagnostics) and mask the password segment.
 const URL_USERINFO_PATTERN = /(:\/\/[^/:@\s]+:)[^@\s]+(@)/gi;
@@ -156,8 +162,8 @@ function redactString(value: string): string {
   out = out.replaceAll(AUTHORIZATION_PATTERN, redactAuthorizationHeader);
   // Cookie before SENSITIVE_KV so the full header body is masked in one
   // pass (otherwise SENSITIVE_KV stops at `;` and leaves later segments).
-  out = out.replaceAll(COOKIE_HEADER_PATTERN, `$1${REDACTED}`);
-  out = out.replaceAll(SENSITIVE_KV_PATTERN, `$1${REDACTED}`);
+  out = out.replaceAll(COOKIE_HEADER_PATTERN, `$1${REDACTED}$3`);
+  out = out.replaceAll(SENSITIVE_KV_PATTERN, `$1${REDACTED}$3`);
   out = out.replaceAll(BARE_BEARER_PATTERN, `$1${REDACTED}`);
   out = out.replaceAll(CLI_FLAG_PATTERN, `$1${REDACTED}`);
   out = out.replaceAll(URL_USERINFO_PATTERN, `$1${REDACTED}$2`);

--- a/mcp/aptl-mcp-common/tests/redaction.test.ts
+++ b/mcp/aptl-mcp-common/tests/redaction.test.ts
@@ -220,11 +220,15 @@ describe('redact - string content traversal', () => {
   });
 
   it('redacts curl command with Authorization header', () => {
+    // Anchor on the labelled replacement form so a regression that
+    // silently dropped the "Bearer" scheme (or the 'abc' value via an
+    // unrelated code path) wouldn't be missed.
     const out = redact({
       command: "curl -H 'Authorization: Bearer abc' https://example.com",
     }) as { command: string };
-    expect(out.command).not.toContain('abc');
-    expect(out.command).toContain('[REDACTED]');
+    expect(out.command).toBe(
+      "curl -H 'Authorization: Bearer [REDACTED]' https://example.com",
+    );
   });
 
   it('redacts URL query string with sensitive params', () => {
@@ -250,8 +254,7 @@ describe('redact - string content traversal', () => {
     const out = redact({
       command: "curl -H 'Cookie: session=xyz' https://x",
     }) as { command: string };
-    expect(out.command).not.toContain('session=xyz');
-    expect(out.command).toContain('[REDACTED]');
+    expect(out.command).toBe("curl -H 'Cookie: [REDACTED]' https://x");
   });
 
   it('redacts multi-segment Cookie header', () => {
@@ -290,13 +293,12 @@ describe('redact - string content traversal', () => {
   });
 
   it('redacts URL userinfo password', () => {
+    // Anchor on the exact replacement form so a regression that mangled
+    // the userinfo structure would be caught.
     const out = redact({
       url: 'https://alice:hunter2@host.example.com/path',
     }) as { url: string };
-    expect(out.url).not.toContain('hunter2');
-    expect(out.url).toContain('alice');
-    expect(out.url).toContain('host.example.com/path');
-    expect(out.url).toContain('[REDACTED]');
+    expect(out.url).toBe('https://alice:[REDACTED]@host.example.com/path');
   });
 
   it('redacts PEM private key block', () => {

--- a/src/aptl/utils/redaction.py
+++ b/src/aptl/utils/redaction.py
@@ -88,8 +88,12 @@ _AUTHORIZATION_RE = re.compile(
 # punctuation all count as separators.
 _KEY_LB = r"(?<![a-zA-Z0-9])"  # left boundary
 _KEY_RB = r"(?![a-zA-Z0-9])"  # right boundary
+# Capture leading and trailing quotes as separate groups so the
+# replacement preserves them (otherwise wrapping `'<value>'` /
+# `"<value>"` loses the closing quote, corrupting downstream
+# diagnostic structure).
 _SENSITIVE_KV_RE = re.compile(
-    rf"({_KEY_LB}{_SENSITIVE_KEY_PATTERN}{_KEY_RB}\s*[=:]\s*)['\"]?[^'\"&\s,;|]+['\"]?",
+    rf"({_KEY_LB}{_SENSITIVE_KEY_PATTERN}{_KEY_RB}\s*[=:]\s*['\"]?)([^'\"&\s,;|]+)(['\"]?)",
     re.IGNORECASE,
 )
 _BARE_BEARER_RE = re.compile(
@@ -105,9 +109,12 @@ _CLI_FLAG_RE = re.compile(
 )
 # Cookie / Set-Cookie header: redact the entire body so multi-segment
 # cookies like `Cookie: lang=en; connect.sid=SECRET` are masked in one
-# pass instead of leaving later segments intact.
+# pass instead of leaving later segments intact. Capture the leading and
+# trailing quotes (when present) as separate groups so the replacement
+# can put them back — otherwise a wrapping `'...'` loses its closing
+# quote.
 _COOKIE_HEADER_RE = re.compile(
-    r"(set-cookie\s*[:=]\s*|cookie\s*[:=]\s*)['\"]?[^'\"\r\n]+['\"]?",
+    r"((?:set-cookie|cookie)\s*[:=]\s*['\"]?)([^'\"\r\n]+)(['\"]?)",
     re.IGNORECASE,
 )
 # URL userinfo: `scheme://user:password@host/path`. Preserve user (often
@@ -154,8 +161,8 @@ def _redact_string(value: str) -> str:
     out = _AUTHORIZATION_RE.sub(_redact_authorization, out)
     # Cookie before SENSITIVE_KV so the full header body is masked in one
     # pass (otherwise SENSITIVE_KV stops at `;` and leaves later segments).
-    out = _COOKIE_HEADER_RE.sub(rf"\1{REDACTED}", out)
-    out = _SENSITIVE_KV_RE.sub(rf"\1{REDACTED}", out)
+    out = _COOKIE_HEADER_RE.sub(rf"\1{REDACTED}\3", out)
+    out = _SENSITIVE_KV_RE.sub(rf"\1{REDACTED}\3", out)
     out = _BARE_BEARER_RE.sub(rf"\1{REDACTED}", out)
     out = _CLI_FLAG_RE.sub(rf"\1{REDACTED}", out)
     out = _URL_USERINFO_RE.sub(rf"\1{REDACTED}\2", out)

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -205,11 +205,16 @@ class TestStringContentTraversal:
         assert out["command"] == expected
 
     def test_curl_command_with_authorization_header(self):
+        # Anchor on the labelled replacement form so a regression that
+        # silently dropped the "Bearer" scheme (or the 'abc' value via an
+        # unrelated code path) wouldn't be missed.
         out = redact(
             {"command": "curl -H 'Authorization: Bearer abc' https://example.com"}
         )
-        assert "abc" not in out["command"]
-        assert REDACTED in out["command"]
+        assert (
+            out["command"]
+            == "curl -H 'Authorization: Bearer [REDACTED]' https://example.com"
+        )
 
     def test_url_query_string_with_sensitive_params(self):
         out = redact({"url": "https://api.example.com?api_key=secret123&user=alice"})
@@ -231,8 +236,7 @@ class TestStringContentTraversal:
 
     def test_redacts_cookie_header(self):
         out = redact({"command": "curl -H 'Cookie: session=xyz' https://x"})
-        assert "session=xyz" not in out["command"]
-        assert "[REDACTED]" in out["command"]
+        assert out["command"] == "curl -H 'Cookie: [REDACTED]' https://x"
 
     def test_redacts_multi_segment_cookie_header(self):
         # `;`-delimited cookie segments must all be masked, not just the
@@ -268,12 +272,10 @@ class TestStringContentTraversal:
         assert REDACTED in out["command"]
 
     def test_redacts_url_userinfo_password(self):
+        # Anchor on the exact replacement form so a regression that
+        # mangled the userinfo structure would be caught.
         out = redact({"url": "https://alice:hunter2@host.example.com/path"})
-        # password masked, user kept for diagnostics, host preserved
-        assert "hunter2" not in out["url"]
-        assert "alice" in out["url"]
-        assert "host.example.com/path" in out["url"]
-        assert "[REDACTED]" in out["url"]
+        assert out["url"] == "https://alice:[REDACTED]@host.example.com/path"
 
     def test_redacts_pem_private_key_block(self):
         pem = (


### PR DESCRIPTION
## Summary

Follow-up to merged PR #275. While running the `review-tests` skill (Step 13 of the implement workflow), I tightened three loose substring assertions in the redaction tests to anchor on the exact replacement form. The tightened **Cookie** assertion exposed a real behavior bug in the merged code:

```
input:  curl -H 'Cookie: session=xyz' https://x
output: curl -H 'Cookie: [REDACTED] https://x   <-- missing closing '
```

### Root cause
Same trailing-quote issue I fixed for `AUTHORIZATION_PATTERN` in cycle 1 of the post-push codex review (#275, codex finding 3), but in two other patterns that share the same shape `(prefix)['"]?<value>['"]?`:

- `COOKIE_HEADER_PATTERN` — added in #275
- `SENSITIVE_KV_PATTERN` — pre-existing (added at the start of #275)

The trailing `['"]?` is matched and consumed but isn't in the capture group, so the replacement `$1[REDACTED]` drops the closing quote.

The bug only surfaced once Cookie + KV both ran on the same chunk — the `Cookie: session=xyz'` input gets handled by `COOKIE_HEADER` first (correctly preserves the closing `'` after this PR's earlier fix in this branch), then `SENSITIVE_KV` runs on the result `Cookie: [REDACTED]'`, matches `cookie\s*[:=]\s*<value>['"]?`, and eats the closing quote.

### Fix
Capture leading and trailing quotes as separate groups in both patterns (Python and TypeScript) so the replacement preserves them:

```
(prefix['"]?)(value)(['"]?)  ->  $1[REDACTED]$3
```

### Tests
- 3 tightened tests (each in Python + TS):
  - `test_curl_command_with_authorization_header` — anchored on `'Authorization: Bearer [REDACTED]'`
  - `test_redacts_cookie_header` — anchored on `'Cookie: [REDACTED]'`
  - `test_redacts_url_userinfo_password` — anchored on `https://alice:[REDACTED]@host.example.com/path`
- All existing redaction + telemetry + snapshot tests still pass: 1268 pytest, 206 vitest.
- Pre-commit (full hook set): green.

If `review-tests` had run before #275 merged, these tightened assertions would have failed on the original PR and surfaced the bug there.

## Test plan
- [x] `pytest` — 1268 passed
- [x] `cd mcp/aptl-mcp-common && npx vitest run` — 206 passed
- [x] `bash mcp/build-all-mcps.sh` — all MCPs rebuild cleanly
- [x] `pre-commit run --all-files` — green
- [x] Inline validation: `redact({'command': "curl -H 'Cookie: session=xyz' https://x"})` → `"curl -H 'Cookie: [REDACTED]' https://x"` (closing `'` preserved)
- [ ] CI green
- [ ] SonarCloud green

Refs #185.