### PR TITLE
Scope Kali Trivy image scan

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -289,8 +289,41 @@ jobs:
             context: .
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Decide whether this image needs scanning
+        id: image-scope
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          scan=true
+          if [ "${{ matrix.name }}" = "kali" ]; then
+            scan=false
+            base=""
+            head="HEAD"
+
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              base="${{ github.event.pull_request.base.sha }}"
+            elif [ "${{ github.event_name }}" = "push" ]; then
+              base="${{ github.event.before }}"
+            fi
+
+            if [ -z "$base" ] || [[ "$base" =~ ^0+$ ]]; then
+              scan=true
+            elif ! git cat-file -e "$base^{commit}"; then
+              scan=true
+            elif git diff --name-only "$base" "$head" | grep -Eq '^(containers/kali/|\.github/workflows/checks\.yml$)'; then
+              scan=true
+            fi
+          fi
+
+          echo "scan=$scan" >> "$GITHUB_OUTPUT"
+          echo "scan=$scan"
       - uses: docker/setup-buildx-action@v3
+        if: steps.image-scope.outputs.scan == 'true'
       - name: Build image
+        if: steps.image-scope.outputs.scan == 'true'
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
@@ -301,6 +334,7 @@ jobs:
           cache-from: type=gha,scope=trivy-${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=trivy-${{ matrix.name }}
       - uses: aquasecurity/trivy-action@v0.36.0
+        if: steps.image-scope.outputs.scan == 'true'
         with:
           scan-type: image
           image-ref: aptl-scan/${{ matrix.name }}:ci
@@ -311,7 +345,7 @@ jobs:
           severity: CRITICAL,HIGH,MEDIUM
           limit-severities-for-sarif: 'true'
       - name: Upload SARIF
-        if: always()
+        if: always() && steps.image-scope.outputs.scan == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: trivy-image-${{ matrix.name }}-sarif

--- a/changelog.d/+scope-kali-trivy.changed.md
+++ b/changelog.d/+scope-kali-trivy.changed.md
@@ -1,0 +1,1 @@
+**Scoped the Kali Trivy image scan.** CI no longer rebuilds and scans the Kali image on every run; the Kali matrix entry runs only when `containers/kali/` or the checks workflow changes, while remaining advisory and artifact-only when it does run.

--- a/docs/adrs/adr-026-advisory-ci-vulnerability-scanning.md
+++ b/docs/adrs/adr-026-advisory-ci-vulnerability-scanning.md
@@ -47,6 +47,10 @@ configuration schema.
 - Treat Trivy as the authoritative scanner for container images and
   filesystem/IaC checks; do not add custom Dockerfile, Compose, or Terraform
   parsing logic.
+- Do not rebuild and scan the Kali image on every PR or protected-branch push.
+  The Kali image is intentionally noisy because it is a rolling security-tooling
+  distribution; scan it when files under `containers/kali/` change, or when the
+  workflow itself changes.
 
 ## Consequences
 
@@ -69,6 +73,10 @@ configuration schema.
 
 - Trivy image scans can become expensive if every Dockerfile is built
   independently without cache-aware job structure.
+- The Kali image can dominate scan noise because most findings come from the
+  upstream tool distribution rather than APTL-owned code. Findings should be
+  triaged when APTL changes the Kali image, exposes host/operator data, weakens
+  lab isolation, or adds an owned package with a practical update path.
 - Scanning built images, filesystems, and IaC are related but distinct concerns;
   conflating them can hide coverage gaps.
 - SARIF upload to GitHub code scanning changes the permission and visibility


### PR DESCRIPTION
## Summary
Limit the Kali Trivy image scan so it no longer rebuilds and scans the Kali image on every CI run.

## Changes
- Skip the `kali` Trivy image matrix entry unless `containers/kali/` or `.github/workflows/checks.yml` changed.
- Keep the scan advisory and artifact-only when it does run.
- Document the Kali scan triage boundary in ADR-026.
- Add a changelog fragment for the CI behavior change.

Closes #298

## Verification
- actionlint .github/workflows/checks.yml
- pre-commit run --files .github/workflows/checks.yml docs/adrs/adr-026-advisory-ci-vulnerability-scanning.md changelog.d/+scope-kali-trivy.changed.md