### PR TITLE
feat(scn-010): author ACES-native TechVault SDL (Phase A)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,12 +42,23 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      # ACES SDL sibling — SCN-010 / issue #319 requires the ACES reference
+      # parser and runtime compiler to validate scenarios/techvault.sdl.yaml
+      # (ADR-035). The repo lives at Brad-Edwards/aces and is consumed in
+      # editable mode below; only this job needs it (pre-commit skips the
+      # pytest hook; mcp-tests and web-tests are TypeScript).
+      - uses: actions/checkout@v6
+        with:
+          repository: Brad-Edwards/aces
+          path: _aces-sdl
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,web]"
+          pip install -e ./_aces-sdl/implementations/python
       - run: |
           coverage run -m pytest tests/ -q -k "not integration"
           coverage xml -o coverage.xml

--- a/changelog.d/319.added.md
+++ b/changelog.d/319.added.md
@@ -1,0 +1,19 @@
+### Added
+
+- ACES-native TechVault scenario at `scenarios/techvault.sdl.yaml`,
+  authored directly against the ACES SDL grammar (no `aptl.core.sdl` or
+  Pydantic `ScenarioDefinition` mirror, no scenario-name preset). The
+  document declares the four legacy enterprise subnets, the webapp /
+  PostgreSQL / Samba AD-DC / fileshare / Windows workstation / mail /
+  DNS / victim target nodes, Kali as a first-class dual-homed attacker
+  apparatus, the SOC stack as a defensive observation surface, plus the
+  vulnerabilities, conditions, accounts, content fixtures, injects,
+  scripts, stories, objectives, metrics, evaluations, and workflows
+  needed for an APTL backend interpreter to realize TechVault from
+  declared structure alone. A new `tests/test_techvault_sdl.py` drives
+  the document through `aces_sdl.parse_sdl_file` and
+  `aces_processor.compiler.compile_runtime_model` from the sibling
+  `Brad-Edwards/aces` repository and asserts the issue's enterprise /
+  Kali surface coverage. The `python-tests` CI job checks out
+  `Brad-Edwards/aces` alongside APTL so the validation runs end-to-end
+  on every push (ADR-035, SCN-010 Phase A, #319).

--- a/docs/aces/parity-inventory.md
+++ b/docs/aces/parity-inventory.md
@@ -121,6 +121,13 @@ accurate. Example PR-description line:
 
 - **ADR-035** — ACES SDL adoption and the parity-inventory boundary
   (the binding document).
+- **TechVault ACES SDL authoring preflight** —
+  `docs/aces/techvault-sdl-authoring-preflight.md` records the SCN-010B
+  authoring guardrails for issue #319. The ACES-authored document that
+  satisfies those guardrails is `scenarios/techvault.sdl.yaml`; its
+  parser / compile / surface-coverage gates live in
+  `tests/test_techvault_sdl.py` and execute against the sibling
+  `Brad-Edwards/aces` checkout the `python-tests` CI job sets up.
 - **ADR-028** — Runtime-rendered service config (generated-secret
   boundary referenced by `env_vars_and_secrets` rows).
 - **ADR-029** — Snapshot / runstore redaction boundary.

--- a/docs/aces/techvault-sdl-authoring-preflight.md
+++ b/docs/aces/techvault-sdl-authoring-preflight.md
@@ -1,0 +1,110 @@
+# TechVault ACES SDL Authoring Preflight
+
+This note is the architecture preflight for SCN-010B / issue #319. It is
+guidance, not an implementation plan. ADR-035 remains the binding adoption
+decision.
+
+## Architecture Decisions
+
+- `scenarios/techvault.sdl.yaml` is an ACES SDL document. Its structural and
+  semantic authority is the ACES reference parser (`aces_sdl.parse_sdl_file`)
+  and ACES runtime compiler (`aces_processor.compiler.compile_runtime_model`),
+  not `aptl.core.sdl`, `aptl.core.scenarios`, or a new APTL model.
+- The TechVault SDL must declare scenario structure explicitly enough for a
+  generic APTL ACES backend to realize it. A scenario name, preset flag,
+  backend hint, or "use legacy TechVault" escape hatch is not parity.
+- The parity inventory is the audit authority for legacy coverage. The SDL
+  should cite and satisfy relevant `parity#...` rows; it must not copy the
+  inventory into a second schema or treat the inventory as runtime input.
+- APTL-authored backend realization remains separate from ACES-authored
+  scenario meaning. Docker Compose profiles, generated config, readiness,
+  endpoint snapshots, and run archives stay owned by the existing APTL
+  boundaries named in ADR-035.
+
+## Cross-Cutting Concerns To Reuse
+
+- ACES parser, models, semantic validators, imports, lockfile, and runtime
+  compiler from the sibling `../aces-sdl` implementation.
+- ACES backend profile and conformance authorities:
+  `contracts/profiles/backend/provisioning-only.json`,
+  `aces_contracts.backend_profiles.load_backend_profile`,
+  `aces_backend_protocols.manifest.backend_manifest_payload`, and
+  `aces conformance backend --profile provisioning-only`.
+- APTL parity inventory:
+  `docs/aces/parity-inventory.yaml`, `docs/aces/parity-inventory.md`, and
+  `tests/test_parity_inventory.py`.
+- APTL lab/config/runtime owners: `AptlConfig`, `EnvVars`,
+  `find_placeholder_env_values`, `_LAB_START_STEPS`, `DeploymentBackend`,
+  `LabResult`, `StartupDiagnostic`, `RangeSnapshot.to_dict()`,
+  `ENDPOINT_REGISTRY`, and `LocalRunStore`.
+- Shared safety helpers and policies: ADR-028, ADR-029, ADR-031, ADR-036,
+  ADR-037, `aptl.utils.redaction.redact`, and `aptl.utils.curl_safe`.
+
+## Security And Runtime Gates
+
+- **ACES SDL shape:** the document must pass ACES `SDLModel` closed-world
+  validation (`extra="forbid"`), ACES semantic validation, and runtime
+  compilation. Do not add local APTL YAML shape checks for ACES fields.
+- **Imports and modules:** if imports are used, resolve and verify them through
+  ACES `aces sdl resolve` / `verify-imports` / lockfile behavior. Do not fetch
+  or execute import content from an APTL helper.
+- **Secret classification:** intentional weak target credentials may be
+  represented only as lab fixture data. Operator/control-plane secrets
+  (`.env`, Wazuh/TheHive/MISP tokens, API passwords, private keys, cookies,
+  bearer tokens, generated rendered config) must stay out of the SDL and under
+  `EnvVars`, ADR-028, and ADR-029.
+- **Environment binding:** durable knobs belong in strict `AptlConfig`;
+  runtime secrets belong in `.env` parsed by `load_dotenv` and shaped by
+  `EnvVars`. Do not add ACES-specific environment parsing.
+- **OS/process exposure:** validation and test commands must not put real
+  tokens, passwords, hashes, or private keys in process argv. Existing SOC HTTP
+  access keeps using `curl_safe`.
+- **Backend/lab execution:** ACES backend work must eventually flow through
+  `RuntimeTarget` / ACES operation envelopes into APTL `DeploymentBackend` and
+  `LabResult` surfaces. Do not shell out to Docker or parse Compose output from
+  SDL authoring or validation helpers.
+- **Error envelopes and observability:** parser, compile, conformance, CLI,
+  API, snapshot, telemetry, and runstore outputs must report narrow diagnostic
+  codes/messages and pass existing redaction boundaries. Do not expose raw
+  exception text or dumped ACES/APTL objects if they can contain credentials.
+- **Persistence:** generated ACES validation reports or future run evidence
+  must use redacted JSON/JSONL boundaries (`LocalRunStore` where run data is
+  involved). The SDL itself is source, not generated runtime state.
+
+## Extensibility Seam
+
+The seam is the ACES `RuntimeModel` resource kind plus backend capability
+profile, with a small APTL realization map from ACES runtime resources to
+existing APTL owners. Add new scenario surfaces by declaring more ACES-native
+resources or citing an ACES schema/profile gap. Do not grow TechVault-specific
+branches into the public backend contract.
+
+Parameterization belongs in ACES `variables`, imports/modules, and backend
+profile declarations. One obvious future scenario in APTL's supported
+expressivity class should not require editing a TechVault-only adapter branch.
+
+## Gotchas And Anti-Patterns
+
+- Recreating `ScenarioDefinition`, a Pydantic mirror of ACES SDL, or a
+  temporary `aptl.core.sdl` compatibility adapter for `techvault.sdl.yaml`.
+- Encoding Docker Compose service names, profile switches, generated config
+  paths, or endpoint snapshot fields as ACES scenario meaning unless the ACES
+  model explicitly represents that concept.
+- Hiding missing ACES expressivity behind `metadata`, `x-aptl-*`, comments, or
+  scenario-name dispatch instead of recording an ACES schema/profile gap.
+- Copying the parity inventory rows into tests as a second truth source rather
+  than reading/citing the inventory.
+- Treating designed vulnerable credentials and operator secrets as the same
+  class because both are credential-shaped strings.
+- Adding new exception, diagnostic, logging, redaction, conformance, or Docker
+  helper layers when existing ACES/APTL boundaries already own them.
+
+## Non-Goals
+
+- Do not implement the ACES backend interpreter, conformance runner, live lab
+  deployment gate, default-scenario flip, archive move, or deletion of
+  `aptl.core.sdl` / `aptl.core.scenarios`.
+- Do not change Docker Compose, generated service config, endpoint registry,
+  run archive layout, or lab startup ordering while authoring the SDL.
+- Do not deprecate DSL/SCN requirements or perform Phase B cutover work from
+  this issue.

--- a/scenarios/techvault.sdl.yaml
+++ b/scenarios/techvault.sdl.yaml
@@ -1,0 +1,839 @@
+name: techvault
+description: >
+  TechVault is APTL's canonical purple-team enterprise scenario, authored
+  directly in ACES SDL per ADR-035 (SCN-010 adoption). Three independent
+  adversary paths traverse the same realistic environment: web-app
+  exploitation through SQL injection / command injection / data
+  exfiltration; Active Directory enumeration / Kerberoasting / lateral
+  movement to Domain Admin; anonymous SMB enumeration into engineering
+  / IT-backup loot. Kali is declared as a first-class attacker
+  apparatus with its own SSH bridge and a loot-listener service so the
+  scenario remains true to the legacy 172.20.4.30 attacker host and is
+  not reduced to a scenario-name preset. The defensive stack — Wazuh
+  SIEM, Suricata IDS, Shuffle SOAR, MISP threat intel, TheHive case
+  management — is represented as observation surfaces and conditions so
+  detection / SOAR / case-creation outcomes can score blue objectives.
+
+nodes:
+  # ----------------------------------------------------------------------
+  # Switches — five enterprise subnets preserving the legacy 172.20.x.0/24
+  # layout from scenarios/prime-enterprise.yaml.
+  # ----------------------------------------------------------------------
+  aptl-public:
+    type: switch
+    description: Lab management and operator ingress (172.20.0.0/24).
+  aptl-dmz:
+    type: switch
+    description: External-facing DMZ hosting the TechVault webapp (172.20.1.0/24).
+  aptl-internal:
+    type: switch
+    description: Internal enterprise network — AD, DB, file share, workstation, mail, DNS (172.20.2.0/24).
+  aptl-security:
+    type: switch
+    description: SOC monitoring network — Wazuh, MISP, TheHive, Shuffle (172.20.3.0/24).
+  aptl-redteam:
+    type: switch
+    description: Red-team network for the Kali attacker apparatus (172.20.4.0/24).
+
+  # ----------------------------------------------------------------------
+  # Target VMs.
+  # ----------------------------------------------------------------------
+  webapp:
+    type: vm
+    description: TechVault customer-facing web application — SQL-injectable login plus a network-tools endpoint that pipes user input into a shell.
+    os: linux
+    source: techvault-webapp
+    resources: {ram: 4 gib, cpu: 2}
+    features:
+      webapp-app: webapp-admin
+    conditions:
+      webapp-healthy: webapp-admin
+      webapp-sqli-detected: webapp-admin
+      webapp-rce-detected: webapp-admin
+      webapp-info-disclosure-detected: webapp-admin
+    services:
+      - {port: 8080, name: webapp-http}
+    roles:
+      webapp-admin:
+        username: webapp
+        entities: [techvault-enterprise.devops]
+    asset_value:
+      confidentiality: high
+      integrity: high
+      availability: high
+
+  postgres-db:
+    type: vm
+    description: PostgreSQL backing the TechVault webapp; carries the customers PII table and a backup_config row with deliberately weak AWS keys.
+    os: linux
+    source: techvault-postgres
+    resources: {ram: 6 gib, cpu: 2}
+    features:
+      postgres-store: postgres-dba
+    conditions:
+      postgres-healthy: postgres-dba
+      postgres-bulk-export-detected: postgres-dba
+    services:
+      - {port: 5432, name: techvault-postgres}
+    roles:
+      postgres-dba:
+        username: postgres
+        entities: [techvault-enterprise.it]
+    asset_value:
+      confidentiality: critical
+      integrity: critical
+      availability: high
+
+  samba-ad-dc:
+    type: vm
+    description: Samba Active Directory domain controller for techvault.local — over-permissive password policy plus Kerberoastable service principal names.
+    os: linux
+    source: techvault-samba-ad
+    resources: {ram: 4 gib, cpu: 2}
+    features:
+      samba-ad-svc: ad-admin
+    conditions:
+      ad-healthy: ad-admin
+      ad-bruteforce-detected: ad-admin
+      ad-kerberoast-detected: ad-admin
+      ad-ldap-enumeration-detected: ad-admin
+    services:
+      - {port: 88, name: kerberos}
+      - {port: 389, name: ldap}
+      - {port: 445, name: ad-smb}
+      - {port: 464, name: kpasswd}
+    roles:
+      ad-admin:
+        username: Administrator
+        entities: [techvault-enterprise.it]
+    asset_value:
+      confidentiality: critical
+      integrity: critical
+      availability: critical
+
+  fileshare:
+    type: vm
+    description: SMB file server with anonymous Public / Shared / Engineering / IT-Backups shares — exposes deploy.sh credentials and wifi passwords.
+    os: linux
+    source: techvault-fileshare
+    resources: {ram: 2 gib, cpu: 1}
+    features:
+      smb-share-svc: fileshare-admin
+    conditions:
+      fileshare-healthy: fileshare-admin
+      fileshare-loot-exfiltrated: fileshare-admin
+    services:
+      - {port: 139, name: smb-netbios}
+      - {port: 445, name: smb-share}
+    roles:
+      fileshare-admin:
+        username: fileadmin
+        entities: [techvault-enterprise.it]
+
+  windows-workstation:
+    type: vm
+    description: Domain-joined Windows 10 workstation belonging to a DevOps user who is also Domain Admin and stores cached AD credentials.
+    os: windows
+    os_version: "10"
+    source: techvault-workstation
+    resources: {ram: 4 gib, cpu: 2}
+    features:
+      rdp-svc: workstation-user
+    conditions:
+      workstation-healthy: workstation-user
+      workstation-lateral-rdp-detected: workstation-user
+    services:
+      - {port: 3389, name: rdp}
+      - {port: 445, name: workstation-smb}
+    roles:
+      workstation-user:
+        username: emily.chen
+        entities: [techvault-enterprise.devops]
+    asset_value:
+      confidentiality: high
+      integrity: medium
+      availability: medium
+
+  mail:
+    type: vm
+    description: TechVault corporate mailbox host — receives phishing lures during the purple-loop story.
+    os: linux
+    source: techvault-mail
+    resources: {ram: 2 gib, cpu: 1}
+    features:
+      mail-svc: mail-admin
+    conditions:
+      mail-healthy: mail-admin
+    services:
+      - {port: 25, name: smtp}
+      - {port: 143, name: imap}
+    roles:
+      mail-admin:
+        username: postmaster
+        entities: [techvault-enterprise.it]
+
+  dns:
+    type: vm
+    description: Internal recursive resolver for techvault.local — also the DNS-tunneling sink during exfiltration.
+    os: linux
+    source: techvault-dns
+    resources: {ram: 1 gib, cpu: 1}
+    features:
+      dns-svc: dns-admin
+    conditions:
+      dns-healthy: dns-admin
+      dns-tunneling-detected: dns-admin
+    services:
+      - {port: 53, protocol: udp, name: dns-udp}
+      - {port: 53, name: dns-tcp}
+    roles:
+      dns-admin:
+        username: bind
+        entities: [techvault-enterprise.it]
+
+  victim:
+    type: vm
+    description: Linux victim host on the lab management network — owns the labadmin SSH credentials used for harvested-credential lateral steps.
+    os: linux
+    source: techvault-victim
+    resources: {ram: 2 gib, cpu: 1}
+    features:
+      ssh-svc: lab-admin
+    conditions:
+      victim-healthy: lab-admin
+      ssh-bruteforce-detected: lab-admin
+    services:
+      - {port: 22, name: victim-ssh}
+    roles:
+      lab-admin:
+        username: labadmin
+        entities: [techvault-enterprise.it]
+
+  kali:
+    type: vm
+    description: Kali Linux attacker apparatus dual-homed on aptl-dmz (DMZ-facing 172.20.1.30) and aptl-redteam (loot-listener 172.20.4.30). Carries the MCP-over-SSH bridge APTL exposes to its red-team MCP server.
+    os: linux
+    source: kali-rolling
+    resources: {ram: 6 gib, cpu: 2}
+    features:
+      kali-toolkit: kali-operator
+      kali-loot-listener: kali-operator
+    conditions:
+      kali-bridge-up: kali-operator
+    services:
+      - {port: 22, name: kali-ssh}
+      - {port: 8888, name: kali-loot-listener}
+    roles:
+      kali-operator:
+        username: kali
+        entities: [red-cartel]
+
+  wazuh-manager:
+    type: vm
+    description: Wazuh manager + dashboard hosting the SIEM rule set; also the Shuffle SOAR + MISP + TheHive control surfaces in the SOC stack.
+    os: linux
+    source: wazuh-stack
+    resources: {ram: 8 gib, cpu: 4}
+    features:
+      wazuh-siem: soc-analyst
+      shuffle-soar: soc-analyst
+      thehive-cases: soc-analyst
+    conditions:
+      wazuh-healthy: soc-analyst
+      shuffle-case-created: soc-analyst
+    services:
+      - {port: 5601, name: wazuh-dashboard}
+      - {port: 55000, name: wazuh-api}
+    roles:
+      soc-analyst:
+        username: socanalyst
+        entities: [techvault-enterprise.incident-command]
+    asset_value:
+      confidentiality: high
+      integrity: critical
+      availability: high
+
+infrastructure:
+  # Subnets — each switch becomes a routable subnet with optional ACLs.
+  aptl-public:
+    count: 1
+    properties: {cidr: 172.20.0.0/24, gateway: 172.20.0.1}
+  aptl-dmz:
+    count: 1
+    properties: {cidr: 172.20.1.0/24, gateway: 172.20.1.1}
+  aptl-internal:
+    count: 1
+    properties: {cidr: 172.20.2.0/24, gateway: 172.20.2.1, internal: true}
+    acls:
+      - {name: allow-dmz-to-postgres, direction: in, from_net: aptl-dmz, protocol: tcp, ports: [5432], action: allow}
+      - {name: allow-dmz-to-ad, direction: in, from_net: aptl-dmz, protocol: tcp, ports: [389, 445], action: allow}
+      - {name: deny-redteam-direct, direction: in, from_net: aptl-redteam, action: deny}
+  aptl-security:
+    count: 1
+    properties: {cidr: 172.20.3.0/24, gateway: 172.20.3.1, internal: true}
+    acls:
+      - {name: deny-redteam-soc, direction: in, from_net: aptl-redteam, action: deny}
+  aptl-redteam:
+    count: 1
+    properties: {cidr: 172.20.4.0/24, gateway: 172.20.4.1, internal: true}
+
+  # VM placements — Kali deliberately dual-homes on aptl-dmz + aptl-redteam.
+  webapp: {count: 1, links: [aptl-dmz]}
+  postgres-db:
+    count: 1
+    links: [aptl-internal]
+    dependencies: [samba-ad-dc]
+  samba-ad-dc:
+    count: 1
+    links: [aptl-internal]
+  fileshare:
+    count: 1
+    links: [aptl-internal]
+    dependencies: [samba-ad-dc]
+  windows-workstation:
+    count: 1
+    links: [aptl-internal]
+    dependencies: [samba-ad-dc]
+  mail: {count: 1, links: [aptl-internal]}
+  dns: {count: 1, links: [aptl-internal]}
+  victim: {count: 1, links: [aptl-public]}
+  kali: {count: 1, links: [aptl-dmz, aptl-redteam]}
+  wazuh-manager: {count: 1, links: [aptl-security, aptl-public]}
+
+features:
+  webapp-app: {type: service, source: techvault-webapp}
+  postgres-store: {type: service, source: postgres-15}
+  samba-ad-svc: {type: service, source: samba-ad-dc-image}
+  smb-share-svc: {type: service, source: samba-fileshare-image}
+  rdp-svc: {type: service, source: windows-rdp}
+  mail-svc: {type: service, source: techvault-mail-image}
+  dns-svc: {type: service, source: bind9}
+  ssh-svc: {type: service, source: openssh-server}
+  kali-toolkit: {type: service, source: kali-tools}
+  kali-loot-listener: {type: service, source: kali-loot-listener}
+  wazuh-siem: {type: service, source: wazuh-manager-image}
+  shuffle-soar: {type: service, source: shuffle-image}
+  thehive-cases: {type: service, source: thehive-image}
+
+conditions:
+  webapp-healthy: {command: /usr/local/bin/check-webapp, interval: 30}
+  webapp-sqli-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh rule 302010 (SQL injection) fired."}
+  webapp-rce-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh rule 302030 (command injection) fired."}
+  webapp-info-disclosure-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh rule 302040 (.env / debug exposure) fired."}
+  postgres-healthy: {command: /usr/local/bin/check-postgres, interval: 30}
+  postgres-bulk-export-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh rule 304030 (large data export from customers/backup_config) fired."}
+  ad-healthy: {command: /usr/local/bin/check-ad, interval: 30}
+  ad-bruteforce-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh rule 301002 (AD brute force) fired."}
+  ad-kerberoast-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh rule 301011 / Suricata SID 1000040 (Kerberoasting) fired."}
+  ad-ldap-enumeration-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh rule 301021 (LDAP enumeration) fired."}
+  fileshare-healthy: {command: /usr/local/bin/check-fileshare, interval: 30}
+  fileshare-loot-exfiltrated: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "deploy.sh or wifi-passwords.txt observed leaving fileshare."}
+  workstation-healthy: {command: /usr/local/bin/check-workstation, interval: 60}
+  workstation-lateral-rdp-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh rule 301040 (service-account interactive login) fired."}
+  mail-healthy: {command: /usr/local/bin/check-mail, interval: 60}
+  dns-healthy: {command: /usr/local/bin/check-dns, interval: 30}
+  dns-tunneling-detected: {command: /usr/local/bin/check-suricata-sid, interval: 30, description: "Suricata SID 1000060 (DNS tunneling) fired."}
+  victim-healthy: {command: /usr/local/bin/check-victim, interval: 30}
+  ssh-bruteforce-detected: {command: /usr/local/bin/check-wazuh-rule, interval: 30, description: "Wazuh built-in rule 5763 (SSH brute force) fired and active-response engaged."}
+  kali-bridge-up: {command: /usr/local/bin/check-kali-bridge, interval: 30, description: "Kali MCP-over-SSH bridge reachable from APTL control plane."}
+  wazuh-healthy: {command: /usr/local/bin/check-wazuh, interval: 30}
+  shuffle-case-created: {command: /usr/local/bin/check-shuffle, interval: 60, description: "Shuffle SOAR auto-created a TheHive case from a level-10+ Wazuh alert."}
+  # Red-side progress conditions — kept distinct from blue-side detected
+  # conditions so the ACES semantic validator (one metric per condition)
+  # holds while still allowing both sides to score the same underlying
+  # event.
+  webapp-attacker-pivot: {command: /usr/local/bin/check-webapp-pivot, interval: 60, description: "Attacker reached RCE on the webapp host (red-side progress marker)."}
+  red-domain-admin-achieved: {command: /usr/local/bin/check-da, interval: 60, description: "Attacker authenticated as a Domain Admin account from the DevOps workstation."}
+  red-pii-exfiltrated: {command: /usr/local/bin/check-pii-exfil, interval: 60, description: "PII rows from customers / backup_config left the enterprise boundary."}
+
+vulnerabilities:
+  webapp-sql-injection:
+    name: Web application SQL injection
+    description: TechVault webapp login form and customer-search endpoint accept un-parameterized SQL fragments.
+    technical: true
+    class: CWE-89
+  webapp-command-injection:
+    name: Web application command injection
+    description: The /tools/ping endpoint pipes the `host` POST parameter into a shell command without sanitization.
+    technical: true
+    class: CWE-77
+  webapp-info-disclosure:
+    name: Web application information disclosure
+    description: The webapp serves /.env and /debug without authentication, exposing database credentials and stack details.
+    technical: true
+    class: CWE-200
+  ad-weak-password-policy:
+    name: Weak Active Directory password policy
+    description: Multiple AD accounts use guessable seasonal passwords (password123, Summer2024, Welcome1!) and no MFA is enforced.
+    technical: true
+    class: CWE-521
+  ad-overprivileged-service-account:
+    name: Over-privileged service accounts
+    description: svc-backup is a Domain Admin; emily.chen carries Domain Admin from her DevOps workstation.
+    technical: true
+    class: CWE-269
+  samba-kerberoastable-spn:
+    name: Kerberoastable service principal names
+    description: AD service accounts have human-set passwords plus SPNs, making TGS tickets crackable offline.
+    technical: true
+    class: CWE-294
+  smb-guest-anonymous:
+    name: Anonymous SMB share access
+    description: Public and Shared file-server drives accept guest authentication, exposing sensitive files without credentials.
+    technical: true
+    class: CWE-287
+  pgsql-trust-internal-subnet:
+    name: PostgreSQL trusts internal subnet
+    description: pg_hba.conf grants the entire internal subnet trust authentication — any host with credentials connects directly.
+    technical: true
+    class: CWE-284
+  creds-in-env-and-share:
+    name: Credential sprawl in .env and shared files
+    description: Database credentials live in webapp/.env, deploy.sh on the file share, .bash_history, and .pgpass.
+    technical: true
+    class: CWE-256
+  no-waf-no-mfa:
+    name: Missing WAF and MFA controls
+    description: No WAF in front of the webapp; no MFA on AD, SSH, or database access.
+    technical: true
+    class: CWE-1021
+
+metrics:
+  blue-detect-webapp-sqli:
+    type: conditional
+    max_score: 100
+    condition: webapp-sqli-detected
+  blue-detect-webapp-rce:
+    type: conditional
+    max_score: 100
+    condition: webapp-rce-detected
+  blue-detect-ad-kerberoast:
+    type: conditional
+    max_score: 100
+    condition: ad-kerberoast-detected
+  blue-detect-fileshare-loot:
+    type: conditional
+    max_score: 100
+    condition: fileshare-loot-exfiltrated
+  blue-shuffle-case-created:
+    type: conditional
+    max_score: 100
+    condition: shuffle-case-created
+  blue-soc-triage-manual:
+    type: manual
+    max_score: 50
+    artifact: true
+  red-webapp-pivot:
+    type: conditional
+    max_score: 150
+    condition: webapp-attacker-pivot
+  red-ad-domain-admin:
+    type: conditional
+    max_score: 200
+    condition: red-domain-admin-achieved
+  red-exfiltrate-pii:
+    type: conditional
+    max_score: 200
+    condition: red-pii-exfiltrated
+
+evaluations:
+  blue-defensive-coverage:
+    metrics: [blue-detect-webapp-sqli, blue-detect-webapp-rce, blue-detect-ad-kerberoast, blue-detect-fileshare-loot, blue-shuffle-case-created, blue-soc-triage-manual]
+    min_score: 50
+  red-multipath-impact:
+    metrics: [red-webapp-pivot, red-ad-domain-admin, red-exfiltrate-pii]
+    min_score: 60
+
+tlos:
+  sustain-techvault-monitoring:
+    name: Sustain TechVault monitoring and response
+    evaluation: blue-defensive-coverage
+  compromise-techvault:
+    name: Compromise TechVault across at least two attack paths
+    evaluation: red-multipath-impact
+
+goals:
+  techvault-blue-goal:
+    description: Detect and triage every red activity within the assigned scoring window.
+    tlos: [sustain-techvault-monitoring]
+  techvault-red-goal:
+    description: Compromise TechVault data, identity, and lateral-movement surfaces.
+    tlos: [compromise-techvault]
+
+entities:
+  techvault-enterprise:
+    name: TechVault Enterprise
+    role: Blue
+    mission: Operate and defend the TechVault enterprise during purple-team exercises.
+    tlos: [sustain-techvault-monitoring]
+    entities:
+      it:
+        name: TechVault IT operations
+      devops:
+        name: TechVault DevOps
+      finance:
+        name: TechVault Finance
+      incident-command:
+        name: TechVault Incident Command (SOC analysts)
+  red-cartel:
+    name: Red Cartel (TechVault adversary)
+    role: Red
+    mission: Compromise TechVault customer data, identity, and lateral-movement surfaces.
+    tlos: [compromise-techvault]
+  white-cell:
+    name: White Cell (exercise control)
+    role: White
+    mission: Run the purple-team exercise, inject events, and arbitrate scoring.
+
+injects:
+  customer-phish:
+    source: customer-phishing-lure
+    from_entity: white-cell
+    to_entities: [techvault-enterprise, red-cartel]
+    description: A targeted phishing lure surfaces in TechVault's mailbox, kicking off the recon phase.
+  webapp-exposure-tip:
+    source: webapp-exposure-tip
+    from_entity: white-cell
+    to_entities: [red-cartel]
+    description: White cell reveals the DMZ-facing webapp endpoint to the attacker apparatus.
+  ad-credential-leak:
+    source: ad-credential-leak
+    from_entity: white-cell
+    to_entities: [red-cartel]
+    description: White cell drops a hint about weak AD credentials and the over-privileged svc-backup account.
+  fileshare-guest-tip:
+    source: fileshare-guest-tip
+    from_entity: white-cell
+    to_entities: [red-cartel]
+    description: White cell reveals that the SMB file share allows anonymous access.
+
+events:
+  scenario-start:
+    injects: [customer-phish]
+  red-knows-webapp:
+    injects: [webapp-exposure-tip]
+  red-knows-ad:
+    injects: [ad-credential-leak]
+    conditions: [webapp-rce-detected]
+  red-knows-fileshare:
+    injects: [fileshare-guest-tip]
+    conditions: [ad-bruteforce-detected]
+
+scripts:
+  arrival-phase:
+    start_time: 0
+    end_time: 15 min
+    speed: 1
+    events:
+      scenario-start: 1 min
+  webapp-compromise-phase:
+    start_time: 15 min
+    end_time: 1 hour
+    speed: 1
+    events:
+      red-knows-webapp: 16 min
+  ad-compromise-phase:
+    start_time: 1 hour
+    end_time: 2 hour
+    speed: 1
+    events:
+      red-knows-ad: 65 min
+  lateral-movement-phase:
+    start_time: 2 hour
+    end_time: 3 hour
+    speed: 1
+    events:
+      red-knows-fileshare: 125 min
+
+stories:
+  purple-loop:
+    description: >
+      The canonical TechVault purple-loop story — arrival, webapp
+      compromise, AD compromise, lateral movement, exfiltration. The
+      three attack paths are independent but share the same enterprise
+      and Kali apparatus.
+    scripts: [arrival-phase, webapp-compromise-phase, ad-compromise-phase, lateral-movement-phase]
+
+content:
+  customers-pii:
+    type: dataset
+    target: postgres-db
+    format: postgres
+    source: techvault-customers-seed
+    sensitive: true
+    description: Synthetic customer PII (names, emails, addresses, phones) for the customers table.
+  backup-config-aws-creds:
+    type: dataset
+    target: postgres-db
+    format: postgres
+    items:
+      - name: backup_config-aws-row
+        tags: [credentials, intentional-weakness]
+        description: Single backup_config row carrying intentionally weak AWS access-key fixture for the exfil objective.
+    sensitive: true
+  deploy-sh-with-creds:
+    type: file
+    target: fileshare
+    path: /share/IT-Backups/deploy.sh
+    text: "#!/usr/bin/env bash\n# Fixture only — intentional credential exposure.\nDB_USER=techvault\nDB_PASS=ChangeMe2024!\n"
+    sensitive: true
+    description: Intentional credential-leak shell script readable from the IT-Backups share.
+  wifi-passwords-txt:
+    type: file
+    target: fileshare
+    path: /share/Shared/wifi-passwords.txt
+    text: "techvault-guest=GuestWifi!\ntechvault-corp=CorpWifi2024!\n"
+    sensitive: true
+  meeting-notes-q3:
+    type: file
+    target: fileshare
+    path: /share/Shared/meeting-notes-q3.txt
+    text: "Q3 strategy: see Engineering/ for technical roadmap.\n"
+    sensitive: false
+  kerberos-spn-list:
+    type: dataset
+    target: samba-ad-dc
+    format: ldif
+    items:
+      - name: svc-sql-spn
+        tags: [spn, kerberoastable]
+        description: SPN for the svc-sql account with a human-set crackable password.
+      - name: svc-backup-spn
+        tags: [spn, kerberoastable, domain-admin]
+        description: SPN for the over-privileged svc-backup Domain Admin service account.
+
+accounts:
+  labadmin:
+    username: labadmin
+    node: victim
+    groups: [Operators]
+    password_strength: strong
+    description: Lab management account on the victim host.
+  jessica.williams:
+    username: jessica.williams
+    node: samba-ad-dc
+    groups: [Domain Users, Finance]
+    password_strength: weak
+    description: AD user with a deliberately weak, guessable password (password123).
+  svc-sql:
+    username: svc-sql
+    node: samba-ad-dc
+    groups: [Domain Users, Service Accounts]
+    password_strength: weak
+    spn: MSSQLSvc/techvault.local:1433
+    description: Service account with an SPN — Kerberoastable.
+  svc-backup:
+    username: svc-backup
+    node: samba-ad-dc
+    groups: [Domain Admins, Service Accounts]
+    password_strength: weak
+    spn: backup/techvault.local
+    description: Over-privileged service account with Domain Admin and an SPN.
+  emily.chen:
+    username: emily.chen
+    node: windows-workstation
+    groups: [Domain Admins, DevOps]
+    password_strength: medium
+    description: DevOps user with Domain Admin privileges and cached credentials on the workstation.
+  techvault-postgres:
+    username: techvault
+    node: postgres-db
+    groups: [postgres]
+    password_strength: weak
+    description: PostgreSQL application user shared with the webapp .env file.
+  postmaster-svc:
+    username: postmaster
+    node: mail
+    groups: [mail]
+    password_strength: medium
+    description: Mail-server administrative account.
+  kali-operator:
+    username: kali
+    node: kali
+    groups: [sudo, redteam]
+    password_strength: strong
+    description: Red-team operator account on the Kali attacker apparatus.
+  soc-analyst:
+    username: socanalyst
+    node: wazuh-manager
+    groups: [SOC]
+    password_strength: strong
+    description: Blue-team SOC analyst account on the Wazuh manager.
+
+relationships:
+  webapp-uses-postgres:
+    type: connects_to
+    source: webapp-app
+    target: postgres-store
+    properties: {protocol: tcp, port: "5432"}
+  webapp-authenticates-ad:
+    type: authenticates_with
+    source: webapp-app
+    target: samba-ad-svc
+    properties: {protocol: ldap}
+  workstation-joined-ad:
+    type: authenticates_with
+    source: rdp-svc
+    target: samba-ad-svc
+  fileshare-trusts-ad:
+    type: authenticates_with
+    source: smb-share-svc
+    target: samba-ad-svc
+  fileshare-depends-on-dns:
+    type: depends_on
+    source: smb-share-svc
+    target: dns-svc
+  kali-targets-webapp:
+    type: connects_to
+    source: kali-toolkit
+    target: webapp-app
+    properties: {protocol: tcp, port: "8080"}
+  kali-targets-ad:
+    type: connects_to
+    source: kali-toolkit
+    target: samba-ad-svc
+    properties: {protocol: tcp, port: "445"}
+  shuffle-creates-thehive-case:
+    type: federates_with
+    source: shuffle-soar
+    target: thehive-cases
+
+agents:
+  red-kali-agent:
+    entity: red-cartel
+    description: Kali-resident attacker apparatus running through APTL's MCP-over-SSH bridge.
+    actions: [Recon, InitialAccess, Execute, CredAccess, Discovery, LateralMove, Collect, Exfiltrate]
+    starting_accounts: [kali-operator]
+    initial_knowledge:
+      hosts: [webapp, kali]
+      subnets: [aptl-dmz, aptl-redteam]
+      services: [webapp-http, kali-ssh, kali-loot-listener]
+      accounts: [kali-operator]
+    allowed_subnets: [aptl-dmz, aptl-redteam, aptl-internal]
+    reward_calculator: MultiPathImpact
+  blue-soc-agent:
+    entity: techvault-enterprise.incident-command
+    description: SOC analyst driving Wazuh, Shuffle SOAR, and TheHive case triage.
+    actions: [Monitor, Triage, Investigate, Contain, Recover]
+    starting_accounts: [soc-analyst]
+    initial_knowledge:
+      hosts: [wazuh-manager, webapp, samba-ad-dc, fileshare, victim, postgres-db, windows-workstation]
+      subnets: [aptl-security, aptl-internal, aptl-public]
+      services: [wazuh-dashboard, wazuh-api]
+      accounts: [soc-analyst]
+    allowed_subnets: [aptl-security, aptl-internal, aptl-public]
+    reward_calculator: CoordinatedResponse
+
+objectives:
+  red-webapp-compromise:
+    description: Compromise the TechVault webapp via SQL injection and command injection.
+    agent: red-kali-agent
+    actions: [Recon, InitialAccess, Execute]
+    targets: [webapp, postgres-db, kali-targets-webapp]
+    success:
+      mode: any_of
+      conditions: [webapp-sqli-detected, webapp-rce-detected, webapp-info-disclosure-detected]
+      metrics: [red-webapp-pivot]
+    window:
+      stories: [purple-loop]
+      scripts: [webapp-compromise-phase]
+      events: [red-knows-webapp]
+  red-ad-domain-admin:
+    description: Reach Domain Admin via Kerberoasting and lateral movement to the DevOps workstation.
+    agent: red-kali-agent
+    actions: [Discovery, CredAccess, LateralMove]
+    targets: [samba-ad-dc, windows-workstation, fileshare, kali-targets-ad]
+    success:
+      mode: any_of
+      conditions: [ad-kerberoast-detected, workstation-lateral-rdp-detected]
+      metrics: [red-ad-domain-admin]
+    depends_on: [red-webapp-compromise]
+    window:
+      stories: [purple-loop]
+      scripts: [ad-compromise-phase, lateral-movement-phase]
+      events: [red-knows-ad]
+  red-exfiltrate-pii:
+    description: Exfiltrate customers PII and the backup_config AWS keys from PostgreSQL.
+    agent: red-kali-agent
+    actions: [Collect, Exfiltrate]
+    targets: [postgres-db, customers-pii, backup-config-aws-creds, dns]
+    success:
+      mode: all_of
+      conditions: [postgres-bulk-export-detected, dns-tunneling-detected]
+      metrics: [red-exfiltrate-pii]
+    depends_on: [red-webapp-compromise]
+    window:
+      stories: [purple-loop]
+      scripts: [lateral-movement-phase]
+  blue-detect-webapp-attacks:
+    description: Detect webapp SQLi / RCE / info-disclosure via Wazuh and Suricata.
+    agent: blue-soc-agent
+    actions: [Monitor, Triage]
+    targets: [webapp, wazuh-manager]
+    success:
+      mode: all_of
+      conditions: [webapp-sqli-detected, webapp-rce-detected]
+      metrics: [blue-detect-webapp-sqli, blue-detect-webapp-rce]
+    window:
+      stories: [purple-loop]
+      scripts: [webapp-compromise-phase]
+      workflows: [techvault-incident-response]
+      steps: [techvault-incident-response.detect-webapp]
+  blue-detect-kerberoast:
+    description: Detect Kerberoasting via Wazuh rule 301011 and Suricata SID 1000040.
+    agent: blue-soc-agent
+    actions: [Monitor, Investigate]
+    targets: [samba-ad-dc, wazuh-manager]
+    success:
+      conditions: [ad-kerberoast-detected]
+      metrics: [blue-detect-ad-kerberoast]
+    depends_on: [blue-detect-webapp-attacks]
+    window:
+      stories: [purple-loop]
+      scripts: [ad-compromise-phase]
+      workflows: [techvault-incident-response]
+      steps: [techvault-incident-response.detect-ad]
+  blue-shuffle-soar-case:
+    description: Auto-create a TheHive case through Shuffle SOAR for any level-10+ Wazuh alert.
+    agent: blue-soc-agent
+    actions: [Triage, Contain]
+    targets: [wazuh-manager, shuffle-creates-thehive-case]
+    success:
+      conditions: [shuffle-case-created]
+      metrics: [blue-shuffle-case-created]
+    depends_on: [blue-detect-webapp-attacks]
+    window:
+      stories: [purple-loop]
+      scripts: [ad-compromise-phase, lateral-movement-phase]
+      workflows: [techvault-incident-response]
+      steps: [techvault-incident-response.soar-triage]
+
+workflows:
+  techvault-incident-response:
+    description: >
+      Canonical TechVault SOC workflow — detect webapp attacks, branch
+      into AD compromise detection plus Shuffle SOAR triage, join, then
+      finish.
+    start: detect-webapp
+    steps:
+      detect-webapp:
+        type: objective
+        objective: blue-detect-webapp-attacks
+        on_success: fanout-ad-soar
+      fanout-ad-soar:
+        type: parallel
+        branches: [detect-ad, soar-triage]
+        join: ad-soar-joined
+      detect-ad:
+        type: objective
+        objective: blue-detect-kerberoast
+        on_success: ad-soar-joined
+      soar-triage:
+        type: objective
+        objective: blue-shuffle-soar-case
+        on_success: ad-soar-joined
+      ad-soar-joined:
+        type: join
+        next: finish
+      finish:
+        type: end

