### PR TITLE
Add community documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Expected Behavior
+
+Participants are expected to keep discussion technical, concrete, and
+respectful. Good-faith disagreement about architecture, security tradeoffs,
+lab fidelity, documentation, and implementation details is welcome.
+
+Expected behavior includes:
+
+- focusing criticism on ideas, code, evidence, and project goals
+- giving enough context for others to understand a concern
+- accepting that maintainers may reject changes that do not fit the project
+- avoiding personal attacks, harassment, and discriminatory language
+- not publishing private information without permission
+- not using project spaces to coordinate unauthorized activity
+
+## Scope
+
+This code of conduct applies to project spaces, including issues, pull
+requests, discussions, documentation contributions, and other repository-linked
+collaboration.
+
+## Reporting
+
+Report conduct concerns privately to the maintainer through the contact path
+listed on Brad Edwards' GitHub profile.
+
+Reports will be handled as practically and fairly as possible, including
+removing comments, closing threads, declining contributions, or blocking
+participants when needed.
+
+## Attribution
+
+This document is intentionally minimal and project-specific. It is informed by
+common open-source conduct policies, including the Contributor Covenant, but it
+is not a verbatim copy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to APTL
+
+APTL is an active purple-team lab and autonomous cyber-operations research
+project. Contributions are useful when they make the lab safer, more
+reproducible, easier to operate, easier to test, or more precise for scenario
+authors and agent integrations.
+
+## Before Opening a Pull Request
+
+- For small documentation fixes, typo fixes, and narrow test improvements, a
+  pull request is enough.
+- For lab topology changes, attack-path changes, detection logic changes, MCP
+  API changes, scenario runtime changes, or container configuration changes,
+  open an issue first. Those changes can affect safety boundaries,
+  reproducibility, and documented workflows.
+- Keep unrelated changes in separate pull requests.
+- Base pull requests on `dev`, not `main`. `main` is the stable release line;
+  `dev` is the integration branch.
+- Do not add red-team capability enhancements to the public repository unless
+  the maintainer has explicitly accepted the scope first.
+
+## Development Setup
+
+Prerequisites:
+
+- Python 3.11 or newer
+- Docker and Docker Compose
+- Node.js and npm for MCP server and web UI work
+- [pre-commit](https://pre-commit.com/)
+
+Set up the Python control plane:
+
+```shell
+git clone https://github.com/Brad-Edwards/aptl.git
+cd aptl
+python -m venv .venv
+. .venv/bin/activate
+pip install -e ".[dev]"
+pre-commit install
+```
+
+Build the MCP servers when working on agent integrations:
+
+```shell
+./mcp/build-all-mcps.sh
+```
+
+Install the web UI dependencies when working under `web/`:
+
+```shell
+cd web
+npm install
+```
+
+## Making Changes
+
+1. Fork the repository and create a branch from `dev`.
+2. Make the smallest coherent change that solves the issue.
+3. Add or update tests when behavior changes.
+4. Update scenarios, schemas, documentation, or examples when the public
+   surface changes.
+5. Add a towncrier fragment under [`changelog.d/`](changelog.d/) for
+   user-visible changes unless the change is docs-only, CI-only, or internal
+   maintenance. See [`changelog.d/README.md`](changelog.d/README.md).
+6. Run the relevant checks locally.
+7. Open a pull request against `dev` with a concrete description of what
+   changed and why.
+
+## Verification
+
+The full repository gate is:
+
+```shell
+pre-commit run --all-files
+```
+
+Useful narrower checks:
+
+```shell
+pytest
+pytest -m fuzz
+cd mcp/aptl-mcp-common && npm test
+cd mcp/mcp-red && npm test
+cd web && npm test
+```
+
+When changing files under `mcp/aptl-mcp-common`, rebuild the common package and
+run tests for dependent MCP servers because they consume the local package.
+
+When changing `docker-compose.yml`, container Dockerfiles, or files under
+`config/`, validate the lab from a clean state:
+
+```shell
+aptl lab stop -v
+aptl lab start
+```
+
+## Safety Boundaries
+
+APTL intentionally runs vulnerable services and gives agents access to
+penetration-testing tools. Keep contributions bounded to authorized lab use.
+Do not include real credentials, production secrets, private target data, or
+instructions for using the project against systems you do not own or have
+permission to test.
+
+The repository contains intentional test credentials for lab functionality.
+Those are not production secrets. New credentials should be dummy values unless
+the design explicitly renders or generates them at runtime.
+
+## Changelog
+
+Release notes are generated from towncrier fragments under `changelog.d/`.
+Do not hand-edit `CHANGELOG.md`.
+
+Fragment names follow the pattern described in
+[`changelog.d/README.md`](changelog.d/README.md).
+
+## Security Reports
+
+Do not open public issues for suspected security vulnerabilities. See
+[SECURITY.md](SECURITY.md).
+
+## Community Expectations
+
+Participation in this project is covered by
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Do not report suspected vulnerabilities through public GitHub issues.
+
+Use GitHub private vulnerability reporting for this repository if it is
+available. If private reporting is not available, contact the maintainer
+privately through the contact path listed on Brad Edwards' GitHub profile.
+
+Include enough detail to reproduce and assess the issue:
+
+- affected package, command, container, MCP server, scenario, or document
+- affected version, commit, or branch
+- reproduction steps
+- expected and actual behavior
+- impact
+- proof of concept, logs, packet captures, or screenshots, if available
+
+## Scope
+
+Security reports are most useful for issues in:
+
+- APTL CLI behavior
+- MCP server behavior
+- web UI and API behavior
+- scenario parsing, compilation, and execution
+- run archives, telemetry export, and secret redaction boundaries
+- Docker Compose, container images, mounted configuration, and generated files
+- lab network isolation and host exposure
+- repository automation that handles untrusted input
+
+APTL intentionally includes vulnerable services, test credentials,
+penetration-testing tools, and unsafe lab targets. Reports are useful when the
+issue crosses an intended lab boundary, exposes host or operator data, leaks
+control-plane secrets, weakens isolation, or makes documented safety
+assumptions false.
+
+## Response Expectations
+
+Reports are reviewed as time permits, with priority given to reproducible
+issues that affect current code, host safety, control-plane secrets, published
+packages, or documented workflows.
+
+Please avoid publishing exploit details until there has been reasonable time to
+triage and prepare a fix or mitigation.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,46 @@
+# Support
+
+APTL is community supported and maintained on a best-effort basis.
+
+## Where to Ask
+
+- Use GitHub issues for reproducible bugs, documentation problems, and focused
+  feature requests.
+- Use GitHub discussions if they are enabled for design questions or broader
+  usage questions.
+- For security issues, do not open a public issue. See [SECURITY.md](SECURITY.md).
+
+## What to Include
+
+For a bug report, include:
+
+- repository commit or package version
+- operating system, Python version, Docker version, and Docker Compose version
+- command or API call used
+- relevant scenario, profile, or configuration file
+- expected result
+- actual result and error output
+- whether the lab was started from a clean state with `aptl lab stop -v`
+
+For MCP server or agent-integration issues, include:
+
+- MCP server name
+- client used to run the tool
+- tool call and sanitized arguments
+- sanitized tool response, logs, or trace output
+- whether the lab containers were healthy at the time
+
+For scenario or lab-topology proposals, include:
+
+- the training, research, or validation problem
+- the current workaround, if any
+- affected containers, networks, services, scenarios, or MCP tools
+- safety and isolation considerations
+- examples of expected telemetry or agent behavior
+
+## Maintenance Expectations
+
+Issues and pull requests are handled as time permits. Well-scoped reports with
+runnable examples are the easiest to review.
+
+There is no commercial support channel for this repository.


### PR DESCRIPTION
## Summary
Add root community documentation for contributors and users:

- CODE_OF_CONDUCT.md
- CONTRIBUTING.md
- SECURITY.md
- SUPPORT.md

## Notes
The language is scoped to this repository: best-effort support, private vulnerability reporting, practical lab safety guidance, and no corporate response claims.

Closes #296

## Verification
- pre-commit run --files CODE_OF_CONDUCT.md CONTRIBUTING.md SECURITY.md SUPPORT.md