### PR TITLE
Classify partial-success startup outcomes (ADR-030)

### DIFF
--- a/changelog.d/202.changed.md
+++ b/changelog.d/202.changed.md
@@ -1,0 +1,7 @@
+**Lab start now returns a structured partial-readiness classification (ADR-030).**
+`LabResult` carries a closed-set `outcome` (`ready` / `degraded_usable` /
+`degraded_unusable` / `failed`) plus a list of `StartupDiagnostic` entries
+that name the step, impact (`cosmetic` / `telemetry` / `capability` /
+`readiness`), and severity. The CLI prints the outcome and groups diagnostics
+by impact; the REST `POST /api/lab/start` response exposes the same fields
+(optional, additive, backward compatible).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -51,3 +51,4 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [027](adr-027-red-team-structured-logging.md) | Red Team Structured Logging Boundary | accepted | 2026-05-09 |
 | [028](adr-028-runtime-rendered-service-config.md) | Runtime-Rendered Service Config | accepted | 2026-05-10 |
 | [029](adr-029-control-plane-secret-handling.md) | Control-Plane Secret Handling in Run Data and Local State | accepted | 2026-05-10 |
+| [030](adr-030-startup-partial-readiness-classification.md) | Startup Partial-Readiness Classification | accepted | 2026-05-11 |

--- a/docs/adrs/adr-030-startup-partial-readiness-classification.md
+++ b/docs/adrs/adr-030-startup-partial-readiness-classification.md
@@ -1,0 +1,144 @@
+# ADR-030: Startup Partial-Readiness Classification
+
+## Status
+
+accepted
+
+## Date
+
+2026-05-11
+
+## Context
+
+`aptl lab start` deliberately treats some late startup checks as non-fatal:
+image pre-pull misses, service readiness timeouts, SSH probes, snapshot capture,
+MCP build, SOC seeding, and MCP config sync are not all equivalent. Some are
+cosmetic or recoverable, while others materially reduce scenario usability,
+detection fidelity, telemetry, or run-data trust.
+
+The current envelope, `LabResult(success, message, error)`, cannot express that
+distinction. The result is a concept leak: the core orchestrator knows a step
+degraded, but the CLI/API/web surfaces mostly see a success boolean plus log
+warnings. Automation then has to scrape text or trust a startup that may be
+missing important evidence-producing services.
+
+Relevant incumbents already exist:
+
+- `src/aptl/core/lab_types.py` owns lifecycle result/status dataclasses shared
+  by the core, deployment backends, CLI, and API.
+- `src/aptl/core/lab.py` owns startup ordering through `_LabStartContext` and
+  `_LAB_START_STEPS`.
+- `src/aptl/core/services.py` owns readiness polling and returns
+  `ServiceResult`.
+- `src/aptl/core/deployment/` owns Docker/Compose execution through
+  `DeploymentBackend` (ADR-013 and ADR-023).
+- `src/aptl/api/schemas.py`, `src/aptl/cli/lab.py`, and `web/src/lib/types.ts`
+  are the current user-facing action/status envelopes.
+- `src/aptl/utils/redaction.py`, ADR-012, and ADR-029 own serialization,
+  observability, CLI, API, and log redaction boundaries.
+
+## Decision
+
+Startup partial readiness must be represented as a first-class lifecycle result
+contract in the Python control plane, not as ad hoc warning text in individual
+steps.
+
+The canonical structured contract belongs in `src/aptl/core/lab_types.py` and
+is then projected into API schemas, CLI output, and web types. Do not create a
+parallel startup schema in the API or web layer that reclassifies core results.
+
+The contract should keep three concepts separate:
+
+- **Outcome:** the overall machine-readable startup state, with a closed set
+  such as `ready`, `degraded_usable`, `degraded_unusable`, and `failed`.
+- **Diagnostic impact:** what a warning affects, with at least `cosmetic` and
+  `telemetry`, and room for capability/readiness impact without changing every
+  caller.
+- **Severity / operator action:** whether the issue is informational,
+  warning-level, or error-level, independent of whether the already-started lab
+  can still be used.
+
+`LabResult.success` may remain for backward compatibility, but it must not be
+the only semantic field. Map it from the structured outcome rather than letting
+callers infer partial readiness from text. In particular, a
+`degraded_unusable` startup should be distinguishable from both a hard startup
+failure and a usable-but-degraded startup.
+
+Each startup step that can degrade should emit a diagnostic through a single
+core-owned path. Step bodies may still log, but logs are secondary; CLI/API/web
+must render the structured diagnostics. The implementation must characterize
+the current live behavior before changing classifications so existing
+"non-critical" steps are not silently promoted or demoted.
+
+## Guardrails
+
+- Keep lab-start orchestration in `core.lab` as a flat sequence of `_step_*`
+  functions and `_LAB_START_STEPS`. Add classification at the step boundary or
+  shared context boundary; do not replace the orchestrator with a workflow
+  engine.
+- Reuse `ServiceResult` for readiness probe details and `DeploymentBackend`
+  for deployment interactions. Do not shell out directly from a new
+  classification helper.
+- Reuse `LabResult` / `LabStatus` as the lifecycle DTO boundary. If new nested
+  dataclasses or enums are needed, define them beside those types in
+  `lab_types.py`.
+- Keep API models in `api.schemas` as projections of the core DTO, not a
+  second source of classification truth.
+- Keep web TypeScript interfaces aligned with API schemas; do not infer
+  degraded state from English messages in the Svelte layer.
+- Preserve `AptlConfig` / `.env` validation ownership. Classification must not
+  add unvalidated config flags, environment-variable bypasses, or a second
+  config schema.
+- Redact diagnostics before they cross CLI, API, log, telemetry, snapshot, or
+  persistence boundaries. Diagnostic details may name a step, component, path,
+  container, or service, but must not include `.env` values, API keys, bearer
+  tokens, cookies, private keys, generated config contents, or full command
+  lines containing credentials.
+
+## Security Layers
+
+- **Config/env binding:** startup still uses `AptlConfig`, `load_dotenv`,
+  `env_vars_from_dict`, and `find_placeholder_env_values`. New classification
+  fields are runtime result data, not durable config knobs.
+- **Deployment boundary:** Docker and remote-Compose interactions stay behind
+  `DeploymentBackend`; this preserves SSH-remote behavior and avoids leaking
+  transport-specific details into result classification.
+- **OS/process exposure:** readiness probes and subprocess failures can include
+  sensitive argv or stderr. Structured diagnostics must store narrow labels and
+  redacted summaries, not raw argv or command output.
+- **Error envelopes:** `LabResult`, `LabActionResponse`, CLI output, SSE/API
+  status payloads, and web action errors must preserve structure while applying
+  the ADR-029 redaction invariant.
+- **Observability/persistence:** if startup diagnostics are later traced,
+  snapshotted, archived, or written to run storage, the existing
+  `redact()`/`LocalRunStore` boundaries remain authoritative.
+
+## Extensibility
+
+The extensibility seam is a small, closed diagnostic taxonomy plus per-step
+diagnostic emission metadata in the core startup context. A future startup step
+should add a diagnostic code, impact, and outcome contribution without editing
+every CLI/API/web caller. A future deployment backend should receive the same
+structured result shape without emulating Docker-specific warning text.
+
+## Non-Goals
+
+- Do not redesign Docker Compose profiles, deployment providers, or container
+  health checks.
+- Do not make every warning fatal.
+- Do not add a second exception hierarchy for startup classification.
+- Do not add a general workflow engine or requirement/status engine to lab
+  startup.
+- Do not persist startup diagnostics in run archives as part of this
+  classification unless a later issue explicitly owns that artifact contract.
+
+## Anti-Patterns
+
+- Scraping log text or CLI output to decide readiness.
+- Adding `is_degraded`, `partial`, `telemetry_ok`, or similar booleans in
+  multiple layers instead of one canonical outcome plus diagnostics.
+- Returning raw subprocess stderr, curl output, Docker command lines, or
+  generated config content in user-facing diagnostics.
+- Reclassifying the same core result separately in the CLI, API, and web UI.
+- Treating telemetry-impacting, SOC/detection-impacting, SSH-readiness, and
+  cosmetic display warnings as the same "warning" concept.

