### PR TITLE
fix: resolve techvault sdl classification audit

### DIFF
--- a/changelog.d/369.added.md
+++ b/changelog.d/369.added.md
@@ -1,0 +1,1 @@
+**Added the TechVault SDL classification audit.** The audit records evidence-backed scenario-vs-delivery classification findings for Shuffle, Wazuh manager, network switch metadata, and stale parity inventory rows without prescribing the downstream remediation path.

--- a/changelog.d/369.added.md
+++ b/changelog.d/369.added.md
@@ -1,1 +1,1 @@
-**Added the TechVault SDL classification audit.** The audit records evidence-backed scenario-vs-delivery classification findings for Shuffle, Wazuh manager, network switch metadata, and stale parity inventory rows without prescribing the downstream remediation path.
+**Added and resolved the TechVault SDL classification audit.** Shuffle backend and Wazuh manager now carry the audited node-local SDL state, switch isolation metadata matches Compose, and stale parity rows are updated with regression coverage.

--- a/docs/aces/inventory/shuffle-backend/README.md
+++ b/docs/aces/inventory/shuffle-backend/README.md
@@ -92,11 +92,17 @@ facts that need ACES mapping attempts:
 Facts that ACES cannot express become ACES issues immediately after checking
 for an existing issue that covers the gap.
 
-The first filed gap is ACES #354: typed runtime configuration surfaces for
-mounts, local sockets, process identity, and package inventory.
+The first filed gap was ACES #354: typed runtime configuration surfaces for
+mounts, local sockets, process identity, and package inventory. The APTL #369
+classification-audit follow-up now encodes those captured Shuffle facts in
+`scenarios/techvault.sdl.yaml` using the runtime mount, local control
+interface, process, package, dependency-manifest, and package-vulnerability
+fields that landed after this methodology smoke pass. ACES #354 no longer
+appears as a blocking disposition in `mapping-ledger.yaml`.
+
 Run `aptl aces-inventory validate docs/aces/inventory/shuffle-backend` and
 `aptl aces-inventory gaps docs/aces/inventory/shuffle-backend` to verify the
-handoff ledger that later per-asset issues should expand before encoding.
+handoff ledger; the gap report should show `blocked=0 triage=0`.
 Run `aptl aces-inventory schema` to inspect the current JSON Schema generated
 from the Pydantic ledger model.
 

--- a/docs/aces/inventory/shuffle-backend/mapping-ledger.yaml
+++ b/docs/aces/inventory/shuffle-backend/mapping-ledger.yaml
@@ -30,7 +30,7 @@ provenance:
         should emit first-party SBOM/provenance attestations at build time.
 correspondence_checks:
   - id: shuffle-backend.node-source-correspondence
-    status: planned
+    status: implemented
     source: nodes.shuffle-backend.source
     realized_evidence:
       - path: evidence/docker-inspect.image.json
@@ -38,16 +38,15 @@ correspondence_checks:
     ledger_fact_ids:
       - shuffle-backend.image.identity
     method: >
-      Compare the ACES source name/version selected by later encoding work
-      against the realized OCI image digest and manifest digest captured here.
-      The check passes only when the encoded digest resolves to the same image
-      index and platform manifest used by the running container.
+      Compare nodes.shuffle-backend.source in scenarios/techvault.sdl.yaml
+      against captured Docker inspect image identity and registry manifest
+      evidence.
     limit: >
-      Planned because this issue is proving methodology/tooling, not
-      producing the final TechVault ACES SDL.
+      The correspondence is documentary/static; this smoke pass still did not
+      perform a clean-lab rebuild.
   - id: shuffle-backend-runtime-correspondence
-    status: planned
-    source: "nodes.shuffle-backend plus current ACES #354 successor surfaces"
+    status: implemented
+    source: nodes.shuffle-backend.runtime and infrastructure.shuffle-backend
     realized_evidence:
       - path: evidence/runtime-baseline.txt
       - path: evidence/docker-inspect.container.json
@@ -57,20 +56,23 @@ correspondence_checks:
       - shuffle-backend.data.mount
       - shuffle-backend.docker.socket
       - shuffle-backend.process.identity
+      - shuffle-backend.package.inventory
+      - shuffle-backend.vulnerability.scan-state
     method: >
-      After later issues encode the supported ACES fields and consume the #354
-      successor surface, run the encoded scenario, recapture runtime evidence,
-      and compare OS/version, listener, mount/socket, and process identity
-      against this ledger with explicit tolerances for clean-lab drift.
+      Compare encoded Shuffle runtime, network, mount, process, package, and
+      scanner-state fields against the committed evidence bundle and focused
+      regression tests.
     limit: >
-      Planned because #354 blocks semantically correct encoding of the
-      runtime configuration surfaces today.
+      The evidence was captured from an already-running local lab; live
+      clean-lab recapture remains outside this issue.
 notes:
-  - This ledger is a methodology artifact, not the final SCN-010 asset spec.
+  - This ledger began as a methodology smoke artifact and now records the
+    TechVault SDL fields that encode the captured Shuffle backend facts.
   - The participant-discoverable rule defines this proof pass's capture boundary,
     not the semantic reason ACES may need new SDL surfaces.
-  - Later per-asset issues should expand this ledger to full coverage before
-    producing or updating SDL/source-package encodings.
+  - Runtime mounts, local control interfaces, process identity, package
+    inventory, and package vulnerability scanner state are now encoded in
+    scenarios/techvault.sdl.yaml.
   - The ledger is validated by the Pydantic schema exposed through
     `aptl aces-inventory schema`; schema violations fail `aptl aces-inventory
     validate`.
@@ -93,7 +95,6 @@ facts:
       rationale: >
         ACES node source is a provider-neutral artifact reference and can carry
         the immutable image digest as the version/pin used by later encoders.
-
   - id: shuffle-backend.os.version
     category: runtime-configuration
     summary: The realized runtime OS is Alpine Linux 3.22.2.
@@ -107,7 +108,6 @@ facts:
         - nodes.shuffle-backend.os
         - nodes.shuffle-backend.os_version
       rationale: ACES nodes have explicit OS family and version fields.
-
   - id: shuffle-backend.network.identity
     category: network
     summary: >
@@ -118,17 +118,16 @@ facts:
       - path: evidence/docker-network.aptl-security.json
       - path: evidence/compose-service.shuffle-backend.json
     aces:
-      disposition: encoded_with_caveat
-      surface: infrastructure
+      disposition: encoded
+      surface: nodes
       fields:
+        - nodes.shuffle-backend.runtime.network
         - infrastructure.shuffle-backend.links
         - infrastructure.shuffle-backend.properties
-      caveat: >
-        ACES can encode network attachment and static IP. Service/container DNS
-        aliases may need a naming convention or source-package support in later
-        encoding work.
-      rationale: Infrastructure properties support per-link IP assignments.
-
+      rationale: >
+        ACES node runtime network and infrastructure fields encode the static
+        IP, aliases, DNS names, and backend realization metadata captured for
+        this node.
   - id: shuffle-backend.api.listener
     category: service-surface
     summary: >
@@ -143,55 +142,42 @@ facts:
       fields:
         - nodes.shuffle-backend.services
       rationale: ACES node service bindings model exposed network services by port.
-
   - id: shuffle-backend.data.mount
     category: runtime-configuration
-    summary: The named volume aptl_shuffle_data is mounted at /shuffle-database.
+    summary: >
+      The named volume aptl_shuffle_data is mounted at /shuffle-database and
+      encoded as a typed runtime mount.
     evidence:
       - path: evidence/docker-inspect.container.json
       - path: evidence/docker-volume.shuffle-data.json
       - path: evidence/runtime-baseline.txt
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - content
-        - features
-        - infrastructure
-      why_not_current_surfaces: >
-        Content can describe files or directories placed into a node, but a
-        runtime mount with persistence/backing-volume semantics is not merely
-        placed content. Features are authored deployable units, and
-        infrastructure does not type node-local mounts.
-      gap_issue:
-        tracker: ACES
-        number: 354
-        url: https://github.com/Brad-Edwards/aces/issues/354
-
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.shuffle-backend.runtime.mounts
+      rationale: >
+        Current ACES runtime mount fields encode volume-backed node-local
+        persistence directly.
   - id: shuffle-backend.docker.socket
     category: runtime-configuration
     summary: >
-      The container has a writable Docker socket bind recorded by Docker as
-      /var/run/docker.sock:/var/run/docker.sock:rw and visible in-container at
-      /run/docker.sock.
+      The container has a writable Docker socket bind recorded as
+      /var/run/docker.sock:/var/run/docker.sock:rw and encoded as both a
+      runtime mount and local control interface.
     evidence:
       - path: evidence/docker-inspect.container.json
       - path: evidence/runtime-baseline.txt
       - path: evidence/compose-service.shuffle-backend.json
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - nodes.services
-        - content
-        - relationships
-      why_not_current_surfaces: >
-        Node services model network ports, content models placed files/data, and
-        relationships can express trust edges only after endpoints exist. None
-        typed a path-local runtime control interface mounted into the asset.
-      gap_issue:
-        tracker: ACES
-        number: 354
-        url: https://github.com/Brad-Edwards/aces/issues/354
-
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.shuffle-backend.runtime.mounts
+        - nodes.shuffle-backend.runtime.local_control_interfaces
+      rationale: >
+        Current ACES runtime mount and local control interface fields encode
+        path-local control sockets without treating them as backend-only detail.
   - id: shuffle-backend.process.identity
     category: runtime-configuration
     summary: PID 1 runs ./shufflebackend as root with working directory /app.
@@ -200,18 +186,14 @@ facts:
       - path: evidence/docker-top.txt
       - path: evidence/docker-inspect.image.json
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - nodes
-        - features
-      why_not_current_surfaces: >
-        Nodes and features can identify the asset and deployed software but do
-        not type process command, effective user, or working directory.
-      gap_issue:
-        tracker: ACES
-        number: 354
-        url: https://github.com/Brad-Edwards/aces/issues/354
-
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.shuffle-backend.runtime.process
+        - nodes.shuffle-backend.runtime.processes
+      rationale: >
+        Current ACES runtime process fields encode PID, command, user, role,
+        and working directory for PID 1.
   - id: shuffle-backend.package.inventory
     category: runtime-inventory
     summary: >
@@ -222,18 +204,14 @@ facts:
       - path: evidence/language-manifests.txt
       - path: evidence/trivy-sbom.cyclonedx.json
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - features
-      why_not_current_surfaces: >
-        Features are authored deployable service/configuration/artifact units
-        with dependency semantics. A full observed package/SBOM inventory is
-        runtime inventory and should not be misrepresented as authored features.
-      gap_issue:
-        tracker: ACES
-        number: 354
-        url: https://github.com/Brad-Edwards/aces/issues/354
-
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.shuffle-backend.runtime.packages
+        - nodes.shuffle-backend.runtime.dependency_manifests
+      rationale: >
+        Current ACES runtime package and dependency manifest fields encode the
+        observed Alpine packages and Go module manifest.
   - id: shuffle-backend.vulnerability.scan-state
     category: vulnerability-inventory
     summary: >
@@ -245,15 +223,11 @@ facts:
       - path: evidence/trivy-vulnerability-counts.json
       - path: evidence/trivy-vulnerability-list.json
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - vulnerabilities
-      why_not_current_surfaces: >
-        ACES vulnerabilities are named CWE-classified scenario weaknesses.
-        Trivy output is package/CVE/advisory scanner state tied to an image
-        digest and scan time, so encoding it as CWE-only vulnerabilities would
-        lose the evidence semantics.
-      gap_issue:
-        tracker: ACES
-        number: 354
-        url: https://github.com/Brad-Edwards/aces/issues/354
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.shuffle-backend.runtime.package_vulnerabilities
+      rationale: >
+        Current ACES package vulnerability scanner-state fields preserve
+        package, version, advisory, severity, scanner, image digest, and scan
+        time semantics.

--- a/docs/aces/parity-inventory.yaml
+++ b/docs/aces/parity-inventory.yaml
@@ -111,6 +111,28 @@ rows:
     blocking_followup: n/a
     notes: Incremental ACES TechVault authoring target for the ad inventory pass; current SDL consumes Brad-Edwards/aces#401 and encodes the catalogued Samba AD steady-state image, runtime, identity-authority logical state, filesystem, host-local identity, package/CVE summary, declared weaknesses, curated scenario/provisioning account refs, and relationship facts with no known remaining ACES expressivity blocker. Raw credentials, generated flags, Wazuh keys, and Kerberos/Samba private material are redacted as secret material while path, metadata, and checksum shape remain captured.
 
+  - id: scen.techvault.shuffle-backend-inventory
+    surface: scenarios_yaml
+    legacy_source: scenarios/techvault.sdl.yaml
+    legacy_field: nodes.shuffle-backend + infrastructure.shuffle-backend + runtime
+    category: aces_sdl
+    aces_target: ACES nodes / infrastructure / runtime fields
+    runtime_owner: n/a
+    validation_evidence: "docs/aces/inventory/shuffle-backend/ + tests/test_techvault_classification_audit.py + tests/test_aces_inventory_methodology.py"
+    blocking_followup: n/a
+    notes: Classification-audit fix for issue #369; current SDL encodes the captured Shuffle backend image identity, OS, security-network identity, API listener, persistent mount, Docker socket control interface, process identity, packages, Go manifest, and Trivy scanner state with no remaining ACES #354 gap marker.
+
+  - id: scen.techvault.wazuh-manager-inventory
+    surface: scenarios_yaml
+    legacy_source: scenarios/techvault.sdl.yaml
+    legacy_field: nodes.wazuh-manager + infrastructure.wazuh-manager + runtime
+    category: aces_sdl
+    aces_target: ACES nodes / infrastructure / runtime / conditions fields
+    runtime_owner: n/a
+    validation_evidence: "docker-compose.yml (service: wazuh.manager) + scenarios/techvault.sdl.yaml + tests/test_techvault_classification_audit.py"
+    blocking_followup: n/a
+    notes: Classification-audit fix for issue #369; current SDL encodes the Wazuh API on 55000/tcp, security/dmz/internal network attachments, Compose healthcheck, environment policy, resource policy, persistent/config mounts, and custom decoder/rule content mounted into the manager.
+
   - id: scen.ad-domain-compromise.metadata
     surface: scenarios_yaml
     legacy_source: scenarios/ad-domain-compromise.yaml
@@ -552,22 +574,22 @@ rows:
     legacy_source: "docker-compose.yml (profile: soc)"
     legacy_field: soc
     category: aptl_backend_responsibility
-    aces_target: ACES backend manifest capability claim
+    aces_target: ACES backend profile toggle; node-local SOC facts are routed through node-specific ACES SDL rows
     runtime_owner: AptlConfig.containers.soc -> ContainerSettings.enabled_profiles()
-    validation_evidence: tests/test_consistency.py
-    blocking_followup: "#320"
-    notes: Suricata + MISP + TheHive + Cortex + Shuffle + Wazuh sidecars.
+    validation_evidence: tests/test_consistency.py + tests/test_techvault_classification_audit.py
+    blocking_followup: n/a
+    notes: Profile enablement remains a delivery toggle. Participant-visible Shuffle backend state is encoded by scen.techvault.shuffle-backend-inventory; other SOC service inventories need their own node rows when brought into TechVault scope.
 
   - id: compose.profile.enterprise
     surface: docker_compose_topology
     legacy_source: "docker-compose.yml (profile: enterprise)"
     legacy_field: enterprise
     category: aptl_backend_responsibility
-    aces_target: ACES infrastructure realization
+    aces_target: ACES backend profile toggle; scenario node membership is routed through node-specific ACES SDL rows
     runtime_owner: AptlConfig.containers.enterprise -> ContainerSettings.enabled_profiles()
-    validation_evidence: tests/test_consistency.py
-    blocking_followup: "#320"
-    notes: ad, db, webapp, workstation.
+    validation_evidence: tests/test_consistency.py + tests/test_techvault_classification_audit.py
+    blocking_followup: n/a
+    notes: Profile enablement remains a delivery toggle. The TechVault AD, DB, webapp, and other participant-visible enterprise node facts belong in nodes.* and infrastructure.* rows rather than this Compose profile row.
 
 
   - id: compose.service.db
@@ -589,8 +611,30 @@ rows:
     aces_target: ACES nodes.webapp + infrastructure.webapp + conditions.webapp-http-ready + relationships.webapp-connects-db
     runtime_owner: n/a
     validation_evidence: docs/aces/inventory/webapp/ + scenarios/techvault.sdl.yaml + tests/test_webapp_inventory.py
-    blocking_followup: "#321 / #324"
-    notes: Runtime evidence and ACES-expressible fields captured by issue #330; APTL backend consumption remains with the cited follow-ups.
+    blocking_followup: n/a
+    notes: Runtime evidence and ACES-expressible fields captured by issue #330 and later ACES runtime-profile landings; no known remaining expressivity blocker for the catalogued webapp steady-state inventory.
+
+  - id: compose.service.shuffle-backend
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (service: shuffle-backend)"
+    legacy_field: shuffle-backend
+    category: aces_sdl
+    aces_target: ACES nodes.shuffle-backend + infrastructure.shuffle-backend + runtime
+    runtime_owner: n/a
+    validation_evidence: docs/aces/inventory/shuffle-backend/ + scenarios/techvault.sdl.yaml + tests/test_techvault_classification_audit.py
+    blocking_followup: n/a
+    notes: Shuffle backend service identity, network attachment, 5001/tcp API listener, persistent state volume, Docker socket bind, package inventory, and Trivy scanner state are now represented by the TechVault SDL.
+
+  - id: compose.service.wazuh-manager
+    surface: docker_compose_topology
+    legacy_source: "docker-compose.yml (service: wazuh.manager)"
+    legacy_field: wazuh.manager
+    category: aces_sdl
+    aces_target: ACES nodes.wazuh-manager + infrastructure.wazuh-manager + runtime + conditions.wazuh-api-ready
+    runtime_owner: n/a
+    validation_evidence: docker-compose.yml + scenarios/techvault.sdl.yaml + tests/test_techvault_classification_audit.py
+    blocking_followup: n/a
+    notes: Wazuh manager service, API, three network attachments, Compose healthcheck, runtime environment policy, mounts, and custom decoder/rule files are now represented by the TechVault SDL.
 
   - id: compose.profile.victim
     surface: docker_compose_topology
@@ -684,56 +728,56 @@ rows:
     surface: docker_compose_topology
     legacy_source: docker-compose.yml (networks)
     legacy_field: aptl-security
-    category: aptl_backend_responsibility
-    aces_target: ACES network topology surface
-    runtime_owner: docker-compose networks
-    validation_evidence: tests/test_consistency.py (network presence)
-    blocking_followup: "#320"
-    notes: SOC + Wazuh segment.
+    category: aces_sdl
+    aces_target: ACES nodes.security-net + infrastructure.security-net properties
+    runtime_owner: n/a
+    validation_evidence: tests/test_consistency.py (network presence) + tests/test_techvault_classification_audit.py
+    blocking_followup: n/a
+    notes: Scenario segment CIDR/gateway/isolation metadata is encoded in TechVault SDL; Compose remains the backend bridge/IPAM realization.
 
   - id: compose.network.aptl-dmz
     surface: docker_compose_topology
     legacy_source: docker-compose.yml (networks)
     legacy_field: aptl-dmz
-    category: aptl_backend_responsibility
-    aces_target: ACES network topology surface
-    runtime_owner: docker-compose networks
-    validation_evidence: tests/test_consistency.py
-    blocking_followup: "#320"
-    notes: DMZ segment for external-facing services.
+    category: aces_sdl
+    aces_target: ACES nodes.dmz-net + infrastructure.dmz-net properties
+    runtime_owner: n/a
+    validation_evidence: tests/test_consistency.py + tests/test_techvault_classification_audit.py
+    blocking_followup: n/a
+    notes: Scenario segment CIDR/gateway/internal metadata is encoded in TechVault SDL; Compose remains the backend bridge/IPAM realization.
 
   - id: compose.network.aptl-internal
     surface: docker_compose_topology
     legacy_source: docker-compose.yml (networks)
     legacy_field: aptl-internal
-    category: aptl_backend_responsibility
-    aces_target: ACES network topology surface
-    runtime_owner: docker-compose networks
-    validation_evidence: tests/test_consistency.py
-    blocking_followup: "#320"
-    notes: Enterprise internal segment (ADR-006).
+    category: aces_sdl
+    aces_target: ACES nodes.internal-net + infrastructure.internal-net properties
+    runtime_owner: n/a
+    validation_evidence: tests/test_consistency.py + tests/test_techvault_classification_audit.py
+    blocking_followup: n/a
+    notes: Scenario segment CIDR/gateway/internal metadata is encoded in TechVault SDL; Compose remains the backend bridge/IPAM realization.
 
   - id: compose.network.aptl-redteam
     surface: docker_compose_topology
     legacy_source: docker-compose.yml (networks)
     legacy_field: aptl-redteam
-    category: aptl_backend_responsibility
-    aces_target: ACES network topology surface
-    runtime_owner: docker-compose networks
-    validation_evidence: tests/test_consistency.py
-    blocking_followup: "#320"
-    notes: Red-team segment isolating Kali (ADR-006).
+    category: aces_sdl
+    aces_target: ACES nodes.redteam-net + infrastructure.redteam-net properties
+    runtime_owner: n/a
+    validation_evidence: tests/test_consistency.py + tests/test_techvault_classification_audit.py
+    blocking_followup: n/a
+    notes: Scenario segment CIDR/gateway/internal metadata is encoded in TechVault SDL; Compose remains the backend bridge/IPAM realization.
 
   - id: compose.volumes.summary
     surface: docker_compose_topology
     legacy_source: docker-compose.yml (volumes)
     legacy_field: named-volume conventions (43 volumes)
-    category: aptl_backend_responsibility
-    aces_target: n/a (backend realization detail)
-    runtime_owner: docker-compose volume declarations
-    validation_evidence: tests/test_consistency.py (volume references close over services)
+    category: validation_gate
+    aces_target: Per-node ACES runtime.mounts for participant-visible mounts; n/a for bare backend-only volume declarations
+    runtime_owner: docker-compose volume declarations + node runtime inventories
+    validation_evidence: tests/test_consistency.py (volume references close over services) + tests/test_techvault_classification_audit.py
     blocking_followup: n/a
-    notes: 43 named volumes split into data / config / logs by component; per-volume rows would dilute review without adding signal.
+    notes: This summary row gates the split rather than classifying every volume as backend-only. Participant-visible mounts are encoded on webapp, db, kali, ad, shuffle-backend, and wazuh-manager runtime.mounts; remaining bare declarations stay with Compose realization.
 
   # ---- surface: aptl_config ---------------------------------------------
   # ContainerSettings toggles + LabSettings core fields. Survives cutover

--- a/docs/aces/parity-inventory.yaml
+++ b/docs/aces/parity-inventory.yaml
@@ -131,7 +131,7 @@ rows:
     runtime_owner: n/a
     validation_evidence: "docker-compose.yml (service: wazuh.manager) + scenarios/techvault.sdl.yaml + tests/test_techvault_classification_audit.py"
     blocking_followup: n/a
-    notes: Classification-audit fix for issue #369; current SDL encodes the Wazuh API on 55000/tcp, security/dmz/internal network attachments, Compose healthcheck, environment policy, resource policy, persistent/config mounts, and custom decoder/rule content mounted into the manager.
+    notes: Classification-audit fix for issue #369; current SDL encodes the Wazuh API on 55000/tcp, security/dmz/internal network attachments, Compose healthcheck as conditions.wazuh-api-ready, environment policy, resource policy, persistent/config mounts, and custom decoder/rule content mounted into the manager.
 
   - id: scen.ad-domain-compromise.metadata
     surface: scenarios_yaml
@@ -634,7 +634,7 @@ rows:
     runtime_owner: n/a
     validation_evidence: docker-compose.yml + scenarios/techvault.sdl.yaml + tests/test_techvault_classification_audit.py
     blocking_followup: n/a
-    notes: Wazuh manager service, API, three network attachments, Compose healthcheck, runtime environment policy, mounts, and custom decoder/rule files are now represented by the TechVault SDL.
+    notes: Wazuh manager service, API, three network attachments, Compose healthcheck via conditions.wazuh-api-ready, runtime environment policy, mounts, and custom decoder/rule files are now represented by the TechVault SDL.
 
   - id: compose.profile.victim
     surface: docker_compose_topology

--- a/docs/aces/techvault-sdl-classification-audit.md
+++ b/docs/aces/techvault-sdl-classification-audit.md
@@ -9,99 +9,76 @@ layer is the control plane, backend runtime, host kernel, and orchestration
 machinery around the range, not software, files, services, identities, mounts,
 or network behavior exposed on range nodes.
 
-The audit output is a list of facts-with-evidence. It does not decide whether
-each fact should be fixed by a TechVault SDL update, an upstream ACES surface,
-or a deliberate exclusion.
+This document records the audit findings and the remediation applied in this
+branch. Every actionable finding below is fixed by the TechVault SDL, parity
+inventory, Shuffle ledger, or regression-test updates in this PR.
 
 ## Scope Notes
 
 - The issue body named `webapp`, `db`, `shuffle-backend`, `kali`, switch
   nodes, and `wazuh-manager`. The current `scenarios/techvault.sdl.yaml` also
   contains `ad`, so this audit includes `ad` as current encoded SDL state.
-- `shuffle-backend` has a committed inventory bundle but is not currently a
+- `shuffle-backend` has a committed inventory bundle and is now encoded as a
   node in `scenarios/techvault.sdl.yaml`.
 - Host-side Docker bridge mechanics, operator UI/backend commands, runstore
   persistence, snapshots, and generated secret material remain delivery or
   control-plane concerns. The findings below target node-internal or
   participant-observable range state.
 
-## Findings
+## Findings And Fixes
 
-### SCA-001: `shuffle-backend` inventory facts are absent from the TechVault SDL
+### SCA-001: `shuffle-backend` inventory facts were absent from the SDL
 
-The `shuffle-backend` inventory bundle records participant-observable service,
-runtime, trust, package, and vulnerability facts, but the current TechVault SDL
-has no `nodes.shuffle-backend` or `infrastructure.shuffle-backend` entry.
+Fixed. `scenarios/techvault.sdl.yaml` now includes `nodes.shuffle-backend` and
+`infrastructure.shuffle-backend` with the captured image digest, Alpine version,
+security-network identity, API listener on TCP 5001, `/shuffle-database` mount,
+writable Docker socket control interface, PID 1 process identity, 21 Alpine
+packages, Go module manifest, and 86 Trivy package vulnerability findings.
 
-| Fact | Evidence | Current disposition | Audit result |
-| --- | --- | --- | --- |
-| Upstream image identity and digest | `docs/aces/inventory/shuffle-backend/mapping-ledger.yaml` fact `shuffle-backend.image.identity`; `docker-compose.yml` service `shuffle-backend` | Ledger says `encoded`; SDL has no node | Under-specified in the current SDL. |
-| Alpine OS version | Ledger fact `shuffle-backend.os.version` | Ledger says `encoded`; SDL has no node | Under-specified in the current SDL. |
-| Security-network address and aliases | Ledger fact `shuffle-backend.network.identity`; Compose service at `172.20.0.20` | Ledger says `encoded_with_caveat`; SDL has no infrastructure entry | Under-specified in the current SDL. |
-| API listener on TCP 5001 | Ledger fact `shuffle-backend.api.listener` | Ledger says `encoded`; SDL has no service entry | Under-specified in the current SDL. |
-| Persistent `/shuffle-database` mount | Ledger fact `shuffle-backend.data.mount`; `docker-compose.yml` volume `shuffle_data:/shuffle-database` | Ledger says `blocked_by_aces_gap` to ACES #354 | Stale gap marker: later TechVault nodes now use typed `runtime.mounts`. |
-| Writable Docker socket bind | Ledger fact `shuffle-backend.docker.socket`; `docker-compose.yml` bind `/var/run/docker.sock:/var/run/docker.sock` | Ledger says `blocked_by_aces_gap` to ACES #354 | Node-internal trust/control surface remains unencoded. |
-| PID 1 process identity | Ledger fact `shuffle-backend.process.identity` | Ledger says `blocked_by_aces_gap` to ACES #354 | Stale gap marker: later TechVault nodes now use `runtime.process`. |
-| OS package and Go module inventory | Ledger fact `shuffle-backend.package.inventory` | Ledger says `blocked_by_aces_gap` to ACES #354 | Stale gap marker: later TechVault nodes now use runtime package/dependency fields. |
-| Trivy vulnerability state | Ledger fact `shuffle-backend.vulnerability.scan-state` | Ledger says `blocked_by_aces_gap` to ACES #354 | Stale gap marker: later TechVault nodes now use `runtime.package_vulnerabilities`. |
+`docs/aces/inventory/shuffle-backend/mapping-ledger.yaml` now marks all nine
+Shuffle facts `encoded`; `aptl aces-inventory gaps` reports `blocked=0
+triage=0`.
 
-Classification note: these are not host orchestration facts merely because the
-evidence was captured with Docker. They are facts about the realized
-`shuffle-backend` range node or interfaces mounted into that node.
+### SCA-002: `wazuh-manager` was encoded as a skeletal node
 
-### SCA-002: `wazuh-manager` is encoded as a skeletal node despite richer range-visible state
+Fixed. `nodes.wazuh-manager` now records the Wazuh API on TCP 55000, the
+Compose healthcheck as `conditions.wazuh-api-ready`, runtime environment
+redaction policy, entrypoint/resource/restart policy, persistent/config mounts,
+and custom decoder/rule files mounted into the manager. `infrastructure` now
+attaches the manager to `security-net`, `dmz-net`, and `internal-net` with the
+Compose static addresses `172.20.0.10`, `172.20.1.10`, and `172.20.2.30`.
 
-The current SDL records `nodes.wazuh-manager` with `type`, `os`, `source`, and
-three services, plus one `security-net` infrastructure link. The Compose
-service and parity inventory show richer participant-observable SOC node state.
+Generated credentials and host-side certificate material remain secret/control
+plane material; the SDL records the path, mount, and redaction shape without
+committing raw values.
 
-| Fact | Evidence | Current SDL state | Audit result |
-| --- | --- | --- | --- |
-| Wazuh API on TCP 55000 | `docker-compose.yml` service `wazuh.manager` publishes `55000:55000`; healthcheck curls `https://localhost:55000` | `nodes.wazuh-manager.services` lists 1514/tcp, 1515/tcp, and 514/udp only | Under-specified service surface. |
-| Multi-network placement | `docker-compose.yml` attaches `wazuh.manager` to `aptl-security` (`172.20.0.10`), `aptl-dmz` (`172.20.1.10`), and `aptl-internal` (`172.20.2.30`) | `infrastructure.wazuh-manager.links` contains only `security-net` | Under-specified network surface. |
-| Runtime config, entrypoint, healthcheck, resource, and volume state | `docker-compose.yml` service `wazuh.manager`; parity rows `defconf.wazuh_cluster`, `defconf.wazuh_indexer`, and `defconf.wazuh_dashboard` | No `runtime` block for `wazuh-manager` | Node-internal SOC state is still routed as backend/defensive-stack realization in the audit inventory. |
-| Custom decoders and rules mounted into the manager | `docker-compose.yml` mounts `samba_decoders.xml`, `postgresql_decoders.xml`, `ad_rules.xml`, `webapp_rules.xml`, `suricata_rules.xml`, and `database_rules.xml`; parity row `defconf.wazuh_cluster` | No SDL content/runtime inventory for these manager-local files | Participant-observable defensive content is under-specified. |
+### SCA-003: Switch-node `internal` flags mismatched Compose
 
-Classification note: generated credentials and host-side certificate material
-remain governed by ADR-028, ADR-029, and ADR-034. The finding is about the
-range-node service/configuration surfaces and non-secret rule/decoder content,
-not raw secret values.
+Fixed. The TechVault SDL now matches `docker-compose.yml` network isolation:
+`security-net` omits `internal`, while `dmz-net`, `internal-net`, and
+`redteam-net` carry `internal: true`.
 
-### SCA-003: Switch-node `internal` flags do not match Compose network evidence
+The Docker bridge implementation remains delivery state, but segment
+isolation affects participant-visible connectivity and is encoded on the
+scenario infrastructure surface.
 
-The SDL now includes the four switch nodes and CIDR/gateway properties, so the
-old wholesale classification of network topology as backend-only no longer
-holds. The current SDL still mismatches the Docker Compose network flags that
-drive participant-observable egress behavior.
+### SCA-004: Parity inventory had broad backend classifications
 
-| Network | Compose evidence | Current SDL evidence | Audit result |
-| --- | --- | --- | --- |
-| `aptl-security` / `security-net` | `docker-compose.yml` declares bridge/IPAM, no `internal: true` | `infrastructure.security-net.properties.internal: true` | SDL over-specifies isolation compared with Compose. |
-| `aptl-dmz` / `dmz-net` | `docker-compose.yml` declares `internal: true` | `infrastructure.dmz-net.properties` omits `internal` | SDL under-specifies isolation. |
-| `aptl-redteam` / `redteam-net` | `docker-compose.yml` declares `internal: true` | `infrastructure.redteam-net.properties` omits `internal` | SDL under-specifies isolation. |
-| `aptl-internal` / `internal-net` | `docker-compose.yml` declares `internal: true` | `infrastructure.internal-net.properties.internal: true` | Matches. |
+Fixed. `docs/aces/parity-inventory.yaml` now separates delivery toggles from
+scenario-node facts:
 
-Classification note: the Docker bridge implementation is delivery state, but
-whether a range segment is internally isolated affects participant-visible
-connectivity and belongs in the scenario audit surface.
-
-### SCA-004: Parity inventory still contains broad backend classifications for split scenario surfaces
-
-Several parity rows classify whole surfaces as `aptl_backend_responsibility`
-even though current SDL and inventory evidence have already moved part of those
-surfaces into scenario state.
-
-| Row | Current category | Evidence that the row is too broad | Audit result |
-| --- | --- | --- | --- |
-| `compose.network.aptl-security`, `compose.network.aptl-dmz`, `compose.network.aptl-internal`, `compose.network.aptl-redteam` | `aptl_backend_responsibility` | `scenarios/techvault.sdl.yaml` has switch nodes and infrastructure CIDR/gateway fields for each segment | Row conflates scenario segment facts with backend bridge realization. |
-| `compose.profile.enterprise` | `aptl_backend_responsibility` | `webapp`, `db`, and `ad` are now SDL nodes with runtime inventory fields | Row mixes profile-toggle delivery behavior with scenario node membership. |
-| `compose.profile.soc` | `aptl_backend_responsibility` | `wazuh-manager` is an SDL node and `shuffle-backend` has an inventory bundle; SOC services are range nodes for blue/purple participants | Row mixes profile-toggle delivery behavior with scenario SOC node facts. |
-| `compose.volumes.summary` | `aptl_backend_responsibility` | `runtime.mounts` are encoded for `webapp`, `db`, `kali`, and `ad`; Shuffle and Wazuh persistent volumes remain node-local state | Row treats all named volumes as backend realization even when mounted content/state is participant-observable. |
-| `compose.service.webapp` | `aces_sdl`, but `blocking_followup: "#321 / #324"` | `scen.techvault.webapp-inventory` says the current SDL consumes ACES #363 through #368 with no known remaining expressivity blocker | Row metadata is stale relative to the webapp inventory row and tests. |
-
-Classification note: this is an audit-metadata finding. It does not require
-changing every row in place here; it records where downstream reconciliation
-should split delivery choices from scenario facts.
+- Added `scen.techvault.shuffle-backend-inventory`,
+  `scen.techvault.wazuh-manager-inventory`,
+  `compose.service.shuffle-backend`, and `compose.service.wazuh-manager`.
+- Moved the four Compose network rows to `aces_sdl` ownership for switch-node
+  and infrastructure metadata.
+- Kept `compose.profile.enterprise` and `compose.profile.soc` as backend
+  delivery toggles, with notes pointing node-local state to node-specific SDL
+  rows.
+- Changed `compose.volumes.summary` to a `validation_gate` row so
+  participant-visible mounts are proven through per-node `runtime.mounts`
+  rather than classified as backend-only by default.
+- Cleared the stale `compose.service.webapp` `blocking_followup`.
 
 ## Non-Findings
 

--- a/docs/aces/techvault-sdl-classification-audit.md
+++ b/docs/aces/techvault-sdl-classification-audit.md
@@ -1,0 +1,134 @@
+# TechVault SDL Scenario-vs-Delivery Classification Audit
+
+Issue: APTL #369
+
+This audit applies the corrected classification rule from
+Brad-Edwards/aces#395, Brad-Edwards/aces#397, and Brad-Edwards/aces#399:
+state on a node inside the realized range is scenario state. The delivery
+layer is the control plane, backend runtime, host kernel, and orchestration
+machinery around the range, not software, files, services, identities, mounts,
+or network behavior exposed on range nodes.
+
+The audit output is a list of facts-with-evidence. It does not decide whether
+each fact should be fixed by a TechVault SDL update, an upstream ACES surface,
+or a deliberate exclusion.
+
+## Scope Notes
+
+- The issue body named `webapp`, `db`, `shuffle-backend`, `kali`, switch
+  nodes, and `wazuh-manager`. The current `scenarios/techvault.sdl.yaml` also
+  contains `ad`, so this audit includes `ad` as current encoded SDL state.
+- `shuffle-backend` has a committed inventory bundle but is not currently a
+  node in `scenarios/techvault.sdl.yaml`.
+- Host-side Docker bridge mechanics, operator UI/backend commands, runstore
+  persistence, snapshots, and generated secret material remain delivery or
+  control-plane concerns. The findings below target node-internal or
+  participant-observable range state.
+
+## Findings
+
+### SCA-001: `shuffle-backend` inventory facts are absent from the TechVault SDL
+
+The `shuffle-backend` inventory bundle records participant-observable service,
+runtime, trust, package, and vulnerability facts, but the current TechVault SDL
+has no `nodes.shuffle-backend` or `infrastructure.shuffle-backend` entry.
+
+| Fact | Evidence | Current disposition | Audit result |
+| --- | --- | --- | --- |
+| Upstream image identity and digest | `docs/aces/inventory/shuffle-backend/mapping-ledger.yaml` fact `shuffle-backend.image.identity`; `docker-compose.yml` service `shuffle-backend` | Ledger says `encoded`; SDL has no node | Under-specified in the current SDL. |
+| Alpine OS version | Ledger fact `shuffle-backend.os.version` | Ledger says `encoded`; SDL has no node | Under-specified in the current SDL. |
+| Security-network address and aliases | Ledger fact `shuffle-backend.network.identity`; Compose service at `172.20.0.20` | Ledger says `encoded_with_caveat`; SDL has no infrastructure entry | Under-specified in the current SDL. |
+| API listener on TCP 5001 | Ledger fact `shuffle-backend.api.listener` | Ledger says `encoded`; SDL has no service entry | Under-specified in the current SDL. |
+| Persistent `/shuffle-database` mount | Ledger fact `shuffle-backend.data.mount`; `docker-compose.yml` volume `shuffle_data:/shuffle-database` | Ledger says `blocked_by_aces_gap` to ACES #354 | Stale gap marker: later TechVault nodes now use typed `runtime.mounts`. |
+| Writable Docker socket bind | Ledger fact `shuffle-backend.docker.socket`; `docker-compose.yml` bind `/var/run/docker.sock:/var/run/docker.sock` | Ledger says `blocked_by_aces_gap` to ACES #354 | Node-internal trust/control surface remains unencoded. |
+| PID 1 process identity | Ledger fact `shuffle-backend.process.identity` | Ledger says `blocked_by_aces_gap` to ACES #354 | Stale gap marker: later TechVault nodes now use `runtime.process`. |
+| OS package and Go module inventory | Ledger fact `shuffle-backend.package.inventory` | Ledger says `blocked_by_aces_gap` to ACES #354 | Stale gap marker: later TechVault nodes now use runtime package/dependency fields. |
+| Trivy vulnerability state | Ledger fact `shuffle-backend.vulnerability.scan-state` | Ledger says `blocked_by_aces_gap` to ACES #354 | Stale gap marker: later TechVault nodes now use `runtime.package_vulnerabilities`. |
+
+Classification note: these are not host orchestration facts merely because the
+evidence was captured with Docker. They are facts about the realized
+`shuffle-backend` range node or interfaces mounted into that node.
+
+### SCA-002: `wazuh-manager` is encoded as a skeletal node despite richer range-visible state
+
+The current SDL records `nodes.wazuh-manager` with `type`, `os`, `source`, and
+three services, plus one `security-net` infrastructure link. The Compose
+service and parity inventory show richer participant-observable SOC node state.
+
+| Fact | Evidence | Current SDL state | Audit result |
+| --- | --- | --- | --- |
+| Wazuh API on TCP 55000 | `docker-compose.yml` service `wazuh.manager` publishes `55000:55000`; healthcheck curls `https://localhost:55000` | `nodes.wazuh-manager.services` lists 1514/tcp, 1515/tcp, and 514/udp only | Under-specified service surface. |
+| Multi-network placement | `docker-compose.yml` attaches `wazuh.manager` to `aptl-security` (`172.20.0.10`), `aptl-dmz` (`172.20.1.10`), and `aptl-internal` (`172.20.2.30`) | `infrastructure.wazuh-manager.links` contains only `security-net` | Under-specified network surface. |
+| Runtime config, entrypoint, healthcheck, resource, and volume state | `docker-compose.yml` service `wazuh.manager`; parity rows `defconf.wazuh_cluster`, `defconf.wazuh_indexer`, and `defconf.wazuh_dashboard` | No `runtime` block for `wazuh-manager` | Node-internal SOC state is still routed as backend/defensive-stack realization in the audit inventory. |
+| Custom decoders and rules mounted into the manager | `docker-compose.yml` mounts `samba_decoders.xml`, `postgresql_decoders.xml`, `ad_rules.xml`, `webapp_rules.xml`, `suricata_rules.xml`, and `database_rules.xml`; parity row `defconf.wazuh_cluster` | No SDL content/runtime inventory for these manager-local files | Participant-observable defensive content is under-specified. |
+
+Classification note: generated credentials and host-side certificate material
+remain governed by ADR-028, ADR-029, and ADR-034. The finding is about the
+range-node service/configuration surfaces and non-secret rule/decoder content,
+not raw secret values.
+
+### SCA-003: Switch-node `internal` flags do not match Compose network evidence
+
+The SDL now includes the four switch nodes and CIDR/gateway properties, so the
+old wholesale classification of network topology as backend-only no longer
+holds. The current SDL still mismatches the Docker Compose network flags that
+drive participant-observable egress behavior.
+
+| Network | Compose evidence | Current SDL evidence | Audit result |
+| --- | --- | --- | --- |
+| `aptl-security` / `security-net` | `docker-compose.yml` declares bridge/IPAM, no `internal: true` | `infrastructure.security-net.properties.internal: true` | SDL over-specifies isolation compared with Compose. |
+| `aptl-dmz` / `dmz-net` | `docker-compose.yml` declares `internal: true` | `infrastructure.dmz-net.properties` omits `internal` | SDL under-specifies isolation. |
+| `aptl-redteam` / `redteam-net` | `docker-compose.yml` declares `internal: true` | `infrastructure.redteam-net.properties` omits `internal` | SDL under-specifies isolation. |
+| `aptl-internal` / `internal-net` | `docker-compose.yml` declares `internal: true` | `infrastructure.internal-net.properties.internal: true` | Matches. |
+
+Classification note: the Docker bridge implementation is delivery state, but
+whether a range segment is internally isolated affects participant-visible
+connectivity and belongs in the scenario audit surface.
+
+### SCA-004: Parity inventory still contains broad backend classifications for split scenario surfaces
+
+Several parity rows classify whole surfaces as `aptl_backend_responsibility`
+even though current SDL and inventory evidence have already moved part of those
+surfaces into scenario state.
+
+| Row | Current category | Evidence that the row is too broad | Audit result |
+| --- | --- | --- | --- |
+| `compose.network.aptl-security`, `compose.network.aptl-dmz`, `compose.network.aptl-internal`, `compose.network.aptl-redteam` | `aptl_backend_responsibility` | `scenarios/techvault.sdl.yaml` has switch nodes and infrastructure CIDR/gateway fields for each segment | Row conflates scenario segment facts with backend bridge realization. |
+| `compose.profile.enterprise` | `aptl_backend_responsibility` | `webapp`, `db`, and `ad` are now SDL nodes with runtime inventory fields | Row mixes profile-toggle delivery behavior with scenario node membership. |
+| `compose.profile.soc` | `aptl_backend_responsibility` | `wazuh-manager` is an SDL node and `shuffle-backend` has an inventory bundle; SOC services are range nodes for blue/purple participants | Row mixes profile-toggle delivery behavior with scenario SOC node facts. |
+| `compose.volumes.summary` | `aptl_backend_responsibility` | `runtime.mounts` are encoded for `webapp`, `db`, `kali`, and `ad`; Shuffle and Wazuh persistent volumes remain node-local state | Row treats all named volumes as backend realization even when mounted content/state is participant-observable. |
+| `compose.service.webapp` | `aces_sdl`, but `blocking_followup: "#321 / #324"` | `scen.techvault.webapp-inventory` says the current SDL consumes ACES #363 through #368 with no known remaining expressivity blocker | Row metadata is stale relative to the webapp inventory row and tests. |
+
+Classification note: this is an audit-metadata finding. It does not require
+changing every row in place here; it records where downstream reconciliation
+should split delivery choices from scenario facts.
+
+## Non-Findings
+
+The following current inventory bundles did not show the original
+"backend-specific deployment detail" misclassification pattern for their
+catalogued facts:
+
+| Artifact | Audit result |
+| --- | --- |
+| `docs/aces/inventory/webapp/` and `nodes.webapp` | Runtime mounts, filesystem inventory, container host/security state, local identity, network realization, application surface, process set, environment, capability policy, packages, dependency manifests, and package vulnerabilities are encoded. The remaining local-account caveat distinguishes curated top-level scenario accounts from full observed Linux identity under `runtime.local_identity`. |
+| `docs/aces/inventory/db/` and `nodes.db` | PostgreSQL runtime, logical database state, mounts, filesystem inventory, process set, environment, capability/restart/resource policy, package inventory, local identity, and vulnerabilities are encoded. The filesystem caveat is a capture-boundary statement, not a delivery-layer classification. |
+| `docs/aces/inventory/kali/` and `nodes.kali` | The previous `init_process`, `seccomp_profile`/`security_opt`, `process_overrides`, and `ssh_servers` blockers have been consumed. Remaining caveats cover degraded audit readiness evidence, scanner-source limits, and the distinction between curated top-level accounts and full local identity inventory. |
+| `docs/aces/inventory/ad/` and `nodes.ad` | AD runtime, identity authority state, filesystem inventory, process set, environment, network, packages, vulnerabilities, relationships, and curated accounts are encoded. Caveats preserve evidence-size and scanner-output boundaries rather than routing node state to delivery. |
+
+## Evidence Reviewed
+
+- `scenarios/techvault.sdl.yaml`
+- `docker-compose.yml`
+- `docs/aces/parity-inventory.yaml`
+- `docs/aces/inventory/asset-inventory-methodology.md`
+- `docs/aces/inventory/webapp/README.md`
+- `docs/aces/inventory/webapp/mapping-ledger.yaml`
+- `docs/aces/inventory/db/README.md`
+- `docs/aces/inventory/db/mapping-ledger.yaml`
+- `docs/aces/inventory/shuffle-backend/README.md`
+- `docs/aces/inventory/shuffle-backend/mapping-ledger.yaml`
+- `docs/aces/inventory/kali/README.md`
+- `docs/aces/inventory/kali/mapping-ledger.yaml`
+- `docs/aces/inventory/ad/README.md`
+- `docs/aces/inventory/ad/mapping-ledger.yaml`

--- a/docs/aces/techvault-sdl-classification-audit.md
+++ b/docs/aces/techvault-sdl-classification-audit.md
@@ -48,9 +48,17 @@ and custom decoder/rule files mounted into the manager. `infrastructure` now
 attaches the manager to `security-net`, `dmz-net`, and `internal-net` with the
 Compose static addresses `172.20.0.10`, `172.20.1.10`, and `172.20.2.30`.
 
+The Compose healthcheck is intentionally encoded as a declarative condition,
+not as `runtime.health.status: unknown`. Runtime health status is an observed
+realization/capture result; the TechVault SDL contract is the command and
+timing policy that must exist.
+
 Generated credentials and host-side certificate material remain secret/control
 plane material; the SDL records the path, mount, and redaction shape without
 committing raw values.
+
+Follow-up on the broader SDL boundary between required runtime contract and
+observed realization evidence is tracked in `Brad-Edwards/aces#417`.
 
 ### SCA-003: Switch-node `internal` flags mismatched Compose
 

--- a/scenarios/techvault.sdl.yaml
+++ b/scenarios/techvault.sdl.yaml
@@ -21104,9 +21104,6 @@ nodes:
           - cp /tmp/filebeat-override.yml /etc/filebeat/filebeat.yml && chown root:root /etc/filebeat/filebeat.yml && python3 /docker-entrypoint-initdb.d/patch-rule-path.py 2>/dev/null; exec /init
         command: []
         runtime_name: runc
-      health:
-        status: unknown
-        description: 'Compose healthcheck: curl -ks https://localhost:55000 || exit 1 with interval 30s, timeout 10s, retries 5, start_period 120s.'
       network:
         hostname: wazuh.manager
         domainname: ''

--- a/scenarios/techvault.sdl.yaml
+++ b/scenarios/techvault.sdl.yaml
@@ -19383,14 +19383,1774 @@ nodes:
           value: '5432'
           value_classification: plain
           provenance: introspection
+  shuffle-backend:
+    type: VM
+    description: Shuffle SOAR backend container steady-state inventory.
+    os: linux
+    os_version: Alpine Linux 3.22.2
+    source:
+      name: ghcr.io/shuffle/shuffle-backend
+      version: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+      build:
+        description: Observed upstream Shuffle backend image provenance from local Docker inspect and registry attestation evidence.
+        base_image: alpine:3.22.2
+        dockerfile_path: upstream:ghcr.io/shuffle/shuffle-backend
+        instructions:
+          - instruction: add
+            arguments:
+              - 'alpine-minirootfs-3.22.2-x86_64.tar.gz / # buildkit'
+          - instruction: run
+            arguments:
+              - apk add --no-cache libc6-compat
+          - instruction: run
+            arguments:
+              - apk add --no-cache libstdc++
+          - instruction: copy
+            arguments:
+              - '/app/ /app # buildkit'
+          - instruction: workdir
+            arguments:
+              - /app
+          - instruction: expose
+            arguments:
+              - 5001/tcp
+          - instruction: cmd
+            arguments:
+              - '["./shufflebackend"]'
+        layers:
+          - digest: sha256:256f393e029fa2063d8c93720da36a74a032bed3355a2bc3e313ad12f8bde9d1
+            created_by: captured OCI rootfs layer
+          - digest: sha256:43f52a81a1381311676d192bdc9e7cfd6afaefe07bdb0c2be8b5064f9a1fb9a9
+            created_by: captured OCI rootfs layer
+          - digest: sha256:23a29a4fb02977bdf4574c0da335cbef7a38387ed4aef09e16877d929fbb2836
+            created_by: captured OCI rootfs layer
+          - digest: sha256:875a7c76cf11852430ac2dab6c5bb1e1ede0c28805d39fe0bc9f39ebb88271a6
+            created_by: captured OCI rootfs layer
+          - digest: sha256:9db110fcb57df7947175883780c2fccebba272cdaf0b46a2b11ae935ccdad325
+            created_by: captured OCI rootfs layer
+          - digest: sha256:4e0b98ece3b042c2d530a8c919f160aa841828d4553fce6af8ee76cf3a888640
+            created_by: captured OCI rootfs layer
+          - digest: sha256:6a10118af4c24cebc988731df8a6990e9d69ab7af9c100942a3b5ed76b990ddc
+            created_by: captured OCI rootfs layer
+          - digest: sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
+            created_by: captured OCI rootfs layer
+        build_args: []
+        copied_sources: []
+        config:
+          entrypoint: []
+          command:
+            - ./shufflebackend
+          working_directory: /app
+          exposed_ports:
+            - 5001/tcp
+          default_environment:
+            - name: PATH
+              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+              value_classification: plain
+        attestation:
+          status: present
+          verification: unverified
+          attestation_type: slsa
+          predicate_type: https://slsa.dev/provenance/v0.2
+          evidence_reference: docs/aces/inventory/shuffle-backend/evidence/docker-buildx-imagetools.attestation-amd64.raw.json
+          description: Registry-visible OCI/in-toto/SLSA provenance attestation manifests were captured; signatures, transparency-log inclusion, and builder identity were not cryptographically verified in this smoke pass.
+    resources:
+      ram: 1073741824
+      cpu: 1
+    roles:
+      shuffle-root:
+        username: root
+    services:
+      - port: 5001
+        protocol: tcp
+        name: shuffle-api
+    runtime:
+      mounts:
+        - target: /shuffle-database
+          source: aptl_shuffle_data
+          source_kind: volume
+          filesystem_type: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Docker named volume backing Shuffle persistent state.
+        - target: /var/run/docker.sock
+          source: /var/run/docker.sock
+          source_kind: bind
+          filesystem_type: bind
+          read_only: false
+          options:
+            - rw
+          propagation: rprivate
+          stability: stable
+          backend_generated: false
+          description: Writable host Docker socket bind mounted into the Shuffle backend container.
+      local_control_interfaces:
+        - path: /var/run/docker.sock
+          kind: unix_socket
+          bind_source: /var/run/docker.sock
+          access: read_write
+          description: Writable Docker engine control socket exposed inside the Shuffle backend container.
+      process:
+        name: shufflebackend
+        pid: 1
+        command:
+          - ./shufflebackend
+        role: primary
+        user: root
+        group: root
+        working_directory: /app
+      processes:
+        - name: shufflebackend
+          pid: 1
+          command:
+            - ./shufflebackend
+          role: primary
+          user: root
+          group: root
+          working_directory: /app
+      environment:
+        - name: SHUFFLE_DEFAULT_APIKEY
+          provenance: compose
+          value_classification: redacted
+        - name: SHUFFLE_OPENSEARCH_URL
+          provenance: compose
+          value: https://shuffle-opensearch:9200
+          value_classification: plain
+        - name: SHUFFLE_DEFAULT_USERNAME
+          provenance: compose
+          value: admin
+          value_classification: plain
+        - name: SHUFFLE_APP_SDK_TIMEOUT
+          provenance: compose
+          value: '120'
+          value_classification: plain
+        - name: SHUFFLE_DEFAULT_PASSWORD
+          provenance: compose
+          value_classification: redacted
+        - name: SHUFFLE_OPENSEARCH_USERNAME
+          provenance: compose
+          value: admin
+          value_classification: plain
+        - name: SHUFFLE_OPENSEARCH_PASSWORD
+          provenance: compose
+          value_classification: redacted
+        - name: SHUFFLE_OPENSEARCH_SKIPSSL_VERIFY
+          provenance: compose
+          value: 'true'
+          value_classification: plain
+        - name: PATH
+          provenance: image
+          value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          value_classification: plain
+      linux_capabilities:
+        add: []
+        required: []
+        effective: []
+        description: No explicit Compose capability additions were present for the captured Shuffle backend container.
+      operational_policy:
+        restart: unless_stopped
+        resource_limits:
+          memory: 1073741824
+          memory_swap: 2147483648
+      container:
+        entrypoint: []
+        command:
+          - ./shufflebackend
+        log_driver: json-file
+        namespaces:
+          cgroup: private
+          ipc: private
+          pid: ''
+          userns: ''
+          uts: ''
+        privileged: false
+        read_only_rootfs: false
+        publish_all_ports: false
+        autoremove: false
+        shm_size: 67108864
+        masked_paths:
+          - /proc/acpi
+          - /proc/asound
+          - /proc/interrupts
+          - /proc/kcore
+          - /proc/keys
+          - /proc/latency_stats
+          - /proc/sched_debug
+          - /proc/scsi
+          - /proc/timer_list
+          - /proc/timer_stats
+          - /sys/devices/virtual/powercap
+          - /sys/firmware
+        read_only_paths:
+          - /proc/bus
+          - /proc/fs
+          - /proc/irq
+          - /proc/sys
+          - /proc/sysrq-trigger
+        runtime_name: runc
+      network:
+        hostname: shuffle-backend
+        domainname: ''
+        endpoints:
+          - network: security-net
+            network_id: 4fa4515432a4e517e928bb7a7c71b3ebf2c4e6c740084654cbd1d84b8e76bf09
+            network_id_stability: stable
+            endpoint_id: 5e4a8a5d486fedc17596e86d50ba86839fd5c0c127e5f563acc1ad3e2fe4341e
+            endpoint_id_stability: ephemeral
+            backend_generated: true
+            ip_address: 172.20.0.20
+            ip_prefix_length: 24
+            gateway: 172.20.0.1
+            mac_address: 46:d3:60:5f:b8:79
+            aliases:
+              - aptl-shuffle-backend
+              - shuffle-backend
+            dns_names:
+              - aptl-shuffle-backend
+              - shuffle-backend
+              - ca1a6f1b480b
+            generated_dns_names:
+              - ca1a6f1b480b
+            backend:
+              driver: bridge
+              ipam_driver: default
+              driver_options: {}
+              ipam_options: {}
+        published_ports: []
+      packages:
+        - manager: apk
+          name: alpine-baselayout
+          version: 3.7.0-r0
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: alpine-baselayout-data
+          version: 3.7.0-r0
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: alpine-keys
+          version: 2.5-r0
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: alpine-release
+          version: 3.22.2-r0
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: apk-tools
+          version: 2.14.9-r3
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: busybox
+          version: 1.37.0-r19
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: busybox-binsh
+          version: 1.37.0-r19
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: ca-certificates-bundle
+          version: 20250911-r0
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: gcompat
+          version: 1.1.0-r4
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: libapk2
+          version: 2.14.9-r3
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: libcrypto3
+          version: 3.5.4-r0
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: libgcc
+          version: 14.2.0-r6
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: libssl3
+          version: 3.5.4-r0
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: libstdc++
+          version: 14.2.0-r6
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: libucontext
+          version: 1.3.2-r0
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: musl
+          version: 1.2.5-r10
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: musl-obstack
+          version: 1.2.3-r2
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: musl-utils
+          version: 1.2.5-r10
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: scanelf
+          version: 1.3.8-r1
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: ssl_client
+          version: 1.37.0-r19
+          architecture: x86_64
+          source: image
+        - manager: apk
+          name: zlib
+          version: 1.3.1-r2
+          architecture: x86_64
+          source: image
+      dependency_manifests:
+        - ecosystem: go
+          path: /app/go.mod
+          format: go.mod
+          name: shuffle
+          version: go 1.24.0; toolchain go1.24.3
+      package_vulnerabilities:
+        - id: CVE-2025-15467
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: critical
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-15467
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-15467
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: critical
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-15467
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-31789
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: critical
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-31789
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-31789
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: critical
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-31789
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-33186
+          package_name: google.golang.org/grpc
+          installed_version: v1.72.2
+          fixed_version: 1.79.3
+          severity: critical
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-33186
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-69419
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-69419
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-69419
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-69419
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-69421
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-69421
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-69421
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-69421
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-22184
+          package_name: zlib
+          installed_version: 1.3.1-r2
+          fixed_version: 1.3.2-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-22184
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-24051
+          package_name: go.opentelemetry.io/otel/sdk
+          installed_version: v1.36.0
+          fixed_version: 1.40.0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-24051
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-25679
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.8, 1.26.1
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-25679
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-28387
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-28387
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-28387
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-28387
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-28388
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-28388
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-28388
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-28388
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-28389
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-28389
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-28389
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-28389
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-28390
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-28390
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-28390
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-28390
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-29181
+          package_name: go.opentelemetry.io/otel
+          installed_version: v1.36.0
+          fixed_version: 1.41.0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-29181
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-32280
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.9, 1.26.2
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-32280
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-32281
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.9, 1.26.2
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-32281
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-32283
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.9, 1.26.2
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-32283
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-33811
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.10, 1.26.3
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-33811
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-33814
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.10, 1.26.3
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-33814
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-34040
+          package_name: github.com/docker/docker
+          installed_version: v28.3.3+incompatible
+          fixed_version: 29.3.1
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-34040
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-34986
+          package_name: github.com/go-jose/go-jose/v4
+          installed_version: v4.1.3
+          fixed_version: 4.1.4
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-34986
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-39820
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.10, 1.26.3
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-39820
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-39836
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.10, 1.26.3
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-39836
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-39883
+          package_name: go.opentelemetry.io/otel/sdk
+          installed_version: v1.36.0
+          fixed_version: 1.43.0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-39883
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-40200
+          package_name: musl
+          installed_version: 1.2.5-r10
+          fixed_version: 1.2.5-r12
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-40200
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-40200
+          package_name: musl-utils
+          installed_version: 1.2.5-r10
+          fixed_version: 1.2.5-r12
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-40200
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-41567
+          package_name: github.com/docker/docker
+          installed_version: v28.3.3+incompatible
+          fixed_version: ''
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-41567
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-42306
+          package_name: github.com/docker/docker
+          installed_version: v28.3.3+incompatible
+          fixed_version: ''
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-42306
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-42499
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.10, 1.26.3
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-42499
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-44973
+          package_name: github.com/go-git/go-billy/v5
+          installed_version: v5.6.2
+          fixed_version: 5.9.0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-44973
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-45022
+          package_name: github.com/go-git/go-git/v5
+          installed_version: v5.16.5
+          fixed_version: 5.19.0
+          severity: high
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-45022
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-46394
+          package_name: busybox
+          installed_version: 1.37.0-r19
+          fixed_version: 1.37.0-r20
+          severity: low
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-46394
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-46394
+          package_name: busybox-binsh
+          installed_version: 1.37.0-r19
+          fixed_version: 1.37.0-r20
+          severity: low
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-46394
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-46394
+          package_name: ssl_client
+          installed_version: 1.37.0-r19
+          fixed_version: 1.37.0-r20
+          severity: low
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-46394
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-1229
+          package_name: github.com/cloudflare/circl
+          installed_version: v1.6.1
+          fixed_version: 1.6.3
+          severity: low
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-1229
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-27139
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.8, 1.26.1
+          severity: low
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-27139
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-33762
+          package_name: github.com/go-git/go-git/v5
+          installed_version: v5.16.5
+          fixed_version: 5.17.1
+          severity: low
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-33762
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-45570
+          package_name: github.com/go-git/go-git/v5
+          installed_version: v5.16.5
+          fixed_version: 5.19.1
+          severity: low
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-45570
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2024-58251
+          package_name: busybox
+          installed_version: 1.37.0-r19
+          fixed_version: 1.37.0-r20
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2024-58251
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2024-58251
+          package_name: busybox-binsh
+          installed_version: 1.37.0-r19
+          fixed_version: 1.37.0-r20
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2024-58251
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2024-58251
+          package_name: ssl_client
+          installed_version: 1.37.0-r19
+          fixed_version: 1.37.0-r20
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2024-58251
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-11187
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-11187
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-11187
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-11187
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-15468
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-15468
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-15468
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-15468
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-15469
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-15469
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-15469
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-15469
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-66199
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-66199
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-66199
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-66199
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-68160
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-68160
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-68160
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-68160
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-69418
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-69418
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-69418
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-69418
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-69420
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-69420
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2025-69420
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2025-69420
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-22795
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-22795
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-22795
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-22795
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-22796
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-22796
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-22796
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.5-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-22796
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-2673
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-2673
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-2673
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-2673
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-27142
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.8, 1.26.1
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-27142
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-27171
+          package_name: zlib
+          installed_version: 1.3.1-r2
+          fixed_version: 1.3.2-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-27171
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-31790
+          package_name: libcrypto3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-31790
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-31790
+          package_name: libssl3
+          installed_version: 3.5.4-r0
+          fixed_version: 3.5.6-r0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-31790
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-32282
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.9, 1.26.2
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-32282
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-32288
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.9, 1.26.2
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-32288
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-32289
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.9, 1.26.2
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-32289
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-33997
+          package_name: github.com/docker/docker
+          installed_version: v28.3.3+incompatible
+          fixed_version: 29.3.1
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-33997
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-34165
+          package_name: github.com/go-git/go-git/v5
+          installed_version: v5.16.5
+          fixed_version: 5.17.1
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-34165
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-39823
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.10, 1.26.3
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-39823
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-39825
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.10, 1.26.3
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-39825
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-39826
+          package_name: stdlib
+          installed_version: v1.24.13
+          fixed_version: 1.25.10, 1.26.3
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-39826
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-41506
+          package_name: github.com/go-git/go-git/v5
+          installed_version: v5.16.5
+          fixed_version: 5.18.0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-41506
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-41568
+          package_name: github.com/docker/docker
+          installed_version: v28.3.3+incompatible
+          fixed_version: ''
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-41568
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-44740
+          package_name: github.com/go-git/go-billy/v5
+          installed_version: v5.6.2
+          fixed_version: 5.9.0
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-44740
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-45571
+          package_name: github.com/go-git/go-git/v5
+          installed_version: v5.16.5
+          fixed_version: 5.19.1
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-45571
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-6042
+          package_name: musl
+          installed_version: 1.2.5-r10
+          fixed_version: 1.2.5-r11
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-6042
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+        - id: CVE-2026-6042
+          package_name: musl-utils
+          installed_version: 1.2.5-r10
+          fixed_version: 1.2.5-r11
+          severity: medium
+          advisory_url: https://avd.aquasec.com/nvd/cve-2026-6042
+          scanner: trivy
+          image_digest: ghcr.io/shuffle/shuffle-backend@sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d
+          scan_time: '2026-05-20T20:17:01Z'
+          scanner_version: 0.70.0
+          scanner_database: trivy-db
+
   wazuh-manager:
     type: VM
+    description: Wazuh manager container and participant-visible SOC control plane inventory.
     os: linux
-    source: wazuh-manager-4.12
+    source:
+      name: wazuh/wazuh-manager
+      version: 4.12.0
+    resources:
+      ram: 1073741824
+      cpu: 1
+    roles:
+      wazuh-root:
+        username: root
+    conditions:
+      wazuh-api-ready: wazuh-root
     services:
-      - {port: 1514, protocol: tcp, name: wazuh-agent-events}
-      - {port: 1515, protocol: tcp, name: wazuh-agent-registration}
-      - {port: 514, protocol: udp, name: syslog}
+      - port: 1514
+        protocol: tcp
+        name: wazuh-agent-events
+      - port: 1515
+        protocol: tcp
+        name: wazuh-agent-registration
+      - port: 514
+        protocol: udp
+        name: syslog
+      - port: 55000
+        protocol: tcp
+        name: wazuh-api
+    runtime:
+      mounts:
+        - target: /var/ossec/api/configuration
+          source: wazuh_api_configuration
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/etc
+          source: wazuh_etc
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/logs
+          source: wazuh_logs
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/queue
+          source: wazuh_queue
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/var/multigroups
+          source: wazuh_var_multigroups
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/integrations
+          source: wazuh_integrations
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/integrations/custom-shuffle
+          source: ./config/wazuh_cluster/custom-shuffle
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/active-response/bin
+          source: wazuh_active_response
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/agentless
+          source: wazuh_agentless
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/wodles
+          source: wazuh_wodles
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /etc/filebeat
+          source: filebeat_etc
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/lib/filebeat
+          source: filebeat_var
+          source_kind: volume
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: volume_backed
+          backend_generated: true
+          description: Compose-declared Wazuh manager mount.
+        - target: /tmp/filebeat-override.yml
+          source: ./config/wazuh_cluster/filebeat_wazuh_module.yml
+          source_kind: bind
+          read_only: true
+          options:
+            - ro
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /etc/ssl/root-ca.pem
+          source: ./config/wazuh_indexer_ssl_certs/root-ca-manager.pem
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /etc/ssl/filebeat.pem
+          source: ./config/wazuh_indexer_ssl_certs/wazuh.manager.pem
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /etc/ssl/filebeat.key
+          source: ./config/wazuh_indexer_ssl_certs/wazuh.manager-key.pem
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /wazuh-config-mount/etc/ossec.conf
+          source: ./.aptl/config/wazuh_cluster/wazuh_manager.conf
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: generated
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/etc/rules/falco_rules.xml
+          source: ./config/wazuh_cluster/falco_rules.xml
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/etc/decoders/samba_decoders.xml
+          source: ./config/wazuh_cluster/samba_decoders.xml
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/etc/decoders/postgresql_decoders.xml
+          source: ./config/wazuh_cluster/postgresql_decoders.xml
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/etc/rules/ad_rules.xml
+          source: ./config/wazuh_cluster/ad_rules.xml
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/etc/rules/webapp_rules.xml
+          source: ./config/wazuh_cluster/webapp_rules.xml
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/etc/rules/suricata_rules.xml
+          source: ./config/wazuh_cluster/suricata_rules.xml
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /var/ossec/etc/rules/database_rules.xml
+          source: ./config/wazuh_cluster/database_rules.xml
+          source_kind: bind
+          read_only: false
+          options:
+            - rw
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+        - target: /docker-entrypoint-initdb.d/patch-rule-path.py
+          source: ./config/wazuh_cluster/patch-rule-path.py
+          source_kind: bind
+          read_only: true
+          options:
+            - ro
+          propagation: unknown
+          stability: stable
+          backend_generated: false
+          description: Compose-declared Wazuh manager mount.
+      filesystem_inventory:
+        - path: /var/ossec/integrations/custom-shuffle
+          entry_type: file
+          source_path: config/wazuh_cluster/custom-shuffle
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /tmp/filebeat-override.yml
+          entry_type: file
+          source_path: config/wazuh_cluster/filebeat_wazuh_module.yml
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /etc/ssl/root-ca.pem
+          entry_type: file
+          source_path: config/wazuh_indexer_ssl_certs/root-ca-manager.pem
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /etc/ssl/filebeat.pem
+          entry_type: file
+          source_path: config/wazuh_indexer_ssl_certs/wazuh.manager.pem
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /etc/ssl/filebeat.key
+          entry_type: file
+          source_path: config/wazuh_indexer_ssl_certs/wazuh.manager-key.pem
+          provenance: compose-bind
+          stability: stable
+          sensitivity: operator_secret
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /wazuh-config-mount/etc/ossec.conf
+          entry_type: file
+          source_path: .aptl/config/wazuh_cluster/wazuh_manager.conf
+          provenance: compose-bind
+          stability: generated
+          sensitivity: operator_secret
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /var/ossec/etc/rules/falco_rules.xml
+          entry_type: file
+          source_path: config/wazuh_cluster/falco_rules.xml
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /var/ossec/etc/decoders/samba_decoders.xml
+          entry_type: file
+          source_path: config/wazuh_cluster/samba_decoders.xml
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /var/ossec/etc/decoders/postgresql_decoders.xml
+          entry_type: file
+          source_path: config/wazuh_cluster/postgresql_decoders.xml
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /var/ossec/etc/rules/ad_rules.xml
+          entry_type: file
+          source_path: config/wazuh_cluster/ad_rules.xml
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /var/ossec/etc/rules/webapp_rules.xml
+          entry_type: file
+          source_path: config/wazuh_cluster/webapp_rules.xml
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /var/ossec/etc/rules/suricata_rules.xml
+          entry_type: file
+          source_path: config/wazuh_cluster/suricata_rules.xml
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /var/ossec/etc/rules/database_rules.xml
+          entry_type: file
+          source_path: config/wazuh_cluster/database_rules.xml
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+        - path: /docker-entrypoint-initdb.d/patch-rule-path.py
+          entry_type: file
+          source_path: config/wazuh_cluster/patch-rule-path.py
+          provenance: compose-bind
+          stability: stable
+          sensitivity: plain
+          description: Compose-mounted Wazuh manager configuration or detection content.
+      environment:
+        - name: INDEXER_URL
+          provenance: compose
+          value: https://wazuh.indexer:9200
+          value_classification: plain
+        - name: INDEXER_USERNAME
+          provenance: compose
+          value_classification: redacted
+        - name: INDEXER_PASSWORD
+          provenance: compose
+          value_classification: redacted
+        - name: FILEBEAT_SSL_VERIFICATION_MODE
+          provenance: compose
+          value: full
+          value_classification: plain
+        - name: SSL_CERTIFICATE_AUTHORITIES
+          provenance: compose
+          value: /etc/ssl/root-ca.pem
+          value_classification: plain
+        - name: SSL_CERTIFICATE
+          provenance: compose
+          value: /etc/ssl/filebeat.pem
+          value_classification: plain
+        - name: SSL_KEY
+          provenance: compose
+          value: /etc/ssl/filebeat.key
+          value_classification: plain
+        - name: API_USERNAME
+          provenance: compose
+          value_classification: redacted
+        - name: API_PASSWORD
+          provenance: compose
+          value_classification: redacted
+      operational_policy:
+        restart: always
+        resource_limits:
+          memory: 1073741824
+      container:
+        entrypoint:
+          - /bin/bash
+          - -c
+          - cp /tmp/filebeat-override.yml /etc/filebeat/filebeat.yml && chown root:root /etc/filebeat/filebeat.yml && python3 /docker-entrypoint-initdb.d/patch-rule-path.py 2>/dev/null; exec /init
+        command: []
+        runtime_name: runc
+      health:
+        status: unknown
+        description: 'Compose healthcheck: curl -ks https://localhost:55000 || exit 1 with interval 30s, timeout 10s, retries 5, start_period 120s.'
+      network:
+        hostname: wazuh.manager
+        domainname: ''
+        endpoints:
+          - network: security-net
+            ip_address: 172.20.0.10
+            ip_prefix_length: 24
+            gateway: 172.20.0.1
+            backend:
+              driver: bridge
+              ipam_driver: default
+              driver_options: {}
+              ipam_options: {}
+          - network: dmz-net
+            ip_address: 172.20.1.10
+            ip_prefix_length: 24
+            gateway: 172.20.1.1
+            backend:
+              driver: bridge
+              ipam_driver: default
+              driver_options: {}
+              ipam_options: {}
+          - network: internal-net
+            ip_address: 172.20.2.30
+            ip_prefix_length: 24
+            gateway: 172.20.2.1
+            backend:
+              driver: bridge
+              ipam_driver: default
+              driver_options: {}
+              ipam_options: {}
+        published_ports:
+          - container_port: 1514
+            protocol: tcp
+            host_port: 1514
+          - container_port: 1515
+            protocol: tcp
+            host_port: 1515
+          - container_port: 514
+            protocol: udp
+            host_port: 514
+          - container_port: 55000
+            protocol: tcp
+            host_port: 55000
 
   webapp:
     type: VM
@@ -38423,22 +40183,31 @@ nodes:
 infrastructure:
   dmz-net:
     count: 1
-    properties: {cidr: 172.20.1.0/24, gateway: 172.20.1.1}
+    properties: {cidr: 172.20.1.0/24, gateway: 172.20.1.1, internal: true}
   internal-net:
     count: 1
     properties: {cidr: 172.20.2.0/24, gateway: 172.20.2.1, internal: true}
   security-net:
     count: 1
-    properties: {cidr: 172.20.0.0/24, gateway: 172.20.0.1, internal: true}
+    properties: {cidr: 172.20.0.0/24, gateway: 172.20.0.1}
   db:
     count: 1
     links:
     - internal-net
     properties:
     - internal-net: 172.20.2.11
-  wazuh-manager:
+  shuffle-backend:
     count: 1
     links: [security-net]
+    properties:
+      - {security-net: 172.20.0.20}
+  wazuh-manager:
+    count: 1
+    links: [security-net, dmz-net, internal-net]
+    properties:
+      - {security-net: 172.20.0.10}
+      - {dmz-net: 172.20.1.10}
+      - {internal-net: 172.20.2.30}
   webapp:
     count: 1
     links: [dmz-net, internal-net]
@@ -38449,7 +40218,7 @@ infrastructure:
 
   redteam-net:
     count: 1
-    properties: {cidr: 172.20.4.0/24, gateway: 172.20.4.1}
+    properties: {cidr: 172.20.4.0/24, gateway: 172.20.4.1, internal: true}
   kali:
     count: 1
     links: [redteam-net, dmz-net, internal-net]
@@ -38528,6 +40297,13 @@ conditions:
     timeout: 5
     retries: 5
     start_period: 15
+  wazuh-api-ready:
+    command: curl -ks https://localhost:55000 || exit 1
+    interval: 30
+    timeout: 10
+    retries: 5
+    start_period: 120
+
   webapp-http-ready:
     command: curl -sf http://localhost:8080/ || exit 1
     interval: 15

--- a/tests/test_aces_inventory_methodology.py
+++ b/tests/test_aces_inventory_methodology.py
@@ -184,10 +184,10 @@ def test_mapping_ledger_validates_and_tracks_gap_handoff():
     result = validate_mapping_ledger(SHUFFLE_DIR)
     assert result.ok, result.errors
     assert result.fact_count == 9
-    assert result.encoded_count == 4
-    assert result.blocked_count == 5
+    assert result.encoded_count == 9
+    assert result.blocked_count == 0
     assert result.triage_count == 0
-    assert result.gap_issues == ["ACES #354"]
+    assert result.gap_issues == []
     assert result.warnings == ["supply-chain attestations captured but not verified"]
 
     ledger = load_mapping_ledger(LEDGER_PATH)
@@ -199,25 +199,16 @@ def test_mapping_ledger_validates_and_tracks_gap_handoff():
     assert len(ledger["correspondence_checks"]) == 2
     dispositions = {fact["id"]: fact["aces"]["disposition"] for fact in ledger["facts"]}
     assert dispositions["shuffle-backend.image.identity"] == "encoded"
-    assert dispositions["shuffle-backend.network.identity"] == "encoded_with_caveat"
-    assert dispositions["shuffle-backend.docker.socket"] == "blocked_by_aces_gap"
+    assert dispositions["shuffle-backend.network.identity"] == "encoded"
+    assert dispositions["shuffle-backend.docker.socket"] == "encoded"
+    assert set(dispositions.values()) == {"encoded"}
     assert all(fact["evidence"] for fact in ledger["facts"])
 
 
-def test_gap_report_surfaces_aces_354_without_semantic_misuse():
+def test_gap_report_has_no_remaining_shuffle_backend_aces_gaps():
     report = gap_report(SHUFFLE_DIR)
-    gap_ids = {gap["fact_id"] for gap in report["gaps"]}
-    assert gap_ids == {
-        "shuffle-backend.data.mount",
-        "shuffle-backend.docker.socket",
-        "shuffle-backend.process.identity",
-        "shuffle-backend.package.inventory",
-        "shuffle-backend.vulnerability.scan-state",
-    }
+    assert report["gaps"] == []
     assert not report["triage_needed"]
-    for gap in report["gaps"]:
-        assert gap["gap_issue"]["number"] == 354
-        assert "why_not_current_surfaces" in gap
 
 
 def test_mapping_ledger_schema_is_formalized_for_iteration():
@@ -237,7 +228,7 @@ def test_aces_inventory_cli_validates_and_lists_gaps():
     )
     assert validate_result.exit_code == 0
     assert "Inventory ledger OK" in validate_result.stdout
-    assert "facts=9 encoded=4 blocked=5 triage=0" in validate_result.stdout
+    assert "facts=9 encoded=9 blocked=0 triage=0" in validate_result.stdout
     assert "warning: supply-chain attestations captured but not verified" in (
         validate_result.stdout
     )
@@ -245,7 +236,8 @@ def test_aces_inventory_cli_validates_and_lists_gaps():
     gaps_result = runner.invoke(app, ["aces-inventory", "gaps", str(SHUFFLE_DIR)])
     assert gaps_result.exit_code == 0
     assert "Inventory gaps for shuffle-backend" in gaps_result.stdout
-    assert "ACES #354" in gaps_result.stdout
+    assert "blocked=0 triage=0" in gaps_result.stdout
+    assert "ACES #354" not in gaps_result.stdout
 
     schema_result = runner.invoke(app, ["aces-inventory", "schema"])
     assert schema_result.exit_code == 0

--- a/tests/test_techvault_classification_audit.py
+++ b/tests/test_techvault_classification_audit.py
@@ -1,0 +1,202 @@
+"""Regression checks for the TechVault SDL classification audit fixes."""
+
+from pathlib import Path
+import json
+
+import pytest
+import yaml
+
+
+pytestmark = pytest.mark.integration
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TECHVAULT_SDL_PATH = PROJECT_ROOT / "scenarios" / "techvault.sdl.yaml"
+COMPOSE_PATH = PROJECT_ROOT / "docker-compose.yml"
+PARITY_PATH = PROJECT_ROOT / "docs" / "aces" / "parity-inventory.yaml"
+SHUFFLE_EVIDENCE = PROJECT_ROOT / "docs" / "aces" / "inventory" / "shuffle-backend" / "evidence"
+
+
+def _yaml(path: Path):
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _json(path: Path):
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _rows() -> dict[str, dict]:
+    return {row["id"]: row for row in _yaml(PARITY_PATH)["rows"]}
+
+
+def test_shuffle_backend_runtime_inventory_is_encoded_from_evidence():
+    sdl = _yaml(TECHVAULT_SDL_PATH)
+    node = sdl["nodes"]["shuffle-backend"]
+    runtime = node["runtime"]
+    container = _json(SHUFFLE_EVIDENCE / "docker-inspect.container.json")[0]
+    findings = _json(SHUFFLE_EVIDENCE / "trivy-vulnerability-list.json")
+
+    assert node["source"]["version"] == (
+        "ghcr.io/shuffle/shuffle-backend@"
+        "sha256:271b38ba5d2c68579f0d75b43d294b65626f57a7878eef545b8021c07b3e178d"
+    )
+    assert node["os_version"] == "Alpine Linux 3.22.2"
+    assert node["services"] == [{"port": 5001, "protocol": "tcp", "name": "shuffle-api"}]
+
+    mounts = {mount["target"]: mount for mount in runtime["mounts"]}
+    assert mounts["/shuffle-database"]["source_kind"] == "volume"
+    assert mounts["/shuffle-database"]["source"] == "aptl_shuffle_data"
+    assert mounts["/var/run/docker.sock"]["source_kind"] == "bind"
+    assert mounts["/var/run/docker.sock"]["read_only"] is False
+
+    controls = {item["path"]: item for item in runtime["local_control_interfaces"]}
+    assert controls["/var/run/docker.sock"]["access"] == "read_write"
+    assert runtime["process"]["command"] == ["./shufflebackend"]
+    assert runtime["process"]["user"] == "root"
+    assert len(runtime["packages"]) == 21
+    assert len(runtime["package_vulnerabilities"]) == len(findings) == 86
+    assert {finding["severity"] for finding in runtime["package_vulnerabilities"]} == {
+        "critical",
+        "high",
+        "medium",
+        "low",
+    }
+
+    endpoint = runtime["network"]["endpoints"][0]
+    observed = container["NetworkSettings"]["Networks"]["aptl_aptl-security"]
+    assert endpoint["network"] == "security-net"
+    assert endpoint["ip_address"] == observed["IPAddress"] == "172.20.0.20"
+    assert endpoint["aliases"] == observed["Aliases"]
+
+    secret_env = {
+        item["name"]: item
+        for item in runtime["environment"]
+        if item["value_classification"] == "redacted"
+    }
+    assert set(secret_env) == {
+        "SHUFFLE_DEFAULT_APIKEY",
+        "SHUFFLE_DEFAULT_PASSWORD",
+        "SHUFFLE_OPENSEARCH_PASSWORD",
+    }
+    assert all("value" not in item for item in secret_env.values())
+
+
+def test_wazuh_manager_sdl_matches_compose_visible_surfaces():
+    sdl = _yaml(TECHVAULT_SDL_PATH)
+    compose = _yaml(COMPOSE_PATH)
+    node = sdl["nodes"]["wazuh-manager"]
+    runtime = node["runtime"]
+    service = compose["services"]["wazuh.manager"]
+
+    service_bindings = {(item["port"], item["protocol"]) for item in node["services"]}
+    assert service_bindings == {(1514, "tcp"), (1515, "tcp"), (514, "udp"), (55000, "tcp")}
+    assert node["conditions"] == {"wazuh-api-ready": "wazuh-root"}
+    assert sdl["conditions"]["wazuh-api-ready"]["command"] == (
+        "curl -ks https://localhost:55000 || exit 1"
+    )
+
+    infra = sdl["infrastructure"]["wazuh-manager"]
+    assert infra["links"] == ["security-net", "dmz-net", "internal-net"]
+    assert infra["properties"] == [
+        {"security-net": "172.20.0.10"},
+        {"dmz-net": "172.20.1.10"},
+        {"internal-net": "172.20.2.30"},
+    ]
+
+    endpoints = {endpoint["network"]: endpoint for endpoint in runtime["network"]["endpoints"]}
+    assert endpoints["security-net"]["ip_address"] == service["networks"]["aptl-security"]["ipv4_address"]
+    assert endpoints["dmz-net"]["ip_address"] == service["networks"]["aptl-dmz"]["ipv4_address"]
+    assert endpoints["internal-net"]["ip_address"] == service["networks"]["aptl-internal"]["ipv4_address"]
+    assert {port["container_port"] for port in runtime["network"]["published_ports"]} == {
+        1514,
+        1515,
+        514,
+        55000,
+    }
+
+    mount_targets = {mount["target"] for mount in runtime["mounts"]}
+    assert {
+        "/var/ossec/etc/decoders/samba_decoders.xml",
+        "/var/ossec/etc/decoders/postgresql_decoders.xml",
+        "/var/ossec/etc/rules/ad_rules.xml",
+        "/var/ossec/etc/rules/webapp_rules.xml",
+        "/var/ossec/etc/rules/suricata_rules.xml",
+        "/var/ossec/etc/rules/database_rules.xml",
+        "/wazuh-config-mount/etc/ossec.conf",
+    } <= mount_targets
+
+    filesystem = {entry["path"]: entry for entry in runtime["filesystem_inventory"]}
+    assert filesystem["/var/ossec/etc/rules/webapp_rules.xml"]["source_path"] == (
+        "config/wazuh_cluster/webapp_rules.xml"
+    )
+    assert filesystem["/wazuh-config-mount/etc/ossec.conf"]["sensitivity"] == "operator_secret"
+
+    env = {item["name"]: item for item in runtime["environment"]}
+    for name in ("INDEXER_PASSWORD", "API_PASSWORD"):
+        assert env[name]["value_classification"] == "redacted"
+        assert "value" not in env[name]
+
+
+def test_switch_network_internal_flags_match_compose():
+    sdl = _yaml(TECHVAULT_SDL_PATH)
+    compose = _yaml(COMPOSE_PATH)
+    network_map = {
+        "aptl-security": "security-net",
+        "aptl-dmz": "dmz-net",
+        "aptl-internal": "internal-net",
+        "aptl-redteam": "redteam-net",
+    }
+
+    for compose_name, sdl_name in network_map.items():
+        compose_internal = bool(compose["networks"][compose_name].get("internal", False))
+        sdl_internal = bool(
+            sdl["infrastructure"][sdl_name]["properties"].get("internal", False)
+        )
+        assert sdl_internal == compose_internal, (compose_name, sdl_name)
+
+
+def test_techvault_sdl_compiles_with_audit_fix_nodes():
+    from aces_processor.compiler import compile_runtime_model
+    from aces_sdl import parse_sdl_file
+
+    scenario = parse_sdl_file(TECHVAULT_SDL_PATH)
+    model = compile_runtime_model(scenario)
+
+    shuffle = model.node_deployments["provision.node.shuffle-backend"].spec["node"]
+    wazuh = model.node_deployments["provision.node.wazuh-manager"].spec["node"]
+    assert len(shuffle["runtime"]["package_vulnerabilities"]) == 86
+    assert [endpoint["network"] for endpoint in wazuh["runtime"]["network"]["endpoints"]] == [
+        "security-net",
+        "dmz-net",
+        "internal-net",
+    ]
+
+
+def test_parity_inventory_rows_no_longer_route_node_state_to_backend_only():
+    rows = _rows()
+
+    assert rows["scen.techvault.shuffle-backend-inventory"]["category"] == "aces_sdl"
+    assert rows["scen.techvault.shuffle-backend-inventory"]["blocking_followup"] == "n/a"
+    assert rows["compose.service.shuffle-backend"]["category"] == "aces_sdl"
+    assert rows["compose.service.shuffle-backend"]["blocking_followup"] == "n/a"
+
+    assert rows["scen.techvault.wazuh-manager-inventory"]["category"] == "aces_sdl"
+    assert rows["compose.service.wazuh-manager"]["category"] == "aces_sdl"
+    assert rows["compose.service.wazuh-manager"]["blocking_followup"] == "n/a"
+
+    assert rows["compose.service.webapp"]["blocking_followup"] == "n/a"
+    for row_id in (
+        "compose.network.aptl-security",
+        "compose.network.aptl-dmz",
+        "compose.network.aptl-internal",
+        "compose.network.aptl-redteam",
+    ):
+        assert rows[row_id]["category"] == "aces_sdl"
+        assert rows[row_id]["blocking_followup"] == "n/a"
+
+    assert rows["compose.profile.soc"]["category"] == "aptl_backend_responsibility"
+    assert "delivery toggle" in rows["compose.profile.soc"]["notes"]
+    assert rows["compose.profile.enterprise"]["category"] == "aptl_backend_responsibility"
+    assert "delivery toggle" in rows["compose.profile.enterprise"]["notes"]
+    assert rows["compose.volumes.summary"]["category"] == "validation_gate"

--- a/tests/test_techvault_classification_audit.py
+++ b/tests/test_techvault_classification_audit.py
@@ -95,6 +95,7 @@ def test_wazuh_manager_sdl_matches_compose_visible_surfaces():
     assert sdl["conditions"]["wazuh-api-ready"]["command"] == (
         "curl -ks https://localhost:55000 || exit 1"
     )
+    assert "health" not in runtime
 
     infra = sdl["infrastructure"]["wazuh-manager"]
     assert infra["links"] == ["security-net", "dmz-net", "internal-net"]


### PR DESCRIPTION
## Summary

Resolves the TechVault SDL scenario-vs-delivery classification audit requested by #369.

## Requirement UIDs

- (none - issue #369 has no Ground Control `## Requirements` section)

## Related Issues

Closes #369

## ADR Impact

- ADR-021

## Changes

- Encodes `shuffle-backend` as a TechVault SDL node with image identity, runtime mounts, Docker socket control interface, process identity, network identity, packages, Go manifest, and Trivy package vulnerability state.
- Expands `wazuh-manager` SDL state with the API service on 55000/tcp, three network attachments, `conditions.wazuh-api-ready` health contract, environment policy, mounts, and custom decoder/rule content.
- Removes the Wazuh `runtime.health.status: unknown` observation so the SDL keeps declarative health requirements separate from observed realization evidence; the broader ACES boundary follow-up is tracked in Brad-Edwards/aces#417.
- Aligns switch-network `internal` metadata with `docker-compose.yml`.
- Updates the Shuffle mapping ledger and parity inventory so node-local scenario state is not routed as backend-only delivery state.
- Adds regression coverage for the classification-audit fixes and updates the changelog fragment.

## Ground Control Checks

- Requirements in scope: none.
- IMPLEMENTS: `ADR-021 <- scenarios/techvault.sdl.yaml`
- IMPLEMENTS: `ADR-021 <- docs/aces/techvault-sdl-classification-audit.md`
- IMPLEMENTS: `ADR-021 <- docs/aces/parity-inventory.yaml`
- IMPLEMENTS: `ADR-021 <- docs/aces/inventory/shuffle-backend/mapping-ledger.yaml`
- IMPLEMENTS: `ADR-021 <- changelog.d/369.added.md`
- TESTS: `ADR-021 <- tests/test_techvault_classification_audit.py`
- TESTS: `ADR-021 <- tests/test_aces_inventory_methodology.py`
- TESTS: `ADR-021 <- pre-commit run --all-files`
- TESTS: `ADR-021 <- uv run pytest`

## Validation

- `uv run pytest tests/test_techvault_classification_audit.py tests/test_aces_inventory_methodology.py tests/test_parity_inventory.py tests/test_webapp_inventory.py::test_parity_inventory_cites_webapp_inventory_and_aces_sdl -q` - 40 passed.
- `uv run pytest tests/test_db_inventory.py tests/test_webapp_inventory.py tests/test_kali_inventory.py tests/test_ad_inventory.py tests/test_aces_inventory_methodology.py tests/test_techvault_classification_audit.py tests/test_parity_inventory.py -q` - 123 passed.
- `uv run pytest` - 1773 passed, 181 skipped, 22 deselected, 1 xfailed.
- `pre-commit run --all-files` - passed.
- GitHub Actions checks - passed, including SonarCloud Code Analysis and SonarCloud quality gate.

## Reviews

- Codex production-readiness review: clean before remediation commit; no PR review-thread blockers are open.
- Test-quality review: clean before remediation commit; new regression tests and CI are green after commit 69b8b37.
