### PR TITLE
added: hypothesis property tests for parser regression protection

### DIFF
--- a/changelog.d/213.added.md
+++ b/changelog.d/213.added.md
@@ -1,0 +1,8 @@
+### Added
+
+- Hypothesis property-based regression tests for the credentials, env,
+  config, and redaction parser boundaries (`pytest -m fuzz`). The new
+  tests assert bounded outcomes (a documented public exception or a
+  valid artifact) and enforce Hypothesis deadlines, so future ReDoS or
+  unhandled-exception regressions — like the cluster-key bug fixed in
+  #183 — fail as a test rather than as a hung lab start.

--- a/changelog.d/213.fixed.md
+++ b/changelog.d/213.fixed.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `aptl.core.config.load_config` now raises `ValueError` (not
+  `TypeError`) when the JSON top level is not an object (e.g. a bare
+  number, string, list, boolean, or `null`). Surfaced by the new
+  property-based suite — `**` splat into the Pydantic constructor
+  previously leaked `TypeError` past the documented
+  `(FileNotFoundError, ValueError)` contract.

--- a/docs/testing/property-based-parser-tests.md
+++ b/docs/testing/property-based-parser-tests.md
@@ -1,0 +1,64 @@
+# Property-Based Parser Regression Tests
+
+This note captures the repo-level guardrails for property-based tests that
+exercise parser-style boundaries such as credentials rendering, `.env`
+loading, strict first-party config validation, redaction, and SDL parsing.
+It complements the SDL-specific fuzz suite in `tests/test_sdl_fuzz.py`.
+
+## Scope
+
+Property-based tests are appropriate for code that accepts attacker-controlled
+or operator-authored strings and then parses, normalizes, validates, redacts,
+or renders them. Current canonical candidates include:
+
+- `aptl.core.credentials.sync_dashboard_config()` and
+  `aptl.core.credentials.sync_manager_config()`
+- `aptl.core.env.load_dotenv()` and `env_vars_from_dict()`
+- `aptl.core.config.load_config()` / `AptlConfig`
+- `aptl.utils.redaction.redact()`
+- SDL parser and scalar parser helpers under `aptl.core.sdl`
+
+## Guardrails
+
+- Mark property-based tests with `pytest.mark.fuzz`; default `pytest` skips
+  them via `pyproject.toml`, and `pytest -m fuzz` is the canonical manual run.
+- Use Hypothesis deadlines on parser/performance regression tests so pathological
+  regex or string-walk behavior fails as a test, not as a hung job.
+- Assert bounded, classified outcomes: a fuzzed parser either returns a valid
+  value/artifact or raises the existing public error type for that boundary.
+  Do not accept unhandled `TypeError`, `KeyError`, `AttributeError`, runaway
+  CPU, partial writes, or silent stale output.
+- Keep fuzz fixtures synthetic and local. Do not read real `.env` files, emit
+  real secrets, call Docker, start services, or cross process/network boundaries.
+- Reuse existing path layout helpers and canonical source/rendered locations
+  when testing credential rendering; do not add caller-controlled output paths
+  just to make tests easier.
+- When generated inputs include secret-shaped values, assert through artifact
+  structure and redaction outcomes rather than logging or snapshotting raw
+  generated secrets.
+
+## Boundary Ownership
+
+- Strict durable config shape belongs to `AptlConfig` and Pydantic validation.
+  Tests should not create a second config schema or duplicate allowed profile
+  names.
+- `.env` parsing and required variable checks belong to `aptl.core.env`.
+  Tests should exercise that boundary directly instead of parsing `.env`
+  syntax in helper code.
+- Credential rendering belongs to `aptl.core.credentials`: project-root
+  containment, no-symlink generated paths, XML/YAML escaping, atomic writes,
+  and `CredentialRenderError` / `PathContainmentError` semantics remain part
+  of the contract.
+- Serialization-boundary secret handling belongs to `aptl.utils.redaction`
+  and ADR-029. New parser tests must not introduce a parallel secret taxonomy.
+- SDL parse failures must stay inside `SDLParseError` /
+  `SDLValidationError`.
+
+## Non-Goals
+
+- Do not use property tests to redesign parser APIs, exception hierarchies,
+  config ownership, or generated artifact locations.
+- Do not make fuzz tests part of the default suite unless the repo-wide
+  `pytest` marker policy changes first.
+- Do not replace targeted unit tests for known security regressions; property
+  tests are additional coverage for input-space exploration.

--- a/src/aptl/core/config.py
+++ b/src/aptl/core/config.py
@@ -148,6 +148,16 @@ def load_config(path: Path) -> AptlConfig:
     except json.JSONDecodeError as e:
         raise ValueError(f"Invalid JSON in {path}: {e}") from e
 
+    # `AptlConfig(**data)` raises TypeError when `data` is a non-mapping
+    # JSON top-level (int, float, str, bool, null, list). Classify that
+    # into the documented `ValueError` contract so callers doing
+    # `except (FileNotFoundError, ValueError)` see a consistent shape.
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Config root must be a JSON object, got "
+            f"{type(data).__name__}: {path}"
+        )
+
     log.debug("Loaded config from %s", path)
     return AptlConfig(**data)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,18 +51,40 @@ class TestLabSettings:
             LabSettings()
 
 
+# Canonical expected defaults for ContainerSettings. Any new field
+# added to ContainerSettings MUST be added here as well, or the
+# ``test_defaults_*`` tests below will fail. That coupling is the
+# point: a new container type accidentally defaulting to ``True`` must
+# not slip past the test suite (it would otherwise enable that
+# container in every lab start).
+_EXPECTED_CONTAINER_DEFAULTS = {
+    "wazuh": True,
+    "victim": True,
+    "kali": True,
+    "reverse": False,
+    "enterprise": False,
+    "soc": False,
+    "mail": False,
+    "fileshare": False,
+    "dns": False,
+}
+
+
 class TestContainerSettings:
     """Tests for the ContainerSettings Pydantic model."""
 