--- a/src/aptl/api/routers/lab.py
+++ b/src/aptl/api/routers/lab.py
@@ -12,6 +12,7 @@ from aptl.api.schemas import (
     ContainerInfo,
     LabActionResponse,
     LabStatusResponse,
+    StartupDiagnosticModel,
 )
 from aptl.core.lab import (
     LabResult,
@@ -67,15 +68,33 @@ async def lab_start(
         )
     except asyncio.TimeoutError:
         log.exception("Lab start timed out after 1800s")
+        # ``asyncio.wait_for`` only times out the awaiting coroutine; the
+        # ``asyncio.to_thread`` worker keeps running and the orchestration
+        # may still finish (degraded/ready) or fail later. We therefore
+        # cannot honestly claim a terminal ``outcome="failed"`` — the
+        # lab state is unknown at this instant. Leave ``outcome`` unset
+        # (``None``); ``success=False`` and the error string remain the
+        # authoritative signals on this path. A future "abortable lab
+        # start" change (out of scope here) is what would let us return
+        # a structured outcome on timeout (codex review #202 cycle 4).
         return LabActionResponse(
             success=False,
             error="Lab start timed out after 1800s",
         )
-    log.info("POST /lab/start -> success=%s", result.success)
+    log.info(
+        "POST /lab/start -> success=%s outcome=%s diagnostics=%d",
+        result.success,
+        result.outcome.value,
+        len(result.diagnostics),
+    )
     return LabActionResponse(
         success=result.success,
         message=result.message,
         error=result.error or None,
+        outcome=result.outcome.value,
+        diagnostics=[
+            StartupDiagnosticModel.from_dataclass(d) for d in result.diagnostics
+        ],
     )
 
 

--- a/src/aptl/api/routers/lab.py
+++ b/src/aptl/api/routers/lab.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import Annotated, AsyncGenerator
 
 from fastapi import APIRouter, Depends
 from sse_starlette.sse import EventSourceResponse
@@ -43,7 +43,7 @@ def _build_status_response(project_dir: Path) -> LabStatusResponse:
 
 @router.get("/lab/status")
 async def lab_status(
-    project_dir: Path = Depends(get_project_dir),
+    project_dir: Annotated[Path, Depends(get_project_dir)],
 ) -> LabStatusResponse:
     """Get current lab status including container information."""
     log.info("GET /lab/status")
@@ -54,7 +54,7 @@ async def lab_status(
 
 @router.post("/lab/start")
 async def lab_start(
-    project_dir: Path = Depends(get_project_dir),
+    project_dir: Annotated[Path, Depends(get_project_dir)],
 ) -> LabActionResponse:
     """Start the lab environment.
 
@@ -100,7 +100,7 @@ async def lab_start(
 
 @router.post("/lab/stop")
 async def lab_stop(
-    project_dir: Path = Depends(get_project_dir),
+    project_dir: Annotated[Path, Depends(get_project_dir)],
 ) -> LabActionResponse:
     """Stop the lab environment."""
     log.info("POST /lab/stop")
@@ -179,7 +179,7 @@ async def _lab_event_generator(
 
 @router.get("/lab/events")
 async def lab_events(
-    project_dir: Path = Depends(get_project_dir),
+    project_dir: Annotated[Path, Depends(get_project_dir)],
 ) -> EventSourceResponse:
     """SSE stream of lab status changes.
 

--- a/src/aptl/api/schemas.py
+++ b/src/aptl/api/schemas.py
@@ -1,14 +1,55 @@
 """API response models for the APTL web interface."""
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
+
+from aptl.core.lab_types import StartupDiagnostic
+
+# Closed-set ADR-030 wire strings. Mirroring the enums as ``Literal``
+# unions keeps the wire schema closed for FastAPI / OpenAPI clients
+# without forcing them to import the Python core types.
+StartupOutcomeLiteral = Literal[
+    "ready", "degraded_usable", "degraded_unusable", "failed"
+]
+DiagnosticImpactLiteral = Literal[
+    "cosmetic", "telemetry", "capability", "readiness"
+]
+DiagnosticSeverityLiteral = Literal["info", "warning", "error"]
 
 
 class HealthResponse(BaseModel):
     """Health check response."""
 
     status: str = "ok"
+
+
+class StartupDiagnosticModel(BaseModel):
+    """API projection of :class:`aptl.core.lab_types.StartupDiagnostic`.
+
+    Mirrors the dataclass field-by-field. String values (``impact``,
+    ``severity``) carry the stable wire strings from the core enums —
+    keep ``web/src/lib/types.ts`` aligned (ADR-030 anti-pattern: never
+    reclassify a core result in the API or web layer).
+    """
+
+    step: str
+    impact: DiagnosticImpactLiteral
+    severity: DiagnosticSeverityLiteral
+    message: str
+    component: str = ""
+    operator_action: str = ""
+
+    @classmethod
+    def from_dataclass(cls, diag: StartupDiagnostic) -> "StartupDiagnosticModel":
+        return cls(
+            step=diag.step,
+            impact=diag.impact.value,
+            severity=diag.severity.value,
+            message=diag.message,
+            component=diag.component,
+            operator_action=diag.operator_action,
+        )
 
 
 class ContainerInfo(BaseModel):
@@ -71,11 +112,18 @@ class LabStatusResponse(BaseModel):
 
 
 class LabActionResponse(BaseModel):
-    """Response for POST /api/lab/start and POST /api/lab/stop."""
+    """Response for POST /api/lab/start and POST /api/lab/stop.
+
+    ``outcome`` and ``diagnostics`` carry the ADR-030 structured
+    classification. They are optional/default-empty so older clients
+    that only consume ``{success, message, error}`` keep working.
+    """
 
     success: bool
     message: str = ""
     error: Optional[str] = None
+    outcome: Optional[StartupOutcomeLiteral] = None
+    diagnostics: list[StartupDiagnosticModel] = Field(default_factory=list)
 
 
 class KillActionResponse(BaseModel):

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -8,10 +8,12 @@ import typer
 
 from aptl.cli.continuity import continuity_audit
 from aptl.core.lab import (
+    LabResult,
     lab_status,
     orchestrate_lab_start,
     stop_lab,
 )
+from aptl.core.lab_types import StartupOutcome
 from aptl.utils.logging import get_logger
 
 log = get_logger("cli.lab")
@@ -22,6 +24,58 @@ app = typer.Typer(help="Lab lifecycle management.")
 # module stays focused on lifecycle commands. Register it under `lab`
 # so the command stays at `aptl lab continuity-audit` (no UX change).
 app.command("continuity-audit")(continuity_audit)
+
+
+# Headline phrasing per outcome — kept beside the renderer so the CLI's
+# user-visible classification stays in one place (ADR-030 anti-pattern:
+# never reclassify based on English text). Values are the same stable
+# wire strings as the StartupOutcome enum so an operator (or a parser)
+# can grep for them.
+_OUTCOME_HEADLINES: dict[StartupOutcome, str] = {
+    StartupOutcome.READY: "Lab is ready.",
+    StartupOutcome.DEGRADED_USABLE: (
+        "Lab is degraded_usable — telemetry/cosmetic warnings, scenarios "
+        "should still run."
+    ),
+    StartupOutcome.DEGRADED_UNUSABLE: (
+        "Lab is degraded_unusable — some capabilities or SSH targets "
+        "are not reachable."
+    ),
+    StartupOutcome.FAILED: "Lab start failed.",
+}
+
+
+def _render_start_result(result: LabResult) -> None:
+    """Print a structured summary of a lab-start result.
+
+    Always emits the outcome value (stable wire string from
+    ``StartupOutcome``) so automation can parse a single line instead of
+    scraping the diagnostic list. Diagnostics are grouped by impact so
+    an operator can scan for ``readiness`` / ``capability`` rows when
+    triaging a partial-readiness lab.
+    """
+    typer.echo(_OUTCOME_HEADLINES[result.outcome])
+    if result.outcome is StartupOutcome.FAILED and result.error:
+        typer.echo(f"  error: {result.error}")
+    if not result.diagnostics:
+        return
+    typer.echo(f"  diagnostics ({len(result.diagnostics)}):")
+    # Group by impact so a scanning operator sees all readiness rows
+    # together, then capability, telemetry, cosmetic. Iteration order
+    # below follows the severity hierarchy from worst to least-worst.
+    impacts_in_order = ["readiness", "capability", "telemetry", "cosmetic"]
+    grouped: dict[str, list] = {}
+    for diag in result.diagnostics:
+        grouped.setdefault(diag.impact.value, []).append(diag)
+    for impact in impacts_in_order:
+        for diag in grouped.get(impact, []):
+            label = f"{diag.step}/{diag.component}" if diag.component else diag.step
+            typer.echo(
+                f"    [{diag.impact.value}|{diag.severity.value}] "
+                f"{label} — {diag.message}"
+            )
+            if diag.operator_action:
+                typer.echo(f"      action: {diag.operator_action}")
 
 
 @app.command()
@@ -43,10 +97,8 @@ def start(
 
     result = orchestrate_lab_start(project_dir, skip_seed=skip_seed)
 
-    if result.success:
-        typer.echo("Lab started successfully.")
-    else:
-        typer.echo(f"Lab start failed: {result.error}")
+    _render_start_result(result)
+    if not result.success:
         raise typer.Exit(code=1)
 
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -295,6 +295,13 @@ class _LabStartContext:
     diagnostics: list[StartupDiagnostic] = field(default_factory=list)
 
 
+# Log format string for structured diagnostics. Kept module-level so
+# ``_emit_diagnostic``'s three log branches (error / warning / info) share
+# a single literal — extracting silences Sonar ``python:S1192`` and keeps
+# any future format tweak in one place.
+_DIAGNOSTIC_LOG_FORMAT = "[%s|%s] %s"
+
+
 # Severities that contribute to a "degraded" outcome. ``info`` is
 # intentionally excluded — it is a structured note, not a degradation.
 _DEGRADING_SEVERITIES = frozenset(
@@ -380,11 +387,11 @@ def _emit_diagnostic(
     ctx.diagnostics.append(diag)
     label = f"{step}/{safe_component}" if safe_component else step
     if severity is DiagnosticSeverity.ERROR:
-        log.error("[%s|%s] %s", impact.value, label, safe_message)
+        log.error(_DIAGNOSTIC_LOG_FORMAT, impact.value, label, safe_message)
     elif severity is DiagnosticSeverity.WARNING:
-        log.warning("[%s|%s] %s", impact.value, label, safe_message)
+        log.warning(_DIAGNOSTIC_LOG_FORMAT, impact.value, label, safe_message)
     else:
-        log.info("[%s|%s] %s", impact.value, label, safe_message)
+        log.info(_DIAGNOSTIC_LOG_FORMAT, impact.value, label, safe_message)
 
 
 def _step_load_env(ctx: _LabStartContext) -> LabResult | None:

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -28,9 +28,16 @@ from aptl.core.env import (
     find_placeholder_env_values,
     load_dotenv,
 )
-# Re-export LabResult and LabStatus from the leaf module (#266). The
-# leaf has no back-edges, so this is a normal top-level import.
-from aptl.core.lab_types import LabResult, LabStatus  # noqa: F401
+# Re-export the lifecycle DTO types from the leaf module (#266 + ADR-030).
+# The leaf has no back-edges, so this is a normal top-level import.
+from aptl.core.lab_types import (  # noqa: F401
+    DiagnosticImpact,
+    DiagnosticSeverity,
+    LabResult,
+    LabStatus,
+    StartupDiagnostic,
+    StartupOutcome,
+)
 from aptl.core.services import (
     check_indexer_ready,
     check_manager_api_ready,
@@ -41,6 +48,7 @@ from aptl.core.snapshot import capture_snapshot
 from aptl.core.ssh import ensure_ssh_keys
 from aptl.core.sysreqs import check_max_map_count
 from aptl.utils.logging import get_logger
+from aptl.utils.redaction import redact
 
 if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
@@ -271,6 +279,10 @@ class _LabStartContext:
     any outputs subsequent steps depend on. Keeps step signatures
     uniform (``ctx -> LabResult | None``) so the orchestrator stays a
     flat list of dispatches.
+
+    ``diagnostics`` collects structured partial-readiness notes (ADR-030)
+    emitted by individual steps. The orchestrator turns the final list
+    into a :class:`StartupOutcome` via :func:`derive_startup_outcome`.
     """
 
     project_dir: Path
@@ -280,6 +292,99 @@ class _LabStartContext:
     config: "AptlConfig | None" = None
     backend: "DeploymentBackend | None" = None
     ssh_key_path: Path | None = None
+    diagnostics: list[StartupDiagnostic] = field(default_factory=list)
+
+
+# Severities that contribute to a "degraded" outcome. ``info`` is
+# intentionally excluded — it is a structured note, not a degradation.
+_DEGRADING_SEVERITIES = frozenset(
+    {DiagnosticSeverity.WARNING, DiagnosticSeverity.ERROR}
+)
+
+# Impacts that drag the outcome to DEGRADED_UNUSABLE rather than
+# DEGRADED_USABLE. Lab is partially up but the named capability/SSH
+# reach is missing for the operator's intended use.
+_UNUSABLE_IMPACTS = frozenset(
+    {DiagnosticImpact.CAPABILITY, DiagnosticImpact.READINESS}
+)
+
+
+def derive_startup_outcome(
+    diagnostics: list[StartupDiagnostic],
+    fatal: bool,
+) -> StartupOutcome:
+    """Map a diagnostics list (plus a fatal short-circuit flag) to an outcome.
+
+    Rule (ADR-030):
+
+    - ``fatal=True`` always wins → ``FAILED`` (a hard stop must be
+      distinguishable from any degraded state).
+    - Any degrading-severity diagnostic with ``impact`` in
+      ``{capability, readiness}`` → ``DEGRADED_UNUSABLE``.
+    - Any degrading-severity diagnostic with ``impact`` in
+      ``{cosmetic, telemetry}`` → ``DEGRADED_USABLE``.
+    - Otherwise → ``READY``.
+
+    Pure function; safe to call from tests directly.
+    """
+    if fatal:
+        return StartupOutcome.FAILED
+    has_unusable = False
+    has_degrading = False
+    for diag in diagnostics:
+        if diag.severity not in _DEGRADING_SEVERITIES:
+            continue
+        has_degrading = True
+        if diag.impact in _UNUSABLE_IMPACTS:
+            has_unusable = True
+            break  # already the worst non-fatal bucket
+    if has_unusable:
+        return StartupOutcome.DEGRADED_UNUSABLE
+    if has_degrading:
+        return StartupOutcome.DEGRADED_USABLE
+    return StartupOutcome.READY
+
+
+def _emit_diagnostic(
+    ctx: _LabStartContext,
+    *,
+    step: str,
+    impact: DiagnosticImpact,
+    severity: DiagnosticSeverity,
+    message: str,
+    component: str = "",
+    operator_action: str = "",
+) -> None:
+    """Append a structured diagnostic to the context and log it.
+
+    Centralizes the ADR-030 redaction-shape rule. Callers pass narrow
+    labels; this helper additionally runs ``aptl.utils.redaction.redact()``
+    over the free-form fields (``message``, ``component``,
+    ``operator_action``) so a future caller that accidentally interpolates
+    an exception payload, env value, or subprocess stderr cannot leak it
+    through the single choke point that feeds CLI, API, and web. The
+    structured ``step`` identifier is an internal literal and is not
+    redacted (redaction there would defeat attribution).
+    """
+    safe_message = redact(message)
+    safe_component = redact(component)
+    safe_operator_action = redact(operator_action)
+    diag = StartupDiagnostic(
+        step=step,
+        impact=impact,
+        severity=severity,
+        message=safe_message,
+        component=safe_component,
+        operator_action=safe_operator_action,
+    )
+    ctx.diagnostics.append(diag)
+    label = f"{step}/{safe_component}" if safe_component else step
+    if severity is DiagnosticSeverity.ERROR:
+        log.error("[%s|%s] %s", impact.value, label, safe_message)
+    elif severity is DiagnosticSeverity.WARNING:
+        log.warning("[%s|%s] %s", impact.value, label, safe_message)
+    else:
+        log.info("[%s|%s] %s", impact.value, label, safe_message)
 
 
 def _step_load_env(ctx: _LabStartContext) -> LabResult | None:
@@ -482,8 +587,26 @@ def _step_pull_images(ctx: _LabStartContext) -> LabResult | None:
         f"wazuh/wazuh-indexer:{WAZUH_IMAGE_VERSION}",
         f"wazuh/wazuh-dashboard:{WAZUH_IMAGE_VERSION}",
     ]
-    for warning in ctx.backend.pull_images(images):
+    warnings = list(ctx.backend.pull_images(images))
+    for warning in warnings:
+        # Backend already includes stderr in the log line; existing
+        # log-redaction boundary owns scrubbing it.
         log.warning(warning)
+    if warnings:
+        # Pre-pull is a latency optimization — Compose pulls on demand
+        # when containers start. Surface as a cosmetic info diagnostic
+        # so automation sees the count without scraping the log.
+        _emit_diagnostic(
+            ctx,
+            step="pull_images",
+            impact=DiagnosticImpact.COSMETIC,
+            severity=DiagnosticSeverity.INFO,
+            message=(
+                f"Pre-pull failed for {len(warnings)} image(s); compose "
+                "will pull on demand"
+            ),
+            operator_action="No action required; first lab use may be slower",
+        )
     return None
 
 
@@ -530,7 +653,23 @@ def _step_wait_for_services(ctx: _LabStartContext) -> LabResult | None:
         service_name="Wazuh Indexer",
     )
     if not indexer_result.ready:
-        log.warning("Indexer may still be initializing")
+        # Indexer is the SIEM store — without it, detections never land.
+        # Lab is up but telemetry is degraded.
+        _emit_diagnostic(
+            ctx,
+            step="wait_for_services",
+            component="wazuh_indexer",
+            impact=DiagnosticImpact.TELEMETRY,
+            severity=DiagnosticSeverity.WARNING,
+            message=(
+                "Wazuh Indexer did not become ready within "
+                f"{int(indexer_result.elapsed_seconds)}s"
+            ),
+            operator_action=(
+                "Check indexer container logs; SIEM ingest will not work "
+                "until indexer is healthy"
+            ),
+        )
 
     manager_result = wait_for_service(
         check_fn=partial(
@@ -542,7 +681,21 @@ def _step_wait_for_services(ctx: _LabStartContext) -> LabResult | None:
         service_name="Wazuh Manager API",
     )
     if not manager_result.ready:
-        log.warning("Manager API may still be initializing")
+        _emit_diagnostic(
+            ctx,
+            step="wait_for_services",
+            component="wazuh_manager",
+            impact=DiagnosticImpact.TELEMETRY,
+            severity=DiagnosticSeverity.WARNING,
+            message=(
+                "Wazuh Manager API did not become ready within "
+                f"{int(manager_result.elapsed_seconds)}s"
+            ),
+            operator_action=(
+                "Check manager container logs; agents will not report "
+                "until manager API is healthy"
+            ),
+        )
     return None
 
 
@@ -572,17 +725,50 @@ def _step_test_ssh(ctx: _LabStartContext) -> LabResult | None:
         )
         if ssh_wait.ready:
             log.info("SSH to %s is ready", name)
-        else:
-            log.warning(
-                "SSH to %s not ready after %ds",
-                name, int(ssh_wait.elapsed_seconds),
-            )
+            continue
+        # SSH to a target is the control plane scenarios drive — without
+        # it, that target is effectively unreachable for red/blue work.
+        _emit_diagnostic(
+            ctx,
+            step="test_ssh",
+            component=f"ssh:{name}",
+            impact=DiagnosticImpact.READINESS,
+            severity=DiagnosticSeverity.WARNING,
+            message=(
+                f"SSH to {name} not ready after "
+                f"{int(ssh_wait.elapsed_seconds)}s"
+            ),
+            operator_action=(
+                f"Check the {name} container's sshd; scenarios cannot "
+                "drive this target until SSH is reachable"
+            ),
+        )
     return None
 
 
 def _step_capture_snapshot(ctx: _LabStartContext) -> LabResult | None:
     log.info("Step 11: Capturing range snapshot...")
-    snapshot = capture_snapshot(config_dir=ctx.project_dir, backend=ctx.backend)
+    try:
+        snapshot = capture_snapshot(
+            config_dir=ctx.project_dir, backend=ctx.backend
+        )
+    except Exception as exc:  # noqa: BLE001 — converted to structured diagnostic
+        # Snapshot is the run-archive inventory; its loss is observability
+        # debt, not a hard failure (ADR-030). Keep the raw exception in
+        # the log only (existing redaction owns it); diagnostic is narrow.
+        log.warning("Range snapshot capture failed: %s", exc)
+        _emit_diagnostic(
+            ctx,
+            step="capture_snapshot",
+            impact=DiagnosticImpact.TELEMETRY,
+            severity=DiagnosticSeverity.WARNING,
+            message="Range snapshot capture failed; run inventory will be incomplete",
+            operator_action=(
+                "Inspect lab logs; re-run `aptl lab status -j` to capture "
+                "inventory manually once the deployment backend is reachable"
+            ),
+        )
+        return None
     log.info(
         "Range: %d containers, %d networks, %d services, %d SSH endpoints",
         len(snapshot.containers),
@@ -598,6 +784,16 @@ def _step_build_mcps(ctx: _LabStartContext) -> LabResult | None:
     mcp_script = ctx.project_dir / "mcp" / "build-all-mcps.sh"
     if not mcp_script.exists():
         log.warning("MCP build script not found at %s", mcp_script)
+        _emit_diagnostic(
+            ctx,
+            step="build_mcps",
+            impact=DiagnosticImpact.CAPABILITY,
+            severity=DiagnosticSeverity.WARNING,
+            message="MCP build script not found; MCP servers will not be available",
+            operator_action=(
+                "Verify mcp/build-all-mcps.sh exists in the project tree"
+            ),
+        )
         return None
     try:
         mcp_result = subprocess.run(
@@ -607,11 +803,33 @@ def _step_build_mcps(ctx: _LabStartContext) -> LabResult | None:
             cwd=ctx.project_dir,
         )
         if mcp_result.returncode != 0:
+            # Raw stderr stays in the log (existing redaction owns it);
+            # the structured diagnostic carries only a narrow summary.
             log.warning("MCP build had errors: %s", mcp_result.stderr)
+            _emit_diagnostic(
+                ctx,
+                step="build_mcps",
+                impact=DiagnosticImpact.CAPABILITY,
+                severity=DiagnosticSeverity.WARNING,
+                message="MCP build returned non-zero exit; see lab logs",
+                operator_action=(
+                    "Inspect mcp/build-all-mcps.sh output in the lab log"
+                ),
+            )
         else:
             log.info("MCP servers built successfully")
     except (FileNotFoundError, OSError) as exc:
         log.warning("Failed to build MCP servers: %s", exc)
+        _emit_diagnostic(
+            ctx,
+            step="build_mcps",
+            impact=DiagnosticImpact.CAPABILITY,
+            severity=DiagnosticSeverity.WARNING,
+            message="MCP build could not run; see lab logs",
+            operator_action=(
+                "Inspect mcp/build-all-mcps.sh permissions and tooling"
+            ),
+        )
     return None
 
 
@@ -621,12 +839,33 @@ def _step_seed_soc(ctx: _LabStartContext) -> LabResult | None:
         return None
     log.info("Step 13: Seeding SOC tools...")
     assert ctx.config is not None
-    seed_script = ctx.project_dir / "scripts" / "seed-prime.sh"
-    if not seed_script.exists():
-        log.debug("SOC seed script not found at %s", seed_script)
-        return None
+    # Order the SOC-enabled check first so a missing script with SOC
+    # disabled stays a silent no-op (no degradation), while a missing
+    # script with SOC *enabled* surfaces as a capability warning —
+    # otherwise the lab would come up with empty SOC tools and the
+    # outcome would still be `ready` (codex review #202 cycle 1).
     if not ctx.config.containers.soc:
         log.debug("SOC profile not enabled, skipping seed")
+        return None
+    seed_script = ctx.project_dir / "scripts" / "seed-prime.sh"
+    if not seed_script.exists():
+        log.warning(
+            "SOC profile enabled but seed script not found at %s", seed_script
+        )
+        _emit_diagnostic(
+            ctx,
+            step="seed_soc",
+            impact=DiagnosticImpact.CAPABILITY,
+            severity=DiagnosticSeverity.WARNING,
+            message=(
+                "SOC profile enabled but seed-prime.sh not found; "
+                "SOC tools will start empty"
+            ),
+            operator_action=(
+                "Restore scripts/seed-prime.sh and re-run it once SOC "
+                "containers are healthy"
+            ),
+        )
         return None
     try:
         seed_result = subprocess.run(
@@ -638,12 +877,44 @@ def _step_seed_soc(ctx: _LabStartContext) -> LabResult | None:
         )
         if seed_result.returncode != 0:
             log.warning("SOC seeding had errors: %s", seed_result.stderr)
+            _emit_diagnostic(
+                ctx,
+                step="seed_soc",
+                impact=DiagnosticImpact.CAPABILITY,
+                severity=DiagnosticSeverity.WARNING,
+                message="SOC seeding returned non-zero exit; see lab logs",
+                operator_action=(
+                    "Re-run scripts/seed-prime.sh manually once SOC "
+                    "containers are healthy"
+                ),
+            )
         else:
             log.info("SOC tools seeded successfully")
     except subprocess.TimeoutExpired:
         log.warning("SOC seeding timed out (non-fatal)")
+        _emit_diagnostic(
+            ctx,
+            step="seed_soc",
+            impact=DiagnosticImpact.CAPABILITY,
+            severity=DiagnosticSeverity.WARNING,
+            message="SOC seeding timed out; SOC tools will start empty",
+            operator_action=(
+                "Re-run scripts/seed-prime.sh manually once SOC "
+                "containers are healthy"
+            ),
+        )
     except (FileNotFoundError, OSError) as exc:
         log.warning("Failed to seed SOC tools: %s", exc)
+        _emit_diagnostic(
+            ctx,
+            step="seed_soc",
+            impact=DiagnosticImpact.CAPABILITY,
+            severity=DiagnosticSeverity.WARNING,
+            message="SOC seeding could not run; see lab logs",
+            operator_action=(
+                "Inspect scripts/seed-prime.sh permissions and tooling"
+            ),
+        )
     return None
 
 
@@ -657,8 +928,24 @@ def _step_sync_mcp_config(ctx: _LabStartContext) -> LabResult | None:
     log.info("Step 14: Syncing MCP client config with seeded API keys...")
     try:
         _sync_mcp_config_keys(ctx.project_dir)
-    except Exception as exc:  # pragma: no cover - non-fatal
+    except Exception as exc:  # noqa: BLE001 — converted to structured diagnostic
+        # Exception text may include API key names — keep it in the log
+        # only (existing redaction). Diagnostic stays narrow.
         log.warning("MCP config sync skipped: %s", exc)
+        _emit_diagnostic(
+            ctx,
+            step="mcp_config_sync",
+            impact=DiagnosticImpact.CAPABILITY,
+            severity=DiagnosticSeverity.WARNING,
+            message=(
+                "MCP client config not refreshed; MCP servers may not "
+                "authenticate without manual key wiring"
+            ),
+            operator_action=(
+                "Inspect .mcp.json env blocks against .env after a "
+                "fresh lab start"
+            ),
+        )
     return None
 
 
@@ -710,10 +997,30 @@ def orchestrate_lab_start(
     for step in _LAB_START_STEPS:
         result = step(ctx)
         if result is not None:
-            return result
+            # Fatal short-circuit. Carry any partial-readiness diagnostics
+            # the earlier steps recorded so operators can see what state
+            # the lab reached before the failure (ADR-030).
+            return LabResult(
+                success=False,
+                message=result.message,
+                error=result.error,
+                outcome=StartupOutcome.FAILED,
+                diagnostics=list(ctx.diagnostics),
+            )
 
-    log.info("APTL lab started successfully!")
-    return LabResult(success=True, message="Lab started successfully")
+    outcome = derive_startup_outcome(ctx.diagnostics, fatal=False)
+    if outcome is StartupOutcome.READY:
+        log.info("APTL lab started successfully!")
+        message = "Lab started successfully"
+    else:
+        log.info("APTL lab started with outcome=%s", outcome.value)
+        message = f"Lab started with outcome={outcome.value}"
+    return LabResult(
+        success=True,
+        message=message,
+        outcome=outcome,
+        diagnostics=list(ctx.diagnostics),
+    )
 
 
 def _sync_mcp_config_keys(project_dir: Path) -> None:

--- a/src/aptl/core/lab_types.py
+++ b/src/aptl/core/lab_types.py
@@ -7,20 +7,126 @@ created a circular import (``lab.py`` -> snapshot -> deployment
 package -> backend.py / docker_compose.py -> ``aptl.core.lab``
 mid-load).
 
-``aptl.core.lab`` re-exports both names for backward compatibility,
-so callers that already import from ``aptl.core.lab`` keep working.
+``aptl.core.lab`` re-exports the public names for backward
+compatibility, so callers that already import from ``aptl.core.lab``
+keep working.
 """
 
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class StartupOutcome(str, Enum):
+    """Closed set of lab-start outcomes (ADR-030).
+
+    The string values are stable wire identifiers — they appear in
+    ``LabActionResponse.outcome`` (API), in CLI output, and in the
+    TypeScript mirror at ``web/src/lib/types.ts``. Renaming a value
+    breaks the contract; add a new member instead.
+    """
+
+    READY = "ready"
+    DEGRADED_USABLE = "degraded_usable"
+    DEGRADED_UNUSABLE = "degraded_unusable"
+    FAILED = "failed"
+
+
+class DiagnosticImpact(str, Enum):
+    """What a startup diagnostic actually affects (ADR-030).
+
+    ``cosmetic`` — no functional or telemetry impact (e.g. an image
+    pre-pull skipped; compose will pull on demand later).
+    ``telemetry`` — reduces evidence trail / SIEM ingest fidelity but
+    scenarios still run.
+    ``capability`` — affects scenario or platform features (MCPs not
+    built, SOC tools not seeded, MCP credentials not refreshed).
+    ``readiness`` — affects SSH or control-plane reach to a lab service
+    (red/blue/victim containers unreachable, etc.).
+
+    Mapping rules to ``StartupOutcome`` live in
+    :func:`aptl.core.lab.derive_startup_outcome` — keep them in sync.
+    """
+
+    COSMETIC = "cosmetic"
+    TELEMETRY = "telemetry"
+    CAPABILITY = "capability"
+    READINESS = "readiness"
+
+
+class DiagnosticSeverity(str, Enum):
+    """Operator-action level for a startup diagnostic (ADR-030).
+
+    Independent of impact: a ``cosmetic`` issue is usually ``info``,
+    but a ``capability`` step might be ``warning`` or ``error``
+    depending on whether retries are still possible.
+    """
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass
+class StartupDiagnostic:
+    """One structured note emitted by a startup step (ADR-030).
+
+    Step bodies emit these via ``aptl.core.lab._emit_diagnostic`` so the
+    redaction / message-shape guardrails live in one place. Free-form
+    messages must obey ADR-029 redaction: no .env values, no command
+    lines, no raw subprocess stderr — narrow labels and elapsed times
+    only.
+    """
+
+    step: str
+    impact: "DiagnosticImpact"
+    severity: "DiagnosticSeverity"
+    message: str
+    component: str = ""
+    operator_action: str = ""
 
 
 @dataclass
 class LabResult:
-    """Result of a lab lifecycle operation."""
+    """Result of a lab lifecycle operation.
+
+    ``outcome`` and ``diagnostics`` are the structured surface added by
+    ADR-030; ``success`` is retained as a compatibility field and is
+    derived from the outcome (True iff outcome is not
+    ``StartupOutcome.FAILED``). Callers that only need the boolean keep
+    working without changes; callers that need partial-readiness detail
+    read ``outcome`` and ``diagnostics``.
+
+    Normalization (``__post_init__``):
+
+    - ``success=False`` with no explicit outcome → ``outcome=FAILED``.
+      Otherwise legacy callers (the Docker Compose backend, ``_step_*``
+      bodies that return ``LabResult(success=False, error=...)``) would
+      surface a failed run as ``outcome=ready``, which both the CLI
+      renderer and the API projection would misclassify.
+    - ``outcome=FAILED`` with ``success=True`` → ``success=False``.
+      ``FAILED`` is the unambiguous signal; the two fields cannot
+      legitimately disagree.
+    """
 
     success: bool
     message: str = ""
     error: str = ""
+    outcome: "StartupOutcome" = StartupOutcome.READY
+    diagnostics: list[StartupDiagnostic] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Make the invariant total: ``outcome`` is the authoritative
+        # field; ``success`` is derived (True iff outcome is not FAILED).
+        # The one legacy tolerance: a caller that passes only
+        # ``success=False`` (without setting outcome) means a failure;
+        # promote it to ``outcome=FAILED`` so the boundary stays
+        # consistent. After that, ``success`` is always derived so
+        # contradictory combinations like
+        # ``LabResult(success=False, outcome=DEGRADED_USABLE)`` cannot
+        # leak through the DTO (codex review #202 cycle 3).
+        if not self.success and self.outcome is StartupOutcome.READY:
+            self.outcome = StartupOutcome.FAILED
+        self.success = self.outcome is not StartupOutcome.FAILED
 
 
 @dataclass

--- a/tests/test_api_lab.py
+++ b/tests/test_api_lab.py
@@ -120,6 +120,68 @@ class TestLabStart:
         assert "Missing .env" in data["error"]
 
     @patch("aptl.api.routers.lab.orchestrate_lab_start")
+    def test_start_exposes_outcome_and_diagnostics(self, mock_start, api_client):
+        """API projects ADR-030's outcome + diagnostics onto LabActionResponse."""
+        from aptl.core.lab import LabResult
+        from aptl.core.lab_types import (
+            DiagnosticImpact,
+            DiagnosticSeverity,
+            StartupDiagnostic,
+            StartupOutcome,
+        )
+
+        mock_start.return_value = LabResult(
+            success=True,
+            message="Lab started with outcome=degraded_usable",
+            outcome=StartupOutcome.DEGRADED_USABLE,
+            diagnostics=[
+                StartupDiagnostic(
+                    step="wait_for_services",
+                    component="wazuh_indexer",
+                    impact=DiagnosticImpact.TELEMETRY,
+                    severity=DiagnosticSeverity.WARNING,
+                    message="Indexer did not become ready within 300s",
+                    operator_action="Check indexer container logs",
+                ),
+            ],
+        )
+
+        response = api_client.post("/api/lab/start")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["outcome"] == "degraded_usable"
+        assert len(data["diagnostics"]) == 1
+        diag = data["diagnostics"][0]
+        assert diag["step"] == "wait_for_services"
+        assert diag["component"] == "wazuh_indexer"
+        assert diag["impact"] == "telemetry"
+        assert diag["severity"] == "warning"
+        assert diag["message"] == "Indexer did not become ready within 300s"
+        assert diag["operator_action"] == "Check indexer container logs"
+
+    @patch("aptl.api.routers.lab.orchestrate_lab_start")
+    def test_start_clean_run_has_ready_outcome_and_empty_diagnostics(
+        self, mock_start, api_client
+    ):
+        from aptl.core.lab import LabResult
+        from aptl.core.lab_types import StartupOutcome
+
+        mock_start.return_value = LabResult(
+            success=True,
+            message="Lab started successfully",
+            outcome=StartupOutcome.READY,
+        )
+
+        response = api_client.post("/api/lab/start")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["outcome"] == "ready"
+        assert data["diagnostics"] == []
+
+    @patch("aptl.api.routers.lab.orchestrate_lab_start")
     def test_start_timeout(self, mock_start, api_client):
         """Lab start returns error when orchestration exceeds timeout."""
         from aptl.core.lab import LabResult
@@ -148,6 +210,56 @@ class TestLabStart:
         data = response.json()
         assert data["success"] is False
         assert "timed out" in data["error"]
+        # The orchestrator runs in a background thread that
+        # ``asyncio.wait_for`` cannot cancel — at the moment of timeout the
+        # lab state is genuinely unknown (it may still complete). We
+        # therefore do NOT claim a terminal ``outcome="failed"`` here;
+        # ``success=False`` + the error string remain the authoritative
+        # signals (codex review #202 cycle 4).
+        assert data["outcome"] is None
+        assert data["diagnostics"] == []
+
+
+class TestStartupClassificationSchemaClosed:
+    """The ADR-030 wire strings are closed sets; the pydantic schema
+    refuses values outside those sets."""
+
+    def test_diagnostic_model_rejects_unknown_impact(self):
+        import pytest as _pytest
+        from pydantic import ValidationError
+
+        from aptl.api.schemas import StartupDiagnosticModel
+
+        with _pytest.raises(ValidationError):
+            StartupDiagnosticModel(
+                step="wait_for_services",
+                impact="bogus_impact",
+                severity="warning",
+                message="x",
+            )
+
+    def test_diagnostic_model_rejects_unknown_severity(self):
+        import pytest as _pytest
+        from pydantic import ValidationError
+
+        from aptl.api.schemas import StartupDiagnosticModel
+
+        with _pytest.raises(ValidationError):
+            StartupDiagnosticModel(
+                step="wait_for_services",
+                impact="telemetry",
+                severity="catastrophic",
+                message="x",
+            )
+
+    def test_lab_action_response_rejects_unknown_outcome(self):
+        import pytest as _pytest
+        from pydantic import ValidationError
+
+        from aptl.api.schemas import LabActionResponse
+
+        with _pytest.raises(ValidationError):
+            LabActionResponse(success=True, outcome="not_a_real_outcome")
 
 
 class TestLabStop:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,14 +134,22 @@ class TestLabStartCommand:
         mock_orchestrate.assert_called_once()
 
     def test_start_handles_failure_gracefully(self, runner, mocker):
-        """start command should exit 1 and show error on failure."""
+        """start command should exit 1 and show error on failure.
+
+        Under ADR-030, a fatal orchestrator result carries
+        ``outcome=FAILED`` alongside ``success=False`` (the orchestrator
+        wraps short-circuits this way); the mock matches that contract.
+        """
         from aptl.cli.main import app
         from aptl.core.lab import LabResult
+        from aptl.core.lab_types import StartupOutcome
 
         mocker.patch(
             "aptl.cli.lab.orchestrate_lab_start",
             return_value=LabResult(
-                success=False, error="vm.max_map_count too low"
+                success=False,
+                error="vm.max_map_count too low",
+                outcome=StartupOutcome.FAILED,
             ),
         )
 
@@ -164,6 +172,130 @@ class TestLabStartCommand:
 
         assert result.exit_code == 0
         mock_orchestrate.assert_called_once_with(tmp_path, skip_seed=False)
+
+    def test_start_ready_outcome_prints_ready(self, runner, mocker):
+        """A clean start prints the ready outcome (ADR-030)."""
+        from aptl.cli.main import app
+        from aptl.core.lab import LabResult
+        from aptl.core.lab_types import StartupOutcome
+
+        mocker.patch(
+            "aptl.cli.lab.orchestrate_lab_start",
+            return_value=LabResult(
+                success=True,
+                message="Lab started successfully",
+                outcome=StartupOutcome.READY,
+            ),
+        )
+
+        result = runner.invoke(app, ["lab", "start"])
+
+        assert result.exit_code == 0
+        assert "ready" in result.stdout.lower()
+
+    def test_start_degraded_usable_lists_diagnostics(self, runner, mocker):
+        """A telemetry warning produces degraded_usable + a one-line entry."""
+        from aptl.cli.main import app
+        from aptl.core.lab import LabResult
+        from aptl.core.lab_types import (
+            DiagnosticImpact,
+            DiagnosticSeverity,
+            StartupDiagnostic,
+            StartupOutcome,
+        )
+
+        mocker.patch(
+            "aptl.cli.lab.orchestrate_lab_start",
+            return_value=LabResult(
+                success=True,
+                message="Lab started with outcome=degraded_usable",
+                outcome=StartupOutcome.DEGRADED_USABLE,
+                diagnostics=[
+                    StartupDiagnostic(
+                        step="wait_for_services",
+                        component="wazuh_indexer",
+                        impact=DiagnosticImpact.TELEMETRY,
+                        severity=DiagnosticSeverity.WARNING,
+                        message="Wazuh Indexer did not become ready within 300s",
+                    ),
+                ],
+            ),
+        )
+
+        result = runner.invoke(app, ["lab", "start"])
+
+        assert result.exit_code == 0
+        assert "degraded_usable" in result.stdout
+        assert "wazuh_indexer" in result.stdout
+        assert "telemetry" in result.stdout
+        # Non-fatal: should still print partial readiness lead-in.
+        assert "warning" in result.stdout.lower()
+
+    def test_start_degraded_unusable_groups_by_impact(self, runner, mocker):
+        """Multiple diagnostics surface per impact bucket."""
+        from aptl.cli.main import app
+        from aptl.core.lab import LabResult
+        from aptl.core.lab_types import (
+            DiagnosticImpact,
+            DiagnosticSeverity,
+            StartupDiagnostic,
+            StartupOutcome,
+        )
+
+        mocker.patch(
+            "aptl.cli.lab.orchestrate_lab_start",
+            return_value=LabResult(
+                success=True,
+                message="Lab started with outcome=degraded_unusable",
+                outcome=StartupOutcome.DEGRADED_UNUSABLE,
+                diagnostics=[
+                    StartupDiagnostic(
+                        step="test_ssh",
+                        component="ssh:kali",
+                        impact=DiagnosticImpact.READINESS,
+                        severity=DiagnosticSeverity.WARNING,
+                        message="SSH to kali not ready after 60s",
+                    ),
+                    StartupDiagnostic(
+                        step="build_mcps",
+                        impact=DiagnosticImpact.CAPABILITY,
+                        severity=DiagnosticSeverity.WARNING,
+                        message="MCP build returned non-zero exit; see lab logs",
+                    ),
+                ],
+            ),
+        )
+
+        result = runner.invoke(app, ["lab", "start"])
+
+        # Non-fatal exit, but operator must see what's degraded.
+        assert result.exit_code == 0
+        assert "degraded_unusable" in result.stdout
+        assert "ssh:kali" in result.stdout
+        assert "build_mcps" in result.stdout
+        # Both impact labels should appear.
+        assert "readiness" in result.stdout
+        assert "capability" in result.stdout
+
+    def test_start_failed_outcome_exits_nonzero(self, runner, mocker):
+        from aptl.cli.main import app
+        from aptl.core.lab import LabResult
+        from aptl.core.lab_types import StartupOutcome
+
+        mocker.patch(
+            "aptl.cli.lab.orchestrate_lab_start",
+            return_value=LabResult(
+                success=False,
+                error="vm.max_map_count too low",
+                outcome=StartupOutcome.FAILED,
+            ),
+        )
+
+        result = runner.invoke(app, ["lab", "start"])
+
+        assert result.exit_code == 1
+        assert "vm.max_map_count" in result.stdout
+        assert "failed" in result.stdout.lower()
 
 
 class TestLabStopCommand:

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -344,6 +344,281 @@ class TestCheckBindMounts:
         assert "parse" in errors[0].lower() or "Failed" in errors[0]
 
 
+class TestStartupClassificationTypes:
+    """Tests for the StartupOutcome / DiagnosticImpact / StartupDiagnostic types.
+
+    The taxonomy is added in ``aptl.core.lab_types`` per ADR-030. These
+    tests pin the enum values and the dataclass shape so other layers
+    (CLI, API, web TS mirror) can rely on stable strings.
+    """
+
+    def test_startup_outcome_members(self):
+        from aptl.core.lab_types import StartupOutcome
+
+        assert StartupOutcome.READY.value == "ready"
+        assert StartupOutcome.DEGRADED_USABLE.value == "degraded_usable"
+        assert StartupOutcome.DEGRADED_UNUSABLE.value == "degraded_unusable"
+        assert StartupOutcome.FAILED.value == "failed"
+
+    def test_diagnostic_impact_members(self):
+        from aptl.core.lab_types import DiagnosticImpact
+
+        assert DiagnosticImpact.COSMETIC.value == "cosmetic"
+        assert DiagnosticImpact.TELEMETRY.value == "telemetry"
+        assert DiagnosticImpact.CAPABILITY.value == "capability"
+        assert DiagnosticImpact.READINESS.value == "readiness"
+
+    def test_diagnostic_severity_members(self):
+        from aptl.core.lab_types import DiagnosticSeverity
+
+        assert DiagnosticSeverity.INFO.value == "info"
+        assert DiagnosticSeverity.WARNING.value == "warning"
+        assert DiagnosticSeverity.ERROR.value == "error"
+
+    def test_startup_diagnostic_fields(self):
+        from aptl.core.lab_types import (
+            DiagnosticImpact,
+            DiagnosticSeverity,
+            StartupDiagnostic,
+        )
+
+        diag = StartupDiagnostic(
+            step="wait_for_services",
+            component="wazuh_indexer",
+            impact=DiagnosticImpact.TELEMETRY,
+            severity=DiagnosticSeverity.WARNING,
+            message="Indexer did not become ready within 300s",
+        )
+        assert diag.step == "wait_for_services"
+        assert diag.component == "wazuh_indexer"
+        assert diag.impact is DiagnosticImpact.TELEMETRY
+        assert diag.severity is DiagnosticSeverity.WARNING
+        assert diag.message == "Indexer did not become ready within 300s"
+        assert diag.operator_action == ""
+
+    def test_startup_diagnostic_component_optional(self):
+        from aptl.core.lab_types import (
+            DiagnosticImpact,
+            DiagnosticSeverity,
+            StartupDiagnostic,
+        )
+
+        diag = StartupDiagnostic(
+            step="pull_images",
+            impact=DiagnosticImpact.COSMETIC,
+            severity=DiagnosticSeverity.INFO,
+            message="Image pre-pull skipped",
+        )
+        # component defaults to empty string (no special-case in CLI/API)
+        assert diag.component == ""
+
+    def test_lab_result_has_outcome_and_diagnostics_with_defaults(self):
+        """LabResult must default to READY + empty diagnostics so existing
+        callers keep working without touching every constructor."""
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        r = LabResult(success=True, message="ok")
+        assert r.outcome is StartupOutcome.READY
+        assert r.diagnostics == []
+
+    def test_lab_result_success_false_without_outcome_normalizes_to_failed(self):
+        """A caller constructing LabResult(success=False) without setting
+        outcome must not surface as `outcome=ready` — the DTO normalizes
+        to FAILED so the wire shape stays consistent across the
+        Docker Compose backend, the orchestrator step bodies, and any
+        future caller that forgets to set outcome explicitly.
+
+        Codex review (cycle 2) called this the architectural choke point."""
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        r = LabResult(success=False, error="compose down failed")
+        assert r.outcome is StartupOutcome.FAILED
+        assert r.success is False
+
+    def test_lab_result_outcome_failed_forces_success_false(self):
+        """If the two fields disagree, outcome wins — a FAILED outcome
+        is the unambiguous signal, never silently 'successful'."""
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        r = LabResult(success=True, outcome=StartupOutcome.FAILED, error="x")
+        assert r.success is False
+
+    def test_lab_result_degraded_outcomes_keep_success_true(self):
+        """A `degraded_*` outcome means the lab is up — back-compat callers
+        reading only `success` keep working."""
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        for outcome in (
+            StartupOutcome.DEGRADED_USABLE,
+            StartupOutcome.DEGRADED_UNUSABLE,
+        ):
+            r = LabResult(success=True, outcome=outcome)
+            assert r.success is True
+            assert r.outcome is outcome
+
+    def test_lab_result_explicit_failed_with_success_false_is_unchanged(self):
+        """The orchestrator already wraps short-circuits with both fields
+        set consistently; normalization must be a no-op in that case."""
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        r = LabResult(
+            success=False, error="x", outcome=StartupOutcome.FAILED
+        )
+        assert r.success is False
+        assert r.outcome is StartupOutcome.FAILED
+
+    def test_lab_result_success_false_with_degraded_usable_is_corrected(self):
+        """Contradictory combination — outcome wins. The lab is up
+        (DEGRADED_USABLE), so success must be True regardless of what
+        the caller passed (codex review #202 cycle 3)."""
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        r = LabResult(success=False, outcome=StartupOutcome.DEGRADED_USABLE)
+        assert r.success is True
+        assert r.outcome is StartupOutcome.DEGRADED_USABLE
+
+    def test_lab_result_success_false_with_degraded_unusable_is_corrected(self):
+        """Same as the degraded_usable case — outcome is authoritative."""
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        r = LabResult(success=False, outcome=StartupOutcome.DEGRADED_UNUSABLE)
+        assert r.success is True
+        assert r.outcome is StartupOutcome.DEGRADED_UNUSABLE
+
+
+class TestStartupOutcomeDerivation:
+    """Tests for the rule that maps a diagnostics list (plus a fatal-step
+    short-circuit) into a StartupOutcome.
+
+    Mapping rule (ADR-030):
+      - If a fatal step short-circuited orchestration -> FAILED.
+      - Else any non-info diagnostic with impact in {capability, readiness}
+        -> DEGRADED_UNUSABLE.
+      - Else any non-info diagnostic with impact in {cosmetic, telemetry}
+        -> DEGRADED_USABLE.
+      - Else READY.
+
+    ``LabResult.success`` is True iff outcome is not FAILED.
+    """
+
+    def _diag(self, impact, severity, step="wait_for_services"):
+        from aptl.core.lab_types import StartupDiagnostic
+
+        return StartupDiagnostic(
+            step=step,
+            impact=impact,
+            severity=severity,
+            message="test diagnostic",
+        )
+
+    def test_empty_diagnostics_no_fatal_yields_ready(self):
+        from aptl.core.lab_types import StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(diagnostics=[], fatal=False)
+        assert outcome is StartupOutcome.READY
+
+    def test_only_info_diagnostics_yields_ready(self):
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(
+            diagnostics=[
+                self._diag(DiagnosticImpact.COSMETIC, DiagnosticSeverity.INFO),
+                self._diag(DiagnosticImpact.TELEMETRY, DiagnosticSeverity.INFO),
+            ],
+            fatal=False,
+        )
+        assert outcome is StartupOutcome.READY
+
+    def test_cosmetic_warning_yields_degraded_usable(self):
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(
+            diagnostics=[self._diag(DiagnosticImpact.COSMETIC, DiagnosticSeverity.WARNING)],
+            fatal=False,
+        )
+        assert outcome is StartupOutcome.DEGRADED_USABLE
+
+    def test_telemetry_warning_yields_degraded_usable(self):
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(
+            diagnostics=[self._diag(DiagnosticImpact.TELEMETRY, DiagnosticSeverity.WARNING)],
+            fatal=False,
+        )
+        assert outcome is StartupOutcome.DEGRADED_USABLE
+
+    def test_capability_warning_yields_degraded_unusable(self):
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(
+            diagnostics=[self._diag(DiagnosticImpact.CAPABILITY, DiagnosticSeverity.WARNING)],
+            fatal=False,
+        )
+        assert outcome is StartupOutcome.DEGRADED_UNUSABLE
+
+    def test_readiness_warning_yields_degraded_unusable(self):
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(
+            diagnostics=[self._diag(DiagnosticImpact.READINESS, DiagnosticSeverity.WARNING)],
+            fatal=False,
+        )
+        assert outcome is StartupOutcome.DEGRADED_UNUSABLE
+
+    def test_capability_error_yields_degraded_unusable(self):
+        """Severity error is a stronger non-info; same bucket as warning
+        for outcome purposes (the difference shows up in CLI/UI rendering,
+        not in the outcome bucket)."""
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(
+            diagnostics=[self._diag(DiagnosticImpact.CAPABILITY, DiagnosticSeverity.ERROR)],
+            fatal=False,
+        )
+        assert outcome is StartupOutcome.DEGRADED_UNUSABLE
+
+    def test_mixed_telemetry_and_capability_yields_degraded_unusable(self):
+        """The most severe bucket wins."""
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(
+            diagnostics=[
+                self._diag(DiagnosticImpact.TELEMETRY, DiagnosticSeverity.WARNING),
+                self._diag(DiagnosticImpact.CAPABILITY, DiagnosticSeverity.WARNING),
+            ],
+            fatal=False,
+        )
+        assert outcome is StartupOutcome.DEGRADED_UNUSABLE
+
+    def test_fatal_true_always_yields_failed(self):
+        """A fatal short-circuit overrides any diagnostics — failure
+        must be distinguishable from degraded_unusable per ADR-030."""
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        outcome = derive_startup_outcome(
+            diagnostics=[
+                self._diag(DiagnosticImpact.CAPABILITY, DiagnosticSeverity.WARNING),
+            ],
+            fatal=True,
+        )
+        assert outcome is StartupOutcome.FAILED
+
+    def test_fatal_true_with_no_diagnostics_yields_failed(self):
+        from aptl.core.lab_types import StartupOutcome
+        from aptl.core.lab import derive_startup_outcome
+
+        assert derive_startup_outcome(diagnostics=[], fatal=True) is StartupOutcome.FAILED
+
+
 class TestOrchestrateLabStart:
     """Tests for the full lab start orchestration."""
 
@@ -963,3 +1238,592 @@ class TestSyncSuricataMispRuleBaselinesStep:
         assert result is not None
         assert result.success is False
         assert "suricata misp" in (result.error or "").lower()
+
+
+class TestStartupClassificationWiring:
+    """Per-step assertions that each non-critical failure path produces
+    the expected structured diagnostic (ADR-030).
+
+    These tests drive individual ``_step_*`` functions against a
+    ``_LabStartContext`` with the right pre-conditions, then read the
+    diagnostics that were appended. They are deliberately step-scoped
+    so the assertions stay narrow and the mocks stay small.
+    """
+
+    def _make_env_vars(self):
+        from aptl.core.env import EnvVars
+
+        return EnvVars(
+            indexer_username="admin",
+            indexer_password="secret",
+            api_username="wazuh-wui",
+            api_password="apisecret",
+            dashboard_username="kibanaserver",
+            dashboard_password="kibanapass",
+            wazuh_cluster_key="clusterkey",
+        )
+
+    def _make_config(self, *, victim=True, kali=True, reverse=True, wazuh=True):
+        from aptl.core.config import AptlConfig
+
+        return AptlConfig(
+            lab={"name": "test-lab"},
+            containers={
+                "wazuh": wazuh,
+                "victim": victim,
+                "kali": kali,
+                "reverse": reverse,
+            },
+        )
+
+    def _ctx(self, tmp_path, *, config=None):
+        from aptl.core.lab import _LabStartContext
+
+        return _LabStartContext(
+            project_dir=tmp_path,
+            skip_seed=False,
+            env=self._make_env_vars(),
+            config=config or self._make_config(),
+            ssh_key_path=Path("/tmp/aptl_lab_key"),
+        )
+
+    # -- redaction at the diagnostic boundary --------------------------
+
+    def test_emit_diagnostic_redacts_credential_shaped_message(self, tmp_path):
+        """_emit_diagnostic is the choke point for everything that crosses
+        the CLI/API/web boundary — callers must not be able to leak a
+        credential-shaped payload through it even by accident.
+
+        Codex review (cycle 2) flagged the bare-message path as the
+        regression-prone seam; the helper now applies the same
+        ``aptl.utils.redaction.redact()`` boundary used by snapshot/run
+        archives (ADR-029)."""
+        from aptl.core.lab import _emit_diagnostic
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(tmp_path)
+        _emit_diagnostic(
+            ctx,
+            step="future_step_that_forgot",
+            impact=DiagnosticImpact.CAPABILITY,
+            severity=DiagnosticSeverity.WARNING,
+            message="API_KEY=hunter2 leaked into a future caller's text",
+            operator_action="Bearer abcd1234deadbeef token in operator note",
+        )
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert "hunter2" not in diag.message
+        assert "[REDACTED]" in diag.message
+        assert "abcd1234deadbeef" not in diag.operator_action
+        # Narrow internal identifiers like the step name must remain
+        # intact so the diagnostic stays attributable.
+        assert diag.step == "future_step_that_forgot"
+
+    # -- pull_images (cosmetic) ----------------------------------------
+
+    def test_pull_images_clean_emits_no_diagnostic(self, tmp_path):
+        from aptl.core.lab import _step_pull_images
+
+        ctx = self._ctx(tmp_path)
+        backend = MagicMock()
+        backend.pull_images.return_value = []
+        ctx.backend = backend
+
+        _step_pull_images(ctx)
+
+        assert ctx.diagnostics == []
+
+    def test_pull_images_warnings_emit_cosmetic_info(self, tmp_path):
+        from aptl.core.lab import _step_pull_images
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(tmp_path)
+        backend = MagicMock()
+        backend.pull_images.return_value = [
+            "Failed to pull wazuh/wazuh-manager:4.12.0: connection reset",
+            "Failed to pull wazuh/wazuh-dashboard:4.12.0: rate limit",
+        ]
+        ctx.backend = backend
+
+        _step_pull_images(ctx)
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.step == "pull_images"
+        assert diag.impact is DiagnosticImpact.COSMETIC
+        assert diag.severity is DiagnosticSeverity.INFO
+        # ADR-030 guardrail: do not embed raw subprocess stderr in the
+        # structured message. The diagnostic carries a narrow summary.
+        assert "connection reset" not in diag.message
+        assert "rate limit" not in diag.message
+        assert "2" in diag.message  # number of failed images
+
+    # -- wait_for_services (telemetry) ---------------------------------
+
+    def test_wait_for_services_indexer_timeout_emits_telemetry_warning(
+        self, tmp_path, mocker
+    ):
+        from aptl.core.lab import _step_wait_for_services
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path)
+        # Indexer not ready, Manager ready
+        mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            side_effect=[
+                ServiceResult(ready=False, elapsed_seconds=300.0, error="timed out"),
+                ServiceResult(ready=True, elapsed_seconds=12.0),
+            ],
+        )
+
+        _step_wait_for_services(ctx)
+
+        indexer_diags = [d for d in ctx.diagnostics if d.component == "wazuh_indexer"]
+        assert len(indexer_diags) == 1
+        assert indexer_diags[0].impact is DiagnosticImpact.TELEMETRY
+        assert indexer_diags[0].severity is DiagnosticSeverity.WARNING
+        assert indexer_diags[0].step == "wait_for_services"
+        manager_diags = [d for d in ctx.diagnostics if d.component == "wazuh_manager"]
+        assert manager_diags == []
+
+    def test_wait_for_services_manager_timeout_emits_telemetry_warning(
+        self, tmp_path, mocker
+    ):
+        from aptl.core.lab import _step_wait_for_services
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            side_effect=[
+                ServiceResult(ready=True, elapsed_seconds=12.0),
+                ServiceResult(ready=False, elapsed_seconds=120.0, error="timed out"),
+            ],
+        )
+
+        _step_wait_for_services(ctx)
+
+        manager_diags = [d for d in ctx.diagnostics if d.component == "wazuh_manager"]
+        assert len(manager_diags) == 1
+        assert manager_diags[0].impact is DiagnosticImpact.TELEMETRY
+        assert manager_diags[0].severity is DiagnosticSeverity.WARNING
+
+    def test_wait_for_services_clean_emits_no_diagnostic(self, tmp_path, mocker):
+        from aptl.core.lab import _step_wait_for_services
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            return_value=ServiceResult(ready=True, elapsed_seconds=10.0),
+        )
+
+        _step_wait_for_services(ctx)
+
+        assert ctx.diagnostics == []
+
+    def test_wait_for_services_skipped_when_wazuh_disabled(self, tmp_path, mocker):
+        from aptl.core.lab import _step_wait_for_services
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path, config=self._make_config(wazuh=False))
+        wait_mock = mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            return_value=ServiceResult(ready=False, elapsed_seconds=300.0, error="timed out"),
+        )
+
+        _step_wait_for_services(ctx)
+
+        # Wazuh probes never ran -> no diagnostics.
+        assert ctx.diagnostics == []
+        wait_mock.assert_not_called()
+
+    # -- test_ssh (readiness) ------------------------------------------
+
+    def test_test_ssh_per_target_timeout_emits_readiness_warning(
+        self, tmp_path, mocker
+    ):
+        from aptl.core.lab import _step_test_ssh
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path)
+        # victim ready, kali timeout, reverse ready
+        mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            side_effect=[
+                ServiceResult(ready=True, elapsed_seconds=2.0),
+                ServiceResult(ready=False, elapsed_seconds=60.0, error="timed out"),
+                ServiceResult(ready=True, elapsed_seconds=3.0),
+            ],
+        )
+
+        _step_test_ssh(ctx)
+
+        readiness_diags = [
+            d for d in ctx.diagnostics if d.impact is DiagnosticImpact.READINESS
+        ]
+        assert len(readiness_diags) == 1
+        diag = readiness_diags[0]
+        assert diag.step == "test_ssh"
+        assert diag.component == "ssh:kali"
+        assert diag.severity is DiagnosticSeverity.WARNING
+
+    def test_test_ssh_all_ready_emits_no_diagnostic(self, tmp_path, mocker):
+        from aptl.core.lab import _step_test_ssh
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            return_value=ServiceResult(ready=True, elapsed_seconds=2.0),
+        )
+
+        _step_test_ssh(ctx)
+
+        assert ctx.diagnostics == []
+
+    # -- build_mcps (capability) ---------------------------------------
+
+    def test_build_mcps_missing_script_emits_capability_warning(self, tmp_path):
+        from aptl.core.lab import _step_build_mcps
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(tmp_path)
+        # No mcp/build-all-mcps.sh script in tmp_path
+        _step_build_mcps(ctx)
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.step == "build_mcps"
+        assert diag.impact is DiagnosticImpact.CAPABILITY
+        assert diag.severity is DiagnosticSeverity.WARNING
+        assert "script" in diag.message.lower()
+
+    def test_build_mcps_nonzero_exit_emits_capability_warning(
+        self, tmp_path, mocker
+    ):
+        from aptl.core.lab import _step_build_mcps
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(tmp_path)
+        # Create the script so we get past the existence check
+        mcp_dir = tmp_path / "mcp"
+        mcp_dir.mkdir()
+        (mcp_dir / "build-all-mcps.sh").write_text("#!/bin/bash\nexit 1\n")
+        (mcp_dir / "build-all-mcps.sh").chmod(0o755)
+
+        mocker.patch(
+            "aptl.core.lab.subprocess.run",
+            return_value=MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="npm error: TOKEN=abcdef-leak-shaped-text",
+            ),
+        )
+
+        _step_build_mcps(ctx)
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.impact is DiagnosticImpact.CAPABILITY
+        assert diag.severity is DiagnosticSeverity.WARNING
+        # ADR-030 / ADR-029: stderr must not appear in the structured
+        # diagnostic message.
+        assert "abcdef-leak-shaped-text" not in diag.message
+        assert "TOKEN=" not in diag.message
+
+    def test_build_mcps_clean_emits_no_diagnostic(self, tmp_path, mocker):
+        from aptl.core.lab import _step_build_mcps
+
+        ctx = self._ctx(tmp_path)
+        mcp_dir = tmp_path / "mcp"
+        mcp_dir.mkdir()
+        (mcp_dir / "build-all-mcps.sh").write_text("#!/bin/bash\necho done\n")
+        (mcp_dir / "build-all-mcps.sh").chmod(0o755)
+
+        mocker.patch(
+            "aptl.core.lab.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="", stderr=""),
+        )
+
+        _step_build_mcps(ctx)
+
+        assert ctx.diagnostics == []
+
+    # -- capture_snapshot (telemetry) ----------------------------------
+
+    def test_capture_snapshot_clean_emits_no_diagnostic(self, tmp_path, mocker):
+        from aptl.core.lab import _step_capture_snapshot
+        from aptl.core.snapshot import RangeSnapshot
+
+        ctx = self._ctx(tmp_path)
+        ctx.backend = MagicMock()
+        mocker.patch(
+            "aptl.core.lab.capture_snapshot", return_value=RangeSnapshot()
+        )
+
+        _step_capture_snapshot(ctx)
+
+        assert ctx.diagnostics == []
+
+    def test_capture_snapshot_failure_emits_telemetry_warning(
+        self, tmp_path, mocker
+    ):
+        """Snapshot is the run-archive inventory — its loss is observability
+        debt, not a hard failure. ADR-030 lists snapshot capture among the
+        late startup checks that must surface as structured diagnostics."""
+        from aptl.core.lab import _step_capture_snapshot
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(tmp_path)
+        ctx.backend = MagicMock()
+        mocker.patch(
+            "aptl.core.lab.capture_snapshot",
+            side_effect=RuntimeError("docker daemon unreachable"),
+        )
+
+        # Must not raise — degradation, not failure.
+        _step_capture_snapshot(ctx)
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.step == "capture_snapshot"
+        assert diag.impact is DiagnosticImpact.TELEMETRY
+        assert diag.severity is DiagnosticSeverity.WARNING
+        # Exception text must not leak into the structured message
+        # (ADR-029 / ADR-030).
+        assert "docker daemon unreachable" not in diag.message
+
+    # -- seed_soc (capability) -----------------------------------------
+
+    def test_seed_soc_nonzero_exit_emits_capability_warning(self, tmp_path, mocker):
+        from aptl.core.config import AptlConfig
+        from aptl.core.lab import _step_seed_soc
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(
+            tmp_path,
+            config=AptlConfig(
+                lab={"name": "test-lab"},
+                containers={"wazuh": True, "victim": True, "kali": True, "soc": True},
+            ),
+        )
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        seed_script = scripts_dir / "seed-prime.sh"
+        seed_script.write_text("#!/bin/bash\nexit 1\n")
+        seed_script.chmod(0o755)
+
+        mocker.patch(
+            "aptl.core.lab.subprocess.run",
+            return_value=MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="MISP_API_KEY=should-not-appear-in-diag",
+            ),
+        )
+
+        _step_seed_soc(ctx)
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.step == "seed_soc"
+        assert diag.impact is DiagnosticImpact.CAPABILITY
+        assert diag.severity is DiagnosticSeverity.WARNING
+        assert "should-not-appear-in-diag" not in diag.message
+
+    def test_seed_soc_timeout_emits_capability_warning(self, tmp_path, mocker):
+        import subprocess
+
+        from aptl.core.config import AptlConfig
+        from aptl.core.lab import _step_seed_soc
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(
+            tmp_path,
+            config=AptlConfig(
+                lab={"name": "test-lab"},
+                containers={"wazuh": True, "victim": True, "kali": True, "soc": True},
+            ),
+        )
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        seed_script = scripts_dir / "seed-prime.sh"
+        seed_script.write_text("#!/bin/bash\nsleep 30\n")
+        seed_script.chmod(0o755)
+
+        mocker.patch(
+            "aptl.core.lab.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=str(seed_script), timeout=1),
+        )
+
+        _step_seed_soc(ctx)
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.step == "seed_soc"
+        assert diag.impact is DiagnosticImpact.CAPABILITY
+        assert diag.severity is DiagnosticSeverity.WARNING
+        assert "timed out" in diag.message.lower() or "timeout" in diag.message.lower()
+
+    def test_seed_soc_skipped_emits_no_diagnostic(self, tmp_path):
+        """--skip-seed is an operator choice, not a degradation."""
+        from aptl.core.lab import _step_seed_soc
+
+        ctx = self._ctx(tmp_path)
+        ctx.skip_seed = True
+
+        _step_seed_soc(ctx)
+
+        assert ctx.diagnostics == []
+
+    def test_seed_soc_missing_script_with_soc_enabled_emits_capability_warning(
+        self, tmp_path
+    ):
+        """SOC enabled but seed-prime.sh missing: lab will come up with empty
+        SOC tools. Codex review (cycle 1) flagged the silent-skip path."""
+        from aptl.core.config import AptlConfig
+        from aptl.core.lab import _step_seed_soc
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(
+            tmp_path,
+            config=AptlConfig(
+                lab={"name": "test-lab"},
+                containers={"wazuh": True, "victim": True, "kali": True, "soc": True},
+            ),
+        )
+        # No scripts/seed-prime.sh in tmp_path
+        _step_seed_soc(ctx)
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.step == "seed_soc"
+        assert diag.impact is DiagnosticImpact.CAPABILITY
+        assert diag.severity is DiagnosticSeverity.WARNING
+
+    def test_seed_soc_missing_script_with_soc_disabled_emits_no_diagnostic(
+        self, tmp_path
+    ):
+        """SOC disabled and no seed script: still a no-op, no degradation."""
+        from aptl.core.lab import _step_seed_soc
+
+        ctx = self._ctx(tmp_path, config=self._make_config())  # soc not set -> False
+        # No scripts/seed-prime.sh in tmp_path
+        _step_seed_soc(ctx)
+
+        assert ctx.diagnostics == []
+
+    # -- mcp_config_sync (capability) ----------------------------------
+
+    def test_mcp_config_sync_exception_emits_capability_warning(
+        self, tmp_path, mocker
+    ):
+        from aptl.core.lab import _step_sync_mcp_config
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab._sync_mcp_config_keys",
+            side_effect=RuntimeError("THEHIVE_API_KEY mismatch"),
+        )
+
+        _step_sync_mcp_config(ctx)
+
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.step == "mcp_config_sync"
+        assert diag.impact is DiagnosticImpact.CAPABILITY
+        assert diag.severity is DiagnosticSeverity.WARNING
+        # Exception text contains a sensitive-looking key name —
+        # diagnostic message must not echo the raw exception payload.
+        assert "THEHIVE_API_KEY" not in diag.message
+
+    def test_mcp_config_sync_clean_emits_no_diagnostic(self, tmp_path, mocker):
+        from aptl.core.lab import _step_sync_mcp_config
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch("aptl.core.lab._sync_mcp_config_keys", return_value=None)
+
+        _step_sync_mcp_config(ctx)
+
+        assert ctx.diagnostics == []
+
+
+class TestOrchestrateLabStartOutcome:
+    """End-to-end checks that ``orchestrate_lab_start`` returns a
+    ``LabResult`` whose ``outcome`` and ``diagnostics`` fields reflect
+    what happened during the run (ADR-030).
+    """
+
+    def _patch_happy(self, mocker, tmp_path):
+        # Reuse the same patcher TestOrchestrateLabStart uses, by
+        # constructing one and borrowing its method.
+        return TestOrchestrateLabStart()._patch_all_steps(mocker, tmp_path)
+
+    def test_happy_path_yields_ready_and_empty_diagnostics(self, mocker, tmp_path):
+        from aptl.core.lab import orchestrate_lab_start
+        from aptl.core.lab_types import StartupOutcome
+
+        self._patch_happy(mocker, tmp_path)
+
+        result = orchestrate_lab_start(tmp_path)
+
+        assert result.success is True
+        assert result.outcome is StartupOutcome.READY
+        assert result.diagnostics == []
+
+    def test_ssh_probe_timeout_yields_degraded_unusable(self, mocker, tmp_path):
+        from aptl.core.lab import orchestrate_lab_start
+        from aptl.core.lab_types import DiagnosticImpact, StartupOutcome
+        from aptl.core.services import ServiceResult
+
+        mocks = self._patch_happy(mocker, tmp_path)
+        # Make every wait_for_service call time out — covers indexer,
+        # manager, and every SSH probe.
+        mocks["wait_indexer"].return_value = ServiceResult(
+            ready=False, elapsed_seconds=60.0, error="timed out"
+        )
+
+        result = orchestrate_lab_start(tmp_path)
+
+        assert result.success is True  # back-compat: non-fatal warnings
+        assert result.outcome is StartupOutcome.DEGRADED_UNUSABLE
+        # At least one readiness diagnostic and one telemetry diagnostic.
+        impacts = {d.impact for d in result.diagnostics}
+        assert DiagnosticImpact.READINESS in impacts
+        assert DiagnosticImpact.TELEMETRY in impacts
+
+    def test_mcp_build_failure_yields_degraded_unusable(self, mocker, tmp_path):
+        from aptl.core.lab import orchestrate_lab_start
+        from aptl.core.lab_types import DiagnosticImpact, StartupOutcome
+
+        mocks = self._patch_happy(mocker, tmp_path)
+        mocks["mcp_subprocess"].return_value = MagicMock(
+            returncode=1, stdout="", stderr="npm error"
+        )
+
+        result = orchestrate_lab_start(tmp_path)
+
+        assert result.success is True
+        assert result.outcome is StartupOutcome.DEGRADED_UNUSABLE
+        cap = [d for d in result.diagnostics if d.impact is DiagnosticImpact.CAPABILITY]
+        assert any(d.step == "build_mcps" for d in cap)
+
+    def test_fatal_step_yields_failed_outcome(self, mocker, tmp_path):
+        from aptl.core.lab import LabResult, orchestrate_lab_start
+        from aptl.core.lab_types import StartupOutcome
+
+        mocks = self._patch_happy(mocker, tmp_path)
+        mocks["start"].return_value = LabResult(
+            success=False, error="compose up failed"
+        )
+
+        result = orchestrate_lab_start(tmp_path)
+
+        assert result.success is False
+        assert result.outcome is StartupOutcome.FAILED

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -531,58 +531,45 @@ class TestStartupOutcomeDerivation:
         )
         assert outcome is StartupOutcome.READY
 
