### PR TITLE
fix: surface effective session mode and await remote SSH close

### DIFF
--- a/changelog.d/282.changed.md
+++ b/changelog.d/282.changed.md
@@ -1,0 +1,9 @@
+### Changed
+
+- `*_session_command` result envelopes now include
+  `session_mode: "raw" | "normal"` carrying the EFFECTIVE per-command
+  mode (per-call override OR inherited session default). The Kali
+  red-team `postToolHook` consumes this field so commands run under
+  an inherited-raw session emit OCSF `status_id=0` / `Unknown`
+  instead of being recorded as successful via raw-mode's transport
+  `exit_code: 0`.

--- a/changelog.d/304.fixed.md
+++ b/changelog.d/304.fixed.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- `PersistentSession.close()` (in `mcp/aptl-mcp-common`) now awaits the
+  remote SSH channel close before returning, so the post-close
+  per-session capture harvest no longer races the Kali wrapper's EXIT
+  trap that flushes tcpdump and `script(1)`'s typescript. The
+  `dockerCpWithRetry` workaround (3 × 250ms backoff) has been removed;
+  local cleanup of in-flight and queued command promises remains
+  synchronous so command callers are not blocked by the remote-close
+  await.

--- a/docs/adrs/adr-004-persistent-ssh-sessions.md
+++ b/docs/adrs/adr-004-persistent-ssh-sessions.md
@@ -143,3 +143,46 @@ If a future Python SSH session layer is introduced, it must first be designed
 as a distinct control-plane boundary. The existing `src/aptl/core/ssh.py`
 module should remain limited to key material lifecycle unless a separate ADR
 expands its ownership.
+
+## Update (2026-05-18): Effective session-mode metadata
+
+`session_command` callers may override raw execution per command, but omitting
+`raw` means "use the session default", not "normal mode". The effective mode is
+therefore a runtime SSH-session fact, not a caller-argument fact.
+
+Implementations that expose command outcomes across the MCP boundary must:
+
+- Surface the effective command mode in the `session_command` result envelope as
+  `session_mode: "raw" | "normal"` using the existing `SessionMode` vocabulary.
+- Keep `list_sessions` / session metadata `mode` as the creation-time session
+  default for diagnostics; do not treat it as proof that a particular command
+  used that mode when a per-command override was supplied.
+- Preserve the existing `SSHError` and MCP response-envelope paths. A mode
+  metadata addition must not introduce a second error hierarchy, a parallel
+  session DTO, or ad hoc validation outside the JSON Schema plus
+  `assertSessionIdContract` ingress boundary.
+- Treat raw-mode `code: 0` as an unknown-outcome transport artifact. Downstream
+  observability must consume the effective mode metadata rather than inferring
+  success from that code.
+
+## Update (2026-05-18): Awaitable remote-close boundary
+
+Issue #304 changes the close contract: local cleanup and `shell.end()` are not
+proof that the remote shell wrapper has exited. The persistent-session close
+boundary must now resolve only after the SSH channel's remote `close` event has
+fired, or after a bounded timeout has logged a warning.
+
+Guardrails:
+
+- Keep the ownership model in `mcp/aptl-mcp-common/src/ssh.ts`: `closed` means
+  cleanup invariants passed and remote close was observed (or the bounded
+  timeout path completed visibly). `error` remains the broken-session path.
+- Preserve the existing `SSHError` and MCP response-envelope behavior. Do not
+  add a second exception hierarchy, close DTO, or handler-specific error shape.
+- Reject in-flight and queued commands during local cleanup; do not wait for the
+  remote close event before unblocking callers whose command promises are being
+  torn down.
+- Keep capture harvest in `mcp/aptl-mcp-common/src/captures.ts` and tool-level
+  orchestration in `handlers.ts`. The SSH layer owns channel lifecycle only.
+- The extensibility seam is the internal close timeout constant, not a new MCP
+  tool argument or config-file key.

--- a/docs/adrs/adr-027-red-team-structured-logging.md
+++ b/docs/adrs/adr-027-red-team-structured-logging.md
@@ -29,6 +29,10 @@ What stays from this ADR is **the OCSF schema work**:
 - Cross-language redaction at the serialization boundary (ADR-029).
 - Best-effort guarantee: classification / extraction / sink failures
   do not break tool execution.
+- Raw-session outcome handling: the Kali `postToolHook` must use the effective
+  mode surfaced in the `session_command` result envelope. The request argument
+  `raw` is only a per-call override and does not reveal inherited raw mode from
+  a session created with raw mode enabled.
 
 What changes is **the sink**:
 
@@ -54,6 +58,19 @@ than the previous SIEM ingestion path.
 
 Everything below this section is the original decision text,
 preserved for historical context.
+
+## Status update - 2026-05-18
+
+For `*_session_command`, OCSF status must be derived from the effective command
+mode and observed command outcome, not from request arguments alone. If the
+`session_command` result envelope reports `session_mode: "raw"`, the OCSF
+record must emit `status_id=0` / `status="Unknown"` even when the raw-mode SSH
+result contains `exit_code: 0`.
+
+This keeps the common MCP session layer as the source of truth for execution
+mode and keeps `mcp-red` as a best-effort observer. Do not duplicate the common
+session mode rules in `mcp-red`, do not parse session ids or query session state
+from the logger, and do not let OCSF logging failures affect tool execution.
 
 ---
 

--- a/docs/adrs/adr-033-agent-reasoning-trace-boundary.md
+++ b/docs/adrs/adr-033-agent-reasoning-trace-boundary.md
@@ -253,20 +253,22 @@ agent CLI ships.
   kali user's reach"](https://github.com/Brad-Edwards/aptl/issues/305)
   — a separate ADR will record the writer-ownership design
   decision when that issue lands.