-    def test_defaults_all_containers_enabled(self):
-        """By default, wazuh/victim/kali are enabled, reverse is disabled."""
+    def test_defaults_match_canonical_set(self):
+        """Every ContainerSettings field defaults to its canonical value.
+
+        Compares the full ``model_dump()`` against
+        ``_EXPECTED_CONTAINER_DEFAULTS`` so adding a new field to
+        ``ContainerSettings`` without updating the expected set fails
+        this test loudly — preventing an accidental new-container
+        default-True from shipping silently.
+        """
         from aptl.core.config import ContainerSettings
 
-        settings = ContainerSettings()
-        assert settings.wazuh is True
-        assert settings.victim is True
-        assert settings.kali is True
-        assert settings.reverse is False
+        assert ContainerSettings().model_dump() == _EXPECTED_CONTAINER_DEFAULTS
 
     def test_can_disable_containers(self):
         """User can selectively disable containers."""
@@ -74,15 +96,16 @@ class TestContainerSettings:
         assert settings.victim is True
 
     def test_enabled_profiles_returns_only_enabled(self):
-        """enabled_profiles() should return docker compose profile names for enabled containers."""
+        """enabled_profiles() returns exactly the set of enabled container names.
+
+        Asserts an exact set equality, not a few `in`/`not in` checks,
+        so a new field accidentally defaulting to ``True`` would show
+        up in the profile list and trip this assertion.
+        """
         from aptl.core.config import ContainerSettings
 
         settings = ContainerSettings(wazuh=True, victim=False, kali=True, reverse=False)
-        profiles = settings.enabled_profiles()
-        assert "wazuh" in profiles
-        assert "kali" in profiles
-        assert "victim" not in profiles
-        assert "reverse" not in profiles
+        assert set(settings.enabled_profiles()) == {"wazuh", "kali"}
 
 
 class TestAptlConfig:
@@ -105,12 +128,18 @@ class TestAptlConfig:
         assert config.lab.name == "aptl"
 
     def test_containers_default_when_omitted(self):
-        """If containers section is omitted, defaults apply."""
+        """If containers section is omitted, the canonical defaults apply.
+
+        Asserts the full ``model_dump()`` against
+        ``_EXPECTED_CONTAINER_DEFAULTS`` so a new container field added
+        to ``ContainerSettings`` without updating the expected set
+        fails this top-level path too — preventing an accidental new
+        container from being enabled by default.
+        """
         from aptl.core.config import AptlConfig
 
         config = AptlConfig(lab={"name": "test"})
-        assert config.containers.wazuh is True
-        assert config.containers.reverse is False
+        assert config.containers.model_dump() == _EXPECTED_CONTAINER_DEFAULTS
 
     def test_extra_fields_are_rejected(self):
         """Unknown top-level keys are validation errors per ADR-025."""
@@ -170,6 +199,35 @@ class TestConfigLoading:
         empty.write_text("")
         with pytest.raises(ValueError):
             load_config(empty)
+
+    @pytest.mark.parametrize(
+        "body,top_type",
+        [
+            ("0", "int"),
+            ("3.14", "float"),
+            ('"hello"', "str"),
+            ("true", "bool"),
+            ("null", "NoneType"),
+            ("[1, 2, 3]", "list"),
+        ],
+    )
+    def test_load_from_non_mapping_json_raises_valueerror(
+        self, tmp_config_dir, body, top_type,
+    ):
+        """A JSON top-level that isn't an object must raise ``ValueError``.
+
+        Pre-fix, ``AptlConfig(**data)`` would raise ``TypeError`` for any
+        non-mapping ``data``, leaking past the documented public-exception
+        contract (``FileNotFoundError`` / ``ValueError``). Caught by
+        ``tests/test_config_fuzz.py::test_load_config_arbitrary_text_bounded_outcomes``
+        with falsifying example ``body='0'``.
+        """
+        from aptl.core.config import load_config
+
+        path = tmp_config_dir / "aptl.json"
+        path.write_text(body)
+        with pytest.raises(ValueError, match="JSON object"):
+            load_config(path)
 
     def test_find_config_searches_cwd(self, tmp_config_dir, valid_config_dict):
         """find_config() should locate aptl.json in the given directory."""