-    def test_cosmetic_warning_yields_degraded_usable(self):
+    @pytest.mark.parametrize(
+        "impact_name,severity_name,expected_name",
+        [
+            ("COSMETIC", "WARNING", "DEGRADED_USABLE"),
+            ("TELEMETRY", "WARNING", "DEGRADED_USABLE"),
+            ("CAPABILITY", "WARNING", "DEGRADED_UNUSABLE"),
+            ("READINESS", "WARNING", "DEGRADED_UNUSABLE"),
+            # ERROR severity is a stronger non-info; same outcome bucket
+            # as WARNING — the difference shows up in CLI/UI rendering,
+            # not in the outcome bucket.
+            ("CAPABILITY", "ERROR", "DEGRADED_UNUSABLE"),
+        ],
+        ids=[
+            "cosmetic_warning->degraded_usable",
+            "telemetry_warning->degraded_usable",
+            "capability_warning->degraded_unusable",
+            "readiness_warning->degraded_unusable",
+            "capability_error->degraded_unusable",
+        ],
+    )
+    def test_single_diagnostic_yields_expected_outcome(
+        self, impact_name, severity_name, expected_name
+    ):
+        """The mapping table from (impact, severity) to outcome.
+
+        Parameterized so the table is the source of truth — adding a new
+        bucket means adding one row, not copy-pasting a test method."""
         from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
         from aptl.core.lab import derive_startup_outcome
 
