### PR TITLE
Land SCN-010 parity inventory (#318)

### DIFF
--- a/changelog.d/318.added.md
+++ b/changelog.d/318.added.md
@@ -1,0 +1,16 @@
+### Added
+
+- **ACES SDL parity inventory (SCN-010A).** Authored a checked-in
+  parity manifest at `docs/aces/parity-inventory.yaml` (and a human
+  overview at `docs/aces/parity-inventory.md`) that maps every legacy
+  APTL scenario / lab / defensive-stack surface to exactly one of five
+  owning categories — `aces_sdl`, `aces_schema_profile_gap`,
+  `aptl_backend_responsibility`, `validation_gate`, or
+  `cutover_only_archive` — per ADR-035's "Parity Inventory Boundary"
+  section. Per-row stable IDs let SCN-010 specification issues
+  (#319 – #324) and the eventual Phase B cutover PR cite individual
+  rows mechanically (`parity#<id>`). A new
+  `tests/test_parity_inventory.py` enforces the schema (required
+  fields, closed-enum categories, unique IDs, non-empty surface and
+  category buckets, every scenarios/*.yaml file covered, no `NAME=`
+  secret-token shapes).

--- a/docs/aces/parity-inventory.md
+++ b/docs/aces/parity-inventory.md
@@ -1,0 +1,132 @@
+# ACES SDL Parity Inventory (SCN-010)
+
+This directory holds the authoritative parity inventory that the
+SCN-010 specification issues (#319 – #324) and the eventual ACES-SDL
+cutover PR must cite when claiming TechVault parity. It is scoped by
+ADR-035, sections **Parity Inventory Boundary** and **ACES Backend
+Integration Guardrails**.
+
+The canonical artifact is the machine-readable YAML:
+
+```
+docs/aces/parity-inventory.yaml
+```
+
+This page explains the schema, the row taxonomy, and how to add or cite
+a row.
+
+## What this inventory is — and is not
+
+This inventory is an **audit surface**. It is:
+
+- a row-per-legacy-field map from APTL's current scenario / lab /
+  defensive-stack surfaces to the post-cutover owner;
+- the document SCN-010 implementation issues cite to prove they have
+  not silently dropped a legacy capability;
+- the gate the Phase B cutover PR uses to demonstrate parity.
+
+It is **not**:
+
+- a runtime schema (the runtime side is ACES SDL + the APTL backend
+  manifest);
+- a second `ScenarioDefinition` (Pydantic models stay in
+  `aptl.core.sdl` until cutover, then are deleted, per ADR-035);
+- a duplicate `docker-compose.yml` parser (the canonical compose
+  inventory is the file itself, queried by `tests/test_consistency.py`);
+- a parallel secret taxonomy, readiness taxonomy, or exception
+  envelope.
+
+## Categories (closed enum)
+
+Every row sits in exactly one of these owning categories. They are the
+five buckets ADR-035 enumerates:
+
+| Category | Meaning |
+| --- | --- |
+| `aces_sdl` | The authored scenario can express this surface directly through the ACES parser, schemas, semantic validators, and compiled `RuntimeModel`. |
+| `aces_schema_profile_gap` | The concept belongs in ACES rather than APTL but is not yet covered. Row MUST cite an upstream ACES follow-up or an APTL issue blocked on one. |
+| `aptl_backend_responsibility` | Backend realization detail: Docker Compose profiles, generated config, lab-managed TLS, SOC seed material, deployment inventory, readiness classification, snapshots, run archive persistence, or host/container interaction. |
+| `validation_gate` | The surface is not authored but must be proven by conformance, static parity tests, live lab validation, snapshots, or run-archive assertions. |
+| `cutover_only_archive` | The legacy field is retained only as reference material after the Phase B move to `scenarios/archive/`. |
+
+Adding a category is a deliberate change to ADR-035 *and*
+`tests/test_parity_inventory.py` *and* `parity-inventory.yaml`'s
+`categories:` list. That triple-edit is the intentional friction.
+
+## Surfaces (closed set)
+
+Every row also belongs to one of these legacy-surface buckets. The
+schema test asserts that every bucket carries at least one row, so the
+inventory cannot silently drop a surface area:
+
+- `scenarios_yaml` — top-level keys of files under `scenarios/*.yaml`
+- `docker_compose_topology` — profiles, networks, named volumes
+- `aptl_config` — `AptlConfig` / `ContainerSettings` / `LabSettings`
+- `env_vars_and_secrets` — `EnvVars` fields and the placeholder gate
+- `lab_lifecycle` — `_LAB_START_STEPS` and ADR-030 readiness taxonomy
+- `deployment_backend` — `DeploymentBackend` protocol methods
+- `snapshots_and_runstore` — `RangeSnapshot` and `RunManifest` fields
+- `defensive_stack_configs` — `config/` subdirectories
+- `test_and_validation` — conformance and parity gates
+
+## Row schema
+
+Each row in `rows[]` is a mapping with the following required keys:
+
+| Key | Meaning |
+| --- | --- |
+| `id` | Stable kebab / dot-segmented anchor used for citation (e.g. `parity#scen.recon-nmap-scan.metadata`). |
+| `surface` | One of the surfaces above. |
+| `legacy_source` | Canonical owner — file path plus symbol or field name. The inventory does not store data; it routes to the existing owner. |
+| `legacy_field` | The specific field, key, or method name being mapped. |
+| `category` | One of the categories above. |
+| `aces_target` | ACES SDL element / contract / profile, or `n/a`. |
+| `runtime_owner` | APTL owner symbol when the row is backend or validation. |
+| `validation_evidence` | Test path or conformance suite proving parity. |
+| `blocking_followup` | Issue reference (`#NNN`) or upstream pointer; `n/a` only when nothing is blocking. `aces_schema_profile_gap` rows MUST cite a concrete follow-up. |
+| `notes` | Short prose, one line preferred. |
+
+The full schema is enforced by `tests/test_parity_inventory.py`. The
+test uses pure-Python assertions so the inventory does not import any
+APTL Pydantic model — that would re-introduce the duplicate
+`ScenarioDefinition` ADR-035 forbids.
+
+## Citing a row
+
+Implementation issues, PR descriptions, and the cutover PR cite rows
+by id, in the form `parity#<id>`. Reviewers grep the inventory for the
+id to verify the row exists and that its category and follow-up are
+accurate. Example PR-description line:
+
+> Covers `parity#scen.recon-nmap-scan.objectives` — moved from
+> `aces_schema_profile_gap` to `aces_sdl` once #312 promotes the
+> backend to `orchestration-evaluation`.
+
+## Adding a row
+
+1. Decide the surface bucket. If none fits, the surface is missing
+   from the closed set — that is a deliberate change requiring a
+   deliberate edit to `surfaces:` and to ADR-035, not a workaround.
+2. Decide the category. The same caveat applies.
+3. Choose a stable, anchor-safe `id` (ASCII alphanumeric plus `.`,
+   `-`, `_`). IDs MUST be unique; the schema test enforces it.
+4. Cite the existing owner in `legacy_source`. Do not re-state the
+   field's contents; the inventory is a map, not a copy.
+5. Populate every required key. Use `n/a` only when truly nothing
+   applies. `aces_schema_profile_gap` rows MUST cite a follow-up.
+6. Run `pytest tests/test_parity_inventory.py -q` to confirm the
+   schema gates stay green.
+
+## Related ADRs
+
+- **ADR-035** — ACES SDL adoption and the parity-inventory boundary
+  (the binding document).
+- **ADR-028** — Runtime-rendered service config (generated-secret
+  boundary referenced by `env_vars_and_secrets` rows).
+- **ADR-029** — Snapshot / runstore redaction boundary.
+- **ADR-030** — Lab startup partial-readiness classification (owner of
+  `StartupOutcome`, `DiagnosticImpact`, `DiagnosticSeverity`,
+  `StartupDiagnostic`, `LabResult` — *not* duplicated here).
+- **ADR-034** — Generated-secret materialization (paired with ADR-028).
+- **ADR-036** — Endpoint-registry boundary (snapshot serialization).
+- **ADR-037** — Docker Compose backend cohesion.

--- a/docs/aces/parity-inventory.yaml
+++ b/docs/aces/parity-inventory.yaml
@@ -1,0 +1,1657 @@
+# SCN-010 parity inventory.
+#
+# Audit surface for the ACES-SDL cutover (ADR-035, "Parity Inventory
+# Boundary"). Every legacy APTL surface that the ACES-authored
+# `techvault.sdl.yaml` scenario must preserve is mapped here to exactly
+# one of the five owning categories. Specification issues #319-#324 and
+# the cutover PR cite rows by `id` (anchor-style, e.g.
+# `parity#scen.recon-nmap.metadata`).
+#
+# This file is NOT a runtime schema, not a new SDL, not a deployment
+# authority. The canonical source for a row's data is the existing
+# owner cited in `legacy_source`; the inventory just routes each owner
+# to its post-cutover home.
+
+schema_version: 1
+generated_for: SCN-010
+related_adr: docs/adrs/adr-035-aces-sdl-adoption.md
+
+# Closed enum. Adding a category is a deliberate change to ADR-035
+# AND `tests/test_parity_inventory.py` AND this list.
+categories:
+  - aces_sdl
+  - aces_schema_profile_gap
+  - aptl_backend_responsibility
+  - validation_gate
+  - cutover_only_archive
+
+# Surface buckets — the canonical legacy owners. The schema test asserts
+# every bucket carries at least one row so the inventory cannot silently
+# drop a surface area.
+surfaces:
+  - scenarios_yaml
+  - docker_compose_topology
+  - aptl_config
+  - env_vars_and_secrets
+  - lab_lifecycle
+  - deployment_backend
+  - snapshots_and_runstore
+  - defensive_stack_configs
+  - test_and_validation
+
+# ---------------------------------------------------------------------------
+# Rows.
+#
+# Per-row fields (all required):
+#   id                    — stable kebab/dot-segmented anchor for citation
+#   surface               — one of surfaces[] above
+#   legacy_source         — canonical owner (file path + symbol/field)
+#   legacy_field          — field/key/method name being mapped
+#   category              — one of categories[] above
+#   aces_target           — ACES SDL element / contract / profile, or n/a
+#   runtime_owner         — APTL owner symbol when backend or validation
+#   validation_evidence   — test path or conformance suite proving parity
+#   blocking_followup     — issue ref or ACES upstream pointer (n/a when none)
+#   notes                 — short prose; one line preferred
+#
+# Required reuse per ADR-035: rows reference existing owners
+# (DeploymentBackend, AptlConfig, EnvVars, _LAB_START_STEPS, LabResult,
+# RangeSnapshot, LocalRunStore, ADR-028 / ADR-029 / ADR-030 / ADR-034)
+# rather than introducing duplicate models, parsers, or taxonomies.
+# ---------------------------------------------------------------------------
+
+rows:
+  # ---- surface: scenarios_yaml ------------------------------------------
+  # One row per top-level key in each scenarios/*.yaml file. Six legacy
+  # scenarios: ad-domain-compromise, detect-brute-force,
+  # lateral-movement-data-theft, prime-enterprise, recon-nmap-scan,
+  # webapp-compromise.
+
+  - id: scen.ad-domain-compromise.metadata
+    surface: scenarios_yaml
+    legacy_source: scenarios/ad-domain-compromise.yaml
+    legacy_field: metadata
+    category: aces_sdl
+    aces_target: ACES scenario header (id, name, description, tags)
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml header parse via aces_sdl.parse_sdl_file
+    blocking_followup: "#319"
+    notes: TechVault scenario header carries the same identifier and description fields.
+
+  - id: scen.ad-domain-compromise.mode
+    surface: scenarios_yaml
+    legacy_source: scenarios/ad-domain-compromise.yaml
+    legacy_field: mode
+    category: cutover_only_archive
+    aces_target: n/a
+    runtime_owner: n/a
+    validation_evidence: scenarios/archive/ README marks legacy `mode` field as reference-only
+    blocking_followup: n/a
+    notes: Legacy execution-mode hint; ACES SDL selects realization via backend profile, not a scenario field.
+
+  - id: scen.ad-domain-compromise.containers
+    surface: scenarios_yaml
+    legacy_source: scenarios/ad-domain-compromise.yaml
+    legacy_field: containers
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure / nodes (lab realization side)
+    runtime_owner: docker-compose profile selection + DeploymentBackend.start
+    validation_evidence: tests/test_consistency.py (compose container presence)
+    blocking_followup: "#320"
+    notes: Maps to docker-compose profiles + ContainerSettings toggle set; not authored in ACES SDL.
+
+  - id: scen.ad-domain-compromise.scoring
+    surface: scenarios_yaml
+    legacy_source: scenarios/ad-domain-compromise.yaml
+    legacy_field: scoring
+    category: aces_schema_profile_gap
+    aces_target: ACES evaluator profile (orchestration-evaluation)
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation (blocked until #312)
+    blocking_followup: "#312"
+    notes: Scoring belongs to the orchestration-evaluation profile; out of scope for the provisioning-only initial backend target.
+
+  - id: scen.ad-domain-compromise.attack_chain
+    surface: scenarios_yaml
+    legacy_source: scenarios/ad-domain-compromise.yaml
+    legacy_field: attack_chain
+    category: aces_sdl
+    aces_target: ACES injects / scenario flow
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml injects equivalence
+    blocking_followup: "#321"
+    notes: Adversary inject sequence; ACES SDL expresses the same shape via inject blocks.
+
+  - id: scen.ad-domain-compromise.steps
+    surface: scenarios_yaml
+    legacy_source: scenarios/ad-domain-compromise.yaml
+    legacy_field: steps
+    category: aces_sdl
+    aces_target: ACES scenario steps / workflow
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml steps equivalence
+    blocking_followup: "#321"
+    notes: Step ordering and per-step actions map directly onto ACES scenario flow.
+
+  - id: scen.detect-brute-force.metadata
+    surface: scenarios_yaml
+    legacy_source: scenarios/detect-brute-force.yaml
+    legacy_field: metadata
+    category: aces_sdl
+    aces_target: ACES scenario header
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml header parse
+    blocking_followup: "#319"
+    notes: Same header shape as ad-domain-compromise.
+
+  - id: scen.detect-brute-force.mode
+    surface: scenarios_yaml
+    legacy_source: scenarios/detect-brute-force.yaml
+    legacy_field: mode
+    category: cutover_only_archive
+    aces_target: n/a
+    runtime_owner: n/a
+    validation_evidence: scenarios/archive/ README marks legacy `mode` as reference-only
+    blocking_followup: n/a
+    notes: See scen.ad-domain-compromise.mode.
+
+  - id: scen.detect-brute-force.containers
+    surface: scenarios_yaml
+    legacy_source: scenarios/detect-brute-force.yaml
+    legacy_field: containers
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure / nodes (lab realization side)
+    runtime_owner: docker-compose profile selection + DeploymentBackend.start
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Backend selects profile set from the authored node list.
+
+  - id: scen.detect-brute-force.preconditions
+    surface: scenarios_yaml
+    legacy_source: scenarios/detect-brute-force.yaml
+    legacy_field: preconditions
+    category: aces_sdl
+    aces_target: ACES conditions (pre-conditions)
+    runtime_owner: n/a
+    validation_evidence: ACES semantic validator
+    blocking_followup: "#321"
+    notes: Conditions are first-class in ACES SDL.
+
+  - id: scen.detect-brute-force.objectives
+    surface: scenarios_yaml
+    legacy_source: scenarios/detect-brute-force.yaml
+    legacy_field: objectives
+    category: aces_schema_profile_gap
+    aces_target: ACES objectives (evaluator profile)
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: Objective-based scoring requires SCN-007 / #312 backend promotion.
+
+  - id: scen.detect-brute-force.scoring
+    surface: scenarios_yaml
+    legacy_source: scenarios/detect-brute-force.yaml
+    legacy_field: scoring
+    category: aces_schema_profile_gap
+    aces_target: ACES evaluator profile
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: See scen.ad-domain-compromise.scoring.
+
+  - id: scen.lateral-movement-data-theft.metadata
+    surface: scenarios_yaml
+    legacy_source: scenarios/lateral-movement-data-theft.yaml
+    legacy_field: metadata
+    category: aces_sdl
+    aces_target: ACES scenario header
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml header parse
+    blocking_followup: "#319"
+    notes: Same shape.
+
+  - id: scen.lateral-movement-data-theft.mode
+    surface: scenarios_yaml
+    legacy_source: scenarios/lateral-movement-data-theft.yaml
+    legacy_field: mode
+    category: cutover_only_archive
+    aces_target: n/a
+    runtime_owner: n/a
+    validation_evidence: scenarios/archive/ README marker
+    blocking_followup: n/a
+    notes: See scen.ad-domain-compromise.mode.
+
+  - id: scen.lateral-movement-data-theft.containers
+    surface: scenarios_yaml
+    legacy_source: scenarios/lateral-movement-data-theft.yaml
+    legacy_field: containers
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure / nodes (lab realization side)
+    runtime_owner: docker-compose profile selection + DeploymentBackend.start
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Backend-realized.
+
+  - id: scen.lateral-movement-data-theft.scoring
+    surface: scenarios_yaml
+    legacy_source: scenarios/lateral-movement-data-theft.yaml
+    legacy_field: scoring
+    category: aces_schema_profile_gap
+    aces_target: ACES evaluator profile
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: See scen.ad-domain-compromise.scoring.
+
+  - id: scen.lateral-movement-data-theft.attack_chain
+    surface: scenarios_yaml
+    legacy_source: scenarios/lateral-movement-data-theft.yaml
+    legacy_field: attack_chain
+    category: aces_sdl
+    aces_target: ACES injects / scenario flow
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml injects equivalence
+    blocking_followup: "#321"
+    notes: See scen.ad-domain-compromise.attack_chain.
+
+  - id: scen.lateral-movement-data-theft.steps
+    surface: scenarios_yaml
+    legacy_source: scenarios/lateral-movement-data-theft.yaml
+    legacy_field: steps
+    category: aces_sdl
+    aces_target: ACES scenario steps / workflow
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml steps equivalence
+    blocking_followup: "#321"
+    notes: See scen.ad-domain-compromise.steps.
+
+  - id: scen.prime-enterprise.metadata
+    surface: scenarios_yaml
+    legacy_source: scenarios/prime-enterprise.yaml
+    legacy_field: metadata
+    category: aces_sdl
+    aces_target: ACES scenario header
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml header parse
+    blocking_followup: "#319"
+    notes: Same shape.
+
+  - id: scen.prime-enterprise.mode
+    surface: scenarios_yaml
+    legacy_source: scenarios/prime-enterprise.yaml
+    legacy_field: mode
+    category: cutover_only_archive
+    aces_target: n/a
+    runtime_owner: n/a
+    validation_evidence: scenarios/archive/ README marker
+    blocking_followup: n/a
+    notes: See scen.ad-domain-compromise.mode.
+
+  - id: scen.prime-enterprise.containers
+    surface: scenarios_yaml
+    legacy_source: scenarios/prime-enterprise.yaml
+    legacy_field: containers
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure / nodes
+    runtime_owner: docker-compose profile selection + DeploymentBackend.start
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Backend-realized.
+
+  - id: scen.prime-enterprise.defenses
+    surface: scenarios_yaml
+    legacy_source: scenarios/prime-enterprise.yaml
+    legacy_field: defenses
+    category: aptl_backend_responsibility
+    aces_target: APTL backend defensive-stack provisioning (no ACES SDL equivalent yet)
+    runtime_owner: docker-compose `soc` profile + config/wazuh_cluster, config/suricata, config/thehive, config/cortex
+    validation_evidence: tests/test_certs.py + lab health smoke (StartupOutcome.READY)
+    blocking_followup: "#322"
+    notes: Defensive-stack composition is backend realization; the authored scenario does not enumerate Wazuh/Suricata/TheHive rules.
+
+  - id: scen.prime-enterprise.objectives
+    surface: scenarios_yaml
+    legacy_source: scenarios/prime-enterprise.yaml
+    legacy_field: objectives
+    category: aces_schema_profile_gap
+    aces_target: ACES objectives (evaluator profile)
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: SCN-007 / #312 promotion.
+
+  - id: scen.prime-enterprise.scoring
+    surface: scenarios_yaml
+    legacy_source: scenarios/prime-enterprise.yaml
+    legacy_field: scoring
+    category: aces_schema_profile_gap
+    aces_target: ACES evaluator profile
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: See scen.ad-domain-compromise.scoring.
+
+  - id: scen.prime-enterprise.attack_chain
+    surface: scenarios_yaml
+    legacy_source: scenarios/prime-enterprise.yaml
+    legacy_field: attack_chain
+    category: aces_sdl
+    aces_target: ACES injects / scenario flow
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml injects equivalence
+    blocking_followup: "#321"
+    notes: Same shape.
+
+  - id: scen.prime-enterprise.steps
+    surface: scenarios_yaml
+    legacy_source: scenarios/prime-enterprise.yaml
+    legacy_field: steps
+    category: aces_sdl
+    aces_target: ACES scenario steps / workflow
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml steps equivalence
+    blocking_followup: "#321"
+    notes: Same shape.
+
+  - id: scen.recon-nmap-scan.metadata
+    surface: scenarios_yaml
+    legacy_source: scenarios/recon-nmap-scan.yaml
+    legacy_field: metadata
+    category: aces_sdl
+    aces_target: ACES scenario header
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml header parse
+    blocking_followup: "#319"
+    notes: Same shape.
+
+  - id: scen.recon-nmap-scan.mode
+    surface: scenarios_yaml
+    legacy_source: scenarios/recon-nmap-scan.yaml
+    legacy_field: mode
+    category: cutover_only_archive
+    aces_target: n/a
+    runtime_owner: n/a
+    validation_evidence: scenarios/archive/ README marker
+    blocking_followup: n/a
+    notes: See scen.ad-domain-compromise.mode.
+
+  - id: scen.recon-nmap-scan.containers
+    surface: scenarios_yaml
+    legacy_source: scenarios/recon-nmap-scan.yaml
+    legacy_field: containers
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure / nodes
+    runtime_owner: docker-compose profile selection + DeploymentBackend.start
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Backend-realized.
+
+  - id: scen.recon-nmap-scan.preconditions
+    surface: scenarios_yaml
+    legacy_source: scenarios/recon-nmap-scan.yaml
+    legacy_field: preconditions
+    category: aces_sdl
+    aces_target: ACES conditions (pre-conditions)
+    runtime_owner: n/a
+    validation_evidence: ACES semantic validator
+    blocking_followup: "#321"
+    notes: First-class in ACES SDL.
+
+  - id: scen.recon-nmap-scan.objectives
+    surface: scenarios_yaml
+    legacy_source: scenarios/recon-nmap-scan.yaml
+    legacy_field: objectives
+    category: aces_schema_profile_gap
+    aces_target: ACES objectives (evaluator profile)
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: SCN-007 / #312 promotion.
+
+  - id: scen.recon-nmap-scan.scoring
+    surface: scenarios_yaml
+    legacy_source: scenarios/recon-nmap-scan.yaml
+    legacy_field: scoring
+    category: aces_schema_profile_gap
+    aces_target: ACES evaluator profile
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: See scen.ad-domain-compromise.scoring.
+
+  - id: scen.webapp-compromise.metadata
+    surface: scenarios_yaml
+    legacy_source: scenarios/webapp-compromise.yaml
+    legacy_field: metadata
+    category: aces_sdl
+    aces_target: ACES scenario header
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml header parse
+    blocking_followup: "#319"
+    notes: Same shape.
+
+  - id: scen.webapp-compromise.mode
+    surface: scenarios_yaml
+    legacy_source: scenarios/webapp-compromise.yaml
+    legacy_field: mode
+    category: cutover_only_archive
+    aces_target: n/a
+    runtime_owner: n/a
+    validation_evidence: scenarios/archive/ README marker
+    blocking_followup: n/a
+    notes: See scen.ad-domain-compromise.mode.
+
+  - id: scen.webapp-compromise.containers
+    surface: scenarios_yaml
+    legacy_source: scenarios/webapp-compromise.yaml
+    legacy_field: containers
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure / nodes
+    runtime_owner: docker-compose profile selection + DeploymentBackend.start
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Backend-realized.
+
+  - id: scen.webapp-compromise.scoring
+    surface: scenarios_yaml
+    legacy_source: scenarios/webapp-compromise.yaml
+    legacy_field: scoring
+    category: aces_schema_profile_gap
+    aces_target: ACES evaluator profile
+    runtime_owner: n/a
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: See scen.ad-domain-compromise.scoring.
+
+  - id: scen.webapp-compromise.attack_chain
+    surface: scenarios_yaml
+    legacy_source: scenarios/webapp-compromise.yaml
+    legacy_field: attack_chain
+    category: aces_sdl
+    aces_target: ACES injects / scenario flow
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml injects equivalence
+    blocking_followup: "#321"
+    notes: Same shape.
+
+  - id: scen.webapp-compromise.steps
+    surface: scenarios_yaml
+    legacy_source: scenarios/webapp-compromise.yaml
+    legacy_field: steps
+    category: aces_sdl
+    aces_target: ACES scenario steps / workflow
+    runtime_owner: n/a
+    validation_evidence: techvault.sdl.yaml steps equivalence
+    blocking_followup: "#321"
+    notes: Same shape.
+
+  # ---- surface: docker_compose_topology ---------------------------------
+  # One row per Compose profile (11), per network (4), and one summary
+  # row for volume conventions (43 volumes; per-volume rows would dilute
+  # rather than aid mechanical review). All are aptl_backend_responsibility.
+
+  - id: compose.profile.wazuh
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: wazuh)"
+    legacy_field: wazuh
+    category: aptl_backend_responsibility
+    aces_target: ACES backend manifest capability claim (provisioning-only)
+    runtime_owner: AptlConfig.containers.wazuh -> ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_consistency.py (compose profile assertions)
+    blocking_followup: "#320"
+    notes: Wazuh manager/indexer/dashboard trio.
+
+  - id: compose.profile.soc
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: soc)"
+    legacy_field: soc
+    category: aptl_backend_responsibility
+    aces_target: ACES backend manifest capability claim
+    runtime_owner: AptlConfig.containers.soc -> ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Suricata + MISP + TheHive + Cortex + Shuffle + Wazuh sidecars.
+
+  - id: compose.profile.enterprise
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: enterprise)"
+    legacy_field: enterprise
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure realization
+    runtime_owner: AptlConfig.containers.enterprise -> ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: ad, db, webapp, workstation.
+
+  - id: compose.profile.victim
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: victim)"
+    legacy_field: victim
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure realization
+    runtime_owner: AptlConfig.containers.victim
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Generic victim host.
+
+  - id: compose.profile.kali
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: kali)"
+    legacy_field: kali
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure realization (red-side node)
+    runtime_owner: AptlConfig.containers.kali
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Attacker box with audit/capture surface (ADR-033).
+
+  - id: compose.profile.reverse
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: reverse)"
+    legacy_field: reverse
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure realization
+    runtime_owner: AptlConfig.containers.reverse
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Reverse-shell sink.
+
+  - id: compose.profile.mail
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: mail)"
+    legacy_field: mail
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure realization
+    runtime_owner: AptlConfig.containers.mail
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: mailserver enterprise fixture.
+
+  - id: compose.profile.dns
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: dns)"
+    legacy_field: dns
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure realization
+    runtime_owner: AptlConfig.containers.dns
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: dns enterprise fixture.
+
+  - id: compose.profile.fileshare
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: fileshare)"
+    legacy_field: fileshare
+    category: aptl_backend_responsibility
+    aces_target: ACES infrastructure realization
+    runtime_owner: AptlConfig.containers.fileshare
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: SMB fileshare fixture.
+
+  - id: compose.profile.otel
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: otel)"
+    legacy_field: otel
+    category: aptl_backend_responsibility
+    aces_target: ACES telemetry adapter (provisioning-only side; no ACES profile claim)
+    runtime_owner: docker-compose profile `otel` + config/otel
+    validation_evidence: tests/test_consistency.py + lab health (OpenTelemetry collector reachable)
+    blocking_followup: "#322"
+    notes: APTL-side OTel collector + Tempo + Grafana stack; not enumerated in ACES SDL.
+
+  - id: compose.profile.web
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (profile: web)"
+    legacy_field: web
+    category: aptl_backend_responsibility
+    aces_target: APTL operator UI (no ACES SDL surface)
+    runtime_owner: docker-compose profile `web` + src/aptl/api
+    validation_evidence: tests/test_api_lab.py
+    blocking_followup: n/a
+    notes: APTL operator API + UI; out of ACES authoring scope.
+
+  - id: compose.network.aptl-security
+    surface: docker_compose_topology
+    legacy_source: docker-compose.yml (networks)
+    legacy_field: aptl-security
+    category: aptl_backend_responsibility
+    aces_target: ACES network topology surface
+    runtime_owner: docker-compose networks
+    validation_evidence: tests/test_consistency.py (network presence)
+    blocking_followup: "#320"
+    notes: SOC + Wazuh segment.
+
+  - id: compose.network.aptl-dmz
+    surface: docker_compose_topology
+    legacy_source: docker-compose.yml (networks)
+    legacy_field: aptl-dmz
+    category: aptl_backend_responsibility
+    aces_target: ACES network topology surface
+    runtime_owner: docker-compose networks
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: DMZ segment for external-facing services.
+
+  - id: compose.network.aptl-internal
+    surface: docker_compose_topology
+    legacy_source: docker-compose.yml (networks)
+    legacy_field: aptl-internal
+    category: aptl_backend_responsibility
+    aces_target: ACES network topology surface
+    runtime_owner: docker-compose networks
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Enterprise internal segment (ADR-006).
+
+  - id: compose.network.aptl-redteam
+    surface: docker_compose_topology
+    legacy_source: docker-compose.yml (networks)
+    legacy_field: aptl-redteam
+    category: aptl_backend_responsibility
+    aces_target: ACES network topology surface
+    runtime_owner: docker-compose networks
+    validation_evidence: tests/test_consistency.py
+    blocking_followup: "#320"
+    notes: Red-team segment isolating Kali (ADR-006).
+
+  - id: compose.volumes.summary
+    surface: docker_compose_topology
+    legacy_source: docker-compose.yml (volumes)
+    legacy_field: named-volume conventions (43 volumes)
+    category: aptl_backend_responsibility
+    aces_target: n/a (backend realization detail)
+    runtime_owner: docker-compose volume declarations
+    validation_evidence: tests/test_consistency.py (volume references close over services)
+    blocking_followup: n/a
+    notes: 43 named volumes split into data / config / logs by component; per-volume rows would dilute review without adding signal.
+
+  # ---- surface: aptl_config ---------------------------------------------
+  # ContainerSettings toggles + LabSettings core fields. Survives cutover
+  # as backend config — the ACES scenario describes nodes/services; the
+  # backend translates that into which profiles to start.
+
+  - id: cfg.containers.wazuh
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.wazuh)
+    legacy_field: containers.wazuh
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: Backend config toggle; ACES SDL does not enumerate profile toggles.
+
+  - id: cfg.containers.victim
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.victim)
+    legacy_field: containers.victim
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: See cfg.containers.wazuh.
+
+  - id: cfg.containers.kali
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.kali)
+    legacy_field: containers.kali
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: See cfg.containers.wazuh.
+
+  - id: cfg.containers.reverse
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.reverse)
+    legacy_field: containers.reverse
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: See cfg.containers.wazuh.
+
+  - id: cfg.containers.enterprise
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.enterprise)
+    legacy_field: containers.enterprise
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: See cfg.containers.wazuh.
+
+  - id: cfg.containers.soc
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.soc)
+    legacy_field: containers.soc
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: See cfg.containers.wazuh.
+
+  - id: cfg.containers.mail
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.mail)
+    legacy_field: containers.mail
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: See cfg.containers.wazuh.
+
+  - id: cfg.containers.fileshare
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.fileshare)
+    legacy_field: containers.fileshare
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: See cfg.containers.wazuh.
+
+  - id: cfg.containers.dns
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (ContainerSettings.dns)
+    legacy_field: containers.dns
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization choice
+    runtime_owner: ContainerSettings.enabled_profiles()
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: See cfg.containers.wazuh.
+
+  - id: cfg.lab.name
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (LabSettings.name)
+    legacy_field: lab.name
+    category: aptl_backend_responsibility
+    aces_target: ACES backend operational identity
+    runtime_owner: AptlConfig.lab.name
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: Backend identity, not authored in ACES SDL.
+
+  - id: cfg.lab.network_subnet
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (LabSettings.network_subnet)
+    legacy_field: lab.network_subnet
+    category: aptl_backend_responsibility
+    aces_target: ACES backend realization detail
+    runtime_owner: AptlConfig.lab.network_subnet
+    validation_evidence: tests/test_config.py
+    blocking_followup: n/a
+    notes: Default 172.20.0.0/16; backend addressing detail.
+
+  - id: cfg.deployment.provider
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (DeploymentConfig.provider)
+    legacy_field: deployment.provider
+    category: aptl_backend_responsibility
+    aces_target: ACES RuntimeTarget selection
+    runtime_owner: AptlConfig.deployment.provider -> DeploymentBackend
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: docker-compose vs ssh-compose; the ACES adapter sits on top of this.
+
+  - id: cfg.run_storage.local_path
+    surface: aptl_config
+    legacy_source: src/aptl/core/config.py (RunStorageConfig.local_path)
+    legacy_field: run_storage.local_path
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot persistence side
+    runtime_owner: AptlConfig.run_storage.local_path -> LocalRunStore
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: n/a
+    notes: APTL-side run persistence root; reused by ACES adapter via LocalRunStore.
+
+  # ---- surface: env_vars_and_secrets ------------------------------------
+  # EnvVars fields + the placeholder gate. All aptl_backend_responsibility
+  # — ADR-028 / ADR-034 own the secret-bearing surface.
+
+  - id: env.indexer_username
+    surface: env_vars_and_secrets
+    legacy_source: src/aptl/core/env.py (EnvVars.indexer_username)
+    legacy_field: INDEXER_USERNAME
+    category: aptl_backend_responsibility
+    aces_target: n/a (lab-side credential, never authored in ACES SDL)
+    runtime_owner: EnvVars + find_placeholder_env_values
+    validation_evidence: tests/test_env.py
+    blocking_followup: n/a
+    notes: ADR-028 generated-config boundary; field name only — value lives in .env.
+
+  - id: env.indexer_password
+    surface: env_vars_and_secrets
+    legacy_source: src/aptl/core/env.py (EnvVars.indexer_password)
+    legacy_field: INDEXER_PASSWORD
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: EnvVars + find_placeholder_env_values
+    validation_evidence: tests/test_env.py + tests/test_credentials.py
+    blocking_followup: n/a
+    notes: See env.indexer_username.
+
+  - id: env.api_username
+    surface: env_vars_and_secrets
+    legacy_source: src/aptl/core/env.py (EnvVars.api_username)
+    legacy_field: API_USERNAME
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: EnvVars + find_placeholder_env_values
+    validation_evidence: tests/test_env.py
+    blocking_followup: n/a
+    notes: See env.indexer_username.
+
+  - id: env.api_password
+    surface: env_vars_and_secrets
+    legacy_source: src/aptl/core/env.py (EnvVars.api_password)
+    legacy_field: API_PASSWORD
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: EnvVars + find_placeholder_env_values (_NO_PLACEHOLDER_VARS)
+    validation_evidence: tests/test_env.py + tests/test_credentials.py
+    blocking_followup: n/a
+    notes: Field is in the placeholder-blocked set; value never embedded in committed files.
+
+  - id: env.dashboard_username
+    surface: env_vars_and_secrets
+    legacy_source: src/aptl/core/env.py (EnvVars.dashboard_username)
+    legacy_field: DASHBOARD_USERNAME
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: EnvVars + find_placeholder_env_values
+    validation_evidence: tests/test_env.py
+    blocking_followup: n/a
+    notes: See env.indexer_username.
+
+  - id: env.dashboard_password
+    surface: env_vars_and_secrets
+    legacy_source: src/aptl/core/env.py (EnvVars.dashboard_password)
+    legacy_field: DASHBOARD_PASSWORD
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: EnvVars + find_placeholder_env_values
+    validation_evidence: tests/test_env.py
+    blocking_followup: n/a
+    notes: See env.indexer_username.
+
+  - id: env.wazuh_cluster_key
+    surface: env_vars_and_secrets
+    legacy_source: src/aptl/core/env.py (EnvVars.wazuh_cluster_key)
+    legacy_field: WAZUH_CLUSTER_KEY
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: EnvVars + find_placeholder_env_values (_NO_PLACEHOLDER_VARS)
+    validation_evidence: tests/test_env.py + tests/test_credentials.py
+    blocking_followup: n/a
+    notes: Placeholder-blocked; bug #183 history motivates the gate.
+
+  - id: env.placeholder_gate
+    surface: env_vars_and_secrets
+    legacy_source: src/aptl/core/env.py (find_placeholder_env_values + _NO_PLACEHOLDER_VARS)
+    legacy_field: find_placeholder_env_values
+    category: validation_gate
+    aces_target: n/a (APTL-side preflight)
+    runtime_owner: find_placeholder_env_values
+    validation_evidence: tests/test_env_fuzz.py + tests/test_env.py
+    blocking_followup: n/a
+    notes: ADR-028 / ADR-034 generated-secret guard; runs in _step_load_env at lab start.
+
+  # ---- surface: lab_lifecycle -------------------------------------------
+  # Every step in _LAB_START_STEPS, plus the readiness taxonomy
+  # (StartupOutcome / DiagnosticImpact / DiagnosticSeverity /
+  # StartupDiagnostic / LabResult). ADR-030 owns the taxonomy; the
+  # inventory does NOT introduce a parallel one.
+
+  - id: lab.step.load_env
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_load_env)
+    legacy_field: _step_load_env
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` lifecycle pre-flight
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py (TestOrchestrateLabStart)
+    blocking_followup: n/a
+    notes: Reads .env via EnvVars.
+
+  - id: lab.step.load_config
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_load_config)
+    legacy_field: _step_load_config
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` lifecycle pre-flight
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: Reads AptlConfig from aptl.json.
+
+  - id: lab.step.ensure_ssh_keys
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_ensure_ssh_keys)
+    legacy_field: _step_ensure_ssh_keys
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` lifecycle pre-flight
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: APTL-side SSH key material; not authored in ACES SDL.
+
+  - id: lab.step.check_sysreqs
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_check_sysreqs)
+    legacy_field: _step_check_sysreqs
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` host pre-flight
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: Host-side capability check.
+
+  - id: lab.step.sync_credentials
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_sync_credentials)
+    legacy_field: _step_sync_credentials
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` lifecycle (backend-only)
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py + tests/test_credentials.py
+    blocking_followup: n/a
+    notes: ADR-028 generated-config materialization.
+
+  - id: lab.step.sync_suricata_misp_rule_baselines
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_sync_suricata_misp_rule_baselines)
+    legacy_field: _step_sync_suricata_misp_rule_baselines
+    category: aptl_backend_responsibility
+    aces_target: n/a (defensive-stack realization)
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: SOC-rules baseline sync; APTL backend defensive plumbing.
+
+  - id: lab.step.generate_certs
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_generate_certs)
+    legacy_field: _step_generate_certs
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_certs.py
+    blocking_followup: n/a
+    notes: Lab-issued PKI; ADR-028.
+
+  - id: lab.step.generate_soc_certs
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_generate_soc_certs)
+    legacy_field: _step_generate_soc_certs
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_certs.py
+    blocking_followup: n/a
+    notes: SOC-side PKI.
+
+  - id: lab.step.check_bind_mounts
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_check_bind_mounts)
+    legacy_field: _step_check_bind_mounts
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py (TestCheckBindMounts)
+    blocking_followup: n/a
+    notes: Container bind-mount staging.
+
+  - id: lab.step.pull_images
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_pull_images)
+    legacy_field: _step_pull_images
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` image fetch
+    runtime_owner: DeploymentBackend.pull_images
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: DeploymentBackend method.
+
+  - id: lab.step.start_containers
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_start_containers)
+    legacy_field: _step_start_containers
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` start
+    runtime_owner: DeploymentBackend.start
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: DeploymentBackend method.
+
+  - id: lab.step.wait_for_services
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_wait_for_services)
+    legacy_field: _step_wait_for_services
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` readiness wait
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: Backend health-wait loop.
+
+  - id: lab.step.test_ssh
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_test_ssh)
+    legacy_field: _step_test_ssh
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` readiness check
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: SSH reachability gate for the kali attacker box.
+
+  - id: lab.step.capture_snapshot
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_capture_snapshot)
+    legacy_field: _step_capture_snapshot
+    category: aptl_backend_responsibility
+    aces_target: ACES `runtime-snapshot-v1` boundary
+    runtime_owner: RangeSnapshot.to_dict() + orchestrate_lab_start
+    validation_evidence: tests/test_snapshot.py
+    blocking_followup: n/a
+    notes: ACES runtime-snapshot envelope wraps APTL's RangeSnapshot dict.
+
+  - id: lab.step.build_mcps
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_build_mcps)
+    legacy_field: _step_build_mcps
+    category: aptl_backend_responsibility
+    aces_target: n/a (MCP servers are APTL-side operator tooling)
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: MCP server build step.
+
+  - id: lab.step.seed_soc
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_seed_soc)
+    legacy_field: _step_seed_soc
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: SOC seed material; defensive stack only.
+
+  - id: lab.step.sync_mcp_config
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab.py (_step_sync_mcp_config)
+    legacy_field: _step_sync_mcp_config
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: orchestrate_lab_start
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: MCP config sync.
+
+  - id: lab.outcome.startup_outcome
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab_types.py (StartupOutcome)
+    legacy_field: StartupOutcome
+    category: aptl_backend_responsibility
+    aces_target: ACES operation-status-v1 envelope (mapped via adapter)
+    runtime_owner: StartupOutcome (ADR-030)
+    validation_evidence: tests/test_lab.py (TestStartupClassificationTypes)
+    blocking_followup: n/a
+    notes: READY / DEGRADED_USABLE / DEGRADED_UNUSABLE / FAILED. ADR-030 is canonical owner.
+
+  - id: lab.outcome.diagnostic_impact
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab_types.py (DiagnosticImpact)
+    legacy_field: DiagnosticImpact
+    category: aptl_backend_responsibility
+    aces_target: ACES operation-status-v1 (mapped)
+    runtime_owner: DiagnosticImpact (ADR-030)
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: COSMETIC / TELEMETRY / CAPABILITY / READINESS. Do not duplicate.
+
+  - id: lab.outcome.diagnostic_severity
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab_types.py (DiagnosticSeverity)
+    legacy_field: DiagnosticSeverity
+    category: aptl_backend_responsibility
+    aces_target: ACES operation-status-v1 (mapped)
+    runtime_owner: DiagnosticSeverity (ADR-030)
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: INFO / WARNING / ERROR.
+
+  - id: lab.outcome.startup_diagnostic
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab_types.py (StartupDiagnostic)
+    legacy_field: StartupDiagnostic
+    category: aptl_backend_responsibility
+    aces_target: ACES operation-status-v1 diagnostic entries
+    runtime_owner: StartupDiagnostic (ADR-030)
+    validation_evidence: tests/test_lab.py
+    blocking_followup: n/a
+    notes: Per-step diagnostic record.
+
+  - id: lab.outcome.lab_result
+    surface: lab_lifecycle
+    legacy_source: src/aptl/core/lab_types.py (LabResult)
+    legacy_field: LabResult
+    category: aptl_backend_responsibility
+    aces_target: ACES operation-receipt-v1 / operation-status-v1 envelopes (mapped)
+    runtime_owner: LabResult
+    validation_evidence: tests/test_lab.py + tests/test_api_lab.py
+    blocking_followup: n/a
+    notes: APTL-facing result shape; ACES adapter translates at boundary.
+
+  # ---- surface: deployment_backend --------------------------------------
+  # Every method of the DeploymentBackend protocol. All
+  # aptl_backend_responsibility — this is the boundary the ACES adapter
+  # sits on top of.
+
+  - id: backend.start
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.start)
+    legacy_field: start
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` start phase
+    runtime_owner: DeploymentBackend.start
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: Compose / SSH-compose start.
+
+  - id: backend.stop
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.stop)
+    legacy_field: stop
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` stop phase
+    runtime_owner: DeploymentBackend.stop
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: Tear-down.
+
+  - id: backend.status
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.status)
+    legacy_field: status
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 source
+    runtime_owner: DeploymentBackend.status
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: Status inventory the snapshot consumes.
+
+  - id: backend.kill
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.kill)
+    legacy_field: kill
+    category: aptl_backend_responsibility
+    aces_target: ACES forceful stop
+    runtime_owner: DeploymentBackend.kill
+    validation_evidence: tests/test_api_kill.py + tests/test_cli_kill.py
+    blocking_followup: n/a
+    notes: Forceful teardown.
+
+  - id: backend.pull_images
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.pull_images)
+    legacy_field: pull_images
+    category: aptl_backend_responsibility
+    aces_target: ACES `apply` image fetch
+    runtime_owner: DeploymentBackend.pull_images
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: Pre-start image hydration.
+
+  - id: backend.container_list
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.container_list)
+    legacy_field: container_list
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 inventory side
+    runtime_owner: DeploymentBackend.container_list
+    validation_evidence: tests/test_deployment_backend.py + tests/test_cli_container.py
+    blocking_followup: n/a
+    notes: ADR-023 (container interaction in deployment backend).
+
+  - id: backend.container_logs
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.container_logs)
+    legacy_field: container_logs
+    category: aptl_backend_responsibility
+    aces_target: n/a (operator tooling)
+    runtime_owner: DeploymentBackend.container_logs
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: APTL-side log retrieval; not authored.
+
+  - id: backend.container_logs_capture
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.container_logs_capture)
+    legacy_field: container_logs_capture
+    category: aptl_backend_responsibility
+    aces_target: n/a (operator tooling)
+    runtime_owner: DeploymentBackend.container_logs_capture
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: Captured-log boundary.
+
+  - id: backend.container_shell
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.container_shell)
+    legacy_field: container_shell
+    category: aptl_backend_responsibility
+    aces_target: n/a (operator tooling)
+    runtime_owner: DeploymentBackend.container_shell
+    validation_evidence: tests/test_deployment_backend.py + tests/test_api_terminal.py
+    blocking_followup: n/a
+    notes: ADR-023.
+
+  - id: backend.container_exec
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.container_exec)
+    legacy_field: container_exec
+    category: aptl_backend_responsibility
+    aces_target: n/a (operator tooling)
+    runtime_owner: DeploymentBackend.container_exec
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: ADR-023.
+
+  - id: backend.container_inspect
+    surface: deployment_backend
+    legacy_source: src/aptl/core/deployment/backend.py (DeploymentBackend.container_inspect)
+    legacy_field: container_inspect
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 inventory side
+    runtime_owner: DeploymentBackend.container_inspect
+    validation_evidence: tests/test_deployment_backend.py
+    blocking_followup: n/a
+    notes: ADR-023.
+
+  # ---- surface: snapshots_and_runstore ----------------------------------
+  # Each RangeSnapshot field + each RunManifest field. Reuses ADR-029
+  # redaction boundary; the inventory does NOT introduce a parallel
+  # redactor.
+
+  - id: snap.software
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/snapshot.py (RangeSnapshot.software)
+    legacy_field: software
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 software section
+    runtime_owner: RangeSnapshot.to_dict()
+    validation_evidence: tests/test_snapshot.py
+    blocking_followup: n/a
+    notes: SoftwareVersions component.
+
+  - id: snap.containers
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/snapshot.py (RangeSnapshot.containers)
+    legacy_field: containers
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 containers section
+    runtime_owner: RangeSnapshot.to_dict()
+    validation_evidence: tests/test_snapshot.py
+    blocking_followup: n/a
+    notes: ContainerSnapshot list.
+
+  - id: snap.wazuh_rules
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/snapshot.py (RangeSnapshot.wazuh_rules)
+    legacy_field: wazuh_rules
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot extension (backend-specific)
+    runtime_owner: RangeSnapshot.to_dict()
+    validation_evidence: tests/test_snapshot.py
+    blocking_followup: n/a
+    notes: Defensive-stack ruleset fingerprint.
+
+  - id: snap.networks
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/snapshot.py (RangeSnapshot.networks)
+    legacy_field: networks
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 networks section
+    runtime_owner: RangeSnapshot.to_dict()
+    validation_evidence: tests/test_snapshot.py
+    blocking_followup: n/a
+    notes: NetworkSnapshot list.
+
+  - id: snap.config_hashes
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/snapshot.py (RangeSnapshot.config_hashes)
+    legacy_field: config_hashes
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot integrity section
+    runtime_owner: RangeSnapshot.to_dict()
+    validation_evidence: tests/test_snapshot.py
+    blocking_followup: n/a
+    notes: ADR-028 generated config integrity.
+
+  - id: snap.services
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/snapshot.py (RangeSnapshot.services)
+    legacy_field: services
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 services section
+    runtime_owner: RangeSnapshot.to_dict() (redacted)
+    validation_evidence: tests/test_snapshot.py
+    blocking_followup: n/a
+    notes: Service endpoints with redaction (ADR-029).
+
+  - id: snap.ssh
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/snapshot.py (RangeSnapshot.ssh)
+    legacy_field: ssh
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 endpoint section
+    runtime_owner: RangeSnapshot.to_dict() (redacted)
+    validation_evidence: tests/test_snapshot.py
+    blocking_followup: n/a
+    notes: SSH endpoint reachability (ADR-029 redaction).
+
+  - id: runstore.run_id
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.run_id)
+    legacy_field: run_id
+    category: aptl_backend_responsibility
+    aces_target: ACES run identity
+    runtime_owner: LocalRunStore.create_run
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: n/a
+    notes: Per-run directory id.
+
+  - id: runstore.scenario_id
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.scenario_id)
+    legacy_field: scenario_id
+    category: aces_sdl
+    aces_target: ACES scenario id (authored)
+    runtime_owner: LocalRunStore
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: "#319"
+    notes: After cutover, scenario_id is the ACES scenario id.
+
+  - id: runstore.scenario_name
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.scenario_name)
+    legacy_field: scenario_name
+    category: aces_sdl
+    aces_target: ACES scenario name
+    runtime_owner: LocalRunStore
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: "#319"
+    notes: ACES authored name.
+
+  - id: runstore.started_at
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.started_at)
+    legacy_field: started_at
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime clock surface
+    runtime_owner: LocalRunStore
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: n/a
+    notes: Backend-recorded.
+
+  - id: runstore.finished_at
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.finished_at)
+    legacy_field: finished_at
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime clock surface
+    runtime_owner: LocalRunStore
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: n/a
+    notes: Backend-recorded.
+
+  - id: runstore.duration_seconds
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.duration_seconds)
+    legacy_field: duration_seconds
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime clock surface
+    runtime_owner: LocalRunStore
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: n/a
+    notes: Derived from started_at/finished_at.
+
+  - id: runstore.trace_id
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.trace_id)
+    legacy_field: trace_id
+    category: aptl_backend_responsibility
+    aces_target: ACES correlation id (OBS-003 hook)
+    runtime_owner: LocalRunStore + trace-context.json
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: n/a
+    notes: Cross-side correlation id (ADR-033).
+
+  - id: runstore.config_snapshot
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.config_snapshot)
+    legacy_field: config_snapshot
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 config-hash section
+    runtime_owner: LocalRunStore (ADR-029 redaction)
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: n/a
+    notes: Config snapshot at run start.
+
+  - id: runstore.containers
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.containers)
+    legacy_field: containers
+    category: aptl_backend_responsibility
+    aces_target: ACES runtime-snapshot-v1 containers section
+    runtime_owner: LocalRunStore
+    validation_evidence: tests/test_runstore.py
+    blocking_followup: n/a
+    notes: Backend-derived container list at run start.
+
+  - id: runstore.flags_captured
+    surface: snapshots_and_runstore
+    legacy_source: src/aptl/core/runstore.py (RunManifest.flags_captured)
+    legacy_field: flags_captured
+    category: aces_schema_profile_gap
+    aces_target: ACES evaluator outcome (orchestration-evaluation profile)
+    runtime_owner: LocalRunStore
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: Scoring outcome; full coverage requires evaluator-profile promotion.
+
+  # ---- surface: defensive_stack_configs ---------------------------------
+  # One row per config/ subdirectory (10). All aptl_backend_responsibility
+  # — ADR-028 generated-config boundary.
+
+  - id: defconf.cortex
+    surface: defensive_stack_configs
+    legacy_source: config/cortex/
+    legacy_field: application.conf
+    category: aptl_backend_responsibility
+    aces_target: n/a (defensive-stack realization)
+    runtime_owner: config/cortex + docker-compose `soc` profile
+    validation_evidence: lab health (Cortex reachable from TheHive)
+    blocking_followup: "#322"
+    notes: Cortex analyzer service config.
+
+  - id: defconf.otel
+    surface: defensive_stack_configs
+    legacy_source: config/otel/
+    legacy_field: otel-collector-config.yaml, tempo-config.yaml, grafana-datasources.yaml
+    category: aptl_backend_responsibility
+    aces_target: n/a (telemetry realization)
+    runtime_owner: config/otel + docker-compose `otel` profile
+    validation_evidence: lab health (collector reachable)
+    blocking_followup: "#322"
+    notes: OTel collector + Tempo + Grafana datasources.
+
+  - id: defconf.soc_certs
+    surface: defensive_stack_configs
+    legacy_source: config/soc_certs/
+    legacy_field: lab-ca.{key,pem} + cortex/, misp/, shuffle-frontend/, thehive/
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: config/soc_certs + _step_generate_soc_certs
+    validation_evidence: tests/test_certs.py + lab health
+    blocking_followup: n/a
+    notes: SOC PKI material (ADR-028 generated).
+
+  - id: defconf.suricata
+    surface: defensive_stack_configs
+    legacy_source: config/suricata/
+    legacy_field: suricata.yaml + rules/
+    category: aptl_backend_responsibility
+    aces_target: n/a (defensive-stack realization)
+    runtime_owner: config/suricata + docker-compose `soc`
+    validation_evidence: tests/test_detection.py
+    blocking_followup: "#322"
+    notes: Suricata config + custom rules.
+
+  - id: defconf.thehive
+    surface: defensive_stack_configs
+    legacy_source: config/thehive/
+    legacy_field: application.conf
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: config/thehive + docker-compose `soc`
+    validation_evidence: lab health (TheHive reachable)
+    blocking_followup: "#322"
+    notes: TheHive case/alert config.
+
+  - id: defconf.wazuh_cluster
+    surface: defensive_stack_configs
+    legacy_source: config/wazuh_cluster/
+    legacy_field: wazuh_manager.conf + custom rule XML
+    category: aptl_backend_responsibility
+    aces_target: n/a (defensive-stack realization)
+    runtime_owner: config/wazuh_cluster + docker-compose `wazuh`
+    validation_evidence: tests/test_detection.py + lab health
+    blocking_followup: "#322"
+    notes: Wazuh manager + custom decoders/rules per component.
+
+  - id: defconf.wazuh_dashboard
+    surface: defensive_stack_configs
+    legacy_source: config/wazuh_dashboard/
+    legacy_field: opensearch_dashboards.yml + wazuh.yml
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: config/wazuh_dashboard + docker-compose `wazuh`
+    validation_evidence: lab health (Dashboard reachable)
+    blocking_followup: n/a
+    notes: Wazuh dashboard UI config.
+
+  - id: defconf.wazuh_indexer
+    surface: defensive_stack_configs
+    legacy_source: config/wazuh_indexer/
+    legacy_field: internal_users.yml + wazuh.indexer.yml
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: config/wazuh_indexer + docker-compose `wazuh`
+    validation_evidence: lab health (Indexer reachable)
+    blocking_followup: n/a
+    notes: Indexer + internal users.
+
+  - id: defconf.wazuh_indexer_ssl_certs
+    surface: defensive_stack_configs
+    legacy_source: config/wazuh_indexer_ssl_certs/
+    legacy_field: admin, indexer, dashboard, root-ca certs
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: config/wazuh_indexer_ssl_certs + _step_generate_certs
+    validation_evidence: tests/test_certs.py
+    blocking_followup: n/a
+    notes: Wazuh PKI bundle.
+
+  - id: defconf.certs_yml
+    surface: defensive_stack_configs
+    legacy_source: config/certs.yml
+    legacy_field: certs.yml
+    category: aptl_backend_responsibility
+    aces_target: n/a
+    runtime_owner: config/certs.yml + _step_generate_certs
+    validation_evidence: tests/test_certs.py
+    blocking_followup: n/a
+    notes: Cert-generation manifest (root + per-component).
+
+  # ---- surface: test_and_validation -------------------------------------
+  # Gates that hold the cutover honest. The conformance suite and the
+  # parity inventory itself are the validation_gate rows.
+
+  - id: gate.aces_conformance_backend_provisioning
+    surface: test_and_validation
+    legacy_source: aces-sdl reference suite
+    legacy_field: aces conformance backend --profile provisioning-only
+    category: validation_gate
+    aces_target: ACES `backend-manifest-v2` conformance
+    runtime_owner: APTL backend manifest (path pinned during #320)
+    validation_evidence: aces conformance backend --profile provisioning-only
+    blocking_followup: "#320"
+    notes: Advisory in Phase A; enforced pre-push at Phase B cutover.
+
+  - id: gate.aces_conformance_backend_evaluation
+    surface: test_and_validation
+    legacy_source: aces-sdl reference suite
+    legacy_field: aces conformance backend --profile orchestration-evaluation
+    category: validation_gate
+    aces_target: ACES evaluator-profile conformance
+    runtime_owner: APTL backend manifest (post-promotion)
+    validation_evidence: aces conformance backend --profile orchestration-evaluation
+    blocking_followup: "#312"
+    notes: Required only once #312 promotes the backend.
+
+  - id: gate.parity_inventory_schema
+    surface: test_and_validation
+    legacy_source: tests/test_parity_inventory.py
+    legacy_field: tests/test_parity_inventory.py
+    category: validation_gate
+    aces_target: n/a
+    runtime_owner: tests/test_parity_inventory.py + docs/aces/parity-inventory.yaml
+    validation_evidence: pytest tests/test_parity_inventory.py
+    blocking_followup: n/a
+    notes: This file's structural gate; runs in CI on every PR.
+
+  - id: gate.scenarios_load
+    surface: test_and_validation
+    legacy_source: tests/test_scenarios.py
+    legacy_field: test_example_scenarios_load
+    category: validation_gate
+    aces_target: ACES parser equivalence at cutover
+    runtime_owner: tests/test_scenarios.py
+    validation_evidence: pytest tests/test_scenarios.py
+    blocking_followup: "#323"
+    notes: Migrates to assert ACES SDL load at cutover.
+
+  - id: gate.compose_consistency
+    surface: test_and_validation
+    legacy_source: tests/test_consistency.py
+    legacy_field: TestComposeConsistency
+    category: validation_gate
+    aces_target: n/a (backend-side gate)
+    runtime_owner: tests/test_consistency.py
+    validation_evidence: pytest tests/test_consistency.py
+    blocking_followup: n/a
+    notes: Compose internal consistency; backend-side.
+
+  - id: gate.placeholder_env_block
+    surface: test_and_validation
+    legacy_source: tests/test_env_fuzz.py
+    legacy_field: find_placeholder_env_values invariants
+    category: validation_gate
+    aces_target: n/a (APTL-side preflight)
+    runtime_owner: find_placeholder_env_values + tests/test_env_fuzz.py
+    validation_evidence: pytest -m fuzz
+    blocking_followup: n/a
+    notes: Property-based gate guarding ADR-028 / ADR-034 secret boundary.

--- a/docs/adrs/adr-035-aces-sdl-adoption.md
+++ b/docs/adrs/adr-035-aces-sdl-adoption.md
@@ -119,6 +119,100 @@ exercise:
 The parity check is reviewed in the cutover PR description and is a hard
 prerequisite. No cutover PR merges without it.
 
+## Parity Inventory Boundary
+
+Issue #318's parity inventory is the authoritative review surface for
+deciding whether the ACES TechVault can replace the legacy scenario set. It
+is not a runtime schema, not a new SDL, and not a deployment authority.
+
+The inventory lives at
+[`docs/aces/parity-inventory.yaml`](../aces/parity-inventory.yaml) with a
+human-readable overview at
+[`docs/aces/parity-inventory.md`](../aces/parity-inventory.md). Its schema
+is enforced by `tests/test_parity_inventory.py`.
+
+The inventory must map every legacy surface to exactly one owning category:
+
+- **ACES SDL** when the authored scenario can express the surface directly
+  through the ACES parser, schemas, semantic validators, and compiled
+  `RuntimeModel`.
+- **ACES schema/profile gap** when the concept belongs in ACES rather than
+  APTL; these rows must cite an ACES follow-up instead of adding an APTL
+  extension that recreates the retired in-tree SDL.
+- **APTL backend responsibility** when the concept is backend realization
+  detail: Docker Compose profiles, generated runtime config, lab-managed TLS,
+  SOC seed material, deployment inventory, readiness classification, snapshots,
+  run archive persistence, or host/container interaction.
+- **Validation gate** when the surface is not authored but must be proven by
+  conformance, static parity tests, live lab validation, snapshots, or run
+  archive assertions.
+- **Cutover-only archive/cleanup** when the legacy field is retained only as
+  reference material after the Phase B move to `scenarios/archive/`.
+
+The canonical source for a row is the existing owner, not the inventory
+document itself. In particular:
+
+- authored legacy fields come from `scenarios/*.yaml` until cutover;
+- topology, profiles, networks, static IPs, hostnames, volumes, health checks,
+  published ports, and service dependencies come from `docker-compose.yml` and
+  the `DeploymentBackend` inventory methods;
+- durable first-party knobs come from `AptlConfig`, not ad hoc YAML keys;
+- `.env` values and generated secret-bearing config come from `EnvVars`,
+  `find_placeholder_env_values`, ADR-028, ADR-029, and ADR-034;
+- lab lifecycle and readiness surfaces come from `_LAB_START_STEPS`,
+  `LabResult`, `StartupOutcome`, and `StartupDiagnostic`;
+- runtime snapshots come from `RangeSnapshot.to_dict()` and the endpoint
+  registry boundary in ADR-036;
+- run archives come from `LocalRunStore` and its redacting JSON/JSONL write
+  boundary.
+
+The inventory may be human-readable or machine-readable, but if it becomes
+machine-readable it must stay a narrow audit manifest: stable legacy
+identifier, canonical source, owning category, ACES/runtime/backend target,
+validation evidence, and blocking follow-up. It must not introduce a second
+Pydantic `ScenarioDefinition`, a second ACES model, a duplicate Docker Compose
+parser, a duplicate secret taxonomy, a duplicate readiness taxonomy, or a
+parallel exception/result envelope.
+
+## ACES Backend Integration Guardrails
+
+APTL's ACES backend target is an adapter over existing APTL control-plane
+boundaries. The implementation must not bypass those boundaries just because
+the caller is ACES.
+
+- ACES SDL documents enter through the ACES reference parser and semantic
+  validators; APTL does not perform structural revalidation of ACES SDL with
+  local models.
+- ACES runtime work enters APTL through the ACES `RuntimeModel`,
+  `ExecutionPlan`, backend manifest, operation receipt/status, and runtime
+  snapshot contracts. The APTL-side target adapts those contracts to existing
+  APTL owners rather than inventing a parallel runtime manager.
+- Docker, container, and host inventory operations continue through
+  `DeploymentBackend`; no ACES adapter code should call raw Docker or parse
+  Compose output directly.
+- Lab start/stop behavior continues to produce `LabResult` and structured
+  startup diagnostics at APTL-facing edges. ACES-facing failures are translated
+  into ACES diagnostics or operation-status envelopes at the adapter boundary;
+  do not add an `AcesAptlError` hierarchy or expose raw backend exception text.
+- Generated config, SOC TLS material, seed outputs, and any other
+  secret-bearing runtime artifacts remain under the ADR-028 / ADR-034 generated
+  artifact model. The backend manifest and parity inventory must not embed
+  `.env` values, private key material, API tokens, cookies, or rendered config.
+- Snapshot, status, telemetry, CLI/API output, run archives, and conformance
+  artifacts remain subject to ADR-029 redaction. New ACES status or run
+  evidence writers must reuse `RangeSnapshot.to_dict()` and `LocalRunStore`
+  JSON/JSONL redaction boundaries where those artifacts cross APTL
+  serialization.
+- Published backend capability stays profile-named and contract-validated:
+  `provisioning-only` is the initial claim, and any profile promotion belongs
+  to the follow-on issues already named here.
+
+The extensibility seam is the ACES backend capability profile plus a small
+backend realization map from ACES runtime resource kinds to existing APTL
+control-plane owners. Do not make TechVault-specific branches the public
+adapter contract; TechVault is the parity proving case for the supported
+expressivity class, not the backend's type system.
+
 ## Migration Plan
 
 The migration splits into a multi-PR prep phase and a single-PR cutover.

--- a/tests/test_parity_inventory.py
+++ b/tests/test_parity_inventory.py
@@ -1,0 +1,228 @@
+"""Schema and coverage checks for the ACES parity inventory (SCN-010).
+
+The inventory at ``docs/aces/parity-inventory.yaml`` is the authoritative
+audit surface SCN-010 specification issues (#319-#324) and the cutover PR
+must cite when claiming TechVault parity (ADR-035, "Parity Inventory
+Boundary"). These tests enforce that the manifest stays a narrow audit
+artifact: closed-enum categories, unique row ids, required fields, and
+coverage of every legacy surface bucket.
+"""
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INVENTORY_PATH = PROJECT_ROOT / "docs" / "aces" / "parity-inventory.yaml"
+
+REQUIRED_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "generated_for",
+    "related_adr",
+    "categories",
+    "surfaces",
+    "rows",
+}
+
+REQUIRED_ROW_KEYS = {
+    "id",
+    "surface",
+    "legacy_source",
+    "legacy_field",
+    "category",
+    "aces_target",
+    "runtime_owner",
+    "validation_evidence",
+    "blocking_followup",
+    "notes",
+}
+
+EXPECTED_CATEGORIES = {
+    "aces_sdl",
+    "aces_schema_profile_gap",
+    "aptl_backend_responsibility",
+    "validation_gate",
+    "cutover_only_archive",
+}
+
+EXPECTED_SURFACES = {
+    "scenarios_yaml",
+    "docker_compose_topology",
+    "aptl_config",
+    "env_vars_and_secrets",
+    "lab_lifecycle",
+    "deployment_backend",
+    "snapshots_and_runstore",
+    "defensive_stack_configs",
+    "test_and_validation",
+}
+
+# Substrings that must never appear inside a row body. If the inventory
+# starts embedding an env-var name immediately followed by ``=``, that is
+# almost certainly a real secret value leaking out of ``.env`` and into a
+# committed file. The check is intentionally crude — the inventory's own
+# rows reference these names as bare identifiers, never as ``NAME=value``.
+SECRET_NAME_TOKENS = (
+    "API_PASSWORD",
+    "WAZUH_CLUSTER_KEY",
+    "MISP_API_KEY",
+    "THEHIVE_SECRET",
+    "SHUFFLE_API_KEY",
+)
+
+
+@pytest.fixture(scope="module")
+def inventory() -> Mapping:
+    assert INVENTORY_PATH.exists(), (
+        f"Parity inventory missing at {INVENTORY_PATH.relative_to(PROJECT_ROOT)}; "
+        "SCN-010 cutover review surface requires it (ADR-035)."
+    )
+    with INVENTORY_PATH.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    assert isinstance(data, Mapping), "Inventory root must be a mapping."
+    return data
+
+
+def test_top_level_keys_present(inventory):
+    missing = REQUIRED_TOP_LEVEL_KEYS - set(inventory)
+    assert not missing, f"Inventory missing top-level keys: {sorted(missing)}"
+
+
+def test_schema_version_is_one(inventory):
+    assert inventory["schema_version"] == 1
+
+
+def test_generated_for_targets_scn_010(inventory):
+    assert inventory["generated_for"] == "SCN-010"
+
+
+def test_related_adr_points_at_adr_035(inventory):
+    assert inventory["related_adr"] == "docs/adrs/adr-035-aces-sdl-adoption.md"
+
+
+def test_categories_match_closed_enum(inventory):
+    assert set(inventory["categories"]) == EXPECTED_CATEGORIES
+
+
+def test_surfaces_match_expected_set(inventory):
+    assert set(inventory["surfaces"]) == EXPECTED_SURFACES
+
+
+def test_rows_is_non_empty_list(inventory):
+    rows = inventory["rows"]
+    assert isinstance(rows, list)
+    assert rows, "Inventory must contain at least one row."
+
+
+def test_every_row_has_required_keys(inventory):
+    missing_by_row = {}
+    for row in inventory["rows"]:
+        assert isinstance(row, Mapping), f"Row is not a mapping: {row!r}"
+        missing = REQUIRED_ROW_KEYS - set(row)
+        if missing:
+            missing_by_row[row.get("id", "<no-id>")] = sorted(missing)
+    assert not missing_by_row, f"Rows missing required keys: {missing_by_row}"
+
+
+def test_row_ids_are_unique(inventory):
+    ids = [row["id"] for row in inventory["rows"]]
+    duplicates = sorted({i for i in ids if ids.count(i) > 1})
+    assert not duplicates, f"Duplicate row ids: {duplicates}"
+
+
+def test_row_ids_are_stable_anchor_safe(inventory):
+    bad = [
+        row["id"]
+        for row in inventory["rows"]
+        if not row["id"] or not all(c.isalnum() or c in ".-_" for c in row["id"])
+    ]
+    assert not bad, (
+        f"Row ids must be ASCII alphanumeric + '.-_' so issues can cite "
+        f"them as anchors; offenders: {bad}"
+    )
+
+
+def test_every_row_category_is_valid(inventory):
+    bad = {
+        row["id"]: row["category"]
+        for row in inventory["rows"]
+        if row["category"] not in EXPECTED_CATEGORIES
+    }
+    assert not bad, f"Rows with category outside the closed enum: {bad}"
+
+
+def test_every_row_surface_is_valid(inventory):
+    bad = {
+        row["id"]: row["surface"]
+        for row in inventory["rows"]
+        if row["surface"] not in EXPECTED_SURFACES
+    }
+    assert not bad, f"Rows with surface outside the declared set: {bad}"
+
+
+def test_every_declared_surface_has_at_least_one_row(inventory):
+    rows_by_surface = {s: 0 for s in EXPECTED_SURFACES}
+    for row in inventory["rows"]:
+        rows_by_surface[row["surface"]] += 1
+    empty = [s for s, n in rows_by_surface.items() if n == 0]
+    assert not empty, (
+        f"Every declared surface bucket must carry at least one row; "
+        f"empty buckets: {empty}"
+    )
+
+
+def test_every_category_has_at_least_one_row(inventory):
+    rows_by_cat = {c: 0 for c in EXPECTED_CATEGORIES}
+    for row in inventory["rows"]:
+        rows_by_cat[row["category"]] += 1
+    empty = [c for c, n in rows_by_cat.items() if n == 0]
+    assert not empty, (
+        f"Every category in the closed enum must carry at least one row "
+        f"so the inventory exercises the whole taxonomy; empty: {empty}"
+    )
+
+
+def test_gap_rows_cite_a_followup(inventory):
+    """Gap rows must cite a concrete follow-up, not 'n/a'."""
+    offenders = []
+    for row in inventory["rows"]:
+        if row["category"] == "aces_schema_profile_gap":
+            followup = row.get("blocking_followup")
+            if not followup or str(followup).strip().lower() in {"n/a", "none", ""}:
+                offenders.append(row["id"])
+    assert not offenders, (
+        f"aces_schema_profile_gap rows must name a blocking follow-up "
+        f"(issue ref or ACES upstream pointer); offenders: {offenders}"
+    )
+
+
+def test_every_legacy_scenario_yaml_is_covered(inventory):
+    """Every existing scenarios/*.yaml file must appear in legacy_source
+    of at least one row in the ``scenarios_yaml`` surface bucket."""
+    scenarios_dir = PROJECT_ROOT / "scenarios"
+    on_disk = {p.name for p in scenarios_dir.glob("*.yaml")}
+    cited = {
+        Path(row["legacy_source"]).name
+        for row in inventory["rows"]
+        if row["surface"] == "scenarios_yaml"
+        and row["legacy_source"].startswith("scenarios/")
+    }
+    missing = on_disk - cited
+    assert not missing, (
+        f"Scenario YAMLs present on disk but not cited by any inventory "
+        f"row: {sorted(missing)}"
+    )
+
+
+def test_no_secret_value_leakage(inventory):
+    """Defence-in-depth: the inventory must reference secret env-var
+    names as bare identifiers, never as ``NAME=value`` pairs."""
+    text = INVENTORY_PATH.read_text(encoding="utf-8")
+    offenders = [tok for tok in SECRET_NAME_TOKENS if f"{tok}=" in text]
+    assert not offenders, (
+        f"Possible secret leakage in inventory (env-var name immediately "
+        f"followed by '='): {offenders}"
+    )


### PR DESCRIPTION
## Summary

SCN-010A: land the ACES-SDL parity inventory at `docs/aces/parity-inventory.yaml` so SCN-010 specification issues (#319-#324) and the eventual Phase B cutover PR can cite individual rows mechanically when claiming TechVault parity.

## Requirement UIDs

- `SCN-010`

## Related Issues

Closes #318

## ADR Impact

- ADR-035

## Changes

- Add `docs/aces/parity-inventory.yaml` — machine-readable manifest mapping every legacy APTL scenario/lab/defensive-stack surface to exactly one of the five owning categories ADR-035 enumerates (`aces_sdl`, `aces_schema_profile_gap`, `aptl_backend_responsibility`, `validation_gate`, `cutover_only_archive`). Per-row stable ids let issues cite rows via `parity#<id>`.
- Add `docs/aces/parity-inventory.md` — human-readable overview, schema reference, category definitions, and citation convention.
- Add `tests/test_parity_inventory.py` — 17 schema / coverage gates: required fields, unique anchor-safe ids, closed-enum categories and surfaces, non-empty bucket coverage, every `scenarios/*.yaml` cited, gap rows must cite a follow-up, no `NAME=` secret-token shapes.
- Add `changelog.d/318.added.md` fragment.
- Update `docs/adrs/adr-035-aces-sdl-adoption.md` with a pointer line under the preflight-authored "Parity Inventory Boundary" section.

## Test Plan

- [x] `pre-commit run --all-files` passes
- [x] `pytest` passes (1658 passed, 176 skipped, 22 deselected, 1 xfailed — includes the 17 new schema gates)
- Unit tests: covered by `tests/test_parity_inventory.py` (the inventory parser/checker the issue acceptance asks for).
- Integration tests: N/A — docs-only change.
- Migration smoke test: N/A — no runtime change.

Pure docs-only diff (one `.yaml` data manifest, one `.md` overview, one ADR pointer line, one changelog fragment) plus one new test file. Codex pre-push review and test-quality pre-push review both returned clean on cycle 1.

## Ground Control Checks

- [x] `gc_codex_review_cycle` returned clean on cycle 1 (decision record on issue thread).
- [x] `gc_test_quality_review_cycle` returned clean on cycle 1 (decision record on issue thread).
- [x] `gc_codex_architecture_preflight` (Step 2.5) consumed; the inventory schema, row coverage, and category enum mirror ADR-035's "Parity Inventory Boundary" guardrails exactly.

## Traceability

- IMPLEMENTS: SCN-010 (the inventory operationalizes ADR-035's "legacy paths shall remain functional until parity holds" gate)
- TESTS: SCN-010 (`tests/test_parity_inventory.py`)

## Out of scope / follow-up

- Suricata bind-mount chown trap surfaced during pre-push pre-commit: split off to #325 — needs its own design discussion (entrypoint wrapper vs. image-side cp vs. internal-path rewriting) and ADR.
