### PR TITLE
chore: add SCN-010 inventory issue templates (per-asset + composition)

### DIFF
--- a/.github/ISSUE_TEMPLATE/scn-010-asset-inventory.md
+++ b/.github/ISSUE_TEMPLATE/scn-010-asset-inventory.md
@@ -1,0 +1,136 @@
+---
+name: SCN-010 per-asset inventory
+about: Inventory a single TechVault container at experiment grade for ACES SDL coverage.
+title: "SCN-010 inventory: <ASSET> container (steady-state asset spec)"
+labels: ["enhancement"]
+assignees: []
+---
+
+<!--
+Use this template when inventorying ONE container that makes up the TechVault
+scenario. Replace every `<ASSET>` / `<IMAGE>` / `<PROFILE>` / `<FAMILY>`
+placeholder before opening the issue.
+
+Family is one of: target | attacker | defensive-wazuh-core |
+defensive-wazuh-sidecar | defensive-soc-app | defensive-soc-backing-store.
+
+The ACES methodology issue this depends on (Brad-Edwards/aces#<METHODOLOGY-ISSUE>)
+MUST already exist and be linked. If it doesn't, file that first.
+-->
+
+## Summary
+
+Apply the ACES asset-inventorying methodology to the `<ASSET>` container as
+realized in a fresh `aptl lab start`, capture the inventory at experiment
+grade, and encode the result in `scenarios/techvault.sdl.yaml` and any
+referenced source packages / supporting artifacts.
+
+**Snapshot point**: steady state *after* `aptl lab start` has fully
+completed and the container has reached its operational state. Time
+dynamics are out of scope; the target is a single steady-state spec
+sufficient to reproduce this asset bit-for-bit (where bit-identity is
+possible) or behaviorally (where it is not).
+
+## Identifying information
+
+- **Container (docker-compose service)**: `<ASSET>`
+- **Image source**: `<IMAGE>` (registry tag for upstream images; for custom
+  builds, `containers/<DIR>/`)
+- **Compose profile**: `<PROFILE>` (e.g. `enterprise`, `soc`, `wazuh`,
+  `mail`, `dns`, `fileshare`, `victim`, `kali`, `reverse`)
+- **Family**: `<FAMILY>` (see template comment)
+- **Parent tracker**: #317
+- **Requirement**: SCN-010
+- **Depends on**: ACES methodology issue Brad-Edwards/aces#<METHODOLOGY-ISSUE>
+  (and any other in-flight gap issues this asset surfaces)
+
+## Scope
+
+Apply every dimension named by the ACES asset-inventorying methodology
+([link to methodology spec when it lands]). At minimum:
+
+- **Image identity**: base image registry + digest, all parent layers,
+  build args used at build time.
+- **Build recipe**: Dockerfile (or absence thereof for upstream images),
+  every COPY / RUN / ARG / ENV line with the inputs each consumed.
+- **Package manifest at build time**: `dpkg -l` / `rpm -qa` /
+  `pip freeze` / `npm ls` / language-specific lockfile snapshot.
+- **Patch state**: CVE inventory at snapshot time per the methodology's
+  cited approach (Trivy / Grype / equivalent), with severity counts and
+  per-vuln IDs.
+- **First-boot / provisioning state**: every script that runs at build
+  or first-start (e.g. `containers/<ASSET>/*.sh`), with inputs and the
+  resulting on-disk state.
+- **Runtime configuration**: env vars (declared in compose + resolved
+  values, redacted per ADR-029 where they're operator secrets), exposed
+  ports, capabilities, mounted volumes (bind + named), network
+  attachments, healthcheck command + interval + retries + start_period,
+  restart policy, ulimits.
+- **Filesystem inventory at steady state**: paths + checksums for
+  scenario-load-bearing content. Exclude transient state (logs,
+  caches); include configuration files, fixture content, certificates,
+  pre-seeded data, agent installers.
+- **Identity surfaces local to this host**: local users + UID/GID,
+  shells, home dirs, sudo entries, any service accounts owned by this
+  container (AD users live in `ad`'s inventory, not in their consumer's).
+- **Service surfaces**: every open port + protocol + bound interface;
+  the application or daemon listening; readiness criteria.
+- **Vulnerability inventory** (target hosts only): declared scenario
+  weaknesses (the SDL `vulnerabilities` entries this host carries),
+  cross-checked against the realized form (CVE state).
+- **Relationships originating at this host**: which services it
+  connects to (with protocol + port + auth method); which observers /
+  sidecars / agents ingest from it; trust relationships it participates
+  in.
+- **Authored-vs-realized split**: explicit per field. Which dimensions
+  are authored intent (encoded in SDL), which are realized form
+  (covered by ACES EXP-722 disclosure surfaces / equivalent), which
+  are provenance (covered by ACES EXP-720 / equivalent). Cite the
+  methodology section that governs each.
+
+The inventory is steady-state. Document what is deliberately excluded
+(time dynamics, attack-induced state changes, log volumes, ephemeral
+runtime telemetry).
+
+## Acceptance
+
+- Inventory captured under `docs/aces/inventory/<ASSET>/` as a frozen
+  artifact, following the methodology's named artifact shape. Every
+  claim cites the source it was observed at (provisioner line,
+  `docker inspect` output, `dpkg -l` line, file checksum, etc.).
+  Reviewer can re-run the cited commands and reproduce each claim.
+- All inventory surfaces that ACES can express today are encoded in
+  `scenarios/techvault.sdl.yaml` (or in a referenced source package
+  under `containers/<ASSET>/` that the SDL pins by name+version).
+- **ACES expressivity gaps**: every surface the inventory captured but
+  ACES grammar cannot represent today has a corresponding new issue
+  filed against `Brad-Edwards/aces`, with the issue URL linked from
+  this issue's body. Each gap issue must cite this inventory as its
+  motivating consumer.
+- **APTL interpretation gaps**: every surface ACES CAN express but
+  APTL backend cannot realize from declared content yet has a
+  corresponding new APTL issue filed and linked from this issue. Each
+  gap issue must name the SDL field(s) and the APTL boundary that
+  needs to consume them.
+- `pytest tests/ -q -k "not integration"` passes.
+- `pre-commit run --all-files` passes.
+- Traceability link added in Ground Control: SCN-010 ← `docs/aces/inventory/<ASSET>/`.
+- The SCN-010 parity inventory at `docs/aces/parity-inventory.yaml` is
+  updated where rows for this asset move between categories (e.g.
+  `aces_schema_profile_gap` → `aces_sdl` once a corresponding ACES
+  upstream issue lands; `aptl_backend_responsibility` rows updated to
+  cite the realized form).
+
+## Honesty / claims framing
+
+- The inventory establishes a *spec* for this asset at steady state,
+  cited against observed reality at a single point in time.
+- The inventory does NOT itself prove byte-identical re-buildability;
+  that's a separate equivalence-checker concern. It does provide the
+  ground truth a future equivalence checker compares against.
+- The inventory does NOT cover time dynamics, attack-induced state
+  transitions, or operator-driven runtime changes. Those are out of
+  scope; document them as such.
+- Any surface where the inventory could not be fully resolved (closed
+  upstream source, opaque image, undocumented behavior) must be flagged
+  in the inventory artifact as a known limit, not silently elided.

--- a/.github/ISSUE_TEMPLATE/scn-010-composition-inventory.md
+++ b/.github/ISSUE_TEMPLATE/scn-010-composition-inventory.md
@@ -1,0 +1,113 @@
+---
+name: SCN-010 scenario composition inventory
+about: Inventory the assembly of TechVault — how its assets compose at steady state.
+title: "SCN-010 inventory: TechVault scenario composition (steady-state)"
+labels: ["enhancement"]
+assignees: []
+---
+
+<!--
+Use this template when inventorying the cross-asset state that no single
+per-asset issue owns. This issue depends on every per-asset issue plus the
+ACES methodology issue.
+-->
+
+## Summary
+
+Inventory the assembly of TechVault from its per-asset inventories: how
+the 28 substantive containers compose into a single scenario at steady
+state. Captures all cross-asset state that no individual asset inventory
+owns: networks, DNS, dependency graph, mounts shared across containers,
+trust relationships, account-to-host mapping, content placement, and
+observation chains.
+
+**Snapshot point**: steady state *after* `aptl lab start` has fully
+completed. Time dynamics are out of scope.
+
+## Identifying information
+
+- **Parent tracker**: #317
+- **Requirement**: SCN-010
+- **Depends on**: ACES methodology issue Brad-Edwards/aces#<METHODOLOGY-ISSUE>;
+  every per-asset inventory issue (SCN-010 inventory: <asset>) — list
+  them here as they get filed.
+
+## Scope
+
+Apply the ACES asset-inventorying methodology to the inter-asset surface.
+At minimum:
+
+- **Network topology**: every Docker network at steady state (CIDR,
+  gateway, internal flag, ACLs at the Docker layer), MTU, driver, IPAM
+  config. Static IP assignment per container per network.
+- **DNS surface**: the `techvault.local` zone and any other authored
+  zones (A, PTR, SRV, CNAME records), resolver chain across hosts,
+  DNS-tunneling sink configuration, fallback / split-horizon behavior.
+- **Dependency graph**: compose `depends_on` edges,
+  healthcheck-conditioned ordering, service-readiness dependencies
+  (Wazuh agents waiting on manager enrollment, MISP → Suricata sync,
+  Shuffle webhook wiring, Cortex ↔ TheHive analyzer registration, etc.).
+- **Volume and bind-mount topology**: every named volume and bind
+  mount, the containers that share each, the directionality of writes,
+  any consistency requirements between writers and readers.
+- **Trust relationships**: AD domain-join graph (who joins, what
+  trusts), SMB share auth chains, TLS trust paths (SOC CA → service
+  certs, target CAs), MISP API key flow, Shuffle webhook credentials,
+  Cortex API integration with TheHive, Wazuh agent enrollment trust.
+- **Account-to-host mapping**: every AD user and local account from
+  the per-asset inventories, the host(s) it can authenticate to,
+  group memberships, SPNs, password policies that apply.
+- **Content placement matrix**: which fixture file / dataset / seed
+  lives on which host (cross-referenced from per-asset inventories),
+  write permissions, persistence model, which other hosts read it.
+- **Observation chains**: which Wazuh agent / sidecar ingests from
+  which host, which decoders apply, which Suricata interface taps
+  which network, OTEL trace propagation paths (if any cross scenario
+  boundaries), log forwarding chains.
+- **Defensive workflow chains**: Wazuh alert → Shuffle workflow →
+  TheHive case → Cortex analyzer flow, including the per-step
+  configuration that wires them. Active-response chains
+  (rule fires → AR script → target effect).
+- **Authored-vs-realized split** at the composition level: which
+  composition surfaces are authored intent (encoded in SDL
+  `infrastructure`, `relationships`, `dependencies`), which are
+  realized form, which are provenance.
+
+## Acceptance
+
+- Composition inventory captured under
+  `docs/aces/inventory/_composition/` as a frozen artifact following the
+  methodology's named artifact shape. Every claim cites observed
+  reality (`docker network inspect`, `docker compose config`,
+  `samba-tool` output, file checksums, etc.).
+- All composition surfaces ACES can express today are encoded in the
+  SDL (`infrastructure`, `relationships`, `dependencies`, network
+  ACLs, account `node` bindings, content `target` bindings, agent
+  `allowed_subnets` / `initial_knowledge`, workflow steps).
+- **ACES expressivity gaps** at the composition level (DNS records,
+  workflow-chain wiring beyond `workflows:`, trust-graph primitives,
+  observation-chain primitives, volume-sharing semantics, etc.) →
+  new issues filed against `Brad-Edwards/aces`, linked from this
+  issue. Each gap issue cites this composition inventory as its
+  motivating consumer.
+- **APTL interpretation gaps** at the composition level → new APTL
+  issues filed, linked from this issue.
+- `pytest tests/ -q -k "not integration"` passes.
+- `pre-commit run --all-files` passes.
+- Traceability link added in Ground Control: SCN-010 ←
+  `docs/aces/inventory/_composition/`.
+- Parity inventory rows for composition-level surfaces updated where
+  they move categories.
+
+## Honesty / claims framing
+
+- The composition inventory documents the *connective tissue* of
+  TechVault as observed at steady state. It does not by itself prove
+  the connections are correct or complete; subsequent validation work
+  (live deployment gates, conformance suites) tests that.
+- The composition inventory does NOT replace per-asset inventories;
+  it depends on them. If any per-asset inventory is incomplete, the
+  composition claims that build on it are correspondingly limited.
+- Out-of-scope surfaces (time dynamics, runtime workflow execution
+  traces, post-attack state) are documented as such in the inventory
+  artifact, not silently elided.


### PR DESCRIPTION
## Summary

Adds two markdown issue templates under `.github/ISSUE_TEMPLATE/` for the
SCN-010 inventory work series:

- `scn-010-asset-inventory.md` — one issue per substantive container,
  carrying the boilerplate scope + gap-handling acceptance + honesty
  framing that the per-asset inventory work shares.
- `scn-010-composition-inventory.md` — the cross-asset / assembly issue.

## Why

The SCN-010 inventory series will land in many iterations (28 per-asset
issues + composition + ACES upstream methodology issue, plus follow-ups
as the methodology evolves). Codifying the shared shape as a repo-level
template keeps every iteration consistent and makes the gap-handling
acceptance criteria explicit: every per-asset issue must surface ACES
expressivity gaps as new upstream issues, and surface APTL interpretation
gaps as new APTL issues.

The canonical methodology these templates apply lives upstream in
Brad-Edwards/aces (to be filed); the templates here are this backend's
vendored copy.

## Test plan

- [x] Templates render correctly under `.github/ISSUE_TEMPLATE/`
- [x] `pre-commit run --files <templates>` passes (yaml frontmatter, EOL,
  trailing whitespace, no private keys)
- [ ] First inventory issue filed from each template produces the
  expected body shape (will verify when the methodology issue + first
  per-asset issue land in this batch)