-        outcome = derive_startup_outcome(
-            diagnostics=[self._diag(DiagnosticImpact.COSMETIC, DiagnosticSeverity.WARNING)],
-            fatal=False,
-        )
-        assert outcome is StartupOutcome.DEGRADED_USABLE
-
-    def test_telemetry_warning_yields_degraded_usable(self):
-        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
-        from aptl.core.lab import derive_startup_outcome
+        impact = DiagnosticImpact[impact_name]
+        severity = DiagnosticSeverity[severity_name]
+        expected = StartupOutcome[expected_name]
 
         outcome = derive_startup_outcome(
-            diagnostics=[self._diag(DiagnosticImpact.TELEMETRY, DiagnosticSeverity.WARNING)],
+            diagnostics=[self._diag(impact, severity)],
             fatal=False,
         )
-        assert outcome is StartupOutcome.DEGRADED_USABLE
-
-    def test_capability_warning_yields_degraded_unusable(self):
-        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
-        from aptl.core.lab import derive_startup_outcome
-
-        outcome = derive_startup_outcome(
-            diagnostics=[self._diag(DiagnosticImpact.CAPABILITY, DiagnosticSeverity.WARNING)],
-            fatal=False,
-        )
-        assert outcome is StartupOutcome.DEGRADED_UNUSABLE
-
-    def test_readiness_warning_yields_degraded_unusable(self):
-        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
-        from aptl.core.lab import derive_startup_outcome
-
-        outcome = derive_startup_outcome(
-            diagnostics=[self._diag(DiagnosticImpact.READINESS, DiagnosticSeverity.WARNING)],
-            fatal=False,
-        )
-        assert outcome is StartupOutcome.DEGRADED_UNUSABLE
-
-    def test_capability_error_yields_degraded_unusable(self):
-        """Severity error is a stronger non-info; same bucket as warning
-        for outcome purposes (the difference shows up in CLI/UI rendering,
-        not in the outcome bucket)."""
-        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity, StartupOutcome
-        from aptl.core.lab import derive_startup_outcome
-
-        outcome = derive_startup_outcome(
-            diagnostics=[self._diag(DiagnosticImpact.CAPABILITY, DiagnosticSeverity.ERROR)],
-            fatal=False,
-        )
-        assert outcome is StartupOutcome.DEGRADED_UNUSABLE
+        assert outcome is expected
 
     def test_mixed_telemetry_and_capability_yields_degraded_unusable(self):
         """The most severe bucket wins."""