-- **Harvest race window** (codex cycle 2 finding-2; tracked in
+- **Harvest race window** (closed by
   [issue #304](https://github.com/Brad-Edwards/aptl/issues/304)):
-  the MCP-server `closeSession` returns after local `shell.end()`
-  but before the remote SSH channel close fires the kali wrapper's
-  EXIT trap that kills tcpdump and flushes script's typescript.
-  The harvest helper applies bounded retries with backoff
-  (3 × 250ms) to cover the typical cleanup window; in pathological
-  cases a partial capture may still be copied. The MCP-side PTY
-  tee is unaffected (it captures byte-by-byte on the MCP-server
-  side). The proper fix — awaiting the remote-close event in
-  `PersistentSession.close()` before `SSHConnectionManager.closeSession`
-  returns — touches ADR-004's SSH close contract and is tracked as
-  [#304 "Await remote SSH channel close in PersistentSession.close
-  before harvest"](https://github.com/Brad-Edwards/aptl/issues/304).
+  `PersistentSession.close()` now resolves only after the SSH stream's
+  remote `close` event has fired (or a bounded
+  `TIMEOUTS.REMOTE_CLOSE_AWAIT` has elapsed with a logged
+  `[SSH] remote close timeout` warning). The kali wrapper's EXIT trap
+  — which kills tcpdump and flushes the `script(1)` typescript — runs
+  on remote channel close, so awaiting that event before the
+  `docker cp` harvest eliminates the truncation race. The
+  `dockerCpWithRetry` helper that previously masked the window with a
+  3 × 250ms backoff has been removed; the missing-source loud-stderr
+  path (which surfaces deletion-by-kali-user as a visible anomaly)
+  remains in place because it is independent of the race fix. Local
+  cleanup — rejecting in-flight and queued command promises — is still
+  synchronous so command callers are not blocked by the remote-close
+  await.
 - **Error envelopes**: capture failures log to stderr only. The
   PostToolHook architecture from ADR-027 still applies: capture or
   OCSF emission errors never break tool execution.

--- a/mcp/aptl-mcp-common/src/captures.ts
+++ b/mcp/aptl-mcp-common/src/captures.ts
@@ -57,9 +57,17 @@ function dockerBin(env: NodeJS.ProcessEnv = process.env): string {
   return DEFAULT_DOCKER_BIN;
 }
 
-function execDockerCp(args: string[]): Promise<{ code: number; stderr: string }> {
+function execDockerCp(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ code: number; stderr: string }> {
+  // Thread the caller's env through so APTL_DOCKER_BIN overrides set on
+  // HarvestOptions actually reach dockerBin(). Without this, the test
+  // mock could not observe the override and the SonarCloud S4036
+  // "no PATH lookup" contract was unverifiable. (Test-quality review
+  // cycle 1 T-002.)
   return new Promise((res) => {
-    const child = spawn(dockerBin(), args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(dockerBin(env), args, { stdio: ['ignore', 'pipe', 'pipe'] });
     let stderr = '';
     child.stderr.on('data', (b) => {
       stderr += b.toString();
@@ -71,36 +79,6 @@ function execDockerCp(args: string[]): Promise<{ code: number; stderr: string }>
       res({ code: code ?? -1, stderr });
     });
   });
-}
-
-const HARVEST_RETRIES = 3;
-const HARVEST_BACKOFF_MS = 250;
-
-/**
- * Run `docker cp` with bounded retries. The MCP-side `closeSession`
- * returns as soon as `shell.end()` resolves locally, but the remote
- * SSH channel close (which fires the Kali wrapper's EXIT trap that
- * kills tcpdump and flushes the script typescript) can take a few
- * hundred milliseconds longer (codex cycle 2 finding-2). Without a
- * retry the harvest can race the cleanup and copy a truncated or
- * partially-flushed tree. The retry isn't a correctness substitute
- * for awaiting remote-close — see the SSH layer for that work — but
- * it makes the practical case land cleanly.
- */
-async function dockerCpWithRetry(args: string[]): Promise<{ code: number; stderr: string }> {
-  let last = await execDockerCp(args);
-  for (let attempt = 1; attempt < HARVEST_RETRIES; attempt += 1) {
-    // Retry on docker-side transient failures and on
-    // "No such file" (the typical "wrapper not finished" symptom).
-    if (last.code === 0) return last;
-    if (/No such file or directory/i.test(last.stderr) || last.code === 1) {
-      await new Promise((r) => setTimeout(r, HARVEST_BACKOFF_MS * attempt));
-      last = await execDockerCp(args);
-      continue;
-    }
-    break;
-  }
-  return last;
 }
 
 async function chmodTreeBestEffort(root: string, fileMode: number, dirMode: number): Promise<void> {
@@ -165,11 +143,10 @@ export async function harvestSession(opts: HarvestOptions, sessionId: string): P
   // copies the source directory itself into dest, producing
   // dest/<session_id>/... which would nest one level too deep.
   const src = `${containerCapturesRoot}/${tid}/${sessionId}/.`;
-  const cpResult = await dockerCpWithRetry([
-    'cp',
-    `${opts.containerName}:${src}`,
-    destDir,
-  ]);
+  const cpResult = await execDockerCp(
+    ['cp', `${opts.containerName}:${src}`, destDir],
+    env,
+  );
   // Track whether the per-session subtree was actually copied — even
   // on a "not found" no-op, we still want to attempt the global
   // captures harvest below (codex cycle 2 finding-6).
@@ -213,11 +190,14 @@ export async function harvestSession(opts: HarvestOptions, sessionId: string): P
   }
   for (const globalSub of ['_audit', '_proc-acct']) {
     const globalSrc = `${containerCapturesRoot}/${globalSub}/.`;
-    const gRes = await dockerCpWithRetry([
-      'cp',
-      `${opts.containerName}:${globalSrc}`,
-      join(globalDest, globalSub.replace(/^_/, '')),
-    ]);
+    const gRes = await execDockerCp(
+      [
+        'cp',
+        `${opts.containerName}:${globalSrc}`,
+        join(globalDest, globalSub.replace(/^_/, '')),
+      ],
+      env,
+    );
     if (gRes.code !== 0 && !/No such file or directory/i.test(gRes.stderr)) {
       console.error(
         `[captures] global ${globalSub} harvest failed (rc=${gRes.code}):`,

--- a/mcp/aptl-mcp-common/src/ssh.ts
+++ b/mcp/aptl-mcp-common/src/ssh.ts
@@ -55,6 +55,12 @@ const TIMEOUTS = {
   KEEP_ALIVE_INTERVAL: 30000,
   FORCE_CLOSE: 3000,
   SESSION_CLOSE: 5000,
+  // #304: close() awaits the SSH stream's remote 'close' event before
+  // returning so harvest does not race the wrapper's EXIT trap. If the
+  // remote never fires close (channel torn down forcibly, ssh2 bug),
+  // we log a [SSH] warning and return anyway — local cleanup is already
+  // verified, so the manager's bookkeeping is unaffected.
+  REMOTE_CLOSE_AWAIT: 3000,
 } as const;
 
 const BUFFER_LIMITS = {
@@ -73,6 +79,13 @@ export interface CommandResult {
   stderr: string;
   code: number | null;
   signal: string | null;
+  /**
+   * Effective execution mode for this command (#282). `raw` carries the
+   * unknown-outcome signal — observability layers (mcp-red OCSF emitter,
+   * tool-call JSONL) consume this rather than guessing from `args.raw`,
+   * which misses inherited-raw sessions whose command omitted the override.
+   */
+  mode: SessionMode;
 }
 
 export class SSHError extends Error {
@@ -139,6 +152,14 @@ export class PersistentSession extends EventEmitter {
   // emit 'close' arbitrarily later. (Codex pre-push cycle 3, ADR-004.)
   private cleanupVerified = false;
   private closedEmitted = false;
+  // #304: latched promise that resolves when the SSH stream's remote
+  // 'close' event fires. close() awaits this before returning so the
+  // post-close harvest does not race the kali wrapper's EXIT trap.
+  // Built once in initialize() and never replaced — re-binding it would
+  // break the "stream-driven close (unsolicited)" path that relies on a
+  // single resolver.
+  private remoteClosed: Promise<void> = Promise.resolve();
+  private resolveRemoteClosed: () => void = () => {};
 
   // Stored alongside the formatter so it's externally inspectable
   // (test-quality review cycle 1 finding-2/3/4 — the shellType
@@ -235,6 +256,12 @@ export class PersistentSession extends EventEmitter {
       this.boundRunId = shellEnv.APTL_RUN_ID;
       this.ptyTee = createPtyTeeWriter(this.sessionInfo.sessionId);
 
+      // #304: rebuild the remote-closed latch for THIS session's shell. A
+      // fresh promise is needed once we have an actual stream so close() can
+      // await the remote shutdown rather than returning the moment the local
+      // cleanup completes.
+      this.remoteClosed = new Promise((res) => { this.resolveRemoteClosed = res; });
+
       this.client.shell({ env: shellEnv }, (err, stream) => {
         if (err) {
           settleReject(new SSHError(`Failed to create shell: ${err.message}`, err));
@@ -257,6 +284,10 @@ export class PersistentSession extends EventEmitter {
 
         stream.on('close', () => {
           this.sessionInfo.isActive = false;
+          // #304: signal the remote-close latch so any in-flight close()
+          // call can return. Idempotent — Promise resolvers ignore second
+          // calls.
+          this.resolveRemoteClosed();
           if (!initSettled) {
             // Shell died before initialize() resolved — reject so the
             // caller does not receive a session that's already gone.
@@ -328,7 +359,10 @@ export class PersistentSession extends EventEmitter {
         stdout: `Command '${command}' queued in background session '${this.sessionInfo.sessionId}'`,
         stderr: '',
         code: 0,
-        signal: null
+        signal: null,
+        // #282: even the immediate-return path carries effective mode so
+        // observability sees the same signal as the eventual completion.
+        mode: request.raw ? 'raw' : 'normal',
       };
     }
 
@@ -379,7 +413,8 @@ export class PersistentSession extends EventEmitter {
               stdout: output,
               stderr: '',
               code: 0, // Unknown in raw mode
-              signal: null
+              signal: null,
+              mode: 'raw',
             });
             this.currentCommand = null;
             this.processNextCommand();
@@ -469,7 +504,8 @@ export class PersistentSession extends EventEmitter {
           stdout: cleanOutput,
           stderr: '',
           code: exitCode,
-          signal: null
+          signal: null,
+          mode: 'normal',
         });
 
         this.currentCommand = null;
@@ -545,29 +581,67 @@ export class PersistentSession extends EventEmitter {
 
     this.sessionTimeout = setTimeout(() => {
       this.emit('timeout');
-      // Timer-callback path: close() asserts postconditions and would throw on
-      // a contract violation. An uncaught throw from a setTimeout callback
-      // crashes Node, so log loud here instead of propagating.
+      // Timer-callback path: close() asserts postconditions synchronously and
+      // would throw on a contract violation, then awaits remote close. An
+      // uncaught throw OR rejection from a setTimeout callback crashes Node,
+      // so we swallow both. The synchronous throw path is preserved via
+      // try/catch; the async-await path uses .catch().
       try {
-        this.close();
+        void this.close().catch((err) => {
+          console.error('[SSH] session timeout close failed:', err);
+        });
       } catch (err) {
         console.error('[SSH] session timeout close failed:', err);
       }
     }, this.sessionTimeoutMs);
   }
 
-  close(): void {
+  async close(): Promise<void> {
     this.doCleanup();
     if (this.shell) {
       this.shell.end();
     }
     // Run the postcondition before flipping cleanupVerified so a violation
     // cannot mark the session as cleanly torn down. If assertion throws,
-    // cleanupVerified stays false; emitClosedIfVerified refuses to fire;
-    // the manager catches the throw and routes failure through its reject
-    // path. (Codex pre-push cycle 3 finding-2 + finding-3.)
+    // cleanupVerified stays false; the manager catches the throw and routes
+    // failure through its reject path. (Codex pre-push cycle 3 finding-2 +
+    // finding-3.)
     this.assertCleanupInvariants();
     this.cleanupVerified = true;
+
+    // #304 + codex review (class-finding): emitClosedIfVerified() does NOT
+    // run yet. The 'closed' event's contract is "local cleanup verified AND
+    // remote close observed or bounded timeout fired" — the manager's
+    // session-map drop must not happen while the kali wrapper's EXIT trap
+    // could still be flushing tcpdump / typescript. The stream.on('close')
+    // handler's cleanup() will emit 'closed' synchronously if the remote
+    // fires close during this await; we cover the timeout case explicitly
+    // below. The closedEmitted latch keeps emission single-shot regardless
+    // of which path wins.
+    await new Promise<void>((res) => {
+      let settled = false;
+      const settle = (timedOut: boolean): void => {
+        if (settled) return;
+        settled = true;
+        if (timedOut) {
+          console.error(
+            `[SSH] remote close timeout for session ${this.sessionInfo.sessionId}; ` +
+              'kali-side capture may be partial. MCP-side captures remain authoritative.',
+          );
+        }
+        clearTimeout(timer);
+        res();
+      };
+      const timer = setTimeout(() => settle(true), TIMEOUTS.REMOTE_CLOSE_AWAIT);
+      this.remoteClosed.then(() => settle(false));
+    });
+
+    // Now safe to signal 'closed' to the manager. If stream.on('close')
+    // already ran cleanup() during the await, emitClosedIfVerified() is a
+    // no-op via the closedEmitted latch. If we reached here via the
+    // bounded timeout, this is the only emission path — the manager
+    // releases the session id only after the wrapper's flush window has
+    // either completed or expired.
     this.emitClosedIfVerified();
   }
 
@@ -704,7 +778,9 @@ export class SSHConnectionManager {
         stream.on('close', (code: number | null, signal: string | null) => {
           clearTimeout(timeoutId);
           if (!hasTimedOut) {
-            resolve({ stdout, stderr, code, signal, sessionId });
+            // One-shot exec has no session-level mode; the wrapping always
+            // emits a real exit code so the effective mode is 'normal'.
+            resolve({ stdout, stderr, code, signal, sessionId, mode: 'normal' });
           }
         });
 
@@ -920,13 +996,14 @@ export class SSHConnectionManager {
       return false;
     }
 
-    // close() is synchronous: it runs cleanup + postcondition synchronously
-    // and either emits 'closed' (success) or throws (postcondition violation).
-    // No need to register an event listener and race against a force-close
-    // timer — both would risk firing inside an async callback where a
-    // contract throw becomes an uncaught exception. (Codex cycle 3 finding-3.)
+    // close() runs cleanup + postcondition synchronously (so in-flight /
+    // queued command promises reject immediately), then awaits the remote
+    // SSH channel close so the post-close harvest cannot race the kali
+    // wrapper's EXIT trap (#304). A postcondition violation throws
+    // synchronously and surfaces here as an awaited rejection; the catch
+    // handles both shapes via the standard rejection path.
     try {
-      session.close();
+      await session.close();
       // 'closed' listener installed in createSession already removed the
       // session synchronously; this delete + ensure is a belt-and-braces
       // postcondition check from the manager-side.
@@ -1025,16 +1102,35 @@ export class SSHConnectionManager {
       });
     };
 
-    const sessionPromises: Array<Promise<TeardownResult>> = Array.from(this.sessions.values()).map(session =>
-      teardown(() => session.close(), session, 'closed')
-    );
+    // Sessions: await close() directly (#304). close() resolves after the
+    // remote SSH channel has actually closed or the bounded timeout fires,
+    // so we no longer need the event-listener race against the SESSION_CLOSE
+    // force-close timer. A throw from the synchronous postcondition stage
+    // surfaces here as a rejection and is captured as TeardownResult.error.
+    const sessionPromises: Array<Promise<TeardownResult>> = Array.from(this.sessions.values()).map(async (session) => {
+      try {
+        await session.close();
+        return { ok: true } as TeardownResult;
+      } catch (err) {
+        return { ok: false, error: err } as TeardownResult;
+      }
+    });
+
+    // #304 + codex review (class-finding): wait for every session's
+    // close() promise to settle BEFORE tearing down the parent SSH
+    // transport. Otherwise client.end() can begin while sessions are
+    // still draining their channels — exactly the race close()
+    // already closes per-session. The connections teardown happens in
+    // a second phase below.
+    const sessionResults = await Promise.all(sessionPromises);
 
     const connectionPromises: Array<Promise<TeardownResult>> = Array.from(this.connections.values()).map(connInfo => {
       if (!connInfo.connected) return Promise.resolve({ ok: true } as TeardownResult);
       return teardown(() => connInfo.client.end(), connInfo.client, 'close');
     });
 
-    const results = await Promise.all([...sessionPromises, ...connectionPromises]);
+    const connectionResults = await Promise.all(connectionPromises);
+    const results = [...sessionResults, ...connectionResults];
     const failures = results.filter((r): r is { ok: false; error: unknown } => r.ok === false);
 
     this.sessions.clear();

--- a/mcp/aptl-mcp-common/src/ssh.ts
+++ b/mcp/aptl-mcp-common/src/ssh.ts
@@ -581,18 +581,13 @@ export class PersistentSession extends EventEmitter {
 
     this.sessionTimeout = setTimeout(() => {
       this.emit('timeout');
-      // Timer-callback path: close() asserts postconditions synchronously and
-      // would throw on a contract violation, then awaits remote close. An
-      // uncaught throw OR rejection from a setTimeout callback crashes Node,
-      // so we swallow both. The synchronous throw path is preserved via
-      // try/catch; the async-await path uses .catch().
-      try {
-        void this.close().catch((err) => {
-          console.error('[SSH] session timeout close failed:', err);
-        });
-      } catch (err) {
+      // Timer-callback path: close() is async, so every failure path —
+      // including the synchronous postcondition throw — surfaces as a
+      // rejection on the returned promise. Catch that to keep timer
+      // callbacks crash-safe under Node.
+      void this.close().catch((err) => {
         console.error('[SSH] session timeout close failed:', err);
-      }
+      });
     }, this.sessionTimeoutMs);
   }
 
@@ -1110,9 +1105,9 @@ export class SSHConnectionManager {
     const sessionPromises: Array<Promise<TeardownResult>> = Array.from(this.sessions.values()).map(async (session) => {
       try {
         await session.close();
-        return { ok: true } as TeardownResult;
+        return { ok: true as const };
       } catch (err) {
-        return { ok: false, error: err } as TeardownResult;
+        return { ok: false as const, error: err };
       }
     });
 

--- a/mcp/aptl-mcp-common/src/tools/definitions.ts
+++ b/mcp/aptl-mcp-common/src/tools/definitions.ts
@@ -117,8 +117,14 @@ export function generateToolDefinitions(serverConfig: LabConfig['server']): Tool
         },
         raw: {
           type: 'boolean',
-          description: 'Execute in raw mode (no echo wrapping, for interactive programs). Defaults to session mode',
-          default: false,
+          description: 'Execute in raw mode (no echo wrapping, for interactive programs). Omit to inherit the session mode set at creation time; supplying false explicitly is an explicit override of an inherited-raw session.',
+          // #282 + codex review: NO default here. A schema default of
+          // `false` causes generated clients (which materialize defaults)
+          // to send `raw: false`, which the handler interprets as an
+          // explicit normal-mode override and runs the command in normal
+          // mode on an inherited-raw session — the exact bug #282 fixes
+          // gone in a different shape. Omitting the field is the only
+          // signal that means "use session default".
         },
       },
       required: ['session_id', 'command'],

--- a/mcp/aptl-mcp-common/src/tools/handlers.ts
+++ b/mcp/aptl-mcp-common/src/tools/handlers.ts
@@ -375,6 +375,11 @@ const baseHandlers: Record<string, ToolHandler> = {
               output: result.stdout,
               stderr: result.stderr,
               exit_code: result.code,
+              // #282: surface the EFFECTIVE mode (per-call override OR
+              // inherited session default) so downstream observability
+              // can distinguish raw (unknown-outcome) from normal even
+              // when args.raw was omitted.
+              session_mode: result.mode,
             }, null, 2),
           },
         ],

--- a/mcp/aptl-mcp-common/tests/captures.test.ts
+++ b/mcp/aptl-mcp-common/tests/captures.test.ts
@@ -32,18 +32,27 @@ interface SpawnControl {
   exitCode: number;
   stderrText: string;
   capturedArgs: string[][];
+  capturedCmds: string[];
   callCount: number;
 }
 const spawnControl: SpawnControl = {
   exitCode: 0,
   stderrText: '',
   capturedArgs: [],
+  capturedCmds: [],
   callCount: 0,
 };
 
 vi.mock('node:child_process', () => ({
-  spawn: (_cmd: string, args: string[]) => {
+  spawn: (cmd: string, args: string[]) => {
     spawnControl.callCount += 1;
+    // Test-quality review cycle 1 T-001/T-002: capture the spawned
+    // binary path so SonarCloud S4036 hardening (the "no PATH lookup"
+    // contract) is actually pinned. Previously the mock discarded
+    // `_cmd`, so both `dockerBin()` regressions (default-vs-override)
+    // and "harvest stopped using docker at all" regressions would
+    // pass vacuously.
+    spawnControl.capturedCmds.push(cmd);
     spawnControl.capturedArgs.push(args);
     const stdout = new EventEmitter();
     const stderr = new EventEmitter();
@@ -72,6 +81,7 @@ beforeEach(() => {
   spawnControl.exitCode = 0;
   spawnControl.stderrText = '';
   spawnControl.capturedArgs = [];
+  spawnControl.capturedCmds = [];
   spawnControl.callCount = 0;
 });
 afterEach(() => {
@@ -172,14 +182,35 @@ describe('harvestSession', () => {
       'sess-1',
     );
 
-    // 3 attempts (per-session + 2 globals), each retried up to 3
-    // times under the retry-with-backoff helper (cycle 2 finding-2).
-    // We don't pin the exact count — the assertion is that the
-    // global attempts happen at all, i.e. > 1 spawn call.
-    expect(spawnControl.callCount).toBeGreaterThan(1);
+    // #304: retry helper removed — remote close is now awaited in
+    // PersistentSession.close before harvest runs, so the 250ms x 3
+    // backoff window is no longer needed. Exactly 3 docker cp calls:
+    // 1 per-session + 2 globals (_audit, _proc-acct), no retries.
+    expect(spawnControl.callCount).toBe(3);
     const globalSrcs = spawnControl.capturedArgs.map((args) => args[1]);
     expect(globalSrcs.some((s) => s.endsWith('_audit/.'))).toBe(true);
     expect(globalSrcs.some((s) => s.endsWith('_proc-acct/.'))).toBe(true);
+  });
+
+  it("#304: per-session docker cp failure invokes spawn exactly once (no retry-with-backoff)", async () => {
+    const tid = 'a'.repeat(32);
+    activateScenario(tid);
+    spawnControl.exitCode = 1;
+    spawnControl.stderrText = 'Error: No such file or directory';
+
+    await harvestSession(
+      { containerName: 'aptl-kali', env: { APTL_STATE_DIR: tmp } },
+      'sess-1',
+    );
+
+    // First call is the per-session attempt; the next two are globals.
+    // With the retry helper removed, the per-session "no such file"
+    // failure is NOT retried — it fails fast and harvest moves on.
+    const perSessionSrc = `aptl-kali:/var/log/aptl/captures/${tid}/sess-1/.`;
+    const perSessionCalls = spawnControl.capturedArgs.filter(
+      (args) => args[1] === perSessionSrc,
+    );
+    expect(perSessionCalls.length).toBe(1);
   });
 
   it('returns false on real docker cp failure but does not throw', async () => {
@@ -267,32 +298,44 @@ describe('captures: docker binary resolution', () => {
     spawnControl.exitCode = 0;
     spawnControl.stderrText = '';
     spawnControl.capturedArgs = [];
+    spawnControl.capturedCmds = [];
   });
 
   it('defaults to /usr/bin/docker (no PATH lookup)', async () => {
-    // Even without APTL_DOCKER_BIN set, spawn target should be the
-    // absolute path so PATH-injection cannot redirect to a hostile
-    // binary (SonarCloud hotspot S4036). We can't directly inspect
-    // the spawned command name in our mock (we capture args, not
-    // the executable), so this test acts as a smoke check that the
-    // harvest path completes with default env.
-    const ok = await harvestSession(
+    // Without APTL_DOCKER_BIN set, the spawned binary must be the
+    // absolute /usr/bin/docker so PATH-injection cannot redirect to
+    // a hostile binary (SonarCloud hotspot S4036). Test-quality
+    // review cycle 1 T-001: the mock now captures the spawned cmd
+    // (previously discarded), so a regression in `dockerBin()` —
+    // e.g., returning plain `'docker'` — fails this test.
+    await harvestSession(
       { containerName: 'aptl-kali', env: { APTL_STATE_DIR: tmp } },
       'sess-bin',
     );
-    expect(typeof ok).toBe('boolean');
     expect(spawnControl.callCount).toBeGreaterThan(0);
+    expect(spawnControl.capturedCmds[0]).toBe('/usr/bin/docker');
+    // Every subsequent spawn (globals harvest) must use the same path.
+    for (const cmd of spawnControl.capturedCmds) {
+      expect(cmd).toBe('/usr/bin/docker');
+    }
   });
 
   it('honours APTL_DOCKER_BIN override', async () => {
-    const ok = await harvestSession(
+    // Test-quality review cycle 1 T-002: previously this test could
+    // not observe whether APTL_DOCKER_BIN was actually consumed —
+    // the mock discarded `_cmd`. With cmd capture in place, a
+    // regression that ignores the env override fails this test.
+    await harvestSession(
       {
         containerName: 'aptl-kali',
         env: { APTL_STATE_DIR: tmp, APTL_DOCKER_BIN: '/opt/docker/bin/docker' },
       },
       'sess-bin',
     );
-    expect(typeof ok).toBe('boolean');
     expect(spawnControl.callCount).toBeGreaterThan(0);
+    expect(spawnControl.capturedCmds[0]).toBe('/opt/docker/bin/docker');
+    for (const cmd of spawnControl.capturedCmds) {
+      expect(cmd).toBe('/opt/docker/bin/docker');
+    }
   });
 });

--- a/mcp/aptl-mcp-common/tests/ssh.test.ts
+++ b/mcp/aptl-mcp-common/tests/ssh.test.ts
@@ -764,17 +764,21 @@ describe('Contract guards (postconditions)', () => {
     }
   });
 
-  it('timer-callback close path swallows postcondition violations and logs', () => {
+  it('timer-callback close path swallows postcondition rejections and logs', async () => {
     // Same defensive contract for the resetSessionTimeout timer callback — an
-    // uncaught throw from setTimeout crashes Node. We stub close() to throw and
-    // verify the timer-callback try/catch catches it.
+    // uncaught rejection from setTimeout crashes Node. After #304, close() is
+    // async so failures always surface as promise rejections; the timer
+    // callback's `void this.close().catch(...)` swallows them. Stub close to
+    // return a rejecting promise and verify the catch handler logs.
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const originalClose = session.close.bind(session);
-    session.close = () => { throw new SSHError('[contract] simulated close failure'); };
+    session.close = async () => {
+      throw new SSHError('[contract] simulated close failure');
+    };
     try {
       // Advance the timer to fire the session-timeout callback.
       // sessionTimeoutMs is 600000 (set in beforeEach).
-      vi.advanceTimersByTime(600000);
+      await vi.advanceTimersByTimeAsync(600000);
 
       const matched = errorSpy.mock.calls.some(call =>
         typeof call[0] === 'string' && call[0].includes('[SSH] session timeout close failed')

--- a/mcp/aptl-mcp-common/tests/ssh.test.ts
+++ b/mcp/aptl-mcp-common/tests/ssh.test.ts
@@ -231,11 +231,14 @@ describe('Shell Type Support', () => {
     expect(session.getShellType()).toBe('bash');
   });
 
-  it('should create sessions with specified shell types', () => {
-    const mockClient = {} as any;
-    const shellTypes: ShellType[] = ['bash', 'sh', 'powershell', 'cmd'];
-
-    shellTypes.forEach(shellType => {
+  // Test-quality review cycle 1 T-004: split the previous forEach loop
+  // into one named test per shell type so a regression affecting only
+  // one type points at that type in the failure output, not at an
+  // anonymous loop iteration.
+  it.each<ShellType>(['bash', 'sh', 'powershell', 'cmd'])(
+    'should create session with %s shell type',
+    (shellType) => {
+      const mockClient = {} as any;
       const session = new PersistentSession(
         `test-${shellType}`,
         'test-host',
@@ -245,7 +248,7 @@ describe('Shell Type Support', () => {
         22,
         'normal',
         60000,
-        shellType
+        shellType,
       );
 
       const info = session.getSessionInfo();
@@ -254,49 +257,60 @@ describe('Shell Type Support', () => {
       // this, a regression that discarded the parameter would still
       // produce a passing test (test-quality review cycle 1 finding-3).
       expect(session.getShellType()).toBe(shellType);
-    });
-  });
+    },
+  );
 
   it('should track shell type through session lifecycle', async () => {
-    const mockClient = {
-      shell: vi.fn((_opts: any, callback: any) => {
-        // Mock shell stream
-        const mockStream = {
-          on: vi.fn(),
-          stderr: { on: vi.fn() },
-          write: vi.fn(),
-          end: vi.fn()
-        };
-        callback(null, mockStream);
-        return mockStream;
-      })
-    } as any;
+    // Test-quality review cycle 1 T-003: PR #304 made
+    // PersistentSession.close() async. The previous unawaited
+    // close() left a 3-second remote-close-await timer hanging
+    // after the test returned. Use a real EventEmitter for the
+    // stream so we can emit 'close' deterministically and await
+    // the close promise cleanly.
+    vi.useFakeTimers();
+    try {
+      const mockStream = Object.assign(new EventEmitter(), {
+        write: vi.fn(),
+        end: vi.fn(() => mockStream.emit('close')),
+        stderr: new EventEmitter(),
+      });
+      const mockClient = {
+        shell: vi.fn((_opts: any, callback: any) => {
+          callback(null, mockStream);
+          return mockStream;
+        })
+      } as any;
 
-    const powershellSession = new PersistentSession(
-      'ps-test',
-      'windows-host',
-      'Administrator',
-      'interactive',
-      mockClient,
-      22,
-      'normal',
-      60000,
-      'powershell'
-    );
+      const powershellSession = new PersistentSession(
+        'ps-test',
+        'windows-host',
+        'Administrator',
+        'interactive',
+        mockClient,
+        22,
+        'normal',
+        60000,
+        'powershell'
+      );
 
-    // Initialize the session
-    await powershellSession.initialize();
-    const info = powershellSession.getSessionInfo();
-    expect(info.sessionId).toBe('ps-test');
-    expect(info.target).toBe('windows-host');
-    expect(info.username).toBe('Administrator');
-    // The shellType must survive initialize() — without this
-    // assertion, a regression where initialize() silently switched
-    // back to bash would still pass (test-quality review cycle 1
-    // finding-4).
-    expect(powershellSession.getShellType()).toBe('powershell');
+      const initP = powershellSession.initialize();
+      await vi.advanceTimersByTimeAsync(1000);
+      await initP;
 
-    powershellSession.close();
+      const info = powershellSession.getSessionInfo();
+      expect(info.sessionId).toBe('ps-test');
+      expect(info.target).toBe('windows-host');
+      expect(info.username).toBe('Administrator');
+      // The shellType must survive initialize() — without this
+      // assertion, a regression where initialize() silently switched
+      // back to bash would still pass (test-quality review cycle 1
+      // finding-4).
+      expect(powershellSession.getShellType()).toBe('powershell');
+
+      await powershellSession.close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -982,7 +996,10 @@ describe('Contract guards (event ordering & concurrency)', () => {
       const onClosed = vi.fn();
       session.on('closed', onClosed);
 
-      expect(() => session.close()).toThrow(/simulated late violation/);
+      // close() is async (#304): the assertCleanupInvariants throw surfaces
+      // as the returned promise's rejection. The 'closed' invariant — never
+      // fired when the postcondition violated — is unchanged.
+      await expect(session.close()).rejects.toThrow(/simulated late violation/);
       expect(onClosed).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
@@ -1175,14 +1192,17 @@ describe('Contract guards (lifecycle correctness — cycle 3)', () => {
   });
 
   it("'closed' is emitted at most once even when shell.end() emits stream-close after close()", async () => {
-    // Codex cycle-3 finding-2: closedEmitted latch must prevent a double-emit
-    // when close() succeeded and then the underlying stream's 'close' event
-    // fires again later (async ssh2 channel behavior). Without the latch, a
-    // listener that resubscribes (e.g. test isolation) could see two events.
+    // Codex cycle-3 finding-2 + #304 codex review (class-finding): the
+    // closedEmitted latch must prevent a double-emit when close()'s
+    // remote-close await resolves AND a subsequent stream-close event
+    // re-runs cleanup(). After the #304 fix, close() defers emitting
+    // 'closed' until AFTER the remote-close latch resolves (or the
+    // bounded timeout fires), so this test now stages the events in
+    // that order: explicit stream emit → close() promise resolves
+    // (and emits 'closed' via the latch's first winner) → second
+    // stream emit must be a no-op.
     vi.useFakeTimers();
     try {
-      // mockStream where end() does NOT immediately emit close; we'll fire
-      // close manually AFTER close() has returned.
       const mockStream = Object.assign(new EventEmitter(), {
         write: vi.fn(),
         end: vi.fn(),
@@ -1199,12 +1219,22 @@ describe('Contract guards (lifecycle correctness — cycle 3)', () => {
       const onClosed = vi.fn();
       session.on('closed', onClosed);
 
-      session.close();
-      // close() should have emitted 'closed' synchronously after assertion.
+      const closeP = session.close();
+      // Before the remote 'close' fires, 'closed' has NOT been emitted —
+      // the #304 fix guarantees the manager's session-id drop happens
+      // only after the wrapper's flush window completes.
+      await Promise.resolve();
+      expect(onClosed).toHaveBeenCalledTimes(0);
+
+      // First stream-close: stream.on('close') handler fires cleanup()
+      // → emitClosedIfVerified emits 'closed' AND resolveRemoteClosed
+      // unblocks the close() await.
+      mockStream.emit('close');
+      await closeP;
       expect(onClosed).toHaveBeenCalledTimes(1);
 
-      // Now the stream fires its delayed 'close' event. The latch must
-      // suppress a second 'closed' emission.
+      // A second stream emit (delayed async ssh2 behavior) must be
+      // a no-op via the closedEmitted latch.
       mockStream.emit('close');
       expect(onClosed).toHaveBeenCalledTimes(1);
     } finally {
@@ -1334,5 +1364,358 @@ describe('Contract guards (lifecycle correctness — cycle 3)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// Helper for the effective-mode + awaitable-close suites below. Driving a
+// command-and-response through the mock shell is identical in every test —
+// extract it so each `it` block reads as "construct → drive → assert".
+async function driveCommand(
+  session: PersistentSession,
+  mockStream: EventEmitter & { write: ReturnType<typeof vi.fn> },
+  command: string,
+  output: string,
+  exitCode: number,
+  raw?: boolean,
+): Promise<import('../src/ssh.js').CommandResult> {
+  const promise = session.executeCommand(command, 60000, raw);
+  // For normal-mode commands the parser keys on the delimiter; for raw-mode
+  // commands the timeout resolves with collected output.
+  const delimiter = (session as any).commandDelimiter;
+  const cmdId = (session as any).currentCommand?.id;
+  if (raw === true || (raw === undefined && session.getSessionInfo().mode === 'raw')) {
+    // Raw path: deliver output then advance past the per-command timeout.
+    mockStream.emit('data', Buffer.from(output));
+    await vi.advanceTimersByTimeAsync(60000);
+  } else {
+    const startMarker = `${delimiter}_START_${cmdId}`;
+    const endMarker = `${delimiter}_END_${cmdId}`;
+    mockStream.emit('data', Buffer.from(`${startMarker}\n${output}\n${endMarker}:${exitCode}\n`));
+  }
+  return promise;
+}
+
+describe('OBS-003 / #282: effective session-mode metadata in CommandResult', () => {
+  let mockStream: EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn>; stderr: EventEmitter };
+  let mockClient: any;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    mockStream = Object.assign(new EventEmitter(), {
+      write: vi.fn(),
+      end: vi.fn(),
+      stderr: new EventEmitter(),
+    });
+    mockClient = { shell: vi.fn((_opts: any, cb: any) => cb(null, mockStream)) };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("executeCommand on a normal session with no override resolves with mode: 'normal'", async () => {
+    const session = new PersistentSession('em-1', 'h', 'u', 'interactive', mockClient, 22, 'normal', 600000);
+    const initP = session.initialize();
+    await vi.advanceTimersByTimeAsync(1000);
+    await initP;
+
+    const result = await driveCommand(session, mockStream, 'echo hi', 'hi', 0);
+    expect(result.mode).toBe('normal');
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('hi');
+  });
+
+  it("executeCommand on a RAW session with no override resolves with mode: 'raw' (the inherited-raw case from issue #282)", async () => {
+    const session = new PersistentSession('em-2', 'h', 'u', 'background', mockClient, 22, 'raw', 600000);
+    const initP = session.initialize();
+    await vi.advanceTimersByTimeAsync(1000);
+    await initP;
+
+    const result = await driveCommand(session, mockStream, 'msfconsole', 'msf6 >', 0);
+    expect(result.mode).toBe('raw');
+    // raw mode resolves with code 0 by design, but `mode` carries the
+    // unknown-outcome signal that downstream observability consumes.
+    expect(result.code).toBe(0);
+  });
+
+  it("per-call raw: true override on a normal session resolves with mode: 'raw'", async () => {
+    const session = new PersistentSession('em-3', 'h', 'u', 'interactive', mockClient, 22, 'normal', 600000);
+    const initP = session.initialize();
+    await vi.advanceTimersByTimeAsync(1000);
+    await initP;
+
+    const result = await driveCommand(session, mockStream, 'something', 'out', 0, true);
+    expect(result.mode).toBe('raw');
+  });
+
+  it("per-call raw: false override on a RAW session resolves with mode: 'normal'", async () => {
+    const session = new PersistentSession('em-4', 'h', 'u', 'interactive', mockClient, 22, 'raw', 600000);
+    const initP = session.initialize();
+    await vi.advanceTimersByTimeAsync(1000);
+    await initP;
+
+    const result = await driveCommand(session, mockStream, 'echo hi', 'hi', 0, false);
+    expect(result.mode).toBe('normal');
+  });
+
+  it("background-session immediate-return envelope carries effective mode (inherited raw)", async () => {
+    const session = new PersistentSession('em-5', 'h', 'u', 'background', mockClient, 22, 'raw', 600000);
+    const initP = session.initialize();
+    await vi.advanceTimersByTimeAsync(1000);
+    await initP;
+
+    // Background sessions resolve immediately with a queued envelope; no
+    // delimiter dance, no advanceTimers needed.
+    const result = await session.executeCommand('long-running', 60000);
+    expect(result.mode).toBe('raw');
+    // The queued-envelope contract from ssh.ts: stdout describes the queue,
+    // code is 0. The new `mode` field reflects the effective mode at queue time.
+    expect(result.stdout).toContain('queued in background');
+  });
+});
+
+describe('#304: PersistentSession.close() awaits remote stream-close', () => {
+  let mockStream: EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn>; stderr: EventEmitter };
+  let mockClient: any;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    mockStream = Object.assign(new EventEmitter(), {
+      write: vi.fn(),
+      end: vi.fn(), // does NOT auto-emit 'close' — tests drive it manually
+      stderr: new EventEmitter(),
+    });
+    mockClient = { shell: vi.fn((_opts: any, cb: any) => cb(null, mockStream)) };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("close() returns a Promise that resolves only after the stream's 'close' event fires", async () => {
+    const session = new PersistentSession('aw-1', 'h', 'u', 'interactive', mockClient, 22, 'normal', 600000);
+    const initP = session.initialize();
+    await vi.advanceTimersByTimeAsync(1000);
+    await initP;
+
+    const closeP = session.close();
+    let resolved = false;
+    closeP.then(() => { resolved = true; });
+
+    // Microtask drain — local cleanup is sync, but the close promise must
+    // still be pending because remote 'close' has not fired.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    // Fire the remote close; close() resolves.
+    mockStream.emit('close');
+    await closeP;
+    expect(resolved).toBe(true);
+  });
+
+  it("close() resolves after the bounded timeout when stream 'close' never fires, and logs a [SSH] warning", async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const session = new PersistentSession('aw-2', 'h', 'u', 'interactive', mockClient, 22, 'normal', 600000);
+      const initP = session.initialize();
+      await vi.advanceTimersByTimeAsync(1000);
+      await initP;
+
+      const closeP = session.close();
+      let resolved = false;
+      closeP.then(() => { resolved = true; });
+
+      // Just shy of the timeout — promise is still pending.
+      await vi.advanceTimersByTimeAsync(2999);
+      expect(resolved).toBe(false);
+
+      // Past the timeout — promise resolves.
+      await vi.advanceTimersByTimeAsync(2);
+      await closeP;
+      expect(resolved).toBe(true);
+
+      const matched = errorSpy.mock.calls.some(call =>
+        typeof call[0] === 'string' && call[0].includes('[SSH] remote close timeout')
+      );
+      expect(matched).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("in-flight and queued command rejections happen BEFORE close()'s remote-await resolves", async () => {
+    const session = new PersistentSession('aw-3', 'h', 'u', 'interactive', mockClient, 22, 'normal', 600000);
+    const initP = session.initialize();
+    await vi.advanceTimersByTimeAsync(1000);
+    await initP;
+
+    const inFlight = session.executeCommand('p1', 60000);
+    const queued1 = session.executeCommand('p2', 60000);
+    const queued2 = session.executeCommand('p3', 60000);
+
+    // Capture order: rejections must settle before closeP — observable via the
+    // microtask queue. Track resolution order with timestamps.
+    const events: string[] = [];
+    inFlight.catch(() => events.push('inFlight'));
+    queued1.catch(() => events.push('queued1'));
+    queued2.catch(() => events.push('queued2'));
+
+    const closeP = session.close();
+    closeP.then(() => events.push('close'));
+
+    // Drain microtasks WITHOUT firing remote close yet — rejections should
+    // already have landed because cleanup runs synchronously inside close().
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(events).toContain('inFlight');
+    expect(events).toContain('queued1');
+    expect(events).toContain('queued2');
+    expect(events).not.toContain('close');
+
+    mockStream.emit('close');
+    await closeP;
+    expect(events[events.length - 1]).toBe('close');
+  });
+
+  it("SSHConnectionManager.closeSession() awaits the remote close before returning", async () => {
+    const manager = new SSHConnectionManager();
+    (manager as any).getConnection = vi.fn().mockResolvedValue(mockClient);
+
+    const createP = manager.createSession('aw-mgr', 'h', 'u', 'interactive', '/k', 22, 'normal', 600000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await createP;
+
+    let resolved = false;
+    const closeP = manager.closeSession('aw-mgr').then(v => { resolved = true; return v; });
+
+    // Microtask drain — manager promise should NOT resolve before remote close.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    mockStream.emit('close');
+    const result = await closeP;
+    expect(result).toBe(true);
+    expect(resolved).toBe(true);
+  });
+
+  it("close() does NOT emit 'closed' before the remote-close await settles (the manager must not release the id while captures are still flushing)", async () => {
+    // Codex pre-push review (class-finding): emitClosedIfVerified must run
+    // AFTER the bounded remote-close await, otherwise a concurrent caller
+    // can re-create the same session id while the old wrapper's EXIT trap
+    // is still flushing tcpdump / typescript captures.
+    const session = new PersistentSession('order-1', 'h', 'u', 'interactive', mockClient, 22, 'normal', 600000);
+    const initP = session.initialize();
+    await vi.advanceTimersByTimeAsync(1000);
+    await initP;
+
+    const onClosed = vi.fn();
+    session.on('closed', onClosed);
+
+    const closeP = session.close();
+    // Several microtask ticks must NOT cause 'closed' to fire — the
+    // remote latch is unresolved and the timeout has not elapsed.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onClosed).toHaveBeenCalledTimes(0);
+
+    // Releasing the remote close lets close() finish; the 'closed'
+    // signal lands at that point, not before.
+    mockStream.emit('close');
+    await closeP;
+    expect(onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnectAll() awaits every session close BEFORE tearing down the parent SSH transport", async () => {
+    // Codex pre-push review (class-finding): client.end() must not fire
+    // while session.close() is still awaiting its remote close. Otherwise
+    // the parent transport drops while channels are still draining.
+    const manager = new SSHConnectionManager();
+
+    const streamA = Object.assign(new EventEmitter(), {
+      write: vi.fn(),
+      end: vi.fn(),
+      stderr: new EventEmitter(),
+    });
+    const clientEnd = vi.fn();
+    const sharedClient: any = Object.assign(new EventEmitter(), {
+      shell: vi.fn((_opts: any, cb: any) => cb(null, streamA)),
+      end: clientEnd,
+    });
+    (manager as any).getConnection = vi.fn().mockResolvedValue(sharedClient);
+    (manager as any).connections.set('u@h:22', { client: sharedClient, connected: true });
+
+    const createA = manager.createSession('a', 'h', 'u', 'interactive', '/k', 22, 'normal', 600000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await createA;
+
+    const disconnectP = manager.disconnectAll();
+    // client.end() MUST NOT have been called yet — sessions are still
+    // awaiting remote close. Drain several microtask ticks to confirm
+    // the ordering is not just "not yet" but "actively blocked on the
+    // session close phase".
+    for (let i = 0; i < 10; i += 1) await Promise.resolve();
+    expect(clientEnd).not.toHaveBeenCalled();
+
+    // Release the session's remote close. Session.close() now resolves
+    // and disconnectAll progresses to the connection teardown phase.
+    streamA.emit('close');
+    // Drain microtasks past session-close → teardown-helper listener
+    // registration. Only THEN can we emit the connection-close that
+    // settles teardown's `emitter.once('close', ...)`.
+    for (let i = 0; i < 20; i += 1) await Promise.resolve();
+    expect(clientEnd).toHaveBeenCalledTimes(1);
+    sharedClient.emit('close');
+    await disconnectP;
+  });
+
+  it("disconnectAll() awaits every session's remote close before clearing the map", async () => {
+    const manager = new SSHConnectionManager();
+
+    // Two separate mock streams so each session has its own close gate.
+    const streamA = Object.assign(new EventEmitter(), {
+      write: vi.fn(),
+      end: vi.fn(),
+      stderr: new EventEmitter(),
+    });
+    const streamB = Object.assign(new EventEmitter(), {
+      write: vi.fn(),
+      end: vi.fn(),
+      stderr: new EventEmitter(),
+    });
+    let i = 0;
+    const sharedClient: any = {
+      shell: vi.fn((_opts: any, cb: any) => {
+        cb(null, i === 0 ? streamA : streamB);
+        i += 1;
+      }),
+    };
+    (manager as any).getConnection = vi.fn().mockResolvedValue(sharedClient);
+
+    const createA = manager.createSession('a', 'h', 'u', 'interactive', '/k', 22, 'normal', 600000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await createA;
+    const createB = manager.createSession('b', 'h', 'u', 'interactive', '/k', 22, 'normal', 600000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await createB;
+
+    let resolved = false;
+    const disconnectP = manager.disconnectAll().then(() => { resolved = true; });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    streamA.emit('close');
+    await Promise.resolve();
+    expect(resolved).toBe(false); // B still pending
+
+    streamB.emit('close');
+    await disconnectP;
+    expect(resolved).toBe(true);
+    expect((manager as any).sessions.size).toBe(0);
   });
 });

--- a/mcp/aptl-mcp-common/tests/tools-handlers.test.ts
+++ b/mcp/aptl-mcp-common/tests/tools-handlers.test.ts
@@ -251,6 +251,57 @@ describe('close_session / close_all_sessions harvest behaviour', () => {
     expect(body.message).toContain('not found');
   });
 
+  it("session_command envelope carries session_mode reflecting effective mode (#282)", async () => {
+    const handlers = generateToolHandlers({
+      toolPrefix: 'test',
+      targetName: 'Test',
+      configKey: 'test-container',
+    });
+    // Session created raw, command without raw override → effective raw.
+    // The fake manager returns the CommandResult shape the real
+    // PersistentSession would produce.
+    const sshManager = {
+      executeInSession: vi.fn(async () => ({
+        stdout: 'msf6 >',
+        stderr: '',
+        code: 0,
+        signal: null,
+        mode: 'raw',
+      })),
+    } as any;
+    const result = await handlers['test_session_command'](
+      { session_id: 'inherited-raw', command: 'msfconsole' },
+      { sshManager, labConfig } as any,
+    );
+    const body = JSON.parse(result.content[0].text);
+    expect(body.success).toBe(true);
+    expect(body.session_mode).toBe('raw');
+    expect(body.exit_code).toBe(0);
+  });
+
+  it("session_command envelope reports session_mode='normal' for a normal-mode command", async () => {
+    const handlers = generateToolHandlers({
+      toolPrefix: 'test',
+      targetName: 'Test',
+      configKey: 'test-container',
+    });
+    const sshManager = {
+      executeInSession: vi.fn(async () => ({
+        stdout: 'hi',
+        stderr: '',
+        code: 0,
+        signal: null,
+        mode: 'normal',
+      })),
+    } as any;
+    const result = await handlers['test_session_command'](
+      { session_id: 's1', command: 'echo hi' },
+      { sshManager, labConfig } as any,
+    );
+    const body = JSON.parse(result.content[0].text);
+    expect(body.session_mode).toBe('normal');
+  });
+
   it('close_all_sessions reports session count', async () => {
     const handlers = generateToolHandlers({
       toolPrefix: 'test',

--- a/mcp/mcp-red/src/effective-mode.ts
+++ b/mcp/mcp-red/src/effective-mode.ts
@@ -1,0 +1,75 @@
+/**
+ * #282: detect whether a Kali tool call ran in effective raw mode so the
+ * OCSF emitter can flag the result as Unknown rather than trusting
+ * raw-mode `exit_code: 0`.
+ *
+ * The authoritative signal is `session_mode` in the `session_command`
+ * result envelope (added in aptl-mcp-common after #282). When that field
+ * is present, this helper consumes it; when it is missing (older common
+ * peer in a mixed-version dev tree), it falls back to `args.raw === true`.
+ * The fallback misses inherited-raw — the whole reason for #282 — so it is
+ * strictly a transitional shim, not a correctness substitute.
+ *
+ * Extracted from `index.ts` so the helper is unit-testable without
+ * spinning up the MCP server side effects index.ts performs at module
+ * load.
+ */
+
+import type { PostToolHookInfo } from 'aptl-mcp-common';
+
+/**
+ * Raw-mode override semantics: raw transport's `exit_code: 0` artifact is
+ * meaningless because the raw read times out, so the OCSF emitter must
+ * surface it as Unknown rather than Success. But the override applies ONLY
+ * to the transport "success-by-default" artifact, NOT to handler-level
+ * KNOWN failures: an MCP handler that returns `{success: false, error: ...}`
+ * (e.g., missing session, validation rejection, SSH layer throw) is a
+ * known failure even when the call ran in raw mode. The post-tool hook
+ * must record it as Failure, not Unknown.
+ *
+ * Codex pre-push review cycle 2 (post-#282 finding D-001).
+ *
+ * @param hasError true when PostToolHookInfo.error is set (handler threw).
+ * @param outcomeSuccess parsed envelope success — `false` is a known
+ *   failure; `null` means the envelope had nothing decisive.
+ * @param isRawSessionCommand whether the call ran in effective raw mode.
+ */
+export function isOutcomeKnown(
+  hasError: boolean,
+  outcomeSuccess: boolean | null,
+  isRawSessionCommand: boolean,
+): boolean {
+  const isKnownFailure = hasError || outcomeSuccess === false;
+  // Known failures stay known regardless of raw mode. Otherwise, raw
+  // mode suppresses the transport's exit_code: 0 success artifact.
+  return isKnownFailure || (!isRawSessionCommand && outcomeSuccess !== null);
+}
+
+export function isEffectiveRawCall(info: PostToolHookInfo): boolean {
+  const result = info.result as
+    | { session_mode?: string; content?: Array<{ text?: string }> }
+    | undefined;
+
+  // MCP tool results are wrapped as `{ content: [{ type: 'text', text: '<json>' }] }`
+  // by the SDK before they reach the post-tool hook. Parse the inner JSON
+  // to read session_mode out of the envelope our handler produced.
+  if (
+    result?.content &&
+    Array.isArray(result.content) &&
+    result.content[0]?.text
+  ) {
+    try {
+      const parsed = JSON.parse(result.content[0].text);
+      if (parsed && typeof parsed.session_mode === 'string') {
+        return parsed.session_mode === 'raw';
+      }
+    } catch {
+      // fall through to args fallback
+    }
+  }
+  // Direct envelope (test paths surface the parsed result directly).
+  if (result && typeof result.session_mode === 'string') {
+    return result.session_mode === 'raw';
+  }
+  return (info.args as { raw?: boolean }).raw === true;
+}

--- a/mcp/mcp-red/src/index.ts
+++ b/mcp/mcp-red/src/index.ts
@@ -14,6 +14,7 @@
 import { startServer, type PostToolHookInfo } from 'aptl-mcp-common';
 import { captureToolCall, type CaptureContext } from './capture.js';
 import { topLevelSegments } from './classifier.js';
+import { isEffectiveRawCall, isOutcomeKnown } from './effective-mode.js';
 import {
   defaultRedTeamSinks,
   deriveCommandOutcome,
@@ -126,9 +127,15 @@ const ocsfSink = defaultRedTeamSinks();
 async function postToolHook(info: PostToolHookInfo): Promise<void> {
   const { toolName, args, durationMs } = info;
   const sessionId = extractSessionId(info);
-  const isRawSessionCommand = (args as { raw?: boolean }).raw === true;
+  // #282: read effective raw mode from the result envelope (which captures
+  // the inherited-raw case), not from args.raw alone. The helper falls
+  // back to args.raw for compatibility with older common builds.
+  const isRawSessionCommand = isEffectiveRawCall(info);
   const outcome = deriveCommandOutcome(info.result, info.error);
-  const outcomeKnown = !isRawSessionCommand && outcome.success !== null;
+  // Raw-mode Unknown ONLY suppresses the transport exit_code: 0 artifact.
+  // Handler-level KNOWN failures (errors, success:false envelopes) stay
+  // known so OCSF emits Failure, not Unknown. Codex review cycle 2 / D-001.
+  const outcomeKnown = isOutcomeKnown(info.error !== undefined, outcome.success, isRawSessionCommand);
 
   const captureTask = captureToolCall(captureContextFor(info, outcome, outcomeKnown));
 

--- a/mcp/mcp-red/tests/effective-mode.test.ts
+++ b/mcp/mcp-red/tests/effective-mode.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import type { PostToolHookInfo } from 'aptl-mcp-common';
+import { isEffectiveRawCall, isOutcomeKnown } from '../src/effective-mode.js';
+
+function baseInfo(overrides: Partial<PostToolHookInfo> = {}): PostToolHookInfo {
+  return {
+    toolName: 'kali_session_command',
+    args: {},
+    result: undefined,
+    error: undefined,
+    durationMs: 1,
+    ...overrides,
+  } as PostToolHookInfo;
+}
+
+describe('#282: isEffectiveRawCall', () => {
+  it("returns true when the wrapped MCP result envelope has session_mode='raw'", () => {
+    // The shape postToolHook actually receives — MCP SDK wraps the handler
+    // output in { content: [{ type: 'text', text: <json> }] }.
+    const info = baseInfo({
+      args: { session_id: 's1', command: 'msfconsole' }, // no `raw` arg — inherited-raw case
+      result: {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              session_id: 's1',
+              command: 'msfconsole',
+              output: 'msf6 >',
+              stderr: '',
+              exit_code: 0,
+              session_mode: 'raw',
+            }),
+          },
+        ],
+      },
+    });
+    expect(isEffectiveRawCall(info)).toBe(true);
+  });
+
+  it("returns false when the wrapped envelope has session_mode='normal'", () => {
+    const info = baseInfo({
+      args: { session_id: 's1', command: 'ls' },
+      result: {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              session_id: 's1',
+              command: 'ls',
+              output: 'file',
+              stderr: '',
+              exit_code: 0,
+              session_mode: 'normal',
+            }),
+          },
+        ],
+      },
+    });
+    expect(isEffectiveRawCall(info)).toBe(false);
+  });
+
+  it("falls back to args.raw === true when the result envelope has no session_mode (mixed-version dev tree)", () => {
+    const info = baseInfo({
+      args: { session_id: 's1', command: 'x', raw: true },
+      // Pre-#282 envelope shape: no session_mode field.
+      result: {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              session_id: 's1',
+              command: 'x',
+              output: '',
+              stderr: '',
+              exit_code: 0,
+            }),
+          },
+        ],
+      },
+    });
+    expect(isEffectiveRawCall(info)).toBe(true);
+  });
+
+  it("returns false when args.raw is omitted AND the envelope has no session_mode (the pre-#282 inherited-raw bug — preserved as the documented fallback gap)", () => {
+    const info = baseInfo({
+      args: { session_id: 's1', command: 'msfconsole' },
+      result: {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              session_id: 's1',
+              command: 'msfconsole',
+              output: 'msf6 >',
+              exit_code: 0,
+            }),
+          },
+        ],
+      },
+    });
+    // This is the exact bug #282 fixes when both peers are upgraded. The
+    // helper documents this as a transitional gap, not a correctness path —
+    // mixed-version trees regress to the pre-#282 behavior, which is the
+    // best we can do without the envelope signal.
+    expect(isEffectiveRawCall(info)).toBe(false);
+  });
+
+  it("returns true on a directly-shaped envelope (test convenience path)", () => {
+    const info = baseInfo({
+      args: { session_id: 's1', command: 'x' },
+      // Direct envelope, no MCP content wrapping — exercises the second
+      // resolution branch in isEffectiveRawCall.
+      result: { session_mode: 'raw' } as unknown,
+    });
+    expect(isEffectiveRawCall(info)).toBe(true);
+  });
+
+  it("treats malformed result content (non-JSON) as missing — falls back to args.raw", () => {
+    const info = baseInfo({
+      args: { session_id: 's1', command: 'x', raw: true },
+      result: {
+        content: [{ type: 'text', text: 'not-json{{' }],
+      },
+    });
+    expect(isEffectiveRawCall(info)).toBe(true);
+  });
+});
+
+describe('Codex review cycle 2 D-001: isOutcomeKnown preserves known failures in raw mode', () => {
+  it("returns true (known) when the handler threw (info.error set) even in raw mode", () => {
+    // Raw transport's exit_code: 0 artifact is irrelevant when the handler
+    // itself threw — the failure is dispositive.
+    expect(isOutcomeKnown(true, false, true)).toBe(true);
+  });
+
+  it("returns true (known) when the envelope reports success:false even in raw mode", () => {
+    // Missing session, validation rejection, SSH layer throw all surface
+    // as `{success: false, error: ...}` in the text envelope, which
+    // deriveCommandOutcome parses to outcome.success === false.
+    expect(isOutcomeKnown(false, false, true)).toBe(true);
+  });
+
+  it("returns false (Unknown) when raw mode and no real failure signal", () => {
+    // Raw transport always returns success-ish, so without a real failure
+    // signal we must report Unknown.
+    expect(isOutcomeKnown(false, true, true)).toBe(false);
+    expect(isOutcomeKnown(false, null, true)).toBe(false);
+  });
+
+  it("returns true (known) on normal-mode success", () => {
+    expect(isOutcomeKnown(false, true, false)).toBe(true);
+  });
+
+  it("returns true (known) on normal-mode failure", () => {
+    expect(isOutcomeKnown(false, false, false)).toBe(true);
+  });
+
+  it("returns false (Unknown) when normal mode and envelope has nothing decisive", () => {
+    expect(isOutcomeKnown(false, null, false)).toBe(false);
+  });
+});

--- a/tests/test_range_integration.py
+++ b/tests/test_range_integration.py
@@ -42,6 +42,7 @@ from tests.helpers import (
     docker_exec,
     kali_exec,
     mcp_call_tool,
+    mcp_jsonrpc,
     mcp_server_cmd,
     mcp_tool_text,
     mcp_tools_list,
@@ -804,8 +805,31 @@ class TestScenarioHarness:
             )
             time.sleep(1)
 
-        # 3. Wait for alerts to be indexed
-        time.sleep(60)
+        # 3. Wait for the brute-force detection to fire. Test-quality
+        # review cycle 1 T-005: previously the test slept 60s then
+        # moved straight to stop/cleanup with no assertion that the
+        # 'live detection' the test name advertises actually fired.
+        # A broken Wazuh rule / decoder / log-forwarding gap would
+        # leave the scenario lifecycle green here while detection was
+        # silently dead. Pin the contract by querying for rule 5763
+        # (SSH brute force) — the same rule the active-response test
+        # asserts is wired into ossec.conf.
+        hit = wait_for_alert(
+            {
+                "bool": {
+                    "must": [
+                        {"match": {"rule.id": "5763"}},
+                        {"range": {
+                            "timestamp": {"gte": "now-3m"},
+                        }},
+                    ]
+                }
+            },
+            timeout=180,
+        )
+        assert hit.get("rule", {}).get("id") == "5763", (
+            f"Expected SSH brute-force alert (rule 5763), got: {hit.get('rule')}"
+        )
 
         # 4. Stop and verify run was assembled
         result = _aptl("stop")
@@ -1400,3 +1424,152 @@ class TestCTFFlags:
                 f"{container} root.txt has perms {perms}, "
                 f"expected 600"
             )
+
+
+# -------------------------------------------------------------------
+# Section 12: MCP harvest race window (#304)
+# -------------------------------------------------------------------
+
+
+@LIVE_LAB
+class TestMCPSessionHarvest:
+    """Per-session harvest is complete and not truncated.
+
+    #304 acceptance: after `PersistentSession.close()` awaits the remote
+    SSH channel close, the kali-side `script(1)` typescript that the
+    wrapper's EXIT trap flushes must be fully present in the host-side
+    harvest. We mark the end of the session with a known terminator and
+    assert it appears intact in the harvested typescript.
+
+    The whole flow runs through ONE MCP-server process so the harvest is
+    invoked by the real `close_session` handler — `mcp_call_tool` spawns
+    per call and would tear the server down between create and close.
+    """
+
+    def test_typescript_ends_with_terminator(self, tmp_path):
+        import json as _json
+        import secrets
+
+        # Unique per-run id satisfying SESSION_ID_SCHEMA
+        # ('^[A-Za-z0-9_][A-Za-z0-9._-]*$'). The previous fixed id used `#`,
+        # which the schema rejects — the wrapper would reroute to anon-* and
+        # the test would assert against the wrong path. Unique-per-run also
+        # avoids matching stale captures from prior failed runs.
+        unique = secrets.token_hex(6)
+        session_id = f"harvest_304_test_{unique}"
+        terminator = f"APTL_HARVEST_TERMINATOR_{unique}"
+
+        # Bring up the lab's MCP server, open an interactive session,
+        # run a command that emits the terminator, then close. The
+        # close handler triggers harvest from the kali container's
+        # capture volume into .aptl/runs/<run>/kali-side/<session>/.
+        init = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "aptl-test", "version": "1.0.0"},
+            },
+        }
+        initialized = {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        }
+        open_session = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "kali_interactive_session",
+                "arguments": {
+                    "session_id": session_id,
+                    "timeout_ms": 60000,
+                },
+            },
+        }
+        emit_terminator = {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "kali_session_command",
+                "arguments": {
+                    "session_id": session_id,
+                    "command": f"echo {terminator}",
+                    "timeout": 10000,
+                },
+            },
+        }
+        close = {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "kali_close_session",
+                "arguments": {"session_id": session_id},
+            },
+        }
+
+        responses = mcp_jsonrpc(
+            "kali-ssh",
+            [init, initialized, open_session, emit_terminator, close],
+            timeout=90,
+        )
+
+        # Sanity check JSON-RPC transport AND the inner success envelope —
+        # these MCP handlers report operational failures inside the text
+        # body as `success: false` rather than as JSON-RPC errors. A
+        # transport-clean response with `success: false` would otherwise
+        # produce false confidence about the harvest race fix.
+        by_id = {r.get("id"): r for r in responses if "id" in r}
+        for call_id in (2, 3, 4):
+            resp = by_id.get(call_id)
+            assert resp is not None, f"missing response for id={call_id}"
+            assert "error" not in resp, (
+                f"MCP transport error on id={call_id}: {resp.get('error')}"
+            )
+            content = resp.get("result", {}).get("content", [])
+            assert content, f"empty content for id={call_id}"
+            body = _json.loads(content[0]["text"])
+            assert body.get("success") is True, (
+                f"tool id={call_id} body reports failure: {body}"
+            )
+
+        # Locate the harvested typescript. The harvest lands under
+        # .aptl/runs/<run_id>/kali-side/<session_id>/. The unique-per-run
+        # session_id guarantees we match only captures from this run.
+        import glob
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        candidates = glob.glob(
+            str(
+                repo_root / ".aptl" / "runs" / "*" / "kali-side"
+                / session_id / "**" / "typescript*"
+            ),
+            recursive=True,
+        )
+        assert candidates, (
+            "No harvested typescript for the test session — harvest "
+            "may have run before remote close, or the kali capture "
+            "wrapper did not produce a typescript."
+        )
+
+        # Read every candidate (PTY + raw typescript variants) and
+        # assert at least one contains the unique terminator intact.
+        found_in_any = False
+        for path in candidates:
+            try:
+                contents = Path(path).read_bytes()
+            except OSError:
+                continue
+            if terminator.encode() in contents:
+                found_in_any = True
+                break
+        assert found_in_any, (
+            f"Terminator '{terminator}' not found in any harvested "
+            f"typescript — capture was truncated. Candidates: "
+            f"{candidates}"
+        )


### PR DESCRIPTION
## Summary

Closes #282 and #304 together. #282 surfaces the effective per-command session mode through the MCP boundary so mcp-red's OCSF emitter classifies inherited-raw commands as Unknown (not false-Success via raw-mode `exit_code: 0`). #304 makes `PersistentSession.close()` await the remote SSH channel close before returning, eliminating the harvest race window that previously truncated kali-side captures; the `dockerCpWithRetry` workaround is removed because the race is closed at the source. Codex pre-push review found a class-level lifecycle-ordering bug (emitClosedIfVerified before the await) and a critical schema-default bug (`raw: default false` defeating #282 end-to-end) — both fixed. Codex cycle 2 (user-authorized) caught a logic bug where the raw-mode Unknown override masked handler-level KNOWN failures — fixed via a new `isOutcomeKnown` helper. Test-quality review uncovered a pre-existing captures.ts bug (APTL_DOCKER_BIN env override was never propagated to dockerBin) and was fixed in the same diff. A second changelog fragment lands at `changelog.d/304.fixed.md` for the #304 work.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #282
Closes #304

## ADR Impact

- ADR-004 (amended 2026-05-18)
- ADR-027 (amended 2026-05-18)
- ADR-033 (Harvest race window rewritten)

## Changes

- aptl-mcp-common: CommandResult gains `mode: SessionMode`; resolution sites in PersistentSession.executeCommand/processNextCommand and SSHConnectionManager.executeCommand populate it from request.raw (or inherited session mode). session_command result envelope surfaces session_mode.
- aptl-mcp-common: PersistentSession.close() is now async. Local cleanup + postcondition remain synchronous so in-flight/queued command promises reject immediately. After cleanupVerified=true, close() awaits the SSH stream's 'close' event (or the bounded TIMEOUTS.REMOTE_CLOSE_AWAIT) before emitting 'closed' to the manager. SSHConnectionManager.closeSession awaits session.close() directly; disconnectAll sequences all session closes before connection teardown. resetSessionTimeout's timer callback uses void+catch so rejections cannot crash Node.
- aptl-mcp-common: captures.ts dockerCpWithRetry helper removed (race window closed at source). execDockerCp now accepts an env parameter; harvestSession threads opts.env through so APTL_DOCKER_BIN actually takes effect on the spawned docker binary path.
- aptl-mcp-common: tools/definitions.ts session_command `raw` schema default removed. Schema-materializing clients no longer auto-send `raw: false`, so omission once again means 'use session default'.
- mcp-red: new effective-mode.ts module with isEffectiveRawCall + isOutcomeKnown helpers. postToolHook reads effective raw mode from the result envelope (falling back to args.raw for older common builds) AND preserves handler-level KNOWN failures (info.error or success:false) as Failure even in raw mode.
- ADR-004: two new Update sections record the effective-mode and awaitable-remote-close contracts. ADR-027: status update records that OCSF status must derive from effective mode + observed outcome. ADR-033 'Harvest race window' rewritten.
- Tests: 10 new vitest cases for effective mode + awaitable close in aptl-mcp-common ssh.test.ts; 2 new session_command envelope tests in tools-handlers.test.ts; updated captures.test.ts to verify docker binary path (catching the pre-existing APTL_DOCKER_BIN bug); 6 new mcp-red tests for isEffectiveRawCall + isOutcomeKnown truth tables; new LIVE_LAB-gated TestMCPSessionHarvest in test_range_integration.py asserting the kali-side typescript contains the unique terminator after close; new wait_for_alert(rule.id=5763) assertion in test_scenario_lifecycle_with_live_detection.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local: vitest 371 passed (aptl-mcp-common), 216 passed (mcp-red), pytest 1641 passed + 176 LIVE_LAB skipped, pre-commit clean. Codex pre-push review: 2 cycles (cycle 2 was user-authorized over-cap), 5 findings total, all `fix`. Test-quality review: 1 cycle, 5 findings, all `fix`. LIVE_LAB integration test (TestMCPSessionHarvest) requires APTL_SMOKE=1 and a running lab — not exercised in CI; will be run manually before close.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #282 ← mcp/aptl-mcp-common/src/ssh.ts (CommandResult.mode + resolution paths), #282 ← mcp/aptl-mcp-common/src/tools/handlers.ts (session_command envelope), #282 ← mcp/aptl-mcp-common/src/tools/definitions.ts (raw schema default removed), #282 ← mcp/mcp-red/src/effective-mode.ts (isEffectiveRawCall, isOutcomeKnown), #282 ← mcp/mcp-red/src/index.ts (postToolHook wiring), #304 ← mcp/aptl-mcp-common/src/ssh.ts (async close + remoteClosed latch + REMOTE_CLOSE_AWAIT), #304 ← mcp/aptl-mcp-common/src/captures.ts (retry removed, env propagated), #304 ← docs/adrs/adr-033-agent-reasoning-trace-boundary.md (Harvest race window rewritten)
- TESTS: #282 ← mcp/aptl-mcp-common/tests/ssh.test.ts (effective session-mode metadata suite), #282 ← mcp/aptl-mcp-common/tests/tools-handlers.test.ts (session_command envelope tests), #282 ← mcp/mcp-red/tests/effective-mode.test.ts (isEffectiveRawCall + isOutcomeKnown), #304 ← mcp/aptl-mcp-common/tests/ssh.test.ts (#304 awaitable close suite + ordering tests), #304 ← mcp/aptl-mcp-common/tests/captures.test.ts (single-shot docker cp, env propagation), #304 ← tests/test_range_integration.py TestMCPSessionHarvest (LIVE_LAB typescript terminator test)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/282.changed.md` and `changelog.d/304.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
