### PR TITLE
fix: reap kali container children and gate readiness on a healthcheck

### DIFF
--- a/changelog.d/293.fixed.md
+++ b/changelog.d/293.fixed.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The Kali red-team container now runs under Docker's bundled init
+  (`init: true`), so PID 1 reaps orphaned child processes instead of
+  leaving them as zombies — the entrypoint's terminal `sleep` is no
+  longer PID 1. Its healthcheck now verifies the usable surface (sshd,
+  the OBS-003 ForceCommand wrapper, and a boot-readiness marker the
+  entrypoint writes only after a complete boot) rather than merely
+  that port 22 is open, so a container whose boot died part-way no
+  longer reports healthy.

--- a/containers/kali/Dockerfile
+++ b/containers/kali/Dockerfile
@@ -112,6 +112,16 @@ RUN chmod 0640 /etc/audit/rules.d/aptl.rules && \
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# ADR-033 §2 / issue #293: container healthcheck script. Installed to
+# /usr/local/bin (root-owned, outside the kali user's home — the same
+# hardening pattern as aptl-wrap-shell.sh above). docker-compose.yml
+# wires it as the kali service healthcheck; it verifies sshd, the
+# OBS-003 ForceCommand wrapper, and the entrypoint's boot-readiness
+# marker rather than merely that port 22 is open.
+COPY healthcheck.sh /usr/local/bin/aptl-healthcheck.sh
+RUN chmod 0755 /usr/local/bin/aptl-healthcheck.sh && \
+    chown root:root /usr/local/bin/aptl-healthcheck.sh
+
 EXPOSE 22
 
 USER kali
@@ -123,7 +133,11 @@ USER root
 
 # Entrypoint starts sshd (via capsh dropping CAP_AUDIT_CONTROL),
 # auditd (rules loaded at boot before the cap is dropped), process
-# accounting, and a keepalive sleep. Wazuh agent + rsyslog-to-SIEM
+# accounting, and a keepalive sleep. The kali service sets
+# `init: true` in docker-compose.yml so PID 1 is Docker's bundled
+# init (docker-init / tini), which reaps orphaned children — the
+# keepalive sleep is its child, not PID 1 (ADR-033 §2 / issue #293).
+# Wazuh agent + rsyslog-to-SIEM
 # forwarding from prior versions were removed under ADR-033
 # (non-contamination): red activity must not bleed into the blue
 # SIEM. The experimental record lives in the docker named volume

--- a/containers/kali/entrypoint.sh
+++ b/containers/kali/entrypoint.sh
@@ -19,6 +19,16 @@
 # blue defensive stack's awareness. See ADR-033.
 set -e
 
+# ADR-033 §2 / issue #293: per-subsystem boot outcomes. Each starts
+# `degraded` and is promoted to `ok` once its boot step succeeds. The
+# values are written into the readiness marker at the end of boot so
+# the healthcheck (aptl-healthcheck.sh) can surface a degraded
+# capture surface instead of masking it behind an open port 22.
+sshd_status=degraded
+auditd_status=degraded
+procacct_status=degraded
+wrapper_status=degraded
+
 # Set up SSH keys from host.
 if [ -f "/host-ssh-keys/authorized_keys" ]; then
     mkdir -p /home/kali/.ssh
@@ -64,9 +74,12 @@ if command -v accton >/dev/null 2>&1; then
     touch /var/log/aptl/captures/_proc-acct/pacct
     chown root:root /var/log/aptl/captures/_proc-acct/pacct
     chmod 0600 /var/log/aptl/captures/_proc-acct/pacct
-    accton /var/log/aptl/captures/_proc-acct/pacct \
-      || echo "[entrypoint] accton failed (best-effort)"
-    echo "Process accounting active"
+    if accton /var/log/aptl/captures/_proc-acct/pacct; then
+        procacct_status=ok
+        echo "Process accounting active"
+    else
+        echo "[entrypoint] accton failed (best-effort)"
+    fi
 fi
 
 # OBS-003: auditd. Load rules with full CAP_AUDIT_CONTROL (we have it
@@ -95,8 +108,11 @@ if [ "$audit_loaded" = "1" ] && command -v auditd >/dev/null 2>&1; then
     # audit events on container restart (codex cycle 2 finding-3).
     touch /var/log/aptl/captures/_audit/audit.log
     chmod 0600 /var/log/aptl/captures/_audit/audit.log
-    auditd >/dev/null 2>&1 \
-      || echo "[entrypoint] auditd start failed (missing CAP_AUDIT_*?)"
+    if auditd >/dev/null 2>&1; then
+        auditd_status=ok
+    else
+        echo "[entrypoint] auditd start failed (missing CAP_AUDIT_*?)"
+    fi
 fi
 
 # Final ownership repair on home dir (cheap, idempotent — NOT the
@@ -114,21 +130,59 @@ if command -v capsh >/dev/null 2>&1; then
     # `--drop=cap_audit_control` removes only the dangerous capability;
     # sshd retains everything else it needs. If capsh fails (unlikely
     # — it's in libcap2-bin which is in the kali base), fall back to
-    # unwrapped sshd so the lab still works, but log loudly.
-    capsh --drop=cap_audit_control -- -c '/usr/sbin/sshd' \
-      || { echo "[entrypoint] capsh-wrapped sshd failed; falling back" >&2 ; \
-           /usr/sbin/sshd ; }
+    # unwrapped sshd so the lab still works, but log loudly. The `if`
+    # guards keep a sshd failure from tripping `set -e` so the boot
+    # still reaches the readiness marker (issue #293).
+    if capsh --drop=cap_audit_control -- -c '/usr/sbin/sshd'; then
+        sshd_status=ok
+    else
+        echo "[entrypoint] capsh-wrapped sshd failed; falling back" >&2
+        if /usr/sbin/sshd; then sshd_status=ok; fi
+    fi
 else
     echo "[entrypoint] capsh missing; sshd running with full caps (auditd disable risk)" >&2
-    /usr/sbin/sshd
+    if /usr/sbin/sshd; then sshd_status=ok; fi
 fi
-echo "SSH daemon started"
+if [ "$sshd_status" = "ok" ]; then
+    echo "SSH daemon started"
+else
+    echo "[entrypoint] WARNING: sshd failed to start" >&2
+fi
+
+# OBS-003 ForceCommand wrapper presence — the per-session capture
+# wiring sshd hands every kali login to. A missing/non-executable
+# wrapper means logins fall back to an unwrapped shell with no
+# capture, so it is part of the usable surface the healthcheck gates.
+if [ -x /usr/local/bin/aptl-wrap-shell.sh ]; then
+    wrapper_status=ok
+else
+    echo "[entrypoint] WARNING: OBS-003 ForceCommand wrapper missing/not executable" >&2
+fi
+
+# ADR-033 §2 / issue #293: boot-readiness marker. Written only after
+# every boot step above — `set -e` aborts the entrypoint before this
+# point on any hard failure, so the marker's presence proves a
+# complete boot. aptl-healthcheck.sh treats a missing marker as
+# unhealthy and surfaces any `=degraded` subsystem in its health log.
+mkdir -p /run
+{
+    echo "ready_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "sshd=${sshd_status}"
+    echo "wrapper=${wrapper_status}"
+    echo "auditd=${auditd_status}"
+    echo "procacct=${procacct_status}"
+} > /run/aptl-kali-ready
 
 echo "=== APTL Kali Red Team Container Ready ==="
 echo "SSH: ssh kali@<container_ip>"
 echo "Working directory: /home/kali/operations"
 echo "Per-session captures: /var/log/aptl/captures/<run_id>/<session_id>/ (in named volume)"
 echo "Harvest target on host: .aptl/runs/<run_id>/kali-side/<session_id>/"
+echo "Boot readiness: sshd=${sshd_status} wrapper=${wrapper_status} auditd=${auditd_status} procacct=${procacct_status}"
 
-# Keep container alive (PID 1 keepalive).
+# ADR-033 §2 / issue #293: terminal keepalive. The kali service sets
+# `init: true` (docker-compose.yml), so PID 1 is Docker's bundled
+# init (docker-init / tini) — it reaps orphaned children and forwards
+# signals. This `sleep` is a child of that init, NOT PID 1, so it no
+# longer needs to (and could not) reap anything itself.
 exec sleep infinity

--- a/containers/kali/healthcheck.sh
+++ b/containers/kali/healthcheck.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# APTL Kali container healthcheck (ADR-033 §2 / issue #293).
+#
+# Verifies the *usable surface* of the container, not merely that
+# port 22 is open. A boot that died after sshd started but before the
+# entrypoint finished bringing up the OBS-003 capture surface
+# previously still reported healthy — this check fails it.
+#
+# Hard requirements (exit 1 -> container marked unhealthy):
+#   - sshd is listening on :22
+#   - the OBS-003 ForceCommand wrapper is installed and executable
+#   - the entrypoint wrote its boot-readiness marker (its presence
+#     proves the entrypoint ran to completion: `set -e` aborts the
+#     entrypoint before the marker on any hard failure)
+#
+# Capture-daemon degradation (auditd / process accounting) is NOT a
+# hard failure here. It is recorded per-subsystem in the readiness
+# marker and the entrypoint logs as the "clear degraded-startup
+# signal" ADR-033 §2 calls for, and echoed below so it shows in
+# `docker inspect`'s health log. auditd legitimately cannot bind the
+# kernel audit netlink socket on hosts already running their own
+# auditd, so failing the container on it would produce false alarms.
+set -u
+
+READY_MARKER="/run/aptl-kali-ready"
+WRAPPER="/usr/local/bin/aptl-wrap-shell.sh"
+
+fail() {
+    echo "[healthcheck] UNHEALTHY: $1" >&2
+    exit 1
+}
+
+# 1. sshd listening on :22. The trailing-boundary match avoids a
+#    false positive on ports like :2200.
+if ! ss -tln 2>/dev/null | grep -qE ':22([[:space:]]|$)'; then
+    fail "sshd is not listening on :22"
+fi
+
+# 2. OBS-003 ForceCommand wrapper present and executable.
+if [ ! -x "$WRAPPER" ]; then
+    fail "ForceCommand wrapper $WRAPPER missing or not executable"
+fi
+
+# 3. Entrypoint completed boot and wrote the readiness marker.
+if [ ! -f "$READY_MARKER" ]; then
+    fail "boot-readiness marker $READY_MARKER absent — entrypoint did not complete boot"
+fi
+
+# Surface (but do not fail on) degraded capture subsystems.
+degraded="$(grep -E '=degraded$' "$READY_MARKER" 2>/dev/null | cut -d= -f1 | tr '\n' ' ')"
+degraded="${degraded%% }"
+if [ -n "$degraded" ]; then
+    echo "[healthcheck] healthy (degraded capture subsystems: ${degraded})"
+else
+    echo "[healthcheck] healthy"
+fi
+exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1102,6 +1102,12 @@ services:
     container_name: aptl-kali
     hostname: kali-redteam
     restart: unless-stopped
+    # ADR-033 §2 / issue #293: run under Docker's bundled init
+    # (docker-init / tini) as PID 1. The entrypoint's terminal
+    # `exec sleep infinity` is otherwise PID 1 and cannot reap
+    # children, so any process orphaned to PID 1 — red-team agents
+    # routinely background processes — zombies out.
+    init: true
     networks:
       aptl-redteam:
         ipv4_address: 172.20.4.30
@@ -1157,8 +1163,13 @@ services:
       - SYS_PACCT
     security_opt:
       - seccomp:unconfined  # Required for some red team tools
+    # ADR-033 §2 / issue #293: the healthcheck verifies the usable
+    # surface — sshd, the OBS-003 ForceCommand wrapper, and the
+    # boot-readiness marker — not merely that port 22 is open. A boot
+    # that died before completing the capture surface no longer
+    # reports healthy.
     healthcheck:
-      test: ["CMD-SHELL", "ss -tlnp | grep ':22' || exit 1"]
+      test: ["CMD", "/usr/local/bin/aptl-healthcheck.sh"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/docs/adrs/adr-033-agent-reasoning-trace-boundary.md
+++ b/docs/adrs/adr-033-agent-reasoning-trace-boundary.md
@@ -97,7 +97,37 @@ process via `capsh --drop=cap_audit_control` so the kali user
 cannot run `sudo auditctl -D` to disable the audit trail
 mid-scenario.
 
-### 2. Per-run aggregation directory
+### 2. Kali process lifecycle and readiness
+
+The Kali entrypoint owns startup of sshd plus the OBS-003 capture
+daemons (`auditd` and process accounting). Because that entrypoint is
+PID 1, it must also own child-process reaping. A plain
+`exec sleep infinity` keepalive is not an acceptable terminal process
+after boot-time children have been spawned: it cannot reap exited
+children and can leave failed startup work hidden behind a healthy,
+long-running container.
+
+The canonical fix for Kali lifecycle bugs is either:
+
+- run the service under a real init/reaper such as `tini`, or
+- keep the entrypoint shell as PID 1 with explicit signal handling and
+  `wait`/reap logic for background children it starts.
+
+Do not solve Kali lifecycle failures by reintroducing the removed
+Wazuh installer, rsyslog forwarding, `install-all.sh`, or any other
+red→SIEM pipe. If a future check mentions Wazuh placeholders on Kali,
+the expected invariant is that no Kali Wazuh config exists at all. Wazuh
+agent rendering and placeholder validation for blue/target containers
+belongs to the shared `_wazuh-agent` path recorded in ADR-020.
+
+Kali health/readiness should represent the services and evidence
+surface that make the container usable: sshd must accept connections,
+the ForceCommand wrapper must be present, and capture daemons that are
+advertised as active should either be running or should have produced a
+clear degraded-startup signal. Health checks must not mask a failed
+boot-time child merely because port 22 is open.
+
+### 3. Per-run aggregation directory
 
 `<state_dir>/runs/<trace_id>/`:
 
@@ -124,7 +154,7 @@ The directory contract is owned by `src/aptl/core/runstore.py`
 (`LocalRunStore`, `resolve_active_run_dir`, session-scoped helpers)
 and mirrored by `mcp/aptl-mcp-common/src/runs.ts`.
 
-### 3. Non-contamination principle
+### 4. Non-contamination principle
 
 **No scenario information crosses the red/blue boundary.** Scenario
 information means:
@@ -170,7 +200,7 @@ active-response wrapper's kali-source-IP whitelist (referenced in
 `wazuh_manager.conf` lines ~224 / ~308) is the blue-side prevention
 chain (ADR-019 / ADR-021 / #248 / #249) and unrelated to this ADR.
 
-### 4. Future path for blue's red-activity awareness
+### 5. Future path for blue's red-activity awareness
 
 When a future requirement wants the blue agent to learn about red
 activity (cross-team summary reports, lessons-learned overlays,
@@ -184,7 +214,7 @@ and NEVER pipe red logs into the SIEM directly. The SIEM is the
 defender's perception layer; it must reflect only what the defender's
 own sensors detected.
 
-### 5. Experimenter-side reasoning capture
+### 6. Experimenter-side reasoning capture
 
 Capturing the LLM's internal reasoning is the experimenter's
 responsibility. Each coding-agent CLI (Claude Code, Codex, Cursor,
@@ -225,6 +255,12 @@ agent CLI ships.
   and `script` running on Kali (`ps aux` will show them). That is
   intentional and acceptable per the non-contamination principle —
   observation tooling is not scenario information.
+- **PID 1 / OS lifecycle**: the Kali container starts child processes
+  during boot. PID 1 must reap children and propagate termination
+  correctly, either through a real init/reaper or through a shell
+  entrypoint that stays PID 1 and waits on the children it starts. A
+  keepalive process that only sleeps is not a lifecycle boundary and
+  must not be used to hide failed boot work.
 - **Capture integrity from a sudo-capable kali user** (residual
   risk, codex pre-push cycle 2 finding-9; tracked in
   [issue #305](https://github.com/Brad-Edwards/aptl/issues/305)):
@@ -325,6 +361,10 @@ policy without changing call sites.
   and outside the OBS-003 boundary.
 - Pcap content redaction — deliberately out of scope. Pcaps are raw
   wire bytes; semantic redaction does not apply.
+- Installing, configuring, or health-checking a Wazuh agent on Kali.
+  That red→SIEM path was removed by this ADR; Wazuh placeholder
+  handling remains in the target/blue agent bootstrap paths, not in
+  Kali.
 
 ## Anti-patterns
 
@@ -342,5 +382,9 @@ policy without changing call sites.
 - Re-introducing any red→SIEM pipe (rsyslog forwarding, Wazuh agent
   on Kali, OCSF dispatch to a SIEM sink, etc.) without an ADR that
   explicitly overrides the non-contamination principle.
+- Ending the Kali entrypoint with an unreaping `sleep`, `tail -f`, or
+  equivalent keepalive after spawning background children.
+- Treating "SSH port open" as complete Kali readiness when the
+  advertised capture surface failed during startup.
 - Treating `APTL_EXPERIMENT_NO_REDACT=1` as a default-on setting in
   production. It is an experimenter-side opt-out, never a baseline.

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -112,6 +112,37 @@ class TestComposeConsistency:
         )
 
 
+class TestKaliContainerLifecycle:
+    """Issue #293 / ADR-033 §2: the kali container must reap children and
+    its healthcheck must reflect the usable surface, not just port 22."""
+
+    def test_kali_service_runs_under_init_reaper(self, compose_config):
+        """The kali service must set `init: true` so Docker injects an
+        init/reaper (docker-init / tini) as PID 1. Without it the
+        entrypoint's `exec sleep infinity` is PID 1 and cannot reap
+        orphaned children — the zombie defect in issue #293."""
+        kali = compose_config["services"]["kali"]
+        assert kali.get("init") is True, (
+            "kali service must set `init: true` (ADR-033 §2): PID 1 must "
+            "reap children, otherwise red-team-spawned background processes "
+            "zombie out (issue #293)."
+        )
+
+    def test_kali_healthcheck_is_not_bare_port_probe(self, compose_config):
+        """The kali healthcheck must not be the port-22-only probe — that
+        masks a failed boot-time child behind an open SSH port
+        (ADR-033 §2). It must invoke the readiness healthcheck script."""
+        kali = compose_config["services"]["kali"]
+        test = kali.get("healthcheck", {}).get("test")
+        assert test, "kali service must define a healthcheck"
+        joined = " ".join(test) if isinstance(test, list) else str(test)
+        assert "aptl-healthcheck.sh" in joined, (
+            "kali healthcheck must invoke /usr/local/bin/aptl-healthcheck.sh, "
+            f"which verifies sshd + the ForceCommand wrapper + the boot "
+            f"readiness marker — not just an open port; got: {test!r}"
+        )
+
+
 class TestCodeReferencesMatchCompose:
     """Ensure docker exec references in code match actual container_name values."""
 

--- a/tests/test_obs003_kali_capture.py
+++ b/tests/test_obs003_kali_capture.py
@@ -246,6 +246,16 @@ class TestEndToEndCapture:
         modes = kali_exec(
             f"find {sess_path} -mindepth 1 -printf '%m %p\\n' 2>/dev/null | head -20"
         ).stdout
+        # Pre-condition: without this, a silently-failed SSH session (or a
+        # wrapper that created no files) leaves `modes` empty, the loop
+        # below never executes, and the test passes having asserted
+        # nothing about permissions. Mirrors the precondition pattern in
+        # test_session_captures_pty_typescript_and_pcap.
+        assert modes.strip(), (
+            f"No capture artifacts found under {sess_path}; the SSH session "
+            "may have failed or the wrapper produced no files — permission "
+            "assertions would otherwise be silently skipped"
+        )
         for line in modes.splitlines():
             parts = line.split(None, 1)
             if len(parts) < 2:
@@ -256,3 +266,98 @@ class TestEndToEndCapture:
                 assert mode in ("700", "0700"), f"{path} dir mode {mode}, expected 0700"
             else:
                 assert mode in ("600", "0600"), f"{path} file mode {mode}, expected 0600"
+
+
+class TestProcessLifecycle:
+    """Issue #293 / ADR-033 §2: PID 1 must reap children, and the
+    container's readiness surface must reflect a completed boot rather
+    than masking a failed boot-time child behind an open port 22."""
+
+    def test_pid1_is_an_init_reaper(self):
+        # `init: true` on the kali service makes Docker inject its
+        # bundled init (docker-init, a tini build) as PID 1. The
+        # entrypoint's terminal `exec sleep infinity` is then a child
+        # of that init — never PID 1 itself — so orphaned children get
+        # reaped instead of zombifying (issue #293).
+        comm = kali_exec("cat /proc/1/comm 2>/dev/null || true").stdout.strip()
+        assert comm in ("docker-init", "tini"), (
+            f"PID 1 should be an init/reaper (docker-init / tini) via "
+            f"`init: true`; got {comm!r}. A bare `sleep` as PID 1 cannot "
+            "reap orphaned children."
+        )
+
+    def test_no_zombie_processes_present(self):
+        # The reaping defect surfaced in issue #293 as a `<defunct>`
+        # process. With a real init as PID 1 there should be no
+        # un-reaped zombies in the container's process table.
+        count = kali_exec(
+            "ps -eo stat= 2>/dev/null | grep -c '^Z' || true"
+        ).stdout.strip()
+        assert count == "0", (
+            f"container process table has {count} zombie process(es); "
+            "PID 1 is not reaping children"
+        )
+
+    def test_boot_readiness_marker_present_and_well_formed(self):
+        # The entrypoint writes /run/aptl-kali-ready only after every
+        # boot step; its presence proves a complete boot. Each capture
+        # subsystem records ok|degraded.
+        marker = kali_exec(
+            "cat /run/aptl-kali-ready 2>/dev/null || true"
+        ).stdout
+        assert marker.strip(), (
+            "/run/aptl-kali-ready is absent — the entrypoint did not "
+            "complete boot (the hidden-failure mode of issue #293)"
+        )
+        keys = dict(
+            line.split("=", 1)
+            for line in marker.splitlines()
+            if "=" in line
+        )
+        for required in ("ready_at", "sshd", "wrapper", "auditd", "procacct"):
+            assert required in keys, (
+                f"readiness marker missing `{required}`; got keys {sorted(keys)}"
+            )
+        for subsystem in ("sshd", "wrapper", "auditd", "procacct"):
+            assert keys[subsystem] in ("ok", "degraded"), (
+                f"readiness marker `{subsystem}` should be ok|degraded; "
+                f"got {keys[subsystem]!r}"
+            )
+        # sshd and the ForceCommand wrapper are the usable surface —
+        # in a healthy lab they must not be degraded.
+        assert keys["sshd"] == "ok", "sshd recorded degraded in readiness marker"
+        assert keys["wrapper"] == "ok", (
+            "OBS-003 ForceCommand wrapper recorded degraded in readiness marker"
+        )
+
+    def test_healthcheck_script_installed_root_owned_executable(self):
+        # aptl-healthcheck.sh lives under /usr/local/bin (outside the
+        # kali user's home) and must be root-owned + executable so the
+        # docker healthcheck can run it.
+        r = kali_exec(
+            "stat -c '%U %a' /usr/local/bin/aptl-healthcheck.sh 2>/dev/null "
+            "|| echo missing"
+        )
+        parts = r.stdout.strip().split()
+        assert len(parts) == 2, (
+            f"aptl-healthcheck.sh not installed; stat output: {r.stdout!r}"
+        )
+        owner, mode = parts
+        assert owner == "root", f"aptl-healthcheck.sh should be root-owned; got {owner!r}"
+        owner_mode = int(mode[-3]) if len(mode) >= 3 else 0
+        assert owner_mode & 1, (
+            f"aptl-healthcheck.sh missing owner-execute bit; mode {mode!r}"
+        )
+
+    def test_healthcheck_passes_on_healthy_container(self):
+        # Running the healthcheck against an up, healthy container must
+        # exit 0 and report healthy — the script is what docker-compose
+        # wires as the kali healthcheck.
+        r = kali_exec("/usr/local/bin/aptl-healthcheck.sh; echo EXIT=$?")
+        assert "EXIT=0" in r.stdout, (
+            f"aptl-healthcheck.sh should pass on a healthy container; "
+            f"output: {r.stdout!r} stderr: {r.stderr!r}"
+        )
+        assert "healthy" in r.stdout, (
+            f"aptl-healthcheck.sh should report healthy; got {r.stdout!r}"
+        )


### PR DESCRIPTION
## Summary

The aptl-kali container's entrypoint ended with `exec sleep infinity`, making `sleep` PID 1 — a process that cannot reap exited children, so anything orphaned to PID 1 (red-team agents routinely background processes) zombifies. The container healthcheck only probed port 22, so a boot that died before completing the OBS-003 capture surface still reported healthy. The fix runs the kali service under Docker's bundled init (`init: true`, i.e. docker-init / tini) so PID 1 reaps children, and replaces the port-22 healthcheck with a script that verifies sshd, the OBS-003 ForceCommand wrapper, and a boot-readiness marker the entrypoint writes only on a complete boot. Per architecture preflight, the issue's Wazuh-install half is moot — ADR-033 already removed Wazuh, rsyslog, and install-all.sh from Kali; no red→SIEM pipe is reintroduced.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #293

## ADR Impact

- ADR-033
- ADR-021

## Changes

- docker-compose.yml: add `init: true` to the kali service so Docker's bundled init (docker-init / tini) is PID 1 and reaps orphaned children; repoint the healthcheck at /usr/local/bin/aptl-healthcheck.sh
- containers/kali/entrypoint.sh: track each subsystem's boot outcome (sshd, auditd, process accounting, ForceCommand wrapper) and write a /run/aptl-kali-ready marker before the keepalive sleep; guard sshd start with `if` so a failure still reaches the marker rather than tripping `set -e`
- containers/kali/healthcheck.sh: new script — hard-fails when sshd is not listening, the ForceCommand wrapper is missing/non-executable, or the readiness marker is absent; records degraded capture daemons without failing the container
- containers/kali/Dockerfile: install healthcheck.sh to /usr/local/bin/aptl-healthcheck.sh (root-owned, executable); correct the now-stale PID 1 / keepalive comments
- tests/test_consistency.py: TestKaliContainerLifecycle — default-run assertions that the kali service sets `init: true` and the healthcheck is not the bare port-22 probe
- tests/test_obs003_kali_capture.py: TestProcessLifecycle — APTL_SMOKE live tests (PID 1 is an init/reaper, no zombie processes, readiness marker well-formed, healthcheck script installed and passes); plus a missing-precondition fix to test_session_dir_permissions_are_restrictive so an empty find result fails instead of silently skipping every assertion

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Container/compose/Dockerfile change — final validation is a clean `aptl lab stop -v && aptl lab start` producing a healthy aptl-kali container. The TestProcessLifecycle suite is APTL_SMOKE-gated and runs against that live container; TestKaliContainerLifecycle runs in the default unit suite (no lab needed).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-033 ← docker-compose.yml (kali service `init: true` + healthcheck), ADR-033 ← containers/kali/entrypoint.sh (boot-readiness marker), ADR-033 ← containers/kali/healthcheck.sh (readiness healthcheck), ADR-033 ← containers/kali/Dockerfile (healthcheck install)
- TESTS: ADR-033 ← tests/test_consistency.py::TestKaliContainerLifecycle, ADR-033 ← tests/test_obs003_kali_capture.py::TestProcessLifecycle

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/293.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