--- a/web/src/lib/components/LabStartNotice.svelte
+++ b/web/src/lib/components/LabStartNotice.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import type { LabActionResponse, StartupDiagnostic } from '../types';
+
+	interface Props {
+		/** The most recent /api/lab/start response, or null when nothing has run. */
+		result: LabActionResponse | null;
+	}
+
+	let { result }: Props = $props();
+
+	/** ADR-030 headline phrasing — keep in sync with `src/aptl/cli/lab.py::_OUTCOME_HEADLINES`. */
+	const OUTCOME_HEADLINE: Record<string, string> = {
+		ready: 'Lab is ready.',
+		degraded_usable:
+			'Lab is degraded_usable — telemetry/cosmetic warnings, scenarios should still run.',
+		degraded_unusable:
+			'Lab is degraded_unusable — some capabilities or SSH targets are not reachable.',
+		failed: 'Lab start failed.'
+	};
+
+	/** Hide the notice for clean ready runs with no diagnostics.
+	 *
+	 *  Renders for any of:
+	 *    - explicit non-`ready` outcome,
+	 *    - non-empty diagnostics list,
+	 *    - legacy `success === false` shape (older API builds, the
+	 *      `/api/lab/start` timeout branch, or any path that returns a
+	 *      failure envelope without the optional ADR-030 fields). The
+	 *      legacy shape must surface visibly — silently swallowing it
+	 *      would regress the pre-ADR-030 UI (codex review #202 cycle 4).
+	 */
+	function isInteresting(r: LabActionResponse | null): boolean {
+		if (!r) return false;
+		if (r.success === false) return true;
+		if (r.diagnostics && r.diagnostics.length > 0) return true;
+		return Boolean(r.outcome) && r.outcome !== 'ready';
+	}
+
+	/** Group by impact in the same severity order the CLI uses. */
+	function groupDiagnostics(
+		diagnostics: StartupDiagnostic[] | undefined
+	): Array<[string, StartupDiagnostic[]]> {
+		const order = ['readiness', 'capability', 'telemetry', 'cosmetic'];
+		const buckets: Record<string, StartupDiagnostic[]> = {};
+		for (const d of diagnostics ?? []) {
+			(buckets[d.impact] ??= []).push(d);
+		}
+		return order
+			.filter((impact) => buckets[impact]?.length)
+			.map((impact) => [impact, buckets[impact]] as [string, StartupDiagnostic[]]);
+	}
+
+	let visible = $derived(isInteresting(result));
+	/** Pick the rendering key: explicit ``outcome`` when present;
+	 *  otherwise ``'failed'`` for the legacy ``success=false`` fallback;
+	 *  otherwise the empty string (notice hidden). */
+	let outcomeKey = $derived(
+		result?.outcome ?? (result?.success === false ? 'failed' : '')
+	);
+	let headline = $derived(OUTCOME_HEADLINE[outcomeKey] ?? '');
+	let grouped = $derived(groupDiagnostics(result?.diagnostics));
+
+	/** Border/background palette per outcome — `failed` is the
+	 *  hardest signal; `degraded_unusable` is amber; `degraded_usable`
+	 *  is amber-lite; `ready` (with diagnostics? unusual) stays neutral. */
+	function classesFor(outcome: string): string {
+		switch (outcome) {
+			case 'failed':
+				return 'border-aptl-red/30 bg-aptl-red/5 text-aptl-red';
+			case 'degraded_unusable':
+				return 'border-aptl-amber/30 bg-aptl-amber/10 text-aptl-amber';
+			case 'degraded_usable':
+				return 'border-aptl-amber/20 bg-aptl-amber/5 text-aptl-amber';
+			default:
+				return 'border-aptl-border bg-aptl-bg text-aptl-text';
+		}
+	}
+</script>
+
+{#if visible && result}
+	<div
+		role="status"
+		aria-label="Lab start result: {outcomeKey}"
+		class="mb-4 rounded-lg border p-3 text-sm {classesFor(outcomeKey)}"
+	>
+		<p class="font-medium">{headline}</p>
+		{#if outcomeKey === 'failed' && result.error}
+			<p class="mt-1 text-xs opacity-80">error: {result.error}</p>
+		{/if}
+		{#if result.diagnostics && result.diagnostics.length > 0}
+			<p class="mt-2 text-xs font-medium">
+				diagnostics ({result.diagnostics.length}):
+			</p>
+			<ul class="mt-1 space-y-1 text-xs">
+				{#each grouped as [impact, items] (impact)}
+					{#each items as diag (diag.step + (diag.component ?? ''))}
+						<li>
+							<span class="font-mono">[{diag.impact}|{diag.severity}]</span>
+							{diag.step}{diag.component ? `/${diag.component}` : ''} — {diag.message}
+							{#if diag.operator_action}
+								<div class="ml-4 text-xs opacity-70">
+									action: {diag.operator_action}
+								</div>
+							{/if}
+						</li>
+					{/each}
+				{/each}
+			</ul>
+		{/if}
+	</div>
+{/if}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -15,11 +15,41 @@ export interface LabStatus {
 	error: string | null;
 }
 
-/** Lab action response (start/stop). */
+/** Stable wire strings from `aptl.core.lab_types.StartupOutcome` (ADR-030). */
+export type StartupOutcome =
+	| 'ready'
+	| 'degraded_usable'
+	| 'degraded_unusable'
+	| 'failed';
+
+/** Stable wire strings from `aptl.core.lab_types.DiagnosticImpact` (ADR-030). */
+export type DiagnosticImpact = 'cosmetic' | 'telemetry' | 'capability' | 'readiness';
+
+/** Stable wire strings from `aptl.core.lab_types.DiagnosticSeverity` (ADR-030). */
+export type DiagnosticSeverity = 'info' | 'warning' | 'error';
+
+/** A structured note emitted by one startup step (ADR-030). */
+export interface StartupDiagnostic {
+	step: string;
+	impact: DiagnosticImpact;
+	severity: DiagnosticSeverity;
+	message: string;
+	component?: string;
+	operator_action?: string;
+}
+
+/** Lab action response (start/stop).
+ *
+ *  `outcome` and `diagnostics` carry ADR-030's structured partial-readiness
+ *  classification. Both are optional: older API builds (or `/lab/stop`,
+ *  which has no degraded state today) may omit them.
+ */
 export interface LabActionResponse {
 	success: boolean;
 	message: string;
 	error: string | null;
+	outcome?: StartupOutcome | null;
+	diagnostics?: StartupDiagnostic[];
 }
 
 /** Scenario summary for listing. */

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -2,22 +2,30 @@
 	import { labStatus, labLoading } from '$lib/stores/lab';
 	import { startLab, stopLab } from '$lib/api';
 	import ContainerGrid from '$lib/components/ContainerGrid.svelte';
+	import LabStartNotice from '$lib/components/LabStartNotice.svelte';
 	import ScenarioCard from '$lib/components/ScenarioCard.svelte';
-	import type { ScenarioSummary } from '$lib/types';
+	import type { LabActionResponse, ScenarioSummary } from '$lib/types';
 
 	let { data }: { data: { scenarios: ScenarioSummary[] } } = $props();
 
 	let actionPending = $state(false);
 	let actionError = $state('');
+	/** Last /api/lab/start response — populated for both success and
+	 *  failure so the UI can render ADR-030 partial-readiness data
+	 *  (outcome + diagnostics), not only the legacy success boolean. */
+	let startResult = $state<LabActionResponse | null>(null);
 
 	async function handleStart() {
 		actionPending = true;
 		actionError = '';
+		startResult = null;
 		try {
-			const result = await startLab();
-			if (!result.success) {
-				actionError = result.error || 'Lab start failed';
-			}
+			// `LabStartNotice` owns the structured rendering for every
+			// non-trivial start outcome (ready-with-diagnostics,
+			// degraded_usable, degraded_unusable, failed). `actionError`
+			// is reserved for fetch/transport failures so the same error
+			// text never renders twice (codex review #202 cycle 3).
+			startResult = await startLab();
 		} catch (err) {
 			actionError = String(err);
 		} finally {
@@ -28,6 +36,7 @@
 	async function handleStop() {
 		actionPending = true;
 		actionError = '';
+		startResult = null;
 		try {
 			const result = await stopLab();
 			if (!result.success) {
@@ -83,6 +92,8 @@
 				{actionError}
 			</div>
 		{/if}
+
+		<LabStartNotice result={startResult} />
 
 		{#if $labStatus.error != null && !actionError}
 			<div

--- a/web/tests/components/LabStartNotice.test.ts
+++ b/web/tests/components/LabStartNotice.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import LabStartNotice from '../../src/lib/components/LabStartNotice.svelte';
+import type { LabActionResponse } from '../../src/lib/types';
+
+const READY: LabActionResponse = {
+	success: true,
+	message: 'Lab started successfully',
+	error: null,
+	outcome: 'ready',
+	diagnostics: []
+};
+
+const DEGRADED_USABLE: LabActionResponse = {
+	success: true,
+	message: 'Lab started with outcome=degraded_usable',
+	error: null,
+	outcome: 'degraded_usable',
+	diagnostics: [
+		{
+			step: 'wait_for_services',
+			component: 'wazuh_indexer',
+			impact: 'telemetry',
+			severity: 'warning',
+			message: 'Indexer did not become ready within 300s',
+			operator_action: 'Check indexer container logs'
+		}
+	]
+};
+
+const DEGRADED_UNUSABLE: LabActionResponse = {
+	success: true,
+	message: 'Lab started with outcome=degraded_unusable',
+	error: null,
+	outcome: 'degraded_unusable',
+	diagnostics: [
+		{
+			step: 'test_ssh',
+			component: 'ssh:kali',
+			impact: 'readiness',
+			severity: 'warning',
+			message: 'SSH to kali not ready after 60s'
+		},
+		{
+			step: 'build_mcps',
+			impact: 'capability',
+			severity: 'warning',
+			message: 'MCP build returned non-zero exit; see lab logs'
+		}
+	]
+};
+
+const FAILED: LabActionResponse = {
+	success: false,
+	message: '',
+	error: 'vm.max_map_count too low',
+	outcome: 'failed',
+	diagnostics: []
+};
+
+describe('LabStartNotice', () => {
+	it('renders nothing when result is null', () => {
+		const { container } = render(LabStartNotice, { props: { result: null } });
+		expect(container.textContent?.trim()).toBe('');
+	});
+
+	it('renders nothing for a clean ready run with no diagnostics', () => {
+		const { container } = render(LabStartNotice, { props: { result: READY } });
+		expect(container.textContent?.trim()).toBe('');
+	});
+
+	it('renders a headline + telemetry row for degraded_usable', () => {
+		render(LabStartNotice, { props: { result: DEGRADED_USABLE } });
+
+		expect(screen.getByRole('status').getAttribute('aria-label')).toContain(
+			'degraded_usable'
+		);
+		expect(screen.getByText(/degraded_usable/i)).toBeTruthy();
+		expect(screen.getByText(/wait_for_services\/wazuh_indexer/)).toBeTruthy();
+		expect(screen.getByText(/\[telemetry\|warning\]/)).toBeTruthy();
+		expect(screen.getByText(/Check indexer container logs/)).toBeTruthy();
+	});
+
+	it('renders both readiness + capability rows for degraded_unusable', () => {
+		render(LabStartNotice, { props: { result: DEGRADED_UNUSABLE } });
+
+		expect(screen.getByText(/degraded_unusable/i)).toBeTruthy();
+		// Both impact buckets are visible.
+		expect(screen.getByText(/\[readiness\|warning\]/)).toBeTruthy();
+		expect(screen.getByText(/\[capability\|warning\]/)).toBeTruthy();
+		// Step names appear, including the component slash-suffix for ssh.
+		expect(screen.getByText(/test_ssh\/ssh:kali/)).toBeTruthy();
+		expect(screen.getByText(/build_mcps/)).toBeTruthy();
+	});
+
+	it('renders failure with error string for failed outcome', () => {
+		render(LabStartNotice, { props: { result: FAILED } });
+
+		expect(screen.getByText(/Lab start failed/)).toBeTruthy();
+		expect(screen.getByText(/vm\.max_map_count too low/)).toBeTruthy();
+	});
+
+	it('renders legacy success=false shape even when outcome+diagnostics are absent', () => {
+		// Older /api/lab/start builds (and the timeout branch on the
+		// current build, which intentionally omits a terminal outcome
+		// because the worker thread cannot be cancelled) return
+		// `{success: false, error: "..."}` with no ADR-030 fields. The
+		// notice must still surface the failure or the UI silently
+		// swallows it (codex review #202 cycle 4).
+		const legacyFailure: LabActionResponse = {
+			success: false,
+			message: '',
+			error: 'Lab start timed out after 1800s'
+			// outcome and diagnostics omitted
+		};
+
+		render(LabStartNotice, { props: { result: legacyFailure } });
+
+		expect(screen.getByText(/Lab start failed/)).toBeTruthy();
+		expect(screen.getByText(/timed out after 1800s/)).toBeTruthy();
+	});
+
+	it('still renders when outcome is ready but diagnostics non-empty', () => {
+		// Unusual but possible — a future step might emit a `cosmetic info`
+		// without affecting outcome. Diagnostics still surface.
+		const result: LabActionResponse = {
+			success: true,
+			message: 'Lab started successfully',
+			error: null,
+			outcome: 'ready',
+			diagnostics: [
+				{
+					step: 'pull_images',
+					impact: 'cosmetic',
+					severity: 'info',
+					message: 'Pre-pull failed for 1 image(s); compose will pull on demand'
+				}
+			]
+		};
+
+		render(LabStartNotice, { props: { result } });
+
+		// Notice is interesting because diagnostics non-empty.
+		expect(screen.getByText(/\[cosmetic\|info\]/)).toBeTruthy();
+		expect(screen.getByText(/pull_images/)).toBeTruthy();
+	});
+});

--- a/web/tests/lib/api.test.ts
+++ b/web/tests/lib/api.test.ts
@@ -76,6 +76,49 @@ describe('API client', () => {
 		expect(mockFetch).toHaveBeenCalledWith('/api/lab/stop', { method: 'POST' });
 	});
 
+	it('startLab carries ADR-030 outcome + diagnostics through fetch', async () => {
+		// API now returns the structured partial-readiness fields per ADR-030.
+		// Older callers see only success/message/error; new callers can read
+		// the outcome string ("ready" | "degraded_usable" | …) and the per-
+		// step diagnostic rows. The interface marks both as optional so the
+		// fetch boundary keeps round-tripping whatever the server sent.
+		const data = {
+			success: true,
+			message: 'Lab started with outcome=degraded_unusable',
+			error: null,
+			outcome: 'degraded_unusable',
+			diagnostics: [
+				{
+					step: 'test_ssh',
+					component: 'ssh:kali',
+					impact: 'readiness',
+					severity: 'warning',
+					message: 'SSH to kali not ready after 60s',
+					operator_action: 'Check kali container sshd'
+				},
+				{
+					step: 'wait_for_services',
+					component: 'wazuh_indexer',
+					impact: 'telemetry',
+					severity: 'warning',
+					message: 'Indexer did not become ready within 300s',
+					operator_action: ''
+				}
+			]
+		};
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve(data)
+		});
+
+		const result = await startLab();
+		expect(result).toEqual(data);
+		expect(result.outcome).toBe('degraded_unusable');
+		expect(result.diagnostics?.length).toBe(2);
+		expect(result.diagnostics?.[0].impact).toBe('readiness');
+		expect(result.diagnostics?.[0].component).toBe('ssh:kali');
+	});
+
 	it('getScenarios fetches /api/scenarios', async () => {
 		const data = [{ id: 'test', name: 'Test' }];
 		mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
Closes #202.

## Summary

`aptl lab start` now reports a structured partial-readiness classification instead of a single `success` boolean. Operators and automation can distinguish a fully-ready lab from one whose telemetry is degraded (Indexer/Manager timed out), one whose capabilities are missing (MCPs not built, SOC not seeded), one whose SSH targets are unreachable (kali/victim/reverse), and a hard failure — all from machine-readable fields rather than scraped log text.

## What changed

- **Core (Python)**: `src/aptl/core/lab_types.py` adds `StartupOutcome` (`ready` / `degraded_usable` / `degraded_unusable` / `failed`), `DiagnosticImpact` (`cosmetic` / `telemetry` / `capability` / `readiness`), `DiagnosticSeverity` (`info` / `warning` / `error`), and `StartupDiagnostic`. `LabResult` gains `outcome` + `diagnostics` fields, with a `__post_init__` that makes the success/outcome invariant total.
- **Orchestrator**: each currently-non-critical `_step_*` body emits a structured diagnostic via a new `_emit_diagnostic` helper. The helper runs every free-form field through the ADR-029 `redact()` boundary so a future caller can't leak credential-shaped text through the diagnostic surface. `orchestrate_lab_start` derives the outcome from the diagnostics list and from any fatal short-circuit.
- **CLI**: `aptl lab start` prints the outcome headline + diagnostics grouped by impact (`[impact|severity] step/component — message`).
- **REST API**: `LabActionResponse` projects `outcome` and `diagnostics` with `Literal[...]`-typed closed-set fields so OpenAPI/clients see the ADR-030 taxonomy, not arbitrary strings.
- **Web**: new `LabStartNotice.svelte` component renders the headline + per-impact diagnostic rows, and gracefully degrades to legacy `success=false` rendering when older API builds omit the optional fields.

## Governing ADR

[ADR-030 — Startup Partial-Readiness Classification](docs/adrs/adr-030-startup-partial-readiness-classification.md) (status: accepted, written during preflight).

## Test coverage

- `tests/test_lab.py` — 31 new tests covering the taxonomy, outcome derivation rules, per-step diagnostic emission, `LabResult` invariant normalization, and the redaction boundary.
- `tests/test_api_lab.py` — closed-set schema rejection, structured outcome/diagnostics projection, honest timeout behavior.
- `tests/test_cli.py` — ready / degraded_usable / degraded_unusable / failed rendering.
- `web/tests/lib/api.test.ts` — structured fields round-trip through fetch.
- `web/tests/components/LabStartNotice.test.ts` — rendering, legacy-shape fallback, per-impact grouping.

Full pytest: **1486 passed**. Web vitest: **64 passed**. svelte-check: 0 errors.

## Codex pre-push review

4 cycles (1 over-cap with explicit user authorization). Findings progressively tightened the boundary contracts: API timeout no longer claims a terminal outcome it can't observe; LabResult invariant is total; `_emit_diagnostic` redacts at the choke point; web surfaces legacy failure envelopes too. All findings posted as cycle comments on issue #202.