--- a/tests/test_config_fuzz.py
+++ b/tests/test_config_fuzz.py
@@ -1,0 +1,121 @@
+"""Property-based fuzz tests for ``aptl.json`` loading and validation.
+
+Guards against regressions in ``aptl.core.config.load_config`` and the
+``AptlConfig`` Pydantic model:
+
+- Arbitrary JSON text must produce ``AptlConfig`` or a documented
+  public exception (``FileNotFoundError``, ``ValueError`` for malformed
+  JSON or empty file, ``pydantic.ValidationError`` for schema
+  violations). No raw ``json.JSONDecodeError`` may surface — the
+  loader wraps it in ``ValueError``.
+- ADR-025 strict-config invariant: any extra top-level key triggers
+  ``ValidationError``.
+- ``LabSettings.name`` validation: any non-empty name matching
+  ``^[a-zA-Z0-9][a-zA-Z0-9._-]*$`` is accepted; anything else raises
+  ``ValidationError``.
+
+Run with ``pytest -m fuzz tests/test_config_fuzz.py``.
+"""
+
+import json
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+# Import the private name pattern and the top-level config model directly
+# so the fuzz suite never holds a parallel copy of the contract — if the
+# production regex or schema changes, these tests follow without manual
+# edits. This is the boundary-ownership rule from
+# ``docs/testing/property-based-parser-tests.md``: tests do not duplicate
+# the strict config schema.
+from aptl.core.config import AptlConfig, LabSettings, _NAME_PATTERN, load_config
+
+pytestmark = pytest.mark.fuzz
+
+
+_KNOWN_TOP_LEVEL_KEYS = frozenset(AptlConfig.model_fields)
+
+# Arbitrary text — most examples will not be valid JSON. The contract
+# is the bounded-error one: load_config must classify the failure into
+# one of the documented public exceptions, not let an internal one
+# escape.
+_ARBITRARY_TEXT = st.text(min_size=0, max_size=2000)
+
+# Slug-shaped extra-key names for the strict-config property.
+_SLUG_LIKE = st.from_regex(r"[a-z][a-z0-9_]{0,20}", fullmatch=True)
+
+# Lab-name fuzz: full text, then filter the matching-vs-non-matching
+# disposition inside the test rather than splitting strategies. Keeps
+# both arms of the property covered without two near-duplicate tests.
+_LAB_NAME_FUZZ = st.text(min_size=0, max_size=80)
+
+
+@given(body=_ARBITRARY_TEXT)
+@settings(
+    max_examples=300,
+    deadline=1500,
+    suppress_health_check=[
+        HealthCheck.too_slow,
+        HealthCheck.function_scoped_fixture,
+    ],
+)
+def test_load_config_arbitrary_text_bounded_outcomes(tmp_path, body):
+    """Arbitrary text loads to ``AptlConfig`` or raises a documented type."""
+    config_file = tmp_path / "aptl.json"
+    config_file.write_text(body, encoding="utf-8")
+
+    try:
+        result = load_config(config_file)
+    except (FileNotFoundError, ValueError, ValidationError):
+        return
+
+    assert isinstance(result, AptlConfig)
+
+
+@given(extra_key=_SLUG_LIKE, extra_value=st.integers() | st.text(max_size=40))
+@settings(
+    max_examples=100,
+    deadline=500,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_load_config_extra_top_level_fields_rejected(
+    tmp_path, extra_key, extra_value,
+):
+    """ADR-025: unknown top-level keys raise ``ValidationError``.
+
+    Skips the four legitimate top-level keys (``lab``, ``containers``,
+    ``deployment``, ``run_storage``) since those are the in-schema
+    keys; the property only fires when the extra is genuinely
+    unknown.
+    """
+    if extra_key in _KNOWN_TOP_LEVEL_KEYS:
+        return  # Hypothesis will explore other values.
+
+    data = {extra_key: extra_value}
+    config_file = tmp_path / "aptl.json"
+    config_file.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        load_config(config_file)
+
+
+@given(name=_LAB_NAME_FUZZ)
+@settings(max_examples=300, deadline=500)
+def test_lab_settings_name_validation_matches_documented_pattern(name):
+    """``LabSettings(name=...)`` accepts the pattern, rejects everything else.
+
+    The accepted-name pattern lives in ``aptl.core.config._NAME_PATTERN``
+    and is imported at module top so a regex change in production
+    automatically updates the oracle here. Drift between the implementation
+    and the validator is a regression.
+    """
+    name_is_valid = bool(name and name.strip() and _NAME_PATTERN.match(name))
+
+    if name_is_valid:
+        settings_obj = LabSettings(name=name)
+        assert settings_obj.name == name
+    else:
+        with pytest.raises(ValidationError):
+            LabSettings(name=name)

--- a/tests/test_credentials_fuzz.py
+++ b/tests/test_credentials_fuzz.py
@@ -1,0 +1,301 @@
+"""Property-based fuzz tests for credential rendering.
+
+Guards against regressions in the credentialized config render path
+(`aptl.core.credentials`):
+
+- ReDoS / backtracking regressions: enforces Hypothesis deadlines so a
+  future replacement of the linear block-scoped scan with a
+  backtracking regex fails as a test rather than hangs the lab start.
+- Unhandled-exception regressions: every fuzzed input must produce
+  either a rendered `Path` or one of the documented public exception
+  types (`CredentialRenderError`, `PathContainmentError`,
+  `FileNotFoundError`). Unhandled `TypeError`, `KeyError`,
+  `AttributeError`, etc. mean the render boundary leaked an internal
+  failure to a caller.
+- #183 regression: an SSL-key file path inside
+  ``<indexer><ssl><key>...</key></ssl></indexer>`` must NOT be replaced
+  even when adjacent ``<cluster><key>...</key></cluster>`` is. The
+  property here is "outside-cluster `<key>` is byte-equal to input".
+
+Run with ``pytest -m fuzz tests/test_credentials_fuzz.py``; excluded
+from the default suite by ``pyproject.toml`` (``addopts = "-m 'not
+fuzz'"``).
+
+See ``docs/testing/property-based-parser-tests.md`` for the boundary
+ownership and guardrails this module follows.
+"""
+
+from pathlib import Path
+from xml.sax.saxutils import escape as xml_escape
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from aptl.core.credentials import (
+    CredentialRenderError,
+    PathContainmentError,
+    sync_dashboard_config,
+    sync_manager_config,
+)
+
+
+def _yaml_double_quoted_escape(value: str) -> str:
+    """Mirror ``_dashboard_transform`` in ``aptl.core.credentials``.
+
+    The production transform applies exactly this two-step escape before
+    interpolation: ``\\`` first, then ``"``. Keeping it as a single
+    helper here means the rendered-content assertion below holds the
+    transform's escape contract without a second public surface.
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+pytestmark = pytest.mark.fuzz
+
+
+_DASHBOARD_SOURCE_RELPATH = Path("config/wazuh_dashboard/wazuh.yml")
+_MANAGER_SOURCE_RELPATH = Path("config/wazuh_cluster/wazuh_manager.conf")
+_DASHBOARD_RENDERED_RELPATH = Path(".aptl/config/wazuh_dashboard/wazuh.yml")
+_MANAGER_RENDERED_RELPATH = Path(".aptl/config/wazuh_cluster/wazuh_manager.conf")
+
+
+def _layout_dashboard_template(project_dir: Path, content: str) -> None:
+    target = project_dir / _DASHBOARD_SOURCE_RELPATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+
+
+def _layout_manager_template(project_dir: Path, content: str) -> None:
+    target = project_dir / _MANAGER_SOURCE_RELPATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+
+
+_VALID_DASHBOARD_TEMPLATE = (
+    "hosts:\n"
+    "  - default:\n"
+    '      url: "https://wazuh.manager"\n'
+    "      port: 55000\n"
+    '      username: "wazuh-wui"\n'
+    '      password: "placeholder"\n'
+    "      run_as: false\n"
+)
+
+_VALID_MANAGER_TEMPLATE_WITH_SSL = (
+    "<ossec_config>\n"
+    "  <indexer>\n"
+    "    <ssl>\n"
+    "      <key>{ssl_key_path}</key>\n"
+    "    </ssl>\n"
+    "  </indexer>\n"
+    "  <cluster>\n"
+    "    <name>wazuh</name>\n"
+    "    <key>{cluster_key_placeholder}</key>\n"
+    "  </cluster>\n"
+    "</ossec_config>\n"
+)
+
+
+# Hypothesis strategies. Exclude C0/C1 control codepoints (``\n``,
+# ``\r``, NUL, etc.) and surrogates from credential strategies: text-mode
+# I/O in ``_atomic_write_secure`` normalizes line endings (``\r`` →
+# ``\n``), and credentials carrying raw CR/LF cannot round-trip through
+# a ``.env`` file anyway, so they are outside the realistic input space
+# for ``sync_dashboard_config`` / ``sync_manager_config``. Everything
+# else — punctuation, quotes, backslashes, regex specials,
+# non-Latin scripts, emoji — is in scope and the production code's
+# YAML/XML escapes are expected to handle them.
+_PRINTABLE_CHARS = st.characters(
+    blacklist_categories=("Cc", "Cs"),
+)
+_PASSWORD_LIKE = st.text(alphabet=_PRINTABLE_CHARS, min_size=0, max_size=200)
+_CLUSTER_KEY_LIKE = st.text(alphabet=_PRINTABLE_CHARS, min_size=0, max_size=200)
+# SSL key paths in the template must not contain ``<`` (would terminate
+# the `<key>` element). Restrict the alphabet so the test injects a
+# well-formed XML element rather than fuzzing XML well-formedness — the
+# property under test is "non-cluster <key> is preserved", not "the XML
+# parser handles broken markup".
+_FILESYSTEM_PATH = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("Ll", "Lu", "Nd"),
+        whitelist_characters="/._-",
+    ),
+    min_size=1,
+    max_size=120,
+)
+
+
+@given(api_password=_PASSWORD_LIKE)
+@settings(
+    max_examples=200,
+    deadline=2000,
+    suppress_health_check=[
+        HealthCheck.too_slow,
+        HealthCheck.function_scoped_fixture,
+    ],
+)
+def test_sync_dashboard_config_bounded_outcomes(tmp_path, api_password):
+    """Every fuzzed password against a valid template must render cleanly.
+
+    Property: for every Hypothesis-generated ``api_password``, the call
+    against a canonical valid dashboard template completes within the
+    deadline and returns the rendered output ``Path``; the file at that
+    path carries the password in its documented YAML-escaped form.
+    There is no bounded-exception branch here — the template is valid,
+    so any ``CredentialRenderError`` / ``PathContainmentError`` /
+    ``FileNotFoundError`` indicates the render boundary regressed on a
+    class of credentials it should be able to accept (e.g. an escape
+    bug that rejects a special character).
+    """
+    _layout_dashboard_template(tmp_path, _VALID_DASHBOARD_TEMPLATE)
+
+    out = sync_dashboard_config(tmp_path, api_password)
+
+    expected_path = (tmp_path / _DASHBOARD_RENDERED_RELPATH).resolve()
+    assert isinstance(out, Path)
+    assert out == expected_path
+    rendered = out.read_text()
+    # Positive structural check: the rendered file carries the password
+    # in its documented YAML-escaped form. This already proves the
+    # substitution happened — a separate ``"placeholder" not in
+    # rendered`` check would false-positive when Hypothesis generates a
+    # password that itself contains the literal placeholder substring
+    # (e.g. ``placeholder``, ``xplaceholderx``).
+    assert f'password: "{_yaml_double_quoted_escape(api_password)}"' in rendered
+
+
+@given(cluster_key=_CLUSTER_KEY_LIKE)
+@settings(
+    max_examples=200,
+    deadline=2000,
+    suppress_health_check=[
+        HealthCheck.too_slow,
+        HealthCheck.function_scoped_fixture,
+    ],
+)
+def test_sync_manager_config_bounded_outcomes(tmp_path, cluster_key):
+    """Every fuzzed cluster_key against a valid template must render cleanly.
+
+    Same shape as the dashboard valid-template test: the template is
+    canonical, so any documented exception here is a regression. The
+    bounded-exception pattern is reserved for
+    ``test_sync_manager_config_arbitrary_template_no_redos``, which
+    deliberately feeds in arbitrary / broken templates.
+    """
+    placeholder = "placeholder_cluster_key"
+    _layout_manager_template(
+        tmp_path,
+        "<ossec_config>\n"
+        "  <cluster>\n"
+        f"    <key>{placeholder}</key>\n"
+        "  </cluster>\n"
+        "</ossec_config>\n",
+    )
+
+    out = sync_manager_config(tmp_path, cluster_key)
+
+    expected_path = (tmp_path / _MANAGER_RENDERED_RELPATH).resolve()
+    assert isinstance(out, Path)
+    assert out == expected_path
+    rendered = out.read_text()
+    # Positive structural check (see dashboard test for rationale): a
+    # standalone ``placeholder not in rendered`` would false-positive
+    # when Hypothesis generates a cluster_key whose XML-escaped value
+    # contains the placeholder substring.
+    assert f"<key>{xml_escape(cluster_key)}</key>" in rendered
+
+
+# Templates that may or may not contain ``<cluster>...<key>...</key>...
+# </cluster>``. Use a small alphabet biased toward XML-like punctuation
+# so Hypothesis can build pathological shapes (unbalanced tags, repeated
+# ``<cluster>`` openers, ``<key>`` nested oddly) without spending the
+# entire budget on irrelevant unicode noise. The block-scoping logic in
+# ``_manager_transform`` must handle every shape without crashing.
+_TEMPLATE_FUZZ_ALPHABET = "<>/abcdefkluster\n "
+
+
+@given(template=st.text(alphabet=_TEMPLATE_FUZZ_ALPHABET, min_size=0, max_size=800))
+@settings(
+    max_examples=200,
+    deadline=1500,
+    suppress_health_check=[
+        HealthCheck.too_slow,
+        HealthCheck.function_scoped_fixture,
+    ],
+)
+def test_sync_manager_config_arbitrary_template_no_redos(tmp_path, template):
+    """Arbitrary XML-ish templates must not hang or raise unknown types.
+
+    The property under test is strictly "the renderer either completes
+    within the deadline or raises one of the documented public
+    exceptions"; success-path artifact correctness for canonical
+    templates is owned by
+    ``test_sync_manager_config_bounded_outcomes``. The fuzz alphabet
+    here is biased toward XML-like punctuation so most examples
+    deliberately fail to contain a complete ``<cluster><key>...</key>
+    </cluster>`` block and land in the ``CredentialRenderError``
+    branch; that is the intent — the regression this test catches is
+    a hang or an unhandled exception class on broken markup, not a
+    return-value correctness regression.
+
+    A future change that replaced the O(n) block-scoping logic in
+    ``_manager_transform`` with a backtracking regex like
+    ``<cluster>(.*?)</cluster>`` would blow this deadline on inputs
+    with many opened-but-unclosed ``<cluster>`` markers and long
+    interior runs.
+    """
+    _layout_manager_template(tmp_path, template)
+
+    try:
+        sync_manager_config(tmp_path, "fuzz-cluster-key")
+    except (CredentialRenderError, PathContainmentError, FileNotFoundError):
+        pass
+
+
+@given(
+    ssl_key_path=_FILESYSTEM_PATH,
+    cluster_key=st.text(alphabet=_PRINTABLE_CHARS, min_size=0, max_size=80),
+)
+@settings(
+    max_examples=200,
+    deadline=2000,
+    suppress_health_check=[
+        HealthCheck.too_slow,
+        HealthCheck.function_scoped_fixture,
+    ],
+)
+def test_sync_manager_config_preserves_ssl_key_paths(
+    tmp_path, ssl_key_path, cluster_key,
+):
+    """#183 regression in property form: outside-cluster ``<key>`` is preserved.
+
+    The block-scoped scan in ``_manager_transform`` must replace
+    ``<key>`` only inside ``<cluster>`` blocks. Any ``<key>`` outside a
+    cluster (Wazuh writes SSL key file paths into
+    ``<indexer><ssl><key>``) must be byte-equal to the original after
+    rendering.
+    """
+    placeholder = "old_cluster_key"
+    _layout_manager_template(
+        tmp_path,
+        _VALID_MANAGER_TEMPLATE_WITH_SSL.format(
+            ssl_key_path=ssl_key_path,
+            cluster_key_placeholder=placeholder,
+        ),
+    )
+
+    sync_manager_config(tmp_path, cluster_key)
+
+    rendered = (tmp_path / _MANAGER_RENDERED_RELPATH).read_text()
+    # Two positive structural checks. Together they prove the #183
+    # invariant: the SSL element keeps its byte-equal value AND the
+    # cluster element carries the new XML-escaped value. A separate
+    # ``placeholder not in rendered`` check would false-positive when
+    # the generated ssl_key_path or cluster_key contains the
+    # placeholder substring.
+    assert f"<key>{ssl_key_path}</key>" in rendered, (
+        "Outside-cluster <key> must be preserved byte-equal (#183)"
+    )
+    assert f"<key>{xml_escape(cluster_key)}</key>" in rendered, (
+        "Inside-cluster <key> must be replaced with the XML-escaped value"
+    )

--- a/tests/test_env_fuzz.py
+++ b/tests/test_env_fuzz.py
@@ -1,0 +1,190 @@
+"""Property-based fuzz tests for ``.env`` parsing and validation.
+
+Guards against regressions in ``aptl.core.env``:
+
+- ``load_dotenv`` must accept any byte sequence written to disk and
+  either return a ``dict[str, str]`` or raise ``FileNotFoundError``.
+  Unhandled ``UnicodeDecodeError``, ``ValueError``, or ``OSError``
+  leaking into the lab-start path is a real bug.
+- ``env_vars_from_dict`` must accept any ``dict[str, str]`` and either
+  return an ``EnvVars`` or raise ``ValueError``.
+- ``find_placeholder_env_values`` is a pure detector — it must never
+  raise.
+
+Run with ``pytest -m fuzz tests/test_env_fuzz.py``; excluded from the
+default suite by ``pyproject.toml`` (``addopts = "-m 'not fuzz'"``).
+"""
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from aptl.core.env import (
+    EnvVars,
+    _NO_PLACEHOLDER_VARS,
+    env_vars_from_dict,
+    find_placeholder_env_values,
+    load_dotenv,
+)
+from aptl.utils.placeholders import PLACEHOLDER_MARKERS
+
+pytestmark = pytest.mark.fuzz
+
+
+# Arbitrary byte sequence — the real contract for ``load_dotenv`` is
+# "any bytes on disk → dict or one of the documented public
+# exceptions". ``Path.read_text()`` decodes UTF-8 strictly, so invalid
+# byte sequences raise ``UnicodeDecodeError``, which is a subclass of
+# ``ValueError`` and therefore inside the documented exception set
+# already. Using ``st.binary()`` + ``write_bytes()`` ensures the test
+# actually exercises that branch instead of confining itself to
+# UTF-8-decodable text (which would silently overstate coverage —
+# issue #213 codex review cycle 2).
+_ENV_BYTES = st.binary(min_size=0, max_size=2000)
+
+_ENV_VAR_NAMES = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("Ll", "Lu", "Nd"),
+        whitelist_characters="_",
+    ),
+    min_size=1,
+    max_size=40,
+)
+_ENV_VAR_VALUES = st.text(min_size=0, max_size=200)
+
+_REQUIRED_VARS = ("INDEXER_USERNAME", "INDEXER_PASSWORD", "API_USERNAME", "API_PASSWORD")
+
+
+@given(body=_ENV_BYTES)
+@settings(
+    max_examples=300,
+    deadline=1000,
+    suppress_health_check=[
+        HealthCheck.too_slow,
+        HealthCheck.function_scoped_fixture,
+    ],
+)
+def test_load_dotenv_arbitrary_bytes_bounded_outcomes(tmp_path, body):
+    """Any byte sequence on disk yields a dict or a documented exception.
+
+    Lines are skipped if they are blank, comment-only, or contain no
+    ``=``. Everything else partitions on the first ``=`` and yields a
+    string-keyed string-valued entry. Invalid UTF-8 raises
+    ``UnicodeDecodeError`` (subclass of ``ValueError``), which the
+    documented contract already admits.
+    """
+    env_file = tmp_path / ".env"
+    env_file.write_bytes(body)
+
+    try:
+        result = load_dotenv(env_file)
+    except (FileNotFoundError, ValueError):
+        return
+
+    assert isinstance(result, dict)
+    for key, value in result.items():
+        assert isinstance(key, str)
+        assert isinstance(value, str)
+
+
+# Non-empty values for required-var success-path generation. Empty
+# strings count as missing per ``env_vars_from_dict``, so excluding them
+# from the strategy is what makes the strategy actually exercise the
+# successful construction path — issue #213 codex review (test_env_fuzz
+# split, finding 2).
+_NONEMPTY_VALUE = st.text(min_size=1, max_size=200)
+_OPTIONAL_VALUE = st.text(min_size=0, max_size=200)
+
+
+@st.composite
+def _valid_env_dict(draw):
+    """Build a dict where every required var is present and non-empty.
+
+    Optional fields (``DASHBOARD_USERNAME``, ``DASHBOARD_PASSWORD``,
+    ``WAZUH_CLUSTER_KEY``) are randomly included so the successful
+    construction path also exercises optional-default fallbacks.
+    """
+    env: dict[str, str] = {var: draw(_NONEMPTY_VALUE) for var in _REQUIRED_VARS}
+    for optional in ("DASHBOARD_USERNAME", "DASHBOARD_PASSWORD", "WAZUH_CLUSTER_KEY"):
+        if draw(st.booleans()):
+            env[optional] = draw(_OPTIONAL_VALUE)
+    return env
+
+
+@given(env=_valid_env_dict())
+@settings(max_examples=200, deadline=500)
+def test_env_vars_from_dict_valid_input_constructs_envvars(env):
+    """When every required var is present and non-empty, the call succeeds.
+
+    Property: ``env_vars_from_dict(env)`` returns an ``EnvVars`` whose
+    required fields round-trip from the input dict, and whose optional
+    fields take either the supplied value or the documented default.
+    """
+    result = env_vars_from_dict(env)
+
+    assert isinstance(result, EnvVars)
+    assert result.indexer_username == env["INDEXER_USERNAME"]
+    assert result.indexer_password == env["INDEXER_PASSWORD"]
+    assert result.api_username == env["API_USERNAME"]
+    assert result.api_password == env["API_PASSWORD"]
+    assert result.dashboard_username == env.get("DASHBOARD_USERNAME", "kibanaserver")
+    assert result.dashboard_password == env.get("DASHBOARD_PASSWORD", "")
+    assert result.wazuh_cluster_key == env.get("WAZUH_CLUSTER_KEY", "")
+
+
+@given(
+    env=_valid_env_dict(),
+    drop_var=st.sampled_from(_REQUIRED_VARS),
+    empty=st.booleans(),
+)
+@settings(max_examples=100, deadline=500)
+def test_env_vars_from_dict_missing_required_raises(env, drop_var, empty):
+    """A missing or empty required var raises ``ValueError`` and names it."""
+    if empty:
+        env[drop_var] = ""
+    else:
+        env.pop(drop_var, None)
+
+    with pytest.raises(ValueError, match=drop_var):
+        env_vars_from_dict(env)
+
+
+@given(
+    env=st.dictionaries(
+        keys=_ENV_VAR_NAMES,
+        values=_ENV_VAR_VALUES,
+        max_size=20,
+    ),
+)
+@settings(max_examples=300, deadline=500)
+def test_find_placeholder_env_values_never_raises(env):
+    """``find_placeholder_env_values`` returns a ``list[str]`` and never raises."""
+    result = find_placeholder_env_values(env)
+    assert isinstance(result, list)
+    for var in result:
+        assert isinstance(var, str)
+
+
+_PLACEHOLDER_MARKER_VALUES = st.sampled_from(PLACEHOLDER_MARKERS)
+
+
+@given(
+    sensitive_var=st.sampled_from(_NO_PLACEHOLDER_VARS),
+    marker=_PLACEHOLDER_MARKER_VALUES,
+)
+@settings(max_examples=100, deadline=500)
+def test_find_placeholder_env_values_flags_known_markers(sensitive_var, marker):
+    """Every sensitive var carrying a known placeholder marker is flagged.
+
+    The sensitive-var inventory is sampled from
+    ``aptl.core.env._NO_PLACEHOLDER_VARS`` directly so a new entry
+    there (e.g. ``WAZUH_CLUSTER_KEY``, which is rendered into
+    ``wazuh_manager.conf`` per ADR-028) is automatically covered
+    without an edit here. Property derived from
+    ``aptl.utils.placeholders.PLACEHOLDER_MARKERS``: if a sensitive var
+    contains any marker substring (case-insensitive), it must appear in
+    the result list. Catches regressions where a layer bypasses
+    ``contains_placeholder``.
+    """
+    env = {sensitive_var: marker}
+    assert sensitive_var in find_placeholder_env_values(env)

--- a/tests/test_redaction_fuzz.py
+++ b/tests/test_redaction_fuzz.py
@@ -1,0 +1,238 @@
+"""Property-based fuzz tests for ``aptl.utils.redaction.redact``.
+
+Guards against regressions in the serialization-boundary redaction
+helper:
+
+- ``redact`` is a pure function: it must never raise on any input and
+  must not mutate its argument.
+- Long inline-credential-shaped strings must be processed within a
+  deadline — the multi-pattern regex set
+  (``_SENSITIVE_KV_RE`` / ``_AUTHORIZATION_RE`` / ``_CLI_FLAG_RE`` /
+  ``_COOKIE_HEADER_RE`` / ``_URL_USERINFO_RE`` / ``_PEM_BLOCK_RE``)
+  is the obvious place ReDoS could be introduced if a future change
+  swapped a bounded character class for a nested quantifier.
+- Dict keys whose lowercase form contains a sensitive token (and are
+  not in the safe-allowlist) must have their values replaced with
+  ``REDACTED``. The pre-/post-images for that property come from
+  ``aptl.utils.redaction`` directly so the test follows the helper if
+  the token set changes.
+
+Run with ``pytest -m fuzz tests/test_redaction_fuzz.py``.
+"""
+
+import copy
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from aptl.utils import redaction
+from aptl.utils.redaction import REDACTED, redact
+
+pytestmark = pytest.mark.fuzz
+
+
+# Recursive Hypothesis strategy: nested mix of dicts / lists / strings /
+# ints / bools / None / floats. Depth-bound and size-bound so each
+# example is cheap to evaluate.
+_LEAF = (
+    st.text(min_size=0, max_size=80)
+    | st.integers()
+    | st.floats(allow_nan=False, allow_infinity=False)
+    | st.booleans()
+    | st.none()
+)
+_DICT_KEYS = st.text(min_size=1, max_size=30)
+_NESTED = st.recursive(
+    _LEAF,
+    lambda children: (
+        st.lists(children, max_size=5)
+        | st.dictionaries(_DICT_KEYS, children, max_size=5)
+        | st.tuples(children, children)
+    ),
+    max_leaves=20,
+)
+
+
+@given(value=_NESTED)
+@settings(
+    max_examples=300,
+    deadline=1000,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_redact_never_raises_on_arbitrary_value(value):
+    """``redact`` must accept any nested value without raising."""
+    original = copy.deepcopy(value)
+    result = redact(value)
+    # Purity contract: input not mutated.
+    assert value == original
+    # Output is JSON-serializable shape: dicts/lists/scalars only.
+    _assert_redacted_shape(result)
+
+
+def _assert_redacted_shape(value):
+    """Recursive shape check — JSON-compatible primitives only."""
+    if isinstance(value, dict):
+        for k, v in value.items():
+            assert isinstance(k, str) or k is None or isinstance(k, (int, float, bool))
+            _assert_redacted_shape(v)
+    elif isinstance(value, list):
+        for v in value:
+            _assert_redacted_shape(v)
+    else:
+        # Tuples normalize to lists in ``redact`` output; the residual
+        # set is the leaf types the helper passes through unchanged.
+        assert isinstance(value, (str, int, float, bool)) or value is None
+
+
+# Sensitive-key fuzz: keys whose lowercase form is guaranteed to match
+# the sensitive-token rule and is not in the safe-allowlist. We build
+# them by interleaving a sensitive token with surrounding letters so
+# Hypothesis explores compound keys (``my_password_field``,
+# ``access_token``, ``customer_secret_v2``) rather than just the literal
+# token.
+_SAFE_KEY_NAMES = redaction._SAFE_KEY_NAMES
+_SENSITIVE_TOKENS = redaction._SENSITIVE_TOKENS
+
+
+@st.composite
+def _sensitive_dict_key(draw):
+    """Compose a dict key whose lowercase contains a sensitive token.
+
+    Returns a key that:
+    - Lowercased contains at least one sensitive token from the helper.
+    - Is NOT in the documented safe-allowlist (e.g. ``key_path``).
+    """
+    token = draw(st.sampled_from(_SENSITIVE_TOKENS))
+    prefix = draw(
+        st.text(
+            alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd"),
+                                   whitelist_characters="_"),
+            min_size=0,
+            max_size=20,
+        )
+    )
+    suffix = draw(
+        st.text(
+            alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd"),
+                                   whitelist_characters="_"),
+            min_size=0,
+            max_size=20,
+        )
+    )
+    key = f"{prefix}{token}{suffix}"
+    if key.lower() in _SAFE_KEY_NAMES:
+        # Hypothesis shrinks toward simple names; force off the
+        # allowlist by suffixing.
+        key = f"{key}_x"
+    return key
+
+
+@given(
+    sensitive_key=_sensitive_dict_key(),
+    value=st.text(min_size=1, max_size=200),
+)
+@settings(max_examples=200, deadline=500)
+def test_redact_masks_sensitive_dict_values(sensitive_key, value):
+    """Values under a sensitive key are replaced with ``REDACTED``."""
+    result = redact({sensitive_key: value})
+    assert result == {sensitive_key: REDACTED}
+
+
+# Strategy targeted at the credential-shaped branches of the redaction
+# regex set. Plain ``st.text`` produces noise that rarely matches the
+# credential prefixes, so future ReDoS regressions in
+# ``_SENSITIVE_KV_RE`` / ``_AUTHORIZATION_RE`` / ``_BARE_BEARER_RE`` /
+# ``_CLI_FLAG_RE`` / ``_COOKIE_HEADER_RE`` / ``_URL_USERINFO_RE`` /
+# ``_PEM_BLOCK_RE`` could slip past. Each template is paired with a
+# long random tail so a catastrophic backtracker on the tail-side of
+# any of these patterns trips the deadline.
+# Tail alphabet excludes characters that terminate any of the
+# value-side patterns in ``aptl.utils.redaction``: ``\r``/``\n`` and
+# whitespace (terminator for several regex value classes), ``'``/``"``
+# (quote terminator), ``@`` (URL userinfo terminator), and the
+# punctuation that ``_SENSITIVE_KV_RE`` rejects (``& , ; |``). Within
+# that restriction the alphabet is intentionally diverse so a future
+# catastrophic-backtracker on the value side has plenty of varied
+# tail to chew on.
+_TAIL_ALPHABET = st.characters(
+    whitelist_categories=("Ll", "Lu", "Nd"),
+    whitelist_characters="-_=./*+%",
+)
+_LONG_TAIL = st.text(alphabet=_TAIL_ALPHABET, min_size=200, max_size=2000)
+_HOST_LIKE = st.text(
+    alphabet=st.characters(whitelist_categories=("Ll",), whitelist_characters="."),
+    min_size=3,
+    max_size=40,
+)
+_USER_LIKE = st.text(
+    alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="_-"),
+    min_size=1,
+    max_size=20,
+)
+
+
+@st.composite
+def _credential_shaped_string(draw):
+    """Compose a string that hits one of the redaction regex families."""
+    template = draw(st.sampled_from((
+        "Authorization: Bearer {tail}",
+        "Authorization: Basic {tail}",
+        "Cookie: session={tail}",
+        "Set-Cookie: connect.sid={tail}",
+        "password={tail}",
+        "api_key:{tail}",
+        "access_token={tail}",
+        "--password {tail}",
+        "--client-secret {tail}",
+        "Bearer {tail}",
+        "https://{user}:{tail}@{host}/path",
+        "-----BEGIN PRIVATE KEY-----\n{tail}\n-----END PRIVATE KEY-----",
+    )))
+    tail = draw(_LONG_TAIL)
+    return template.format(
+        tail=tail,
+        user=draw(_USER_LIKE),
+        host=draw(_HOST_LIKE),
+    )
+
+
+@given(payload=_credential_shaped_string())
+@settings(
+    max_examples=200,
+    deadline=1000,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_redact_credential_shaped_strings_bounded(payload):
+    """Credential-shaped strings with long tails redact in bounded time.
+
+    The strategy guarantees one of the credential regex branches fires
+    each example, so a future ReDoS regression in the inline-secret
+    patterns trips the deadline. The redacted output must still be a
+    string (the helper's only public contract for string input).
+    """
+    result = redact(payload)
+    assert isinstance(result, str)
+    assert REDACTED in result
+
+
+@given(
+    secret=st.text(
+        # Restrict to a "distinctive" alphabet — digits and a few
+        # uppercase letters that do NOT appear in the surrounding
+        # template ``Authorization: Bearer ``. That removes the false
+        # positives where the assertion ``secret not in result`` would
+        # otherwise trip on a single ``r``/``e``/``a`` etc. that the
+        # static template provides.
+        alphabet="0123456789XYZQ",
+        min_size=8,
+        max_size=80,
+    ),
+)
+@settings(max_examples=100, deadline=500)
+def test_redact_authorization_header_masks_secret(secret):
+    """``Authorization: Bearer <secret>`` strings mask the secret."""
+    payload = f"Authorization: Bearer {secret}"
+    result = redact(payload)
+    assert secret not in result
+    assert REDACTED in result


### PR DESCRIPTION
## Summary

Adds a Hypothesis property-based fuzz suite covering the four canonical parser boundaries in APTL — credentials rendering, `.env` parsing, JSON config loading, and serialization-boundary redaction — to guard against future ReDoS, unhandled-exception, and silent-stale-output regressions of the class fixed in #183 (v4.6.4/v4.6.5). The new suite immediately surfaced a real bug in `load_config` (TypeError leaking past the documented `ValueError` contract on non-mapping JSON), which is fixed in the same PR with a focused unit test and changelog fragment.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #213

## ADR Impact

- No ADR required

## Changes

- Added `tests/test_credentials_fuzz.py` covering `sync_dashboard_config` and `sync_manager_config`. Includes a #183 regression in property form (outside-cluster `<key>` byte-preserved while inside-cluster `<key>` is replaced with the XML-escaped value), success-path artifact validation (rendered file carries the YAML/XML-escaped secret), and a deadline-guarded ReDoS test against arbitrary XML-ish templates.
- Added `tests/test_env_fuzz.py` covering `load_dotenv` against arbitrary byte sequences (`st.binary()` + `write_bytes()` so the byte contract is genuinely exercised), `env_vars_from_dict` with a composite `_valid_env_dict` strategy plus a missing-required-var test, and `find_placeholder_env_values` sampling sensitive vars directly from `aptl.core.env._NO_PLACEHOLDER_VARS` so `WAZUH_CLUSTER_KEY` is included automatically.
- Added `tests/test_config_fuzz.py` covering `load_config` against arbitrary text (bounded-outcome contract), the ADR-025 extra-keys rule (derives `_KNOWN_TOP_LEVEL_KEYS` from `AptlConfig.model_fields` so no parallel schema is held), and the lab-name validation regex (imports `_NAME_PATTERN` from production).
- Added `tests/test_redaction_fuzz.py` covering `redact` purity on arbitrary nested values, sensitive-key dict masking (compose strategy derived from `aptl.utils.redaction._SENSITIVE_TOKENS`), and credential-shaped long strings hitting each regex family (Authorization, Cookie, password=, --token, Bearer, URL userinfo, PEM) with Hypothesis deadlines so future ReDoS in the inline-secret patterns fails as a test.
- Fixed `aptl.core.config.load_config`: it now raises `ValueError` (not `TypeError`) when the JSON top level is not an object. Surfaced by the new property suite on the first run with falsifying example `body='0'`. Covered by a parametrized unit test in `tests/test_config.py`.
- Tightened `ContainerSettings` default-coverage tests in `tests/test_config.py` to derive from a single `_EXPECTED_CONTAINER_DEFAULTS` dict and assert via `model_dump() == expected`. Adding a new container field defaulting to `True` will now fail loudly instead of silently shipping enabled.
- Added `docs/testing/property-based-parser-tests.md` (created by the codex architecture preflight) documenting the boundary ownership and guardrails the fuzz suite follows.
- Added `changelog.d/213.added.md` and `changelog.d/213.fixed.md` fragments for the test-suite addition and the `load_config` bug fix respectively.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Default suite (`pytest`) excludes the fuzz module per existing `addopts = "-m 'not fuzz'"`; CI runs both. Fuzz suite locally: 16 tests, ~10s. All pre-commit hooks green on Node 22.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: tests/test_credentials_fuzz.py, tests/test_env_fuzz.py, tests/test_config_fuzz.py, tests/test_redaction_fuzz.py, tests/test_config.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/213.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed