### PR TITLE
fix: address lab ssh targets by container ip, not localhost port

### DIFF
--- a/changelog.d/293.fixed.md
+++ b/changelog.d/293.fixed.md
@@ -8,3 +8,11 @@
   entrypoint writes only after a complete boot) rather than merely
   that port 22 is open, so a container whose boot died part-way no
   longer reports healthy.
+- Lab SSH access now addresses targets (kali, victim, workstation) by
+  container IP instead of `localhost:<published-port>`. Those targets
+  sit on `internal: true` networks, for which Docker publishes no host
+  port — so the old model left `aptl lab start` reporting
+  `degraded_unusable` and the snapshot SSH endpoints empty. The
+  readiness probe and `build_ssh_endpoints` now resolve the
+  host-reachable container IP; the dead `ports:` mappings on those
+  services are removed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -993,8 +993,11 @@ services:
     networks:
       aptl-internal:
         ipv4_address: 172.20.2.20
-    ports:
-      - "2022:22"    # SSH access
+    # No host port published: victim is attached only to an
+    # internal-only network, and Docker does not publish host ports
+    # for internal-only containers. The control plane reaches victim
+    # by container IP over the bridge — see endpoints.py
+    # select_ssh_host (issue #293).
     environment:
       - SIEM_IP=172.20.2.30  # wazuh.manager on aptl-internal
       - LABADMIN_SSH_KEY_FILE=/keys/aptl_lab_key.pub
@@ -1038,8 +1041,11 @@ services:
     networks:
       aptl-internal:
         ipv4_address: 172.20.2.40
-    ports:
-      - "2028:22"    # SSH access
+    # No host port published: workstation is attached only to an
+    # internal-only network, and Docker does not publish host ports
+    # for internal-only containers. The control plane reaches it by
+    # container IP over the bridge — see endpoints.py select_ssh_host
+    # (issue #293).
     environment:
       - SIEM_IP=172.20.2.30  # wazuh.manager on aptl-internal
       - LABADMIN_SSH_KEY_FILE=/keys/aptl_lab_key.pub
@@ -1115,8 +1121,11 @@ services:
         ipv4_address: 172.20.1.30
       aptl-internal:
         ipv4_address: 172.20.2.35
-    ports:
-      - "2023:22"    # SSH access for MCP
+    # No host port published: kali is attached only to internal-only
+    # networks (aptl-redteam / aptl-dmz / aptl-internal), and Docker
+    # does not publish host ports for internal-only containers. The
+    # MCP / control plane reaches kali by container IP over the bridge
+    # — see endpoints.py select_ssh_host (issue #293).
     environment:
       - VICTIM_IP=172.20.2.20
     extra_hosts:

--- a/src/aptl/core/endpoints.py
+++ b/src/aptl/core/endpoints.py
@@ -184,6 +184,28 @@ def parse_host_port(
     return None
 
 
+def select_ssh_host(networks: dict[str, str]) -> str | None:
+    """Pick a host-reachable IP for SSH from a container's network map.
+
+    Lab target containers (kali, victim, workstation) sit only on
+    ``internal: true`` networks — SAF-002 makes them internal to block
+    target internet egress — so Docker publishes no host port for them
+    and a ``localhost:<port>`` endpoint is unreachable. The host can
+    still reach those containers directly by container IP over the
+    bridge (``internal: true`` blocks container↔internet and
+    cross-network traffic, not host↔container). Any of a container's
+    bridge IPs is host-reachable; the lowest network name is chosen so
+    a multi-homed container (kali spans three networks) resolves to a
+    stable IP across snapshots. Blank IPs are skipped; ``None`` means
+    no addressable interface (the caller omits the endpoint).
+    """
+    for net_name in sorted(networks):
+        ip = networks[net_name]
+        if ip:
+            return ip
+    return None
+
+
 def _running(container: ContainerSnapshot) -> bool:
     """True if the container's status string indicates an up-and-running container."""
     return "Up" in container.status
@@ -250,21 +272,20 @@ def build_ssh_endpoints(
         # The assert documents this for the type checker without leaving
         # an unreachable defensive branch.
         assert entry.ssh_user is not None
-        host_port = parse_host_port(
-            container.ports,
-            entry.target_port,
-            protocol=entry.transport_protocol,
-        )
-        if host_port is None:
+        # Lab SSH targets sit on internal-only networks with no
+        # published host port (issue #293), so they are addressed by
+        # container IP — the host reaches them over the bridge. The
+        # endpoint connects to the container-side target port directly,
+        # not a remapped host port.
+        host = select_ssh_host(container.networks)
+        if host is None:
             continue
-        command = (
-            f"ssh -i {_SSH_KEY_PATH} {entry.ssh_user}@localhost -p {host_port}"
-        )
+        command = f"ssh -i {_SSH_KEY_PATH} {entry.ssh_user}@{host}"
         endpoints.append(
             SSHEndpoint(
                 name=entry.display_name,
-                host="localhost",
-                port=host_port,
+                host=host,
+                port=entry.target_port,
                 user=entry.ssh_user,
                 key_path=_SSH_KEY_PATH,
                 command=command,

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -53,7 +53,8 @@ from aptl.core.services import (
     test_ssh_connection,
     wait_for_service,
 )
-from aptl.core.snapshot import capture_snapshot
+from aptl.core.endpoints import select_ssh_host
+from aptl.core.snapshot import capture_snapshot, container_networks
 from aptl.core.ssh import ensure_ssh_keys
 from aptl.core.sysreqs import check_max_map_count
 from aptl.utils.logging import get_logger
@@ -904,21 +905,46 @@ def _step_wait_for_services(ctx: _LabStartContext) -> LabResult | None:
 )
 def _step_test_ssh(ctx: _LabStartContext) -> LabResult | None:
     log.info("Step 10: Testing SSH connectivity...")
-    assert ctx.config is not None and ctx.ssh_key_path is not None  # runtime guards above
-    ssh_tests: list[tuple[str, int, str]] = []
+    # config / ssh_key guarded by the decorators above; backend is set
+    # by the earlier compose-up step and is a structural invariant here.
+    assert (
+        ctx.config is not None
+        and ctx.ssh_key_path is not None
+        and ctx.backend is not None
+    )
+    ssh_tests: list[tuple[str, str]] = []
     if ctx.config.containers.victim:
-        ssh_tests.append(("victim", 2022, "labadmin"))
+        ssh_tests.append(("victim", "labadmin"))
     if ctx.config.containers.kali:
-        ssh_tests.append(("kali", 2023, "kali"))
+        ssh_tests.append(("kali", "kali"))
     if ctx.config.containers.reverse:
-        ssh_tests.append(("reverse", 2027, "labadmin"))
+        ssh_tests.append(("reverse", "labadmin"))
 
-    for name, port, user in ssh_tests:
+    for name, user in ssh_tests:
+        # Lab targets sit on internal-only networks with no published
+        # host port (issue #293), so a `localhost:<port>` probe never
+        # connects. Address sshd by container IP — the host reaches it
+        # over the bridge — on the container-side port 22 directly.
+        host = select_ssh_host(container_networks(ctx.backend, f"aptl-{name}"))
+        if host is None:
+            _emit_diagnostic(
+                ctx,
+                step="test_ssh",
+                component=f"ssh:{name}",
+                impact=DiagnosticImpact.READINESS,
+                severity=DiagnosticSeverity.WARNING,
+                message=f"{name} container has no resolvable network IP",
+                operator_action=(
+                    f"Check that the aptl-{name} container is running and "
+                    "attached to a lab network"
+                ),
+            )
+            continue
         ssh_wait = wait_for_service(
             check_fn=partial(
                 test_ssh_connection,
-                host="localhost",
-                port=port,
+                host=host,
+                port=22,
                 user=user,
                 key_path=ctx.ssh_key_path,
             ),

--- a/src/aptl/core/snapshot.py
+++ b/src/aptl/core/snapshot.py
@@ -201,9 +201,15 @@ def _parse_health(status: str) -> str:
     return ""
 
 
-def _container_networks(
+def container_networks(
     backend: "DeploymentBackend", name: str
 ) -> dict[str, str]:
+    """Return a container's ``{network_name: IPv4 address}`` map.
+
+    Public because the lab-start SSH readiness step (``lab.py``) needs
+    the same per-network IPs the snapshot builder records, to address
+    internal-only targets by container IP (issue #293).
+    """
     networks: dict[str, str] = {}
     info = backend.container_inspect(name)
     net_data = info.get("NetworkSettings", {}).get("Networks", {})
@@ -229,7 +235,7 @@ def _row_to_snapshot(
         status=status,
         health=_parse_health(status),
         labels=row.get("labels", {}),
-        networks=_container_networks(backend, name),
+        networks=container_networks(backend, name),
         ports=row.get("ports", []),
     )
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -24,6 +24,7 @@ from aptl.core.endpoints import (
     build_service_endpoints,
     build_ssh_endpoints,
     parse_host_port,
+    select_ssh_host,
 )
 from aptl.core.snapshot import ContainerSnapshot
 
@@ -268,52 +269,93 @@ class TestBuildServiceEndpoints:
         assert not hasattr(ENDPOINT_REGISTRY[0], "credentials")
 
 
-class TestBuildSSHEndpoints:
-    """``build_ssh_endpoints`` mirrors the service builder."""
+class TestSelectSSHHost:
+    """``select_ssh_host`` picks a deterministic, host-reachable
+    container IP from a container's per-network IP map (issue #293)."""
 
-    def test_victim_ssh(self):
+    def test_picks_the_only_ip(self):
+        assert select_ssh_host({"aptl_aptl-internal": "172.20.2.20"}) == "172.20.2.20"
+
+    def test_picks_lowest_network_name_deterministically(self):
+        # A container on several networks (e.g. kali) must resolve to a
+        # stable IP across snapshots; the lowest network name wins.
+        nets = {
+            "aptl_aptl-redteam": "172.20.4.30",
+            "aptl_aptl-dmz": "172.20.1.30",
+            "aptl_aptl-internal": "172.20.2.35",
+        }
+        assert select_ssh_host(nets) == "172.20.1.30"
+
+    def test_skips_blank_ip(self):
+        nets = {"aptl_aptl-dmz": "", "aptl_aptl-internal": "172.20.2.35"}
+        assert select_ssh_host(nets) == "172.20.2.35"
+
+    def test_no_networks_returns_none(self):
+        assert select_ssh_host({}) is None
+
+    def test_all_blank_returns_none(self):
+        assert select_ssh_host({"a": "", "b": ""}) is None
+
+
+class TestBuildSSHEndpoints:
+    """``build_ssh_endpoints`` addresses targets by container IP. Lab
+    targets sit on ``internal: true`` networks with no published host
+    port, so a ``localhost:<port>`` endpoint is unreachable; the host
+    reaches them by container IP over the bridge (issue #293)."""
+
+    def test_victim_ssh_by_container_ip(self):
         containers = [
             ContainerSnapshot(
                 name="aptl-victim",
                 status="Up 5 minutes",
-                ports=["0.0.0.0:2022->22/tcp"],
+                networks={"aptl_aptl-internal": "172.20.2.20"},
+                ports=[],
             ),
         ]
         endpoints = build_ssh_endpoints(containers)
         assert len(endpoints) == 1
         assert endpoints[0].name == "Victim"
-        assert endpoints[0].port == 2022
+        assert endpoints[0].host == "172.20.2.20"
+        assert endpoints[0].port == 22
         assert endpoints[0].user == "labadmin"
-        assert "labadmin@localhost" in endpoints[0].command
-        assert "-p 2022" in endpoints[0].command
+        assert "labadmin@172.20.2.20" in endpoints[0].command
+        assert "localhost" not in endpoints[0].command
 
     def test_all_ssh_containers(self):
         containers = [
             ContainerSnapshot(
                 name="aptl-victim",
                 status="Up 5 minutes",
-                ports=["0.0.0.0:2022->22/tcp"],
+                networks={"aptl_aptl-internal": "172.20.2.20"},
             ),
             ContainerSnapshot(
                 name="aptl-kali",
                 status="Up 5 minutes",
-                ports=["0.0.0.0:2023->22/tcp"],
+                networks={
+                    "aptl_aptl-redteam": "172.20.4.30",
+                    "aptl_aptl-internal": "172.20.2.35",
+                },
             ),
             ContainerSnapshot(
                 name="aptl-reverse",
                 status="Up 5 minutes",
-                ports=["0.0.0.0:2027->22/tcp"],
+                networks={"aptl_aptl-security": "172.20.0.27"},
             ),
         ]
         endpoints = build_ssh_endpoints(containers)
-        assert {e.port for e in endpoints} == {2022, 2023, 2027}
+        assert {e.host for e in endpoints} == {
+            "172.20.2.20",
+            "172.20.2.35",
+            "172.20.0.27",
+        }
+        assert all(e.port == 22 for e in endpoints)
 
     def test_skips_stopped_containers(self):
         containers = [
             ContainerSnapshot(
                 name="aptl-kali",
                 status="Exited (137) 1 minute ago",
-                ports=["0.0.0.0:2023->22/tcp"],
+                networks={"aptl_aptl-redteam": "172.20.4.30"},
             ),
         ]
         assert build_ssh_endpoints(containers) == []
@@ -323,22 +365,25 @@ class TestBuildSSHEndpoints:
             ContainerSnapshot(
                 name="aptl-wazuh-manager",
                 status="Up 5 minutes",
-                ports=["0.0.0.0:55000->55000/tcp"],
+                networks={"aptl_aptl-security": "172.20.0.10"},
             ),
             ContainerSnapshot(
                 name="aptl-unregistered",
                 status="Up 5 minutes",
-                ports=["0.0.0.0:1234->22/tcp"],
+                networks={"aptl_aptl-internal": "172.20.2.99"},
             ),
         ]
         assert build_ssh_endpoints(containers) == []
 
-    def test_omits_endpoint_when_host_port_missing(self):
+    def test_omits_endpoint_when_no_network_ip(self):
+        # A registered SSH container with no resolvable network IP
+        # cannot be addressed — omit it rather than emit a broken
+        # localhost endpoint.
         containers = [
             ContainerSnapshot(
                 name="aptl-victim",
                 status="Up 5 minutes",
-                ports=[],
+                networks={},
             ),
         ]
         assert build_ssh_endpoints(containers) == []
@@ -348,7 +393,7 @@ class TestBuildSSHEndpoints:
             ContainerSnapshot(
                 name="aptl-kali",
                 status="Up 5 minutes",
-                ports=["0.0.0.0:2023->22/tcp"],
+                networks={"aptl_aptl-redteam": "172.20.4.30"},
             ),
         ]
         endpoints = build_ssh_endpoints(containers)

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -742,6 +742,13 @@ class TestOrchestrateLabStart:
             return_value=MagicMock(returncode=0, stdout="", stderr=""),
         )
 
+        # Mock container IP resolution for the SSH readiness step —
+        # lab targets are addressed by container IP (issue #293).
+        mocks["container_networks"] = mocker.patch(
+            "aptl.core.lab.container_networks",
+            return_value={"aptl_aptl-internal": "172.20.2.20"},
+        )
+
         return mocks
 
     def test_orchestrates_all_steps_in_order(self, mocker, tmp_path):
@@ -1283,6 +1290,7 @@ class TestStartupClassificationWiring:
             env=self._make_env_vars(),
             config=config or self._make_config(),
             ssh_key_path=Path("/tmp/aptl_lab_key"),
+            backend=MagicMock(),
         )
 
     # -- redaction at the diagnostic boundary --------------------------
@@ -1449,6 +1457,12 @@ class TestStartupClassificationWiring:
         from aptl.core.services import ServiceResult
 
         ctx = self._ctx(tmp_path)
+        # Targets are addressed by container IP (issue #293), not a
+        # published host port — resolve a stub IP for every target.
+        mocker.patch(
+            "aptl.core.lab.container_networks",
+            return_value={"aptl_aptl-internal": "172.20.2.20"},
+        )
         # victim ready, kali timeout, reverse ready
         mocker.patch(
             "aptl.core.lab.wait_for_service",
@@ -1470,11 +1484,63 @@ class TestStartupClassificationWiring:
         assert diag.component == "ssh:kali"
         assert diag.severity is DiagnosticSeverity.WARNING
 
+    def test_test_ssh_probes_container_ip_on_port_22(self, tmp_path, mocker):
+        # Regression for issue #293: the SSH probe must target the
+        # container IP on port 22, not localhost on a (never-published)
+        # remapped host port.
+        from aptl.core.lab import _step_test_ssh
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.container_networks",
+            return_value={"aptl_aptl-redteam": "172.20.4.30"},
+        )
+        wait = mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            return_value=ServiceResult(ready=True, elapsed_seconds=1.0),
+        )
+
+        _step_test_ssh(ctx)
+
+        # Inspect the partial passed to wait_for_service for the SSH probe.
+        for call in wait.call_args_list:
+            check_fn = call.kwargs["check_fn"]
+            assert check_fn.keywords["host"] == "172.20.4.30"
+            assert check_fn.keywords["port"] == 22
+
+    def test_test_ssh_unresolvable_ip_emits_readiness_warning(
+        self, tmp_path, mocker
+    ):
+        # A target whose container has no resolvable network IP cannot
+        # be probed — surface it as a readiness diagnostic rather than
+        # silently skipping (issue #293).
+        from aptl.core.lab import _step_test_ssh
+        from aptl.core.lab_types import DiagnosticImpact
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch("aptl.core.lab.container_networks", return_value={})
+        wait = mocker.patch("aptl.core.lab.wait_for_service")
+
+        _step_test_ssh(ctx)
+
+        readiness_diags = [
+            d for d in ctx.diagnostics if d.impact is DiagnosticImpact.READINESS
+        ]
+        assert {d.component for d in readiness_diags} >= {"ssh:kali"}
+        assert all("no resolvable network IP" in d.message for d in readiness_diags)
+        # No SSH probe is attempted when the IP cannot be resolved.
+        wait.assert_not_called()
+
     def test_test_ssh_all_ready_emits_no_diagnostic(self, tmp_path, mocker):
         from aptl.core.lab import _step_test_ssh
         from aptl.core.services import ServiceResult
 
         ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.container_networks",
+            return_value={"aptl_aptl-internal": "172.20.2.20"},
+        )
         mocker.patch(
             "aptl.core.lab.wait_for_service",
             return_value=ServiceResult(ready=True, elapsed_seconds=2.0),

--- a/tests/test_obs003_kali_capture.py
+++ b/tests/test_obs003_kali_capture.py
@@ -169,8 +169,35 @@ class TestEndToEndCapture:
     """
 
     SSH_KEY = "keys/aptl_lab_key"
-    SSH_HOST = "kali@localhost"
-    SSH_PORT = "2023"
+    SSH_USER = "kali"
+
+    def _kali_ip(self) -> str:
+        """Resolve aptl-kali's container IP.
+
+        kali sits only on internal-only networks and publishes no host
+        port (issue #293), so the host reaches it by container IP over
+        the bridge — the same path the control plane uses. Any of
+        kali's bridge IPs is reachable; the lowest is taken for a
+        deterministic target.
+        """
+        import subprocess as sp
+
+        r = sp.run(
+            [
+                "docker",
+                "inspect",
+                "aptl-kali",
+                "--format",
+                "{{range .NetworkSettings.Networks}}{{.IPAddress}}\n{{end}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        ips = sorted(ip for ip in r.stdout.split() if ip)
+        if not ips:
+            pytest.skip("could not resolve aptl-kali container IP")
+        return ips[0]
 
     def _ssh_with_env(self, run_id: str, session_id: str, command: str) -> str:
         """SSH into kali with APTL_* env vars and return stdout."""
@@ -186,15 +213,13 @@ class TestEndToEndCapture:
             "ssh",
             "-i",
             self.SSH_KEY,
-            "-p",
-            self.SSH_PORT,
             "-o",
             "StrictHostKeyChecking=no",
             "-o",
             "UserKnownHostsFile=/dev/null",
             "-o",
-            f"SendEnv=APTL_SESSION_ID APTL_RUN_ID APTL_TRACE_ID",
-            self.SSH_HOST,
+            "SendEnv=APTL_SESSION_ID APTL_RUN_ID APTL_TRACE_ID",
+            f"{self.SSH_USER}@{self._kali_ip()}",
             command,
         ]
         env = {

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -481,7 +481,8 @@ class TestCaptureSnapshot:
                 name="aptl-victim",
                 image="aptl/victim:latest",
                 status="Up 5 minutes",
-                ports=["0.0.0.0:2022->22/tcp"],
+                networks={"aptl_aptl-internal": "172.20.2.20"},
+                ports=[],
             ),
         ]
         mock_wazuh.return_value = WazuhRulesSnapshot(total_rules=100)
@@ -500,9 +501,11 @@ class TestCaptureSnapshot:
         assert snap.wazuh_rules.total_rules == 100
         assert len(snap.networks) == 1
         assert "aptl.json" in snap.config_hashes
-        # SSH endpoints derived from registry + runtime ContainerSnapshot.ports
+        # SSH endpoints address the target by container IP — internal-only
+        # targets publish no host port (issue #293).
         assert len(snap.ssh) == 1
-        assert snap.ssh[0].port == 2022
+        assert snap.ssh[0].host == "172.20.2.20"
+        assert snap.ssh[0].port == 22
 
     @patch("aptl.core.snapshot._get_network_snapshots")
     @patch("aptl.core.snapshot._get_wazuh_rules_snapshot")


### PR DESCRIPTION
## Summary

Lab target containers (kali, victim, workstation) are attached only to `internal: true` networks — SAF-002 makes them internal to block target internet egress — and Docker publishes no host port for an internal-only container. The `ports: "<host>:22"` mappings on those services were therefore dead config: `aptl lab start`'s readiness probe SSHed `localhost:2023`/`2022`/`2028` and always timed out (the lab reported `degraded_unusable`), and `build_ssh_endpoints` skipped any target whose port did not publish, leaving the snapshot's SSH endpoint list empty. The host can still reach those containers by container IP over the bridge — `internal: true` blocks container↔internet, not host↔container — so lab SSH access now resolves the container IP instead of a published host port. This preserves SAF-002 (targets stay air-gapped from the internet); no target is moved onto the routable `aptl-security` network, which would also violate red/blue non-contamination (ADR-033). Surfaced during the live-lab validation of #293 / PR #362; folded in here as the follow-up that PR's merge made into its own PR.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #363

## ADR Impact

- ADR-036
- ADR-021

## Changes

- src/aptl/core/endpoints.py: new `select_ssh_host` resolves a deterministic, host-reachable container IP from a container's per-network IP map; `build_ssh_endpoints` builds `ssh user@<ip>` against the container-side port 22 instead of `ssh user@localhost -p <published-host-port>`
- src/aptl/core/snapshot.py: `_container_networks` promoted to public `container_networks` so the lab-start readiness step can reuse the same per-network IP resolution
- src/aptl/core/lab.py: `_step_test_ssh` resolves each target's container IP and probes it on port 22; a target with no resolvable network IP now emits a readiness diagnostic instead of being silently skipped
- docker-compose.yml: the dead `ports:` mappings on the kali, victim, and workstation services are removed, each replaced with a comment recording why an internal-only container has no published host port
- tests/test_obs003_kali_capture.py: TestEndToEndCapture resolves aptl-kali's container IP via `docker inspect` and SSHes there instead of the never-published `localhost:2023`

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Unit-level: TestSelectSSHHost / TestBuildSSHEndpoints (endpoints), the `_step_test_ssh` container-IP + unresolvable-IP tests (lab), and the updated snapshot test all run in the default `pytest` suite (1684 passed). The TestEndToEndCapture container-IP path is APTL_SMOKE-gated and was exercised against a live lab during the #293 validation (host SSH to kali's container IP succeeded on all three of its networks).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-036 ← src/aptl/core/endpoints.py (select_ssh_host + container-IP SSH endpoints), ADR-036 ← src/aptl/core/snapshot.py (public container_networks), ADR-030 ← src/aptl/core/lab.py (_step_test_ssh container-IP readiness probe + diagnostic)
- TESTS: ADR-036 ← tests/test_endpoints.py (TestSelectSSHHost, TestBuildSSHEndpoints), ADR-030 ← tests/test_lab.py (_step_test_ssh container-IP probe + unresolvable-IP diagnostic tests)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/293.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
