### PR TITLE
docs: add SecTor Arsenal 2026 acceptance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=Brad-Edwards_aptl&token=4dd88be3421d6d030a4615b86ac8ab0e3c9eb4d3)](https://sonarcloud.io/summary/new_code?id=Brad-Edwards_aptl)
 
-🎤 **Accepted to [Black Hat USA Arsenal 2026](https://blackhat.com/us-26/arsenal/schedule/#aptl-advanced-purple-team-labs-52322).** Live demo at the conference.
+🎤 **Accepted to [Black Hat USA Arsenal 2026](https://blackhat.com/us-26/arsenal/schedule/#aptl-advanced-purple-team-labs-52322) and [SecTor Arsenal 2026](https://blackhat.com/sector/arsenal/schedule/index.html#aptl-advanced-purple-team-labs-54785).** Live demos at both conferences.
 
 # APTL — Advanced Purple Team Lab
 


### PR DESCRIPTION
## Summary

- Combined the Black Hat USA Arsenal 2026 and SecTor Arsenal 2026 acceptances into a single line at the top of `README.md`

Closes #398