--- a/tests/test_parity_inventory.py
+++ b/tests/test_parity_inventory.py
@@ -200,10 +200,19 @@ def test_gap_rows_cite_a_followup(inventory):
 
 
 def test_every_legacy_scenario_yaml_is_covered(inventory):
-    """Every existing scenarios/*.yaml file must appear in legacy_source
-    of at least one row in the ``scenarios_yaml`` surface bucket."""
+    """Every existing legacy ``scenarios/<name>.yaml`` file must appear in
+    ``legacy_source`` of at least one row in the ``scenarios_yaml`` bucket.
+
+    The ACES-authored ``scenarios/<name>.sdl.yaml`` documents (SCN-010
+    Phase A, issue #319 onward) are deliberately excluded: they are the
+    *replacement* surface, not legacy material to audit.
+    """
     scenarios_dir = PROJECT_ROOT / "scenarios"
-    on_disk = {p.name for p in scenarios_dir.glob("*.yaml")}
+    on_disk = {
+        p.name
+        for p in scenarios_dir.glob("*.yaml")
+        if not p.name.endswith(".sdl.yaml")
+    }
     cited = {
         Path(row["legacy_source"]).name
         for row in inventory["rows"]

--- a/tests/test_techvault_sdl.py
+++ b/tests/test_techvault_sdl.py
@@ -1,0 +1,307 @@
+"""ACES-native TechVault SDL acceptance tests (SCN-010 / issue #319).
+
+These tests drive ``scenarios/techvault.sdl.yaml`` through the ACES reference
+parser and runtime compiler in the sibling ``../aces-sdl`` repository. They
+encode the issue's acceptance criteria as structural assertions, not by
+copying parity-inventory rows as a second truth source (per
+``docs/aces/techvault-sdl-authoring-preflight.md``).
+
+The ACES packages are imported under ``pytest.importorskip``: locally a dev
+that has not run ``pip install -e ../aces-sdl/implementations/python``
+sees the module skip; CI runs the suite with the sibling checked out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+aces_sdl = pytest.importorskip("aces_sdl")
+aces_processor_compiler = pytest.importorskip("aces_processor.compiler")
+
+from aces_sdl import parse_sdl_file  # noqa: E402 (imports gated above)
+from aces_processor.compiler import compile_runtime_model  # noqa: E402
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SDL_PATH = PROJECT_ROOT / "scenarios" / "techvault.sdl.yaml"
+
+# The four legacy enterprise subnets (per scenarios/*.yaml and the
+# parity inventory rows under ``compose.network.*``). The new SDL must
+# expose at least these CIDRs through its infrastructure block.
+EXPECTED_LEGACY_CIDRS = {
+    "172.20.0.0/24",  # lab / management
+    "172.20.1.0/24",  # DMZ
+    "172.20.2.0/24",  # internal enterprise
+    "172.20.4.0/24",  # red team / Kali
+}
+
+# Target nodes called out in the issue Scope. Each must exist by exactly
+# this name (kebab-case node id) in the parsed scenario, with at least
+# one declared service — that is the "enough declared structure for APTL
+# backend interpretation" acceptance criterion.
+REQUIRED_TARGET_NODES = (
+    "webapp",
+    "postgres-db",
+    "samba-ad-dc",
+    "fileshare",
+    "mail",
+    "dns",
+    "windows-workstation",
+)
+
+# Vulnerability ids the issue's Scope enumerates as "vulnerabilities,
+# features, conditions" surfaces. One per major attack-class so a
+# missing surface fails loudly.
+REQUIRED_VULNERABILITY_IDS = (
+    "webapp-sql-injection",
+    "samba-kerberoastable-spn",
+    "smb-guest-anonymous",
+)
+
+
+@pytest.fixture(scope="module")
+def scenario():
+    assert SDL_PATH.exists(), (
+        f"TechVault SDL missing at {SDL_PATH.relative_to(PROJECT_ROOT)}; "
+        "SCN-010B requires authoring this file (issue #319)."
+    )
+    return parse_sdl_file(SDL_PATH)
+
+
+@pytest.fixture(scope="module")
+def runtime_model(scenario):
+    return compile_runtime_model(scenario)
+
+
+@pytest.fixture(scope="module")
+def raw_sdl_yaml():
+    return yaml.safe_load(SDL_PATH.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: ACES reference parser accepts the document.
+# ---------------------------------------------------------------------------
+
+
+def test_parses_under_aces_reference_parser(scenario):
+    assert scenario.name == "techvault"
+    assert scenario.semantic_validated is True
+    # Advisories (non-fatal warnings) are tolerated but recorded here so
+    # an unexpected new one shows up in test output rather than being
+    # silently absorbed.
+    assert isinstance(scenario.advisories, list)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: compiles into ACES RuntimeModel without legacy APTL SDL.
+# ---------------------------------------------------------------------------
+
+
+def test_compiles_to_runtime_model(runtime_model):
+    assert runtime_model.scenario_name == "techvault"
+    assert runtime_model.networks, "RuntimeModel must declare at least one network."
+    assert runtime_model.node_deployments, (
+        "RuntimeModel must declare at least one node deployment."
+    )
+    assert runtime_model.feature_templates, (
+        "RuntimeModel must declare at least one feature template."
+    )
+    assert runtime_model.agent_specs, (
+        "RuntimeModel must declare at least one agent (Kali apparatus)."
+    )
+    assert runtime_model.objectives, (
+        "RuntimeModel must declare at least one objective so APTL backend "
+        "interpretation has actionable scenario state."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: required TechVault target nodes are declared with services.
+# ---------------------------------------------------------------------------
+
+
+def test_required_techvault_target_nodes_declared(scenario):
+    missing = [name for name in REQUIRED_TARGET_NODES if name not in scenario.nodes]
+    assert not missing, (
+        f"TechVault SDL is missing target nodes named in issue #319: {missing}."
+    )
+    nodes_without_services = [
+        name
+        for name in REQUIRED_TARGET_NODES
+        if not getattr(scenario.nodes[name], "services", None)
+    ]
+    assert not nodes_without_services, (
+        f"TechVault target nodes must each declare at least one service so "
+        f"backend interpretation has explicit structure; offenders: "
+        f"{nodes_without_services}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: Kali declared as first-class attacker apparatus.
+# ---------------------------------------------------------------------------
+
+
+def test_kali_apparatus_declared(scenario):
+    assert "kali" in scenario.nodes, "Kali must be declared as a first-class node."
+    kali_node = scenario.nodes["kali"]
+    assert kali_node.services, "Kali must declare its own services (SSH/MCP/loot)."
+
+    kali_infra = scenario.infrastructure.get("kali")
+    assert kali_infra is not None, "Kali must appear in the infrastructure block."
+    links = list(getattr(kali_infra, "links", []) or [])
+    assert "aptl-dmz" in links, "Kali must attach to the DMZ network."
+    assert "aptl-redteam" in links, "Kali must attach to the red-team network."
+
+    red_agents = [
+        agent_id
+        for agent_id, agent in scenario.agents.items()
+        if str(getattr(agent, "entity", "")).startswith("red")
+    ]
+    assert red_agents, (
+        "Kali apparatus must be exposed as at least one ACES agent under a "
+        "Red-entity (no scenario-name-only attacker)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: network topology preserves the four legacy subnets.
+# ---------------------------------------------------------------------------
+
+
+def test_network_topology_carries_four_legacy_subnets(scenario):
+    declared_cidrs = set()
+    for infra in scenario.infrastructure.values():
+        props = getattr(infra, "properties", None) or {}
+        cidr = props.get("cidr") if isinstance(props, dict) else getattr(props, "cidr", None)
+        if cidr:
+            declared_cidrs.add(cidr)
+    missing = EXPECTED_LEGACY_CIDRS - declared_cidrs
+    assert not missing, (
+        f"TechVault SDL must preserve the legacy 172.20.x.0/24 subnet "
+        f"layout from scenarios/prime-enterprise.yaml; missing CIDRs: "
+        f"{sorted(missing)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: accounts + weak-password fixtures + overprivileged service acct.
+# ---------------------------------------------------------------------------
+
+
+def test_accounts_and_weak_password_fixtures(scenario):
+    accounts = scenario.accounts
+    assert "jessica.williams" in accounts, (
+        "jessica.williams is the canonical weak-AD-credential fixture."
+    )
+    assert "svc-backup" in accounts, (
+        "svc-backup is the canonical overprivileged service account."
+    )
+    weak = [
+        name
+        for name, account in accounts.items()
+        if getattr(getattr(account, "password_strength", None), "value", "") == "weak"
+    ]
+    assert weak, "At least one account must carry password_strength: weak."
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: vulnerabilities cover the issue's enumerated attack surfaces.
+# ---------------------------------------------------------------------------
+
+
+def test_vulnerabilities_cover_issue_surfaces(scenario):
+    declared = set(scenario.vulnerabilities)
+    missing = [vuln for vuln in REQUIRED_VULNERABILITY_IDS if vuln not in declared]
+    assert not missing, (
+        f"TechVault SDL must declare at least one vulnerability per major "
+        f"legacy attack class; missing: {missing}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: content placement (PII + backup-config creds).
+# ---------------------------------------------------------------------------
+
+
+def test_content_and_pii_fixtures_present(scenario):
+    content = scenario.content
+    assert "customers-pii" in content, (
+        "customers-pii dataset (legacy PostgreSQL customer table) must be declared."
+    )
+    assert "backup-config-aws-creds" in content, (
+        "backup_config table with deliberately weak AWS creds must be declared."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: ACES-native scenario flow, no legacy attack_chain/steps fields.
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_flow_is_aces_native(scenario, raw_sdl_yaml):
+    assert scenario.injects, "Scenario must declare adversary injects."
+    assert scenario.events, "Scenario must declare events that bind injects."
+    assert scenario.scripts, "Scenario must declare scripts (time-ordered phases)."
+    assert scenario.stories, "Scenario must declare at least one story."
+    assert scenario.workflows, "Scenario must declare at least one workflow."
+
+    # No legacy `attack_chain` / `steps` / `mode` / `containers` / `mitre_attack`
+    # keys at the top level — those are cutover-only-archive surfaces per
+    # the parity inventory.
+    forbidden = {"attack_chain", "steps", "mode", "containers", "mitre_attack"}
+    leaked = forbidden & set(raw_sdl_yaml.keys())
+    assert not leaked, (
+        f"Legacy aptl.core.sdl keys must not appear in the ACES TechVault "
+        f"SDL: {sorted(leaked)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defence: only ACES SDL top-level keys are present (no x-aptl-* escape).
+# ---------------------------------------------------------------------------
+
+
+def test_no_extension_keys_present(raw_sdl_yaml):
+    from aces_sdl.scenario import Scenario  # local import: only after importorskip
+
+    allowed = set(Scenario.model_fields.keys())
+    extra = [key for key in raw_sdl_yaml.keys() if key not in allowed]
+    assert not extra, (
+        f"TechVault SDL must contain only ACES-native top-level keys; "
+        f"unexpected: {sorted(extra)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: RuntimeModel carries enough realization surface for APTL.
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_model_has_realization_surface(runtime_model):
+    # Host class — node deployments mapped onto compiled nodes.
+    deployment_node_names = {
+        deployment.name for deployment in runtime_model.node_deployments.values()
+    }
+    assert REQUIRED_TARGET_NODES[0] in deployment_node_names, (
+        f"RuntimeModel.node_deployments must include the first required "
+        f"target node ('{REQUIRED_TARGET_NODES[0]}') so backend "
+        f"interpretation has a host-class anchor."
+    )
+
+    # Network class — at least the DMZ and internal switches.
+    network_names = {network.name for network in runtime_model.networks.values()}
+    assert "aptl-dmz" in network_names and "aptl-internal" in network_names, (
+        "RuntimeModel.networks must include aptl-dmz and aptl-internal so "
+        "backend interpretation has a network-class anchor."
+    )
+
+    # Objective bindings — proves the model carries scenario semantics, not
+    # just a header.
+    objective_names = {objective.name for objective in runtime_model.objectives.values()}
+    assert objective_names, (
+        "RuntimeModel.objectives must declare at least one objective."
+    )


### PR DESCRIPTION
## Summary

Author the canonical ACES-native TechVault scenario at `scenarios/techvault.sdl.yaml` (SCN-010 Phase A authoring slice). The document declares the four legacy 172.20.x.0/24 subnets, the webapp / PostgreSQL / Samba AD-DC / fileshare / Windows workstation / mail / DNS / victim target nodes, Kali as a first-class dual-homed attacker apparatus, the SOC stack as a defensive observation surface, plus the vulnerabilities, conditions, accounts, content fixtures, injects, scripts, stories, objectives, metrics, evaluations, and workflows needed for a future APTL backend interpreter to realize TechVault from declared structure alone. Authoring only — no backend interpreter, no cutover, no archive move, no legacy deletions.

## Requirement UIDs

- `SCN-010`

## Related Issues

Closes #319

## ADR Impact

- ADR-035
- ADR-021

## Changes

- Add `scenarios/techvault.sdl.yaml` — ACES SDL doc validated against the sibling `Brad-Edwards/aces` reference parser; no `aptl.core.sdl` mirror, no `ScenarioDefinition`, no scenario-name preset.
- Add `tests/test_techvault_sdl.py` — drives the SDL through `aces_sdl.parse_sdl_file` and `aces_processor.compiler.compile_runtime_model` and asserts the issue's enterprise / Kali surface coverage. `pytest.importorskip` keeps the suite green for local devs without the sibling repo.
- Update `.github/workflows/checks.yml` — the `python-tests` job now checks out `Brad-Edwards/aces` into `_aces-sdl/` and `pip install -e`s it so the ACES validation runs end-to-end on every push.
- Update `tests/test_parity_inventory.py` — exclude `*.sdl.yaml` from the legacy-yaml coverage check; the ACES-authored documents are the replacement surface, not legacy material.
- Update `docs/aces/parity-inventory.md` — point at the new SDL and its test module.
- Add `docs/aces/techvault-sdl-authoring-preflight.md` — codex architecture-preflight binding note (created by Step 2.5 of /implement).
- Add `changelog.d/319.added.md` — towncrier fragment.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- `.venv/bin/pytest tests/ -q -k "not integration"` → 1654 passed, 81 skipped, 132 deselected, 1 xfailed.
- `.venv/bin/pre-commit run --all-files` → all hooks pass (including the local pytest hook).
- Tests gated by `pytest.importorskip("aces_sdl")` so the suite stays green on a local checkout without the sibling repo; CI runs them with the `Brad-Edwards/aces` sibling installed.
- Codex pre-push review (Step 6.5): clean, zero findings.
- Test-quality pre-push review (Step 6.6): underlying reviewer returned clean (`ship`, zero findings), but the cycle wrapper hit an envelope parse bug (`notes[0].text > 300 chars`). Filed as Brad-Edwards/Ground-Control#936. The clean decision record was posted manually per user authorization.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SCN-010 ← scenarios/techvault.sdl.yaml
- TESTS: SCN-010 ← tests/test_techvault_sdl.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/319.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed