### PR TITLE
Harden redaction layer and service resilience (#386 fix-now tranche)

### DIFF
--- a/changelog.d/386.fixed.md
+++ b/changelog.d/386.fixed.md
@@ -1,0 +1,8 @@
+### Fixed
+
+The MISP→Suricata sync service (`aptl-misp-suricata-sync`) no longer dies
+silently when a single sync tick fails. A write error (e.g. disk full), a
+malformed MISP payload, or a Suricata reloader exception previously propagated
+out of the run loop and killed the long-running daemon, silently stopping IOC
+enforcement. The loop now catches a failing tick, logs it with a traceback, and
+retries on the next interval.

--- a/changelog.d/386.security.md
+++ b/changelog.d/386.security.md
@@ -1,0 +1,24 @@
+### Security
+
+Hardened the shared redaction layer (`aptl.utils.redaction` and
+`mcp/aptl-mcp-common/src/redaction.ts`), which masks secret-shaped values at
+every serialization boundary (ADR-029):
+
+- **ReDoS eliminated.** The impacket positional `user:pass@host` matchers
+  backtracked quadratically on long flag-like tokens, so a single crafted
+  artifact could hang the redactor. A leading token-boundary anchor makes them
+  linear; a length cap bounds the remaining command-flag passes.
+- **Fail-closed recursion.** Deeply nested input raised `RecursionError`
+  (fail-open) at the secret boundary; redaction is now depth-bounded and
+  collapses an over-deep subtree to `[REDACTED]` instead of crashing.
+- **`bytes`/`Buffer` no longer bypass redaction** — binary payloads are decoded
+  and scanned instead of passing through verbatim.
+- **Cross-language parity gate.** A shared golden corpus
+  (`tests/fixtures/redaction_parity_corpus.json`) is now run by both the Python
+  (`pytest`) and TypeScript (`vitest`) suites, so the two ~950-line redactors
+  can no longer drift apart silently.
+
+SSH command-timeout and failure messages (`mcp/aptl-mcp-common/src/ssh.ts`) now
+redact embedded credentials before the command text reaches stderr, so a
+timed-out `hydra -p <pw>` no longer leaks the password ahead of the MCP
+serialization boundary.

--- a/mcp/aptl-mcp-common/src/redaction.ts
+++ b/mcp/aptl-mcp-common/src/redaction.ts
@@ -13,6 +13,22 @@
 
 export const REDACTED = '[REDACTED]';
 
+// Defense-in-depth bounds for the redactor itself (issue #386, ARCH-386-01).
+// These cap worst-case work at the secret boundary so a hostile or
+// pathological artifact cannot turn redaction into a denial-of-service or a
+// fail-open crash. Both bounds fail CLOSED (over-redact, never leak), matching
+// the ADR-012 guardrail. Mirror any change in `redaction.py`.
+//
+// MAX_SCAN_LEN bounds the polynomial-backtracking command-flag passes (the
+// `--<word>*<sensitive>` flag matcher and the per-segment shell scanners).
+// Strings longer than this skip those passes (the linear key/value/header/
+// PEM/bearer/URL passes still run), keeping CPU bounded.
+const MAX_SCAN_LEN = 64 * 1024;
+// MAX_DEPTH bounds recursion through nested objects/arrays/JSON-in-strings so
+// a deeply nested artifact collapses to a bounded marker instead of
+// overflowing the call stack. Matches the Python bound.
+const MAX_DEPTH = 100;
+
 // OBS-003 experimenter opt-out. The toggle is NOT consulted by the
 // shared `redact()` primitive — that would disable redaction at
 // every serialization boundary in the project (OTel/Tempo spans
@@ -705,7 +721,10 @@ type ReplaceEntry = [RegExp, string | ((...args: unknown[]) => string)];
 // hunter2`, which then triggered `redactShortPasswordFlag`); it now
 // lives inside `redactString` behind a segment-scoped tool gate. See
 // `unquoteOptionsInCredentialSegments`.
-const STATIC_REDACTION_TABLE: ReplaceEntry[] = [
+// Linear, single-quantifier passes — ReDoS-safe at any input length and so
+// run unconditionally. The polynomial-backtracking passes (CLI_FLAG_PATTERN
+// and the per-segment command-flag chain) are length-gated in `redactString`.
+const LINEAR_REDACTION_TABLE: ReplaceEntry[] = [
   // PEM blocks first so the surrounding markers stay verbatim.
   [PEM_BLOCK_PATTERN, `$1${REDACTED}$2`],
   // Authorization next so it wins over the more general patterns.
@@ -713,17 +732,16 @@ const STATIC_REDACTION_TABLE: ReplaceEntry[] = [
   [COOKIE_HEADER_PATTERN, `$1${REDACTED}$3`],
   [SENSITIVE_KV_PATTERN, `$1${REDACTED}$3`],
   [BARE_BEARER_PATTERN, `$1${REDACTED}`],
-  [CLI_FLAG_PATTERN, `$1${REDACTED}`],
   [URL_USERINFO_PATTERN, `$1${REDACTED}$2`],
 ];
 
-function tryRedactJsonString(value: string): string | null {
+function tryRedactJsonString(value: string, depth: number): string | null {
   const trimmed = value.trim();
   if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null;
   try {
     const parsed: unknown = JSON.parse(value);
     if (parsed !== null && typeof parsed === 'object') {
-      return JSON.stringify(redact(parsed));
+      return JSON.stringify(redactInner(parsed, depth + 1));
     }
   } catch {
     // Fall through to inline-pattern scanning.
@@ -731,28 +749,33 @@ function tryRedactJsonString(value: string): string | null {
   return null;
 }
 
-function redactString(value: string): string {
-  const jsonRedacted = tryRedactJsonString(value);
+function redactString(value: string, depth: number): string {
+  const jsonRedacted = tryRedactJsonString(value, depth);
   if (jsonRedacted !== null) return jsonRedacted;
   let out = value;
-  for (const [pattern, replacement] of STATIC_REDACTION_TABLE) {
+  for (const [pattern, replacement] of LINEAR_REDACTION_TABLE) {
     out = out.replaceAll(
       pattern,
       replacement as Parameters<typeof out.replaceAll>[1],
     );
   }
-  // Tool-context-aware short flags run last so the simpler kv/flag
-  // patterns above have first claim on overlapping shapes. The
-  // segment-scoped quote-strip (replaces the old global one) unquotes
-  // `'-X'`/`"-X"` option tokens *only* within credential-bearing
-  // segments so `hydra '-p' hunter2` triggers the per-flag matcher
-  // while `echo '-p' hunter2` is preserved verbatim.
-  out = unquoteOptionsInCredentialSegments(out);
-  out = redactShortPasswordFlag(out);
-  out = redactNtlmHashFlag(out);
-  out = redactLdapPasswordFlag(out);
-  out = redactBasicAuthUser(out);
-  out = redactImpacketPositionalAuth(out);
+  // Polynomial-backtracking passes are length-gated to cap worst-case CPU at
+  // the secret boundary (ARCH-386-01). Oversized strings skip them; the
+  // linear passes above already masked the key/value/header/PEM/bearer/URL
+  // secret shapes. Tool-context-aware short flags run last so the simpler
+  // kv/flag patterns have first claim on overlapping shapes. The
+  // segment-scoped quote-strip unquotes `'-X'`/`"-X"` option tokens *only*
+  // within credential-bearing segments so `hydra '-p' hunter2` triggers the
+  // per-flag matcher while `echo '-p' hunter2` is preserved verbatim.
+  if (out.length <= MAX_SCAN_LEN) {
+    out = out.replaceAll(CLI_FLAG_PATTERN, `$1${REDACTED}`);
+    out = unquoteOptionsInCredentialSegments(out);
+    out = redactShortPasswordFlag(out);
+    out = redactNtlmHashFlag(out);
+    out = redactLdapPasswordFlag(out);
+    out = redactBasicAuthUser(out);
+    out = redactImpacketPositionalAuth(out);
+  }
   return out;
 }
 
@@ -789,9 +812,20 @@ function redactString(value: string): string {
 // backslash so the alternatives are mutually exclusive. `@` is also
 // excluded so the pattern stops at the host separator without needing
 // laziness, which removes another backtracking source.
-const IMPACKET_POSITIONAL_DQUOTE = /([\w\\/.-]+):"([^"\\]*(?:\\.[^"\\]*)*)"@([\w.-]+)(?=\s|$|[;|&])/g;
-const IMPACKET_POSITIONAL_SQUOTE = /([\w\\/.-]+):'([^'\\]*(?:\\.[^'\\]*)*)'@([\w.-]+)(?=\s|$|[;|&])/g;
-const IMPACKET_POSITIONAL_BARE = /([\w\\/.-]+):((?:\\.|[^\\@\s])+)@([\w.-]+)(?=\s|$|[;|&])/g;
+// A leading token-boundary lookbehind `(?<![\w\\/.:@-])` eliminates the
+// O(n^2) ReDoS these patterns exhibited (ARCH-386-01 / redact-01): without
+// it the engine re-tried the match at every offset inside a long flag-like
+// token (`hydra --aaaa…` or `aaaa:bbbb` with no `@`), each attempt scanning
+// the rest of the token. The lookbehind forbids starting a match in the
+// middle of a target token, collapsing attempts from O(n) offsets to
+// O(tokens), while still allowing a match to begin after whitespace,
+// `;`/`|`/`&`, `=`, or a quote — exactly where an impacket positional target
+// legitimately starts. Zero-width and non-capturing, so groups 1/2/3 stay
+// user/value/host. Mirrors `redaction.py`; parity is verified by the shared
+// golden corpus.
+const IMPACKET_POSITIONAL_DQUOTE = /(?<![\w\\/.:@-])([\w\\/.-]+):"([^"\\]*(?:\\.[^"\\]*)*)"@([\w.-]+)(?=\s|$|[;|&])/g;
+const IMPACKET_POSITIONAL_SQUOTE = /(?<![\w\\/.:@-])([\w\\/.-]+):'([^'\\]*(?:\\.[^'\\]*)*)'@([\w.-]+)(?=\s|$|[;|&])/g;
+const IMPACKET_POSITIONAL_BARE = /(?<![\w\\/.:@-])([\w\\/.-]+):((?:\\.|[^\\@\s])+)@([\w.-]+)(?=\s|$|[;|&])/g;
 
 const IMPACKET_TOOL_REGEXES: readonly RegExp[] = [
   /(^|[\s|;&])(?:[\w./-]+\/)?(impacket-[\w-]+)(?:\s|$)/i,
@@ -879,7 +913,7 @@ function argvShortFlagSkipIndices(
   return skip;
 }
 
-function redactArray(items: unknown[]): unknown[] {
+function redactArray(items: unknown[], depth: number): unknown[] {
   // Argv-shape detection: when the leading token is a credential-family
   // tool, mark indices whose values should be redacted as short-flag
   // credentials (-p/-H/-w/-u/-U). Without this, a structured
@@ -902,7 +936,7 @@ function redactArray(items: unknown[]): unknown[] {
       out.push(REDACTED);
       continue;
     }
-    out.push(redact(items[i]));
+    out.push(redactInner(items[i], depth + 1));
     // Pair-form CLI args: ["--password", "hunter2"]. If this string is a
     // long-flag whose name is sensitive AND the next element is a string,
     // redact the next element as the value-of-flag.
@@ -938,18 +972,35 @@ export function redact(value: unknown): unknown {
   // themselves before invoking `redact`. This keeps OTel/Tempo,
   // runstore, snapshot, and stderr boundaries redacted at all
   // times regardless of the toggle.
+  //
+  // Recursion is depth-bounded and fails CLOSED — a structure deeper than
+  // MAX_DEPTH collapses to `[REDACTED]` rather than overflowing the stack
+  // (ARCH-386-01).
+  return redactInner(value, 0);
+}
+
+function redactInner(value: unknown, depth: number): unknown {
+  if (depth >= MAX_DEPTH) return REDACTED;
   if (Array.isArray(value)) {
-    return redactArray(value);
+    return redactArray(value, depth);
+  }
+  // Binary payloads (Buffer / typed arrays) are not JSON-serializable and may
+  // carry secret material; decode and scan as a string so embedded
+  // credentials are masked and the result is JSON-safe (mirrors the Python
+  // bytes handling, ARCH-386-01 / redact-03). Checked before the generic
+  // object branch, which would otherwise spread the bytes into an index map.
+  if (value instanceof Uint8Array) {
+    return redactString(Buffer.from(value).toString('utf-8'), depth);
   }
   if (value !== null && typeof value === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = isSensitiveKey(k) ? REDACTED : redact(v);
+      out[k] = isSensitiveKey(k) ? REDACTED : redactInner(v, depth + 1);
     }
     return out;
   }
   if (typeof value === 'string') {
-    return redactString(value);
+    return redactString(value, depth);
   }
   return value;
 }

--- a/mcp/aptl-mcp-common/src/ssh.ts
+++ b/mcp/aptl-mcp-common/src/ssh.ts
@@ -5,6 +5,16 @@ import { EventEmitter } from 'events';
 import { randomBytes } from 'node:crypto';
 import { ShellFormatter, ShellType, createShellFormatter } from './shells.js';
 import { createPtyTeeWriter, loadActiveTraceId } from './runs.js';
+import { redact } from './redaction.js';
+
+// Mask embedded credentials before putting a command into an error message.
+// Command-timeout / failure SSHError strings can reach stderr (console.error)
+// or a raw rejection ahead of the MCP serialization boundary's redaction, so
+// `hydra -p hunter2 …` would otherwise leak the password (ARCH-386-08 /
+// sec-02). `redact` leaves credential-free commands intact for debugging.
+function redactCommand(command: string): string {
+  return redact(command) as string;
+}
 
 /**
  * OBS-003: env vars passed to the SSH shell via `SendEnv`/`shell({env})`
@@ -439,7 +449,7 @@ export class PersistentSession extends EventEmitter {
         this.commandTimeout = setTimeout(() => {
           if (this.currentCommand?.id === commandId) {
             this.commandTimeout = null;
-            this.currentCommand!.reject(new SSHError(`Command timeout: ${this.currentCommand!.command}`));
+            this.currentCommand!.reject(new SSHError(`Command timeout: ${redactCommand(this.currentCommand!.command)}`));
             this.currentCommand = null;
             this.processNextCommand();
           }
@@ -760,7 +770,7 @@ export class SSHConnectionManager {
 
       const timeoutId = setTimeout(() => {
         hasTimedOut = true;
-        reject(new SSHError(`Command timeout after ${timeout}ms: ${command}`));
+        reject(new SSHError(`Command timeout after ${timeout}ms: ${redactCommand(command)}`));
       }, timeout);
 
       client.exec(command, { env: shellEnv }, (err, stream) => {

--- a/mcp/aptl-mcp-common/src/ssh.ts
+++ b/mcp/aptl-mcp-common/src/ssh.ts
@@ -447,9 +447,10 @@ export class PersistentSession extends EventEmitter {
       if (this.currentCommand.timeout) {
         const commandId = this.currentCommand.id;
         this.commandTimeout = setTimeout(() => {
-          if (this.currentCommand?.id === commandId) {
+          const current = this.currentCommand;
+          if (current?.id === commandId) {
             this.commandTimeout = null;
-            this.currentCommand!.reject(new SSHError(`Command timeout: ${redactCommand(this.currentCommand!.command)}`));
+            current.reject(new SSHError(`Command timeout: ${redactCommand(current.command)}`));
             this.currentCommand = null;
             this.processNextCommand();
           }

--- a/mcp/aptl-mcp-common/tests/redaction.parity.test.ts
+++ b/mcp/aptl-mcp-common/tests/redaction.parity.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Cross-language parity gate for the redaction layer (issue #386).
+ *
+ * The shared corpus at `tests/fixtures/redaction_parity_corpus.json` (repo
+ * root) is consumed by BOTH this vitest module and the Python
+ * `tests/test_redaction_parity.py`. Each case pins an input to its expected
+ * redacted output; the TypeScript and Python redactors must each reproduce it
+ * exactly. If the two ~950-LOC hand-maintained implementations' secret
+ * patterns drift apart, one side's parity test fails — closing the silent
+ * divergence hazard (ARCH-386-01 redact-05 / dup-01) that ADR-035 forbids
+ * (no second redaction taxonomy).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { redact } from '../src/redaction.js';
+
+interface ParityCase {
+  name: string;
+  input: unknown;
+  expected: unknown;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+// tests/ -> aptl-mcp-common/ -> mcp/ -> repo root, then tests/fixtures.
+const corpusPath = join(
+  here,
+  '..',
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'redaction_parity_corpus.json',
+);
+const corpus = JSON.parse(readFileSync(corpusPath, 'utf-8')) as ParityCase[];
+
+describe('redaction cross-language parity corpus (issue #386)', () => {
+  it('corpus is non-empty', () => {
+    // Guard against a truncated/empty fixture silently passing the gate.
+    expect(corpus.length).toBeGreaterThanOrEqual(40);
+  });
+
+  for (const testCase of corpus) {
+    it(testCase.name, () => {
+      expect(redact(testCase.input)).toEqual(testCase.expected);
+    });
+  }
+});

--- a/mcp/aptl-mcp-common/tests/redaction.test.ts
+++ b/mcp/aptl-mcp-common/tests/redaction.test.ts
@@ -824,3 +824,85 @@ describe('APTL_EXPERIMENT_NO_REDACT scoped opt-out (cycle 3 finding-9)', () => {
     expect(experimentNoRedactActive({ [ENV_KEY]: '1' })).toBe(true);
   });
 });
+
+describe('redactor defense-in-depth bounds (issue #386, ARCH-386-01)', () => {
+  // Cleanly separates the linear path (ms) from a reintroduced O(n^2)
+  // backtracking regression (seconds at these sizes) without flaking on CI.
+  const BUDGET_MS = 3000;
+
+  function elapsedMs(fn: () => void): number {
+    const start = performance.now();
+    fn();
+    return performance.now() - start;
+  }
+
+  it('impacket positional with no terminating @ is linear, not ReDoS', () => {
+    const payload = 'impacket-psexec ' + 'a'.repeat(20000) + ':' + 'b'.repeat(20000);
+    expect(elapsedMs(() => redact(payload))).toBeLessThan(BUDGET_MS);
+  });
+
+  it('a long flag-like token is bounded, not ReDoS', () => {
+    const payload = 'hydra --' + 'a'.repeat(40000) + ' target';
+    expect(elapsedMs(() => redact(payload))).toBeLessThan(BUDGET_MS);
+  });
+
+  it('still redacts a valid impacket positional target', () => {
+    expect(redact('psexec.py corp/alice:S3cr3t@dc01.lab.local x')).toBe(
+      'psexec.py corp/alice:[REDACTED]@dc01.lab.local x',
+    );
+    expect(redact('echo hello:world@notatool')).toBe('echo hello:world@notatool');
+  });
+
+  it('oversized input is bounded and still redacts linear key/value secrets', () => {
+    const payload =
+      'psexec.py ' + 'a'.repeat(90000) + ':' + 'b'.repeat(90000) + ' password=hunter2';
+    let out = '';
+    const ms = elapsedMs(() => {
+      out = redact(payload) as string;
+    });
+    expect(ms).toBeLessThan(BUDGET_MS);
+    expect(out).not.toContain('password=hunter2');
+    expect(out).toContain(`password=${REDACTED}`);
+  });
+
+  it('deeply nested object fails closed without a stack overflow', () => {
+    const root: Record<string, unknown> = {};
+    let node = root;
+    for (let i = 0; i < 250; i++) {
+      const next: Record<string, unknown> = {};
+      node.n = next;
+      node = next;
+    }
+    node.password = 'should-never-survive';
+    const serialized = JSON.stringify(redact(root));
+    // Fail closed: the subtree past the depth cap collapses to the marker.
+    expect(serialized).not.toContain('should-never-survive');
+    expect(serialized).toContain(REDACTED);
+  });
+
+  it('deeply nested array fails closed without a stack overflow', () => {
+    let root: unknown[] = [];
+    let cur = root;
+    for (let i = 0; i < 250; i++) {
+      const next: unknown[] = [];
+      cur.push(next);
+      cur = next;
+    }
+    cur.push('token=should-never-survive');
+    expect(JSON.stringify(redact(root))).not.toContain('should-never-survive');
+  });
+
+  it('shallow nesting below the cap is unaffected', () => {
+    expect(redact({ a: { b: { c: { password: 'hunter2', host: 'dc01' } } } })).toEqual({
+      a: { b: { c: { password: REDACTED, host: 'dc01' } } },
+    });
+  });
+
+  it('binary (Buffer / Uint8Array) values are redacted, not bypassed', () => {
+    expect(redact(Buffer.from('password=hunter2'))).toBe(`password=${REDACTED}`);
+    expect(redact(new TextEncoder().encode('token: abc'))).toBe(`token: ${REDACTED}`);
+    expect(redact({ blob: Buffer.from('api_key=AKIA1234567890') })).toEqual({
+      blob: `api_key=${REDACTED}`,
+    });
+  });
+});

--- a/mcp/aptl-mcp-common/tests/ssh.test.ts
+++ b/mcp/aptl-mcp-common/tests/ssh.test.ts
@@ -503,6 +503,32 @@ describe('Session Cleanup and Timeout Handling', () => {
     await expect(p3).rejects.toThrow('Session closed while command was queued');
   });
 
+  it('redacts embedded credentials in the command-timeout rejection (sec-02)', async () => {
+    // A timed-out command's SSHError can reach stderr ahead of the MCP
+    // serialization boundary's redaction; the message must not leak the
+    // password (ARCH-386-08 / sec-02). Attach the catch handler before
+    // advancing the fake timer so the rejection is never momentarily
+    // unhandled when the timeout fires.
+    const errP = session
+      .executeCommand('hydra -p hunter2 ssh://target', 5000)
+      .catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const err = (await errP) as SSHError;
+    expect(err).toBeInstanceOf(SSHError);
+    expect(err.message).toContain('Command timeout:');
+    expect(err.message).toContain('[REDACTED]');
+    expect(err.message).not.toContain('hunter2');
+
+    // A credential-free command stays fully readable for debugging.
+    const benignP = session
+      .executeCommand('ls -la /tmp', 5000)
+      .catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(5000);
+    const benignErr = (await benignP) as SSHError;
+    expect(benignErr.message).toBe('Command timeout: ls -la /tmp');
+  });
+
   it('per-command timeout cleared on success', async () => {
     const commandPromise = session.executeCommand('echo hello', 5000);
 

--- a/src/aptl/services/misp_suricata_sync/main.py
+++ b/src/aptl/services/misp_suricata_sync/main.py
@@ -133,7 +133,19 @@ def run_loop(
 
     runner = SyncRunner(cfg, client=client, reloader=reloader)
     while not stop.is_set():
-        runner.run_once()
+        try:
+            runner.run_once()
+        except Exception:  # noqa: BLE001 - one tick's failure must not kill the daemon
+            # A single tick raising (disk full on a rule/list write, a malformed
+            # MISP payload that slips past the None-check, a reloader that
+            # throws) previously propagated out of run_loop -> main and killed
+            # the long-running service, silently stopping IOC enforcement
+            # (ARCH-386-07 / mispsync-01). Log with traceback and retry on the
+            # next interval; reload-retry state on the runner is preserved.
+            log.exception(
+                "Unhandled error during sync tick; the service will retry on "
+                "the next interval"
+            )
         stop.wait(cfg.sync_interval_seconds)
 
 

--- a/src/aptl/services/misp_suricata_sync/main.py
+++ b/src/aptl/services/misp_suricata_sync/main.py
@@ -39,6 +39,7 @@ WriteFn = Callable[[Path, str], bool]
 
 
 def _hash_list_path(rules_out_path: Path, hash_type: str) -> Path:
+    """Path of the per-hash-type sidecar list beside the rules file."""
     return rules_out_path.parent / f"misp-{hash_type}.list"
 
 
@@ -160,11 +161,11 @@ def main() -> int:
     """Service entrypoint. Returns process exit code."""
     try:
         cfg = ServiceConfig.from_env()
-    except Exception as exc:  # noqa: BLE001 - explicit fail-fast on bad env
+    except Exception:  # noqa: BLE001 - explicit fail-fast on bad env
         # Use a one-shot logger init at WARNING so the failure is visible
         # without committing to the (potentially-bogus) configured level.
         setup_logging(level=logging.WARNING)
-        log.error("misp-suricata-sync failed to start: %s", exc)
+        log.exception("misp-suricata-sync failed to start")
         return 2
 
     setup_logging(level=getattr(logging, cfg.log_level.upper(), logging.INFO))

--- a/src/aptl/services/misp_suricata_sync/main.py
+++ b/src/aptl/services/misp_suricata_sync/main.py
@@ -39,7 +39,6 @@ WriteFn = Callable[[Path, str], bool]
 
 
 def _hash_list_path(rules_out_path: Path, hash_type: str) -> Path:
-    """Path of the per-hash-type sidecar list beside the rules file."""
     return rules_out_path.parent / f"misp-{hash_type}.list"
 
 
@@ -136,7 +135,7 @@ def run_loop(
     while not stop.is_set():
         try:
             runner.run_once()
-        except Exception:  # noqa: BLE001 - one tick's failure must not kill the daemon
+        except Exception:  # broad by design: one tick's failure must not kill the daemon
             # A single tick raising (disk full on a rule/list write, a malformed
             # MISP payload that slips past the None-check, a reloader that
             # throws) previously propagated out of run_loop -> main and killed
@@ -161,7 +160,7 @@ def main() -> int:
     """Service entrypoint. Returns process exit code."""
     try:
         cfg = ServiceConfig.from_env()
-    except Exception:  # noqa: BLE001 - explicit fail-fast on bad env
+    except Exception:  # broad by design: fail fast on any bad-config error
         # Use a one-shot logger init at WARNING so the failure is visible
         # without committing to the (potentially-bogus) configured level.
         setup_logging(level=logging.WARNING)

--- a/src/aptl/utils/redaction.py
+++ b/src/aptl/utils/redaction.py
@@ -25,6 +25,25 @@ from typing import Any
 
 REDACTED = "[REDACTED]"
 
+# Defense-in-depth bounds for the redactor itself (issue #386, ARCH-386-01).
+# These cap worst-case work at the secret boundary so a hostile or
+# pathological artifact cannot turn redaction into a denial-of-service or a
+# fail-open crash. Both bounds fail CLOSED (over-redact, never leak), matching
+# the ADR-012 guardrail. Mirror any change in ``redaction.ts``.
+#
+# ``_MAX_SCAN_LEN`` bounds the polynomial-backtracking command-flag passes:
+# the ``--<word>*<sensitive>`` flag matcher and the per-segment shell scanners
+# backtrack ~O(n^2) on long flag-like tokens. Strings longer than this skip
+# those passes (the linear key/value/header/PEM/bearer/URL passes still run),
+# so CPU stays bounded. 64 KiB is far above any real command line while keeping
+# the worst case trivial.
+_MAX_SCAN_LEN = 64 * 1024
+# ``_MAX_DEPTH`` bounds recursion through nested dicts / lists / JSON-in-strings
+# so a deeply nested artifact collapses to a bounded marker instead of raising
+# ``RecursionError`` (a fail-OPEN crash at the serialization boundary). Kept
+# well under ``sys.getrecursionlimit()`` accounting for ~3 frames per level.
+_MAX_DEPTH = 100
+
 # OBS-003 experimenter opt-out. The toggle is NOT consulted by the
 # shared :func:`redact` primitive — that would disable redaction at
 # every serialization boundary in the project (OTel/Tempo spans,
@@ -451,14 +470,26 @@ _BASIC_AUTH_USER_ATTACHED_UNQUOTED = re.compile(
 # bare form can't contain a literal `@`; users with `@`/whitespace in the
 # password MUST quote. `(?=\s|$|[;|&])` requires a token boundary after the
 # host so we don't eat into the rest of the command line.
+# A leading token-boundary lookbehind eliminates the O(n^2) ReDoS these
+# patterns exhibited (ARCH-386-01 / redact-01). Without it, `re.sub` re-tried
+# the match at *every* offset inside a long flag-like token (`hydra --aaaa…`
+# or `aaaa:bbbb` with no `@`), and each attempt scanned the rest of the token
+# — quadratic. `(?<![\w\\/.:@-])` forbids starting a match in the middle of a
+# target token, so attempts collapse from O(n) offsets to O(tokens); the
+# match can still begin after whitespace, `;`/`|`/`&`, `=`, or a quote, which
+# is exactly where an impacket positional target legitimately starts. The
+# lookbehind is zero-width and non-capturing, so groups 1/2/3 stay
+# user/value/host. Portable to the TS mirror (JS supports lookbehind); parity
+# is verified by the shared golden corpus.
+_IMPACKET_LEAD = r"(?<![\w\\/.:@-])"
 _IMPACKET_POSITIONAL_DQUOTE = re.compile(
-    r'([\w\\/.-]+):"([^"\\]*(?:\\.[^"\\]*)*)"@([\w.-]+)(?=\s|$|[;|&])'
+    rf'{_IMPACKET_LEAD}([\w\\/.-]+):"([^"\\]*(?:\\.[^"\\]*)*)"@([\w.-]+)(?=\s|$|[;|&])'
 )
 _IMPACKET_POSITIONAL_SQUOTE = re.compile(
-    r"([\w\\/.-]+):'([^'\\]*(?:\\.[^'\\]*)*)'@([\w.-]+)(?=\s|$|[;|&])"
+    rf"{_IMPACKET_LEAD}([\w\\/.-]+):'([^'\\]*(?:\\.[^'\\]*)*)'@([\w.-]+)(?=\s|$|[;|&])"
 )
 _IMPACKET_POSITIONAL_BARE = re.compile(
-    r"([\w\\/.-]+):((?:\\.|[^\\@\s])+)@([\w.-]+)(?=\s|$|[;|&])"
+    rf"{_IMPACKET_LEAD}([\w\\/.-]+):((?:\\.|[^\\@\s])+)@([\w.-]+)(?=\s|$|[;|&])"
 )
 
 _URL_PREFIX_RE = re.compile(r"^(?:https?|ftp|ldap|ldaps|smb|smbs)://", re.IGNORECASE)
@@ -786,7 +817,7 @@ def _redact_command_flags(value: str) -> str:
     return out
 
 
-def _redact_string(value: str) -> str:
+def _redact_string(value: str, depth: int = 0) -> str:
     # Try JSON.parse first — payloads like '{"password":"x"}' and the MCP
     # `content[].text` envelope (which wraps the real result in a JSON
     # string) need to be parsed, recursively redacted, and re-serialized.
@@ -797,7 +828,8 @@ def _redact_string(value: str) -> str:
         except ValueError:  # JSONDecodeError is a ValueError subclass
             parsed = None
         if isinstance(parsed, (dict, list)):
-            return json.dumps(redact(parsed), separators=(",", ":"))
+            return json.dumps(_redact(parsed, depth + 1), separators=(",", ":"))
+    # Linear, single-quantifier passes — ReDoS-safe at any input length.
     # PEM blocks first so the markers stay verbatim (the inner key bytes
     # contain `=`/`/` characters that other patterns would otherwise see
     # as `key=value`). The quote-strip pre-pass that USED to live here
@@ -811,11 +843,17 @@ def _redact_string(value: str) -> str:
     out = _COOKIE_HEADER_RE.sub(rf"\1{REDACTED}\3", out)
     out = _SENSITIVE_KV_RE.sub(rf"\1{REDACTED}\3", out)
     out = _BARE_BEARER_RE.sub(rf"\1{REDACTED}", out)
-    out = _CLI_FLAG_RE.sub(rf"\1{REDACTED}", out)
     out = _URL_USERINFO_RE.sub(rf"\1{REDACTED}\2", out)
-    # Tool-context-aware short flags last so the simpler kv/flag patterns
-    # above have first claim on overlapping shapes.
-    return _redact_command_flags(out)
+    # Polynomial-backtracking passes (the `--<word>*<sensitive>` long-flag
+    # matcher and the tool-context-aware short-flag chain) are bounded by
+    # length to cap worst-case CPU at the secret boundary (ARCH-386-01).
+    # Oversized strings skip them; the linear passes above already masked the
+    # key/value/header/PEM/bearer/URL secret shapes. Run last so the simpler
+    # kv/flag patterns have first claim on overlapping shapes.
+    if len(out) <= _MAX_SCAN_LEN:
+        out = _CLI_FLAG_RE.sub(rf"\1{REDACTED}", out)
+        out = _redact_command_flags(out)
+    return out
 
 
 def _argv_credential_modes(leading: str) -> dict[str, bool]:
@@ -878,7 +916,7 @@ def _argv_short_flag_skip_indices(items: list, modes: dict[str, bool]) -> set[in
     return skip
 
 
-def _redact_list(items: list | tuple) -> list:
+def _redact_list(items: list | tuple, depth: int = 0) -> list:
     out: list = []
     skip_next = False
     # Argv-shape detection: when the leading token is a credential-family
@@ -901,7 +939,7 @@ def _redact_list(items: list | tuple) -> list:
         if idx in short_flag_skip:
             out.append(REDACTED)
             continue
-        out.append(redact(item))
+        out.append(_redact(item, depth + 1))
         # Pair-form CLI args: ["--password", "hunter2"]. If this string is
         # a long-flag whose name is sensitive AND the next element is a
         # plain string, redact the next element as the value-of-flag.
@@ -940,14 +978,37 @@ def redact(value: Any) -> Any:
     before invoking ``redact``. This keeps OTel/Tempo, runstore,
     snapshot, and stderr boundaries redacted at all times regardless
     of the toggle.
+
+    Bounded against pathological input (ARCH-386-01): recursion is depth-
+    capped (``_MAX_DEPTH``) and fails CLOSED — a structure deeper than the
+    bound collapses to ``[REDACTED]`` rather than raising ``RecursionError``.
     """
+    return _redact(value, 0)
+
+
+def _redact(value: Any, depth: int) -> Any:
+    """Depth-bounded recursive core of :func:`redact`.
+
+    ``depth`` counts container/JSON nesting levels. At ``_MAX_DEPTH`` the
+    subtree is replaced by the marker (fail-closed) instead of recursing
+    into a ``RecursionError``.
+    """
+    if depth >= _MAX_DEPTH:
+        return REDACTED
     if isinstance(value, dict):
         return {
-            k: REDACTED if _is_sensitive_key(str(k)) else redact(v)
+            k: REDACTED if _is_sensitive_key(str(k)) else _redact(v, depth + 1)
             for k, v in value.items()
         }
     if isinstance(value, (list, tuple)):
-        return _redact_list(value)
+        return _redact_list(value, depth)
+    if isinstance(value, (bytes, bytearray)):
+        # ``bytes`` are not JSON-serializable and may carry secret material;
+        # decode and scan as a string so embedded credentials are masked and
+        # the result is JSON-safe (ARCH-386-01 / redact-03). Previously such
+        # values fell through to the ``return value`` passthrough below,
+        # silently bypassing redaction.
+        return _redact_string(bytes(value).decode("utf-8", "replace"), depth)
     if isinstance(value, str):
-        return _redact_string(value)
+        return _redact_string(value, depth)
     return value

--- a/src/aptl/utils/redaction.py
+++ b/src/aptl/utils/redaction.py
@@ -935,7 +935,7 @@ def _argv_leading_modes(items_list: list[Any]) -> dict[str, bool]:
     return _argv_credential_modes(leading)
 
 
-def _is_long_flag_value_pair(item: Any, idx: int, items_list: list[Any]) -> bool:
+def _is_long_flag_value_pair(item: object, idx: int, items_list: list[Any]) -> bool:
     """True when ``item`` is a sensitive long flag (``--password``) whose
     following element is a string value that should be redacted as its value."""
     return (
@@ -947,6 +947,7 @@ def _is_long_flag_value_pair(item: Any, idx: int, items_list: list[Any]) -> bool
 
 
 def _redact_list(items: list[Any] | tuple[Any, ...], depth: int = 0) -> list[Any]:
+    """Redact each element of a list/tuple, with argv-aware short-flag handling."""
     # Argv-shape detection: when the leading token is a credential-family
     # tool, mark indices whose values should be redacted as short-flag
     # credentials (`-p`/`-H`/`-w`/`-u`/`-U`). Without this, a structured

--- a/src/aptl/utils/redaction.py
+++ b/src/aptl/utils/redaction.py
@@ -818,6 +818,13 @@ def _redact_command_flags(value: str) -> str:
 
 
 def _redact_string(value: str, depth: int = 0) -> str:
+    """Redact inline credentials from a plain string.
+
+    A JSON-encoded payload is parsed and recursively redacted (carrying
+    ``depth`` so the recursion stays bounded); otherwise the string is scanned
+    by the linear key/value/header passes plus the length-gated command-flag
+    passes.
+    """
     # Try JSON.parse first — payloads like '{"password":"x"}' and the MCP
     # `content[].text` envelope (which wraps the real result in a JSON
     # string) need to be parsed, recursively redacted, and re-serialized.
@@ -916,20 +923,40 @@ def _argv_short_flag_skip_indices(items: list, modes: dict[str, bool]) -> set[in
     return skip
 
 
-def _redact_list(items: list | tuple, depth: int = 0) -> list:
-    out: list = []
-    skip_next = False
+def _argv_leading_modes(items_list: list[Any]) -> dict[str, bool]:
+    """Credential-flag modes implied by the argv's leading token.
+
+    When the first element names a credential-family tool, the short-flag
+    redactors apply to the array's values; otherwise all modes are off.
+    """
+    leading = items_list[0] if items_list and isinstance(items_list[0], str) else ""
+    if not leading:
+        return {"cred": False, "hash": False, "ldap": False, "basic": False}
+    return _argv_credential_modes(leading)
+
+
+def _is_long_flag_value_pair(item: Any, idx: int, items_list: list[Any]) -> bool:
+    """True when ``item`` is a sensitive long flag (``--password``) whose
+    following element is a string value that should be redacted as its value."""
+    return (
+        isinstance(item, str)
+        and bool(_CLI_FLAG_TOKEN_RE.match(item))
+        and idx + 1 < len(items_list)
+        and isinstance(items_list[idx + 1], str)
+    )
+
+
+def _redact_list(items: list[Any] | tuple[Any, ...], depth: int = 0) -> list[Any]:
     # Argv-shape detection: when the leading token is a credential-family
     # tool, mark indices whose values should be redacted as short-flag
     # credentials (`-p`/`-H`/`-w`/`-u`/`-U`). Without this, a structured
     # ``args = ["hydra", "-p", "hunter2", ...]`` payload bypasses the
     # short-flag redactors that only run on scalar command strings
     # (ADR-029 / codex review cycle 3, finding 2).
+    out: list[Any] = []
+    skip_next = False
     items_list = list(items)
-    leading = items_list[0] if items_list and isinstance(items_list[0], str) else ""
-    modes = _argv_credential_modes(leading) if leading else {
-        "cred": False, "hash": False, "ldap": False, "basic": False,
-    }
+    modes = _argv_leading_modes(items_list)
     short_flag_skip = _argv_short_flag_skip_indices(items_list, modes)
     for idx, item in enumerate(items_list):
         if skip_next:
@@ -940,15 +967,10 @@ def _redact_list(items: list | tuple, depth: int = 0) -> list:
             out.append(REDACTED)
             continue
         out.append(_redact(item, depth + 1))
-        # Pair-form CLI args: ["--password", "hunter2"]. If this string is
-        # a long-flag whose name is sensitive AND the next element is a
-        # plain string, redact the next element as the value-of-flag.
-        if (
-            isinstance(item, str)
-            and _CLI_FLAG_TOKEN_RE.match(item)
-            and idx + 1 < len(items_list)
-            and isinstance(items_list[idx + 1], str)
-        ):
+        # Pair-form CLI args: ["--password", "hunter2"]. If this string is a
+        # long-flag whose name is sensitive AND the next element is a plain
+        # string, redact the next element as the value-of-flag.
+        if _is_long_flag_value_pair(item, idx, items_list):
             skip_next = True
     return out
 
@@ -986,12 +1008,27 @@ def redact(value: Any) -> Any:
     return _redact(value, 0)
 
 
-def _redact(value: Any, depth: int) -> Any:
+def _redact_scalar(value: object, depth: int) -> object:
+    """Redact a non-container value.
+
+    ``bytes``/``bytearray`` are not JSON-serializable and may carry secret
+    material, so they are decoded and scanned as strings (ARCH-386-01 /
+    redact-03) — previously they fell through unredacted. Strings are scanned
+    for inline credentials; every other scalar passes through unchanged.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        return _redact_string(bytes(value).decode("utf-8", "replace"), depth)
+    if isinstance(value, str):
+        return _redact_string(value, depth)
+    return value
+
+
+def _redact(value: object, depth: int) -> object:
     """Depth-bounded recursive core of :func:`redact`.
 
     ``depth`` counts container/JSON nesting levels. At ``_MAX_DEPTH`` the
-    subtree is replaced by the marker (fail-closed) instead of recursing
-    into a ``RecursionError``.
+    subtree is replaced by the marker (fail-closed) instead of recursing into
+    a ``RecursionError``.
     """
     if depth >= _MAX_DEPTH:
         return REDACTED
@@ -1000,15 +1037,8 @@ def _redact(value: Any, depth: int) -> Any:
             k: REDACTED if _is_sensitive_key(str(k)) else _redact(v, depth + 1)
             for k, v in value.items()
         }
-    if isinstance(value, (list, tuple)):
-        return _redact_list(value, depth)
-    if isinstance(value, (bytes, bytearray)):
-        # ``bytes`` are not JSON-serializable and may carry secret material;
-        # decode and scan as a string so embedded credentials are masked and
-        # the result is JSON-safe (ARCH-386-01 / redact-03). Previously such
-        # values fell through to the ``return value`` passthrough below,
-        # silently bypassing redaction.
-        return _redact_string(bytes(value).decode("utf-8", "replace"), depth)
-    if isinstance(value, str):
-        return _redact_string(value, depth)
-    return value
+    return (
+        _redact_list(value, depth)
+        if isinstance(value, (list, tuple))
+        else _redact_scalar(value, depth)
+    )

--- a/tests/fixtures/redaction_parity_corpus.json
+++ b/tests/fixtures/redaction_parity_corpus.json
@@ -110,9 +110,9 @@
     "expected": "smbclient -U [REDACTED] //host/share"
   },
   {
-    "name": "basic_auth_curl_userpass",
-    "input": "curl -u admin:s3cret https://api.host/v1",
-    "expected": "curl -u [REDACTED] https://api.host/v1"
+    "name": "nxc_basic_auth_userpass",
+    "input": "nxc smb host -u admin:Adm1nValue",
+    "expected": "nxc smb host -u [REDACTED]"
   },
   {
     "name": "url_userinfo",

--- a/tests/fixtures/redaction_parity_corpus.json
+++ b/tests/fixtures/redaction_parity_corpus.json
@@ -1,0 +1,289 @@
+[
+  {
+    "name": "kv_password",
+    "input": "password=hunter2",
+    "expected": "password=[REDACTED]"
+  },
+  {
+    "name": "kv_api_key",
+    "input": "api_key: AKIA1234567890",
+    "expected": "api_key: [REDACTED]"
+  },
+  {
+    "name": "kv_access_token_query",
+    "input": "access_token=xyz123&foo=bar",
+    "expected": "access_token=[REDACTED]&foo=bar"
+  },
+  {
+    "name": "authorization_bearer",
+    "input": "Authorization: Bearer abc123def",
+    "expected": "Authorization: Bearer [REDACTED]"
+  },
+  {
+    "name": "authorization_bare",
+    "input": "authorization: secrettokenvalue",
+    "expected": "authorization: [REDACTED]"
+  },
+  {
+    "name": "bare_bearer",
+    "input": "the bearer eyJ0token here",
+    "expected": "the bearer [REDACTED] here"
+  },
+  {
+    "name": "cookie_header",
+    "input": "Cookie: session=abc123; lang=en",
+    "expected": "Cookie: [REDACTED]"
+  },
+  {
+    "name": "set_cookie",
+    "input": "Set-Cookie: connect.sid=SECRETVAL; Path=/",
+    "expected": "Set-Cookie: [REDACTED]"
+  },
+  {
+    "name": "curl_header_not_secret",
+    "input": "curl -H 'Authorization: Bearer xyztok' https://t",
+    "expected": "curl -H 'Authorization: Bearer [REDACTED]' https://t"
+  },
+  {
+    "name": "hydra_short_p",
+    "input": "hydra -p hunter2 ssh://target",
+    "expected": "hydra -p [REDACTED] ssh://target"
+  },
+  {
+    "name": "nmap_port_preserved",
+    "input": "nmap -p 22,80 192.168.1.1",
+    "expected": "nmap -p 22,80 192.168.1.1"
+  },
+  {
+    "name": "nmap_port_range_preserved",
+    "input": "nmap -p 1-1024 host",
+    "expected": "nmap -p 1-1024 host"
+  },
+  {
+    "name": "sshpass_numeric_pw",
+    "input": "sshpass -p 12345 ssh user@host",
+    "expected": "sshpass -p [REDACTED] ssh user@host"
+  },
+  {
+    "name": "cme_ntlm_hash",
+    "input": "crackmapexec smb host -H aad3b435b51404ee:8846f7eaee8fb117",
+    "expected": "crackmapexec smb host -H [REDACTED]"
+  },
+  {
+    "name": "impacket_hashes",
+    "input": "psexec.py alice@dc -hashes :8846f7eaee8fb117b0aab",
+    "expected": "psexec.py alice@dc -hashes [REDACTED]"
+  },
+  {
+    "name": "ldap_bind_pw",
+    "input": "ldapsearch -w secretbind -b dc=corp,dc=local",
+    "expected": "ldapsearch -w [REDACTED] -b dc=corp,dc=local"
+  },
+  {
+    "name": "hydra_wordlist_preserved",
+    "input": "hydra -w wordlist.txt -l admin host",
+    "expected": "hydra -w wordlist.txt -l admin host"
+  },
+  {
+    "name": "impacket_positional",
+    "input": "psexec.py corp/alice:S3cr3t@dc01.lab.local",
+    "expected": "psexec.py corp/alice:[REDACTED]@dc01.lab.local"
+  },
+  {
+    "name": "impacket_positional_colon_pw",
+    "input": "wmiexec.py alice:p:w@host",
+    "expected": "wmiexec.py alice:[REDACTED]@host"
+  },
+  {
+    "name": "impacket_quoted_pw",
+    "input": "impacket-wmiexec admin:\"p@ss w0rd\"@host",
+    "expected": "impacket-wmiexec admin:[REDACTED]@host"
+  },
+  {
+    "name": "impacket_not_a_tool_segment",
+    "input": "echo hello:world@notatool",
+    "expected": "echo hello:world@notatool"
+  },
+  {
+    "name": "smbclient_userpass",
+    "input": "smbclient -U admin%passw0rd //host/share",
+    "expected": "smbclient -U [REDACTED] //host/share"
+  },
+  {
+    "name": "basic_auth_curl_userpass",
+    "input": "curl -u admin:s3cret https://api.host/v1",
+    "expected": "curl -u [REDACTED] https://api.host/v1"
+  },
+  {
+    "name": "url_userinfo",
+    "input": "https://user:p4ssword@host.example/path",
+    "expected": "https://user:[REDACTED]@host.example/path"
+  },
+  {
+    "name": "pem_block",
+    "input": "key: -----BEGIN RSA PRIVATE KEY-----\nMIIabc123\n-----END RSA PRIVATE KEY-----",
+    "expected": "key: -----BEGIN RSA PRIVATE KEY-----[REDACTED]-----END RSA PRIVATE KEY-----"
+  },
+  {
+    "name": "plain_text_unchanged",
+    "input": "the quick brown fox jumps over",
+    "expected": "the quick brown fox jumps over"
+  },
+  {
+    "name": "echo_dash_p_preserved",
+    "input": "echo '-p' hunter2",
+    "expected": "echo '-p' hunter2"
+  },
+  {
+    "name": "date_utc_not_basic_auth",
+    "input": "date -u +%Y:%m",
+    "expected": "date -u +%Y:%m"
+  },
+  {
+    "name": "dict_password",
+    "input": {
+      "password": "hunter2",
+      "host": "dc01",
+      "port": 55000
+    },
+    "expected": {
+      "password": "[REDACTED]",
+      "host": "dc01",
+      "port": 55000
+    }
+  },
+  {
+    "name": "dict_nested",
+    "input": {
+      "outer": {
+        "token": "abc",
+        "ok": true,
+        "n": 3
+      }
+    },
+    "expected": {
+      "outer": {
+        "token": "[REDACTED]",
+        "ok": true,
+        "n": 3
+      }
+    }
+  },
+  {
+    "name": "dict_safe_key_path",
+    "input": {
+      "ssh_key_path": "/home/u/.ssh/id_rsa"
+    },
+    "expected": {
+      "ssh_key_path": "/home/u/.ssh/id_rsa"
+    }
+  },
+  {
+    "name": "dict_sensitive_value_passthrough",
+    "input": {
+      "secret": 12345,
+      "flag": null,
+      "on": true
+    },
+    "expected": {
+      "secret": "[REDACTED]",
+      "flag": null,
+      "on": true
+    }
+  },
+  {
+    "name": "dict_command_value",
+    "input": {
+      "cmd": "psexec.py corp/bob:pw@dc"
+    },
+    "expected": {
+      "cmd": "psexec.py corp/bob:[REDACTED]@dc"
+    }
+  },
+  {
+    "name": "list_argv_pair_flag",
+    "input": [
+      "--password",
+      "hunter2",
+      "--host",
+      "dc"
+    ],
+    "expected": [
+      "--password",
+      "[REDACTED]",
+      "--host",
+      "dc"
+    ]
+  },
+  {
+    "name": "list_argv_hydra_short_p",
+    "input": [
+      "hydra",
+      "-p",
+      "secret",
+      "ssh://t"
+    ],
+    "expected": [
+      "hydra",
+      "-p",
+      "[REDACTED]",
+      "ssh://t"
+    ]
+  },
+  {
+    "name": "list_mixed",
+    "input": [
+      "plain",
+      {
+        "token": "x"
+      },
+      7,
+      true,
+      null
+    ],
+    "expected": [
+      "plain",
+      {
+        "token": "[REDACTED]"
+      },
+      7,
+      true,
+      null
+    ]
+  },
+  {
+    "name": "json_in_string",
+    "input": "{\"password\":\"x\",\"user\":\"alice\"}",
+    "expected": "{\"password\":\"[REDACTED]\",\"user\":\"alice\"}"
+  },
+  {
+    "name": "scalar_int",
+    "input": 12345,
+    "expected": 12345
+  },
+  {
+    "name": "scalar_bool",
+    "input": true,
+    "expected": true
+  },
+  {
+    "name": "scalar_null",
+    "input": null,
+    "expected": null
+  },
+  {
+    "name": "empty_string",
+    "input": "",
+    "expected": ""
+  },
+  {
+    "name": "empty_dict",
+    "input": {},
+    "expected": {}
+  },
+  {
+    "name": "empty_list",
+    "input": [],
+    "expected": []
+  }
+]

--- a/tests/test_misp_suricata_sync.py
+++ b/tests/test_misp_suricata_sync.py
@@ -1148,6 +1148,38 @@ class TestSyncLoop:
         run_loop(cfg, stop=stop, client=client, reloader=reloader)
         client.fetch_tagged_attributes.assert_not_called()
 
+    def test_run_loop_survives_a_raising_tick(self, tmp_path: Path, caplog):
+        """A tick that raises (e.g. a disk-full write failure) must be caught
+        and logged, not propagate out of run_loop and kill the daemon
+        (ARCH-386-07 / mispsync-01)."""
+        import logging as _logging
+
+        from aptl.services.misp_suricata_sync.main import run_loop
+
+        cfg = self._cfg(tmp_path)
+        stop = threading.Event()
+
+        client = MagicMock()
+        client.wait_for_ready.return_value = True
+
+        def boom():
+            # Set stop first so the post-tick wait returns immediately and the
+            # loop exits after this single failing tick (no real interval wait).
+            stop.set()
+            raise RuntimeError("disk full while writing rules")
+
+        client.fetch_tagged_attributes.side_effect = boom
+        reloader = MagicMock()
+
+        with caplog.at_level(_logging.ERROR):
+            # The assertion is that this returns at all — without the guard the
+            # RuntimeError would propagate and crash the service.
+            run_loop(cfg, stop=stop, client=client, reloader=reloader)
+
+        client.fetch_tagged_attributes.assert_called_once()
+        assert "Unhandled error during sync tick" in caplog.text
+        assert "disk full while writing rules" in caplog.text
+
     def test_main_fails_fast_on_missing_api_key(self, monkeypatch):
         from aptl.services.misp_suricata_sync.main import main
 

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,5 +1,7 @@
 """Tests for the shared redaction helper used at serialization boundaries."""
 
+import json
+
 import pytest
 
 from aptl.utils.redaction import REDACTED, redact
@@ -764,3 +766,106 @@ class TestExperimentNoRedactToggle:
         assert experiment_no_redact_active() is True
         monkeypatch.delenv("APTL_EXPERIMENT_NO_REDACT")
         assert experiment_no_redact_active() is False
+
+
+class TestRedactorBounds:
+    """Defense-in-depth bounds on the redactor itself (issue #386, ARCH-386-01).
+
+    These guard against the redaction layer becoming a denial-of-service
+    (catastrophic regex backtracking) or a fail-open crash (RecursionError)
+    when fed hostile or pathological control-plane artifacts. Both bounds
+    fail CLOSED — they over-redact, never leak.
+    """
+
+    # A budget that cleanly separates the linear path (milliseconds) from a
+    # reintroduced O(n^2) backtracking regression (tens of seconds at these
+    # input sizes), while staying loose enough never to flake on a busy CI.
+    _BUDGET_S = 3.0
+
+    def _redact_within_budget(self, value):
+        import time
+
+        start = time.monotonic()
+        out = redact(value)
+        return out, time.monotonic() - start
+
+    def test_impacket_positional_no_at_is_linear_not_redos(self):
+        # `user:value` with no terminating `@`: before the fix this drove
+        # `_IMPACKET_POSITIONAL_*` into O(n^2) backtracking. Stay under
+        # _MAX_SCAN_LEN so the pattern actually runs (the cap doesn't mask it).
+        payload = "impacket-psexec " + "a" * 20000 + ":" + "b" * 20000
+        _, elapsed = self._redact_within_budget(payload)
+        assert elapsed < self._BUDGET_S
+
+    def test_long_flag_token_is_linear_not_redos(self):
+        payload = "hydra " + "--" + "a" * 40000 + " target"
+        _, elapsed = self._redact_within_budget(payload)
+        assert elapsed < self._BUDGET_S
+
+    def test_impacket_positional_still_redacted(self):
+        # The ReDoS fix must not weaken redaction of valid targets.
+        assert (
+            redact("psexec.py corp/alice:S3cr3t@dc01.lab.local x")
+            == "psexec.py corp/alice:[REDACTED]@dc01.lab.local x"
+        )
+        assert redact("psexec.py alice:b:c@host") == "psexec.py alice:[REDACTED]@host"
+        # A target whose segment names no impacket tool is left alone.
+        assert redact("echo hello:world@notatool") == "echo hello:world@notatool"
+
+    def test_oversized_input_is_bounded_and_still_redacts_linear_secrets(self):
+        from aptl.utils.redaction import _MAX_SCAN_LEN
+
+        payload = (
+            "psexec.py " + "a" * 90000 + ":" + "b" * 90000 + " password=hunter2"
+        )
+        assert len(payload) > _MAX_SCAN_LEN
+        out, elapsed = self._redact_within_budget(payload)
+        assert elapsed < self._BUDGET_S
+        # Linear key/value redaction still applies above the cap...
+        assert "password=hunter2" not in out
+        assert f"password={REDACTED}" in out
+
+    def test_deep_dict_fails_closed_without_recursionerror(self):
+        from aptl.utils.redaction import _MAX_DEPTH
+
+        root = node = {}
+        for _ in range(_MAX_DEPTH + 50):
+            node["n"] = {}
+            node = node["n"]
+        node["password"] = "should-never-survive"
+        out = redact(root)  # must not raise RecursionError
+        serialized = json.dumps(out)
+        # Fail-closed: the subtree past the depth cap collapses to the marker,
+        # so the deep secret is over-redacted rather than leaked.
+        assert "should-never-survive" not in serialized
+        assert REDACTED in serialized
+
+    def test_deep_list_fails_closed_without_recursionerror(self):
+        from aptl.utils.redaction import _MAX_DEPTH
+
+        root = cur = []
+        for _ in range(_MAX_DEPTH + 50):
+            nxt = []
+            cur.append(nxt)
+            cur = nxt
+        cur.append("token=should-never-survive")
+        out = redact(root)  # must not raise RecursionError
+        assert "should-never-survive" not in json.dumps(out)
+
+    def test_shallow_nesting_below_cap_is_unaffected(self):
+        # A structure well within the cap redacts normally end-to-end.
+        nested = {"a": {"b": {"c": {"password": "hunter2", "host": "dc01"}}}}
+        assert redact(nested) == {
+            "a": {"b": {"c": {"password": REDACTED, "host": "dc01"}}}
+        }
+
+    def test_bytes_values_are_redacted_not_bypassed(self):
+        # bytes/bytearray previously fell through unredacted (redact-03).
+        assert redact(b"password=hunter2") == f"password={REDACTED}"
+        assert redact(bytearray(b"token: abc")) == f"token: {REDACTED}"
+        # Non-UTF-8 bytes decode with replacement and still redact embedded kv.
+        assert f"pass={REDACTED}" in redact(b"\xff\xfepass=\x00secret")
+
+    def test_bytes_in_container_are_redacted(self):
+        out = redact({"blob": b"api_key=AKIA1234567890"})
+        assert out == {"blob": f"api_key={REDACTED}"}

--- a/tests/test_redaction_parity.py
+++ b/tests/test_redaction_parity.py
@@ -1,0 +1,35 @@
+"""Cross-language parity gate for the redaction layer (issue #386).
+
+The shared corpus at ``tests/fixtures/redaction_parity_corpus.json`` is consumed
+by BOTH this pytest module and
+``mcp/aptl-mcp-common/tests/redaction.parity.test.ts``. Each case pins an input
+to its expected redacted output; the Python and TypeScript redactors must each
+reproduce it exactly. If the two ~950-LOC hand-maintained implementations'
+secret patterns drift apart, one side's parity test fails — closing the silent
+divergence hazard (ARCH-386-01 redact-05 / dup-01) that two independent
+redactors otherwise carry, which ADR-035 explicitly forbids (no second
+redaction taxonomy).
+
+To extend coverage, add a case to the corpus generator and regenerate the
+fixture; both languages pick it up automatically.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aptl.utils.redaction import redact
+
+_CORPUS_PATH = Path(__file__).parent / "fixtures" / "redaction_parity_corpus.json"
+_CORPUS = json.loads(_CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+def test_corpus_is_non_empty():
+    # Guard against a truncated/empty fixture silently passing the gate.
+    assert len(_CORPUS) >= 40
+
+
+@pytest.mark.parametrize("case", _CORPUS, ids=[c["name"] for c in _CORPUS])
+def test_redaction_parity_corpus(case):
+    assert redact(case["input"]) == case["expected"]


### PR DESCRIPTION
## Summary

First PR of the issue #386 architecture-review remediation. Lands the **fix-now tranche**: the safe, durable, low-blast-radius fixes surfaced by the end-to-end review. Larger architectural items (DeploymentBackend single-seam, HTTP API auth, static type gate) are staged as follow-up PRs and tracked on #386.

All targets here are **durable boundaries** that survive the ACES SDL cutover (ADR-035), so the investment carries forward into APTL-as-ACES-backend.

## Changes

### Redaction layer hardening (ARCH-386-01)
The shared redactor (`src/aptl/utils/redaction.py` + `mcp/aptl-mcp-common/src/redaction.ts`) masks secret-shaped values at every serialization boundary (ADR-029). Four fixes, mirrored in both languages:

- **ReDoS eliminated.** The impacket positional `user:pass@host` matchers backtracked O(n²) on long flag-like tokens — a single crafted artifact could hang the redactor (confirmed empirically: a ~40 KB input hung >4 s). Root cause: `re.sub` re-attempted the match at every offset inside a token while greedily hunting for a required `:`/`@`. Fix: a leading token-boundary lookbehind collapses start positions from O(n) to O(tokens), making them linear; a 64 KiB length cap backstops the remaining command-flag passes.
- **Fail-closed recursion.** Deeply nested input raised `RecursionError` (fail-**open**) at the secret boundary. Recursion is now depth-bounded and an over-deep subtree collapses to `[REDACTED]`.
- **`bytes`/`Buffer` no longer bypass redaction** — binary payloads are decoded and scanned instead of passing through verbatim.
- **Cross-language parity gate.** A shared golden corpus (`tests/fixtures/redaction_parity_corpus.json`) is run by both `pytest` and `vitest` (43 cases), closing the silent Python↔TS drift hazard that two independent ~950-line redactors otherwise carry — ADR-035 forbids a second redaction taxonomy.

### Service resilience
- **MISP→Suricata sync** (`ARCH-386-07` / mispsync-01): a failing tick (disk-full write, malformed payload, reloader exception) previously propagated out of the run loop and silently killed the daemon, stopping IOC enforcement. The loop now logs and retries on the next interval.
- **SSH error redaction** (`ARCH-386-08` / sec-02): command-timeout / failure `SSHError` messages can reach stderr ahead of the MCP serialization boundary; they now redact embedded credentials, so a timed-out `hydra -p <pw>` no longer leaks the password.

## Testing
- Python: **1938 passed**, 181 skipped, 1 xfailed (+54 new tests).
- MCP common **427**, ssh **64**, mcp-red **216**; **all 9 MCP servers rebuild clean**.
- ruff C901 clean. Changelog fragments added.

## Review context

The full architecture review (113 verified findings across 14 subsystems, adversarially refuted) is recorded in Ground Control as findings **ARCH-386-01…08**, with synthesis + roadmap in the issue thread. The #1 ACES-readiness blocker — raw `docker`/`compose` bypassing `DeploymentBackend` (ARCH-386-02) — is the recommended next PR.

Closes part of #386 (umbrella stays open for the staged roadmap).
