### PR TITLE
Encode wazuh-indexer datastore surfaces unblocked by ACES #468/#469/#470

### DIFF
--- a/docs/aces/inventory/wazuh.indexer/README.md
+++ b/docs/aces/inventory/wazuh.indexer/README.md
@@ -25,7 +25,7 @@ Use it as a frozen observation of that local steady state, not as clean-lab rebu
 | Host-published ports | 9200/tcp on 0.0.0.0 and :: |
 | OpenSearch version | 2.19.1 (Wazuh-indexer 4.12.0/rc1, build hash `dae2bfc93896178873b43cdf4781f183c72b238f`) |
 | Cluster | single-node `opensearch` cluster, uuid `u-vGl1n0Q7e-SKz1tWvb-w`, status green |
-| Indices | 41 indices, 102 primary shards, 1,053,842 documents, ~1.39 GB store (per-index uuid/doc-count/store-size/mapping schema blocked on ACES #468/#469 — see ACES Mapping Result) |
+| Indices | 41 indices, 102 primary shards, 1,053,842 documents, ~1.39 GB store (per-index uuid/doc-count/store-size + per-family mapping schema encoded via ACES #468/#469 — see ACES Mapping Result) |
 | Plugins | 18 installed OpenSearch plugins at 2.19.1.0 (alerting, anomaly-detection, asynchronous-search, cross-cluster-replication, geospatial, index-management, job-scheduler, knn, ml, neural-search, notifications, notifications-core, observability, performance-analyzer, reports-scheduler, security, security-analytics, sql) |
 | Internal users | 6 OpenSearch Security built-in users (`admin`, `kibanaserver`, `kibanaro`, `logstash`, `readall`, `snapshotrestore`); bcrypt hashes redacted |
 | Package inventory | 110 RPM packages and 840 Syft SBOM components |
@@ -41,7 +41,7 @@ Use it as a frozen observation of that local steady state, not as clean-lab rebu
 | Runtime state is recorded. | `evidence/docker-inspect.container.json`, `evidence/docker-network.aptl-security.json`, `evidence/docker-top.txt`, `evidence/runtime-baseline.txt` |
 | Persistent volume is recorded. | `evidence/docker-volume.wazuh-indexer-data.json` |
 | OpenSearch logical state is recorded. | `evidence/wazuh-indexer-state.txt`, `evidence/wazuh-indexer-api-probe.json`, `evidence/filesystem-tree.txt`, `evidence/filesystem-checksums.txt` |
-| Structured index mappings + template bodies are recorded (blocked surfaces). | `evidence/wazuh-indexer-templates.json.gz`, `evidence/wazuh-indexer-family-mappings.json.gz`, `evidence/wazuh-indexer-index-mappings-census.json` |
+| Structured index mappings + template bodies are recorded and encoded as typed mappings/templates. | `evidence/wazuh-indexer-templates.json.gz`, `evidence/wazuh-indexer-family-mappings.json.gz`, `evidence/wazuh-indexer-index-mappings-census.json` |
 | OS packages and SBOM component inventories are recorded. | `evidence/os-packages.txt`, `evidence/language-manifests.txt`, `evidence/trivy-sbom.cyclonedx.json.gz`, `evidence/syft-sbom.cyclonedx.json.gz` |
 | Patch state is machine-readable. | `evidence/trivy-vulnerability-counts.json`, `evidence/trivy-vulnerability-list.json` |
 | osquery table attempts are recorded. | `evidence/osquery-apt-sources.json`, `evidence/osquery-docker-containers.json`, `evidence/osquery-docker-images.json`, `evidence/osquery-installed-applications.json`, `evidence/osquery-listening-ports.json`, `evidence/osquery-processes.json`, `evidence/osquery-programs.json` |
@@ -76,13 +76,13 @@ Use it as a frozen observation of that local steady state, not as clean-lab rebu
   indices, 102 primary shards, 1,053,842 documents, ~1.39 GB store at snapshot
   time) and the node carries `cluster_manager`, `data`, `ingest`, and
   `remote_cluster_client` roles. The cluster `uuid` and these aggregate
-  cardinality/size totals are evidence-only, blocked on ACES #468.
+  cardinality/size totals are encoded on `RuntimeDatastoreCluster` (ACES #468).
 - 18 OpenSearch plugins are installed at 2.19.1.0, including the
   `opensearch-security`, `opensearch-security-analytics`,
   `opensearch-performance-analyzer`, and the OpenSearch Alerting / ML /
-  Notifications stacks. Plugin **names** are encoded; per-plugin version is
-  evidence-only, blocked on ACES #470 with the rest of the node engine
-  provenance (`build_hash`, JVM heap, publish addresses).
+  Notifications stacks. Plugin **names and per-plugin versions** are encoded as
+  typed `RuntimeDatastoreEnginePlugin` entries (ACES #470), alongside the rest of
+  the node engine provenance (`build_hash`, JVM heap, publish endpoints).
 - Indexed content is the standard TechVault Wazuh layout: `wazuh-alerts-4.x-*`
   daily indices, `wazuh-archives-4.x-*` daily indices,
   `wazuh-monitoring-2026.*w` weekly indices, `wazuh-statistics-2026.*w`
@@ -91,10 +91,10 @@ Use it as a frozen observation of that local steady state, not as clean-lab rebu
   (`.kibana_1`, `.opendistro_security`, `.opensearch-observability`,
   `.plugins-ml-config`). Each index's **name, shard geometry, and health** are
   encoded as a `RuntimeDatastorePartition`; each index's `uuid`, doc count,
-  store size, creation date, and structured field mapping (up to 947 leaf
-  fields for `wazuh-archives-*`) are evidence-only, blocked on ACES #468
-  (cardinality/size/identity) and ACES #469 (structured mappings + template
-  bodies).
+  store size, creation date, and open/closed status are encoded on the same
+  `RuntimeDatastorePartition` (ACES #468), and the per-family structured field
+  mapping (up to 947 leaf fields for `wazuh-archives-*`) is encoded as a
+  `RuntimeDatastoreMapping` with its field-type census (ACES #469).
 - Persistence is rooted at `path.home=/usr/share/wazuh-indexer`,
   `path.data=/var/lib/wazuh-indexer` (backed by the `wazuh-indexer-data`
   named volume), `path.logs=/var/log/wazuh-indexer`. No snapshot repository
@@ -140,29 +140,31 @@ authc/authz chain on `runtime.identity_authorities`. The
 `data_model=search_index`, `partition_kind=index`) carries the
 OpenSearch-specific surface.
 
-### Blocked surfaces (open ACES expressivity gaps)
+### ACES expressivity — fully encoded
 
-Three catalogued, in-scope observable surfaces have **no typed ACES home today**.
-They are NOT forced into SDL `description` prose — they are captured in the
-evidence bundle and recorded as `blocked_by_aces_gap` facts in
-`mapping-ledger.yaml`, each linked to a filed ACES issue. **This inventory
-issue (Brad-Edwards/aptl#341) stays open until these ACES surfaces land and the
-SDL is updated:**
+Three catalogued observable surfaces previously had no typed ACES home and were
+recorded as `blocked_by_aces_gap` facts pending upstream ACES work. **Those ACES
+surfaces have now landed on aces `dev` and every surface is encoded from the
+captured evidence. No known ACES expressivity gap remains:**
 
 - **Search-index cardinality, size, and identity** — per-index `uuid`,
-  `doc.count`, `doc.deleted`, `store.size`, `creation.date`, open/closed status,
-  and the cluster-level `cluster_uuid` + aggregate node/shard/doc/store totals.
-  `RuntimeDatastoreCluster`/`RuntimeDatastorePartition` have no field for these.
-  → **[Brad-Edwards/aces#468](https://github.com/Brad-Edwards/aces/issues/468)**.
+  `doc_count`, `doc_count_deleted`, `store_size_bytes`, `creation_timestamp`,
+  `open_closed_status`, and the cluster-level `uuid` + aggregate
+  `node_count`/`shard_total`/`shard_primaries`/`doc_count`/`store_size_bytes`,
+  now typed on `RuntimeDatastoreCluster`/`RuntimeDatastorePartition`.
+  → resolved by **[Brad-Edwards/aces#468](https://github.com/Brad-Edwards/aces/issues/468)**.
 - **Structured index mapping + template-body inventory** — the field→type
-  schema each index enforces (wazuh-archives mappings reach 947 leaf fields) and
-  the index-template bodies that seed them. `mappings`/`templates`/`aliases` are
-  name-only `list[str]`; there is no field-schema or template-body model.
-  → **[Brad-Edwards/aces#469](https://github.com/Brad-Edwards/aces/issues/469)**.
+  census each index family enforces (wazuh-archives mappings reach 947 leaf
+  fields) and the index-template bodies that seed them, now typed on
+  `RuntimeDatastoreMapping` (per-family schema geometry, field-type census,
+  dynamic policy, schema digest) and the structured `RuntimeDatastoreTemplate`
+  (index_patterns, settings_summary, template digest).
+  → resolved by **[Brad-Edwards/aces#469](https://github.com/Brad-Edwards/aces/issues/469)**.
 - **Datastore node engine provenance** — engine `version`, `build_hash`,
-  per-plugin versions, JVM heap, and the http/transport publish-address split.
-  `RuntimeDatastoreNode` has none of these; `engine_plugins` is name-only.
-  → **[Brad-Edwards/aces#470](https://github.com/Brad-Edwards/aces/issues/470)**.
+  `build_type`, JVM heap posture, the http/transport publish endpoint split, and
+  typed per-plugin versions, now typed on `RuntimeDatastoreNode` +
+  `RuntimeDatastoreEnginePlugin` + `RuntimeDatastoreNodeEndpoint`.
+  → resolved by **[Brad-Edwards/aces#470](https://github.com/Brad-Edwards/aces/issues/470)**.
 
 The capture does not assert a destructive clean-lab reset, byte-identical
 rebuildability, full root filesystem equivalence outside the scoped capture, or

--- a/docs/aces/inventory/wazuh.indexer/mapping-ledger.yaml
+++ b/docs/aces/inventory/wazuh.indexer/mapping-ledger.yaml
@@ -79,8 +79,8 @@ correspondence_checks:
 notes:
   - Capture used the existing running local aptl project as authorized by the user on 2026-06-05 and did not reset the lab.
   - INDEXER_USERNAME / INDEXER_PASSWORD were sourced from the lab .env at capture time and passed only via docker exec environment variables; the raw values are never written to evidence, and redact_stream remains the final defence against accidental leakage of credentials, bcrypt hashes, bearer tokens, and TLS private keys.
-  - ACES runtime.datastore_services (`RuntimeDatastoreService` with engine=OPENSEARCH and data_model=SEARCH_INDEX) is consumed for the typed indexer cluster identity, node membership/roles, partition shard geometry, persistence, transport_security, settings, and plugin/template NAMES.
-  - "Three catalogued surfaces are blocked on ACES expressivity gaps and are NOT forced into SDL prose - they live in evidence and are recorded as blocked_by_aces_gap facts. (1) Per-index and cluster cardinality/size/identity (uuid, doc count, deleted count, store size, creation date, open/closed status) blocked on Brad-Edwards/aces#468. (2) Structured index field mappings and template bodies blocked on Brad-Edwards/aces#469. (3) Datastore node engine provenance (version, build hash, per-plugin versions, JVM heap, http/transport publish addresses) blocked on Brad-Edwards/aces#470. This issue stays open until those ACES surfaces land and the SDL is updated."
+  - ACES runtime.datastore_services (`RuntimeDatastoreService` with engine=OPENSEARCH and data_model=SEARCH_INDEX) is consumed for the typed indexer cluster identity + aggregate cardinality, node membership/roles + engine provenance + per-plugin versions + endpoint topology, per-index partition shard geometry + cardinality, per-family structured mappings + template bodies, transport_security, and settings.
+  - "All three formerly-blocked datastore surfaces are now encoded: ACES #468 (per-index and cluster cardinality/size/identity - uuid, doc count, deleted count, store size, creation date, open/closed status), ACES #469 (structured index field mappings and template bodies), and ACES #470 (node engine provenance - version, build hash, typed per-plugin versions, JVM heap, http/transport publish endpoints) shipped to aces dev and are consumed via typed fields. No known ACES expressivity gap remains."
   - The SDL build-history strings normalize braced shell parameter syntax to shell-equivalent unbraced syntax because ACES reserves ${...} for scenario variables; raw history remains in evidence.
 facts:
   - id: wazuh-indexer.image.identity
@@ -300,89 +300,88 @@ facts:
       rationale: ACES runtime package vulnerabilities encode scanner-derived package finding IDs, affected package versions, severities, fixed versions, and scan provenance.
   - id: wazuh-indexer.datastore.cluster-identity
     category: datastore
-    summary: The single-node OpenSearch 2.19.1 cluster has cluster_name "opensearch", status green, single-node discovery, and native protocol version 2.19.1. (The cluster_uuid and aggregate node/shard/doc/store totals are a separate blocked fact - see wazuh-indexer.datastore.cluster-cardinality.)
+    summary: The single-node OpenSearch 2.19.1 cluster has cluster_name "opensearch", status green, single-node discovery, and native protocol version 2.19.1. (The cluster_uuid and aggregate node/shard/doc/store totals are the sibling wazuh-indexer.datastore.cluster-cardinality fact, now encoded via ACES #468.)
     evidence:
       - path: evidence/wazuh-indexer-state.txt
     aces:
-      disposition: encoded_with_caveat
+      disposition: encoded
       surface: nodes
       fields:
         - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer
         - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.cluster
-      caveat: RuntimeDatastoreCluster encodes name/health/discovery_mode/native_protocol_version only. The cluster_uuid, node count, and aggregate shard/doc/store totals have no typed field and are blocked on Brad-Edwards/aces#468.
-      rationale: ACES runtime_datastore RuntimeDatastoreCluster supplies the cluster identity and health under engine=OPENSEARCH and data_model=SEARCH_INDEX; aggregate cardinality/size is not typeable today.
+      rationale: ACES runtime_datastore RuntimeDatastoreCluster supplies the cluster identity and health under engine=OPENSEARCH and data_model=SEARCH_INDEX; the cluster uuid and aggregate cardinality/size are the sibling cluster-cardinality fact.
   - id: wazuh-indexer.datastore.cluster-cardinality
     category: datastore
     summary: The cluster exposes cluster_uuid u-vGl1n0Q7e-SKz1tWvb-w, 1 node, 102 total shards (102 primaries, 0 replicas), 1,053,842 documents, and ~1.39 GB store at snapshot time.
     evidence:
       - path: evidence/wazuh-indexer-state.txt
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - nodes
-        - runtime_contract
-      why_not_current_surfaces: RuntimeDatastoreCluster has no uuid, node_count, or aggregate doc_count/store_size_bytes/shard-total fields; the only place these fit today is free-text description, which is the prose-forcing this inventory must avoid. RuntimeDatastoreService carries no aggregate cardinality either.
-      gap_issue:
-        tracker: Brad-Edwards/aces
-        number: 468
-        url: https://github.com/Brad-Edwards/aces/issues/468
-      rationale: Cluster identity (uuid) and aggregate cardinality/size are participant-observable via _cluster/stats but have no typed ACES home; recorded as evidence and blocked on the linked ACES issue rather than forced into prose.
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.cluster.uuid
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.cluster.node_count
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.cluster.shard_total
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.cluster.shard_primaries
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.cluster.doc_count
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.cluster.store_size_bytes
+      rationale: ACES #468 added RuntimeDatastoreCluster.uuid/node_count/shard_total/shard_primaries/doc_count/store_size_bytes; the cluster identity + aggregate cardinality/size observed via _cluster/stats are now typed.
   - id: wazuh-indexer.datastore.node-membership
     category: datastore
-    summary: The cluster has one node (name wazuh.indexer) holding the cluster_manager + data + ingest roles (remote_cluster_client maps to the OPEN 'other' role tail), transport address 172.20.0.12:9300. (Engine version/build/heap/publish-address provenance is a separate blocked fact - see wazuh-indexer.datastore.node-provenance.)
+    summary: The cluster has one node (name wazuh.indexer) holding the cluster_manager + data + ingest roles (remote_cluster_client maps to the OPEN 'other' role tail), transport address 172.20.0.12:9300. (Engine version/build/heap/publish-address provenance is the sibling wazuh-indexer.datastore.node-provenance fact, now encoded via ACES #470.)
     evidence:
       - path: evidence/wazuh-indexer-state.txt
     aces:
-      disposition: encoded_with_caveat
+      disposition: encoded
       surface: nodes
       fields:
         - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes
-      caveat: RuntimeDatastoreNode encodes node_id/name/roles/is_coordinator/address only. Engine version, build_hash, per-plugin versions, JVM heap, and the http/transport publish-address split have no typed field and are blocked on Brad-Edwards/aces#470.
-      rationale: ACES RuntimeDatastoreNode + RuntimeDatastoreNodeRole vocab supplies the node identity and role set; engine provenance is not typeable today.
+      rationale: ACES RuntimeDatastoreNode + RuntimeDatastoreNodeRole vocab supplies the node identity and role set; engine provenance, JVM heap, per-plugin versions, and endpoint topology are the sibling node-provenance fact.
   - id: wazuh-indexer.datastore.node-provenance
     category: datastore
     summary: The OpenSearch node reports engine version 2.19.1, build_type rpm, build_hash dae2bfc93896178873b43cdf4781f183c72b238f, JVM heap 1 GiB init / 1 GiB max with mlockall, http publish 172.20.0.12:9200, transport publish 172.20.0.12:9300, and 18 plugins each with their own 2.19.1.0 version.
     evidence:
       - path: evidence/wazuh-indexer-state.txt
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - nodes
-        - runtime_contract
-      why_not_current_surfaces: RuntimeDatastoreNode has no engine version/build_hash/heap/publish-address fields, and RuntimeDatastoreService.engine_plugins is a name-only list[str] that drops per-plugin version. node.runtime.packages records OS/SBOM packages, not OpenSearch engine plugin bundles.
-      gap_issue:
-        tracker: Brad-Edwards/aces
-        number: 470
-        url: https://github.com/Brad-Edwards/aces/issues/470
-      rationale: Engine provenance and per-plugin versions are observable via _nodes/_local and _cat/plugins but have no typed ACES home; recorded as evidence and blocked on the linked ACES issue.
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.engine_version
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.build_hash
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.build_type
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.heap_init_bytes
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.heap_max_bytes
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.memory_locked
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.endpoints
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.plugins
+      rationale: ACES #470 added RuntimeDatastoreNode engine provenance (version/build_hash/build_type), JVM heap posture, typed RuntimeDatastoreEnginePlugin (per-plugin version), and RuntimeDatastoreNodeEndpoint (client/peer publish split); all observed via _nodes/_local and _cat/plugins are now typed.
   - id: wazuh-indexer.datastore.partition-geometry
     category: datastore
     summary: The cluster carries 41 index partitions (wazuh-alerts-4.x-* daily, wazuh-archives-4.x-* daily, wazuh-monitoring-2026.*w weekly, wazuh-statistics-2026.*w weekly, wazuh-states-vulnerabilities-wazuh.manager, plus the bootstrap system indices .kibana / .kibana_1 / .opendistro_security / .opensearch-observability / .plugins-ml-config). Each partition's name, kind=index, primary/replica shard counts, and health are encoded.
     evidence:
       - path: evidence/wazuh-indexer-state.txt
     aces:
-      disposition: encoded_with_caveat
+      disposition: encoded
       surface: nodes
       fields:
         - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.partitions
-      caveat: RuntimeDatastorePartition (kind=index) encodes name/shard_count/replica_count/health only. Per-index uuid/doc-count/deleted-count/store-size/creation-date/open-closed status (Brad-Edwards/aces#468) and the structured field mapping (Brad-Edwards/aces#469) have no typed field and are separate blocked facts.
-      rationale: ACES RuntimeDatastorePartition with kind=INDEX models the OpenSearch index shard geometry; per-index cardinality/size/identity and structured mappings are not typeable today.
+      rationale: ACES RuntimeDatastorePartition with kind=INDEX models the OpenSearch index shard geometry; per-index cardinality/size/identity is the partition-cardinality fact and structured mappings are the index-mappings fact.
   - id: wazuh-indexer.datastore.partition-cardinality
     category: datastore
     summary: Each of the 41 indices exposes its own uuid, doc count, deleted-doc count, store size, creation date, and open/closed status (e.g. wazuh-archives-4.x-2026.05.28 uuid s0fv6XlzTEuJ..., 68993 docs, 0 deleted, 92.4mb, open, created 2026-05-28).
     evidence:
       - path: evidence/wazuh-indexer-state.txt
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - nodes
-        - runtime_contract
-      why_not_current_surfaces: RuntimeDatastorePartition has no uuid/doc_count/doc_count_deleted/store_size_bytes/creation_date/open_closed_status field; datatype_census is a dict[str,int] for key-value datatype censuses, semantically distinct from a search-index document count. The only place these fit today is free-text description.
-      gap_issue:
-        tracker: Brad-Edwards/aces
-        number: 468
-        url: https://github.com/Brad-Edwards/aces/issues/468
-      rationale: Per-index cardinality, size, and identity are observable via _cat/indices but have no typed ACES home; recorded as evidence and blocked on the linked ACES issue rather than forced into prose.
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.partitions.0.uuid
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.partitions.0.doc_count
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.partitions.0.doc_count_deleted
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.partitions.0.store_size_bytes
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.partitions.0.creation_timestamp
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.partitions.0.open_closed_status
+      rationale: ACES #468 added per-RuntimeDatastorePartition uuid/doc_count/doc_count_deleted/store_size_bytes/creation_timestamp/open_closed_status; each index's cardinality/size/identity from _cat/indices is now typed (store_size_bytes derived from the human-rounded _cat size).
   - id: wazuh-indexer.datastore.index-mappings
     category: datastore
     summary: Every index carries a structured field mapping (wazuh-archives-4.x-* up to 947 leaf fields, wazuh-alerts-4.x-* ~670 leaf, .kibana_1 132 leaf, with typed date/keyword/ip/geo_point/object fields, dynamic policy, and dynamic_templates), seeded by four index templates (wazuh, wazuh-agent, wazuh-statistics, wazuh-states-vulnerabilities-wazuh.manager_template) whose bodies carry index_patterns + settings + mappings.
@@ -391,16 +390,12 @@ facts:
       - path: evidence/wazuh-indexer-family-mappings.json.gz
       - path: evidence/wazuh-indexer-index-mappings-census.json
     aces:
-      disposition: blocked_by_aces_gap
-      checked_surfaces:
-        - nodes
-        - runtime_contract
-      why_not_current_surfaces: RuntimeDatastoreService.mappings/templates/aliases are name-only list[str] and cannot hold a field-to-type schema or a template body; RuntimeDatastorePartition carries no mapping sub-model. The relational fold has a structured DatabaseSchema but the search-datastore spine has no analog. The template NAMES are encoded on RuntimeDatastoreService.templates; the structured bodies are blocked.
-      gap_issue:
-        tracker: Brad-Edwards/aces
-        number: 469
-        url: https://github.com/Brad-Edwards/aces/issues/469
-      rationale: Structured index mappings and template bodies are the index data contract (field schema, dynamic policy); they are observable via _mapping and _template but have no typed ACES home and are blocked on the linked ACES issue. Template/index names are encoded; bodies are evidence-only pending ACES.
+      disposition: encoded
+      surface: nodes
+      fields:
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.mappings
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.templates
+      rationale: ACES #469 added RuntimeDatastoreMapping (per-family schema geometry, field-type census, dynamic policy, schema digest) and structured RuntimeDatastoreTemplate (index_patterns, settings_summary, template digest); the index data contract observed via _mapping and _template is now typed.
   - id: wazuh-indexer.datastore.persistence
     category: datastore
     summary: OpenSearch persistence is rooted at path.home=/usr/share/wazuh-indexer with path.data=/var/lib/wazuh-indexer (backed by the wazuh-indexer-data named volume) and path.logs=/var/log/wazuh-indexer; no path.repo is configured (no snapshot repository registered).
@@ -443,12 +438,11 @@ facts:
     evidence:
       - path: evidence/wazuh-indexer-state.txt
     aces:
-      disposition: encoded_with_caveat
+      disposition: encoded
       surface: nodes
       fields:
-        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.engine_plugins
-      caveat: Plugin NAMES are encoded on RuntimeDatastoreService.engine_plugins (list[str]); the per-plugin VERSION (all 2.19.1.0) is dropped by the name-only list and is blocked on Brad-Edwards/aces#470 with the rest of the node engine provenance.
-      rationale: The installed-plugin name set is the node's capability surface and is encodable today; per-plugin version is not.
+        - nodes.techvault.wazuh-indexer.runtime.datastore_services.techvault-wazuh-indexer.nodes.0.plugins
+      rationale: ACES #470 replaced the name-only RuntimeDatastoreService.engine_plugins with typed per-node RuntimeDatastoreEnginePlugin entries carrying name + version; all 18 plugins and their 2.19.1.0 versions are now typed.
   - id: wazuh-indexer.identity.internal-users
     category: identity
     summary: internal_users.yml declares six built-in OpenSearch Security internal users - admin (reserved, backend_role admin), kibanaserver (reserved), kibanaro (backend_roles kibanauser+readall, three demo attributes), logstash (backend_role logstash), readall (backend_role readall), snapshotrestore (backend_role snapshotrestore). All bcrypt hashes are <REDACTED-INDEXER-INTERNAL-USER-HASH>; reserved/hidden flags and role memberships are recorded.

--- a/scenarios/techvault/nodes/misp-redis.sdl.yaml
+++ b/scenarios/techvault/nodes/misp-redis.sdl.yaml
@@ -1353,7 +1353,6 @@ nodes:
             maxmemory 0 (unbounded by Redis, bounded only by the 128 MiB container memory limit).
         pubsub_channels: []
         queues_streams: []
-        engine_plugins: []
         transport_security:
           transport_security_id: misp_redis_transport
           mode: none

--- a/scenarios/techvault/nodes/wazuh-indexer.sdl.yaml
+++ b/scenarios/techvault/nodes/wazuh-indexer.sdl.yaml
@@ -13772,13 +13772,19 @@ nodes:
           name: TechVault Wazuh Indexer
           cluster:
             cluster_id: techvault-wazuh-indexer-cluster
+            uuid: u-vGl1n0Q7e-SKz1tWvb-w
             name: opensearch
             health: green
             discovery_mode: single-node
             partitioner: opensearch_default
             native_protocol_version: 2.19.1
-            description: Single-node OpenSearch cluster. Cluster uuid, node count, and aggregate shard/doc/store totals blocked
-              on Brad-Edwards/aces#468; observed in docs/aces/inventory/wazuh.indexer/evidence/wazuh-indexer-state.txt.
+            node_count: 1
+            shard_total: 102
+            shard_primaries: 102
+            doc_count: 1053842
+            store_size_bytes: 1391460626
+            description: Single-node OpenSearch cluster; cluster identity (uuid) and aggregate node/shard/doc/store totals observed
+              via _cluster/stats in evidence/wazuh-indexer-state.txt.
           nodes:
             - node_id: 5N5vnFZERhu2OYBxv5Lo8Q
               name: wazuh.indexer
@@ -13788,412 +13794,860 @@ nodes:
                 - ingest
                 - other
               is_coordinator: true
-              address: 172.20.0.12:9300
-              description: 'Single OpenSearch member of the TechVault Wazuh indexer cluster. OpenSearch roles outside the
-                ACES vocabulary mapped to ''other'': remote_cluster_client. Engine version / build hash / per-plugin versions
-                / JVM heap / publish-address split are observed in docs/aces/inventory/wazuh.indexer/evidence/wazuh-indexer-state.txt
-                and blocked on Brad-Edwards/aces#470 (no typed node-provenance fields).'
+              engine_version: 2.19.1
+              build_hash: dae2bfc93896178873b43cdf4781f183c72b238f
+              build_type: rpm
+              heap_init_bytes: 1073741824
+              heap_max_bytes: 1073741824
+              memory_locked: false
+              endpoints:
+                - endpoint_id: wazuh-indexer-http
+                  role: client
+                  protocol: https
+                  address: 172.20.0.12
+                  port: 9200
+                  description: OpenSearch REST/HTTP publish address (_nodes http.publish_address).
+                - endpoint_id: wazuh-indexer-transport
+                  role: peer
+                  protocol: tls
+                  address: 172.20.0.12
+                  port: 9300
+                  description: OpenSearch inter-node transport publish address (_nodes transport.publish_address).
+              plugins:
+                - plugin_id: opensearch-alerting
+                  name: opensearch-alerting
+                  version: 2.19.1.0
+                - plugin_id: opensearch-anomaly-detection
+                  name: opensearch-anomaly-detection
+                  version: 2.19.1.0
+                - plugin_id: opensearch-asynchronous-search
+                  name: opensearch-asynchronous-search
+                  version: 2.19.1.0
+                - plugin_id: opensearch-cross-cluster-replication
+                  name: opensearch-cross-cluster-replication
+                  version: 2.19.1.0
+                - plugin_id: opensearch-geospatial
+                  name: opensearch-geospatial
+                  version: 2.19.1.0
+                - plugin_id: opensearch-index-management
+                  name: opensearch-index-management
+                  version: 2.19.1.0
+                - plugin_id: opensearch-job-scheduler
+                  name: opensearch-job-scheduler
+                  version: 2.19.1.0
+                - plugin_id: opensearch-knn
+                  name: opensearch-knn
+                  version: 2.19.1.0
+                - plugin_id: opensearch-ml
+                  name: opensearch-ml
+                  version: 2.19.1.0
+                - plugin_id: opensearch-neural-search
+                  name: opensearch-neural-search
+                  version: 2.19.1.0
+                - plugin_id: opensearch-notifications
+                  name: opensearch-notifications
+                  version: 2.19.1.0
+                - plugin_id: opensearch-notifications-core
+                  name: opensearch-notifications-core
+                  version: 2.19.1.0
+                - plugin_id: opensearch-observability
+                  name: opensearch-observability
+                  version: 2.19.1.0
+                - plugin_id: opensearch-performance-analyzer
+                  name: opensearch-performance-analyzer
+                  version: 2.19.1.0
+                - plugin_id: opensearch-reports-scheduler
+                  name: opensearch-reports-scheduler
+                  version: 2.19.1.0
+                - plugin_id: opensearch-security
+                  name: opensearch-security
+                  version: 2.19.1.0
+                - plugin_id: opensearch-security-analytics
+                  name: opensearch-security-analytics
+                  version: 2.19.1.0
+                - plugin_id: opensearch-sql
+                  name: opensearch-sql
+                  version: 2.19.1.0
+              description: 'Single OpenSearch member of the TechVault Wazuh indexer cluster. OpenSearch roles outside the ACES vocabulary
+                mapped to ''other'': remote_cluster_client. Engine provenance, JVM heap posture, per-plugin versions, and the http/transport
+                publish split observed via _nodes/_local and _cat/plugins.'
           partitions:
             - partition_id: -kibana_1
               kind: index
               name: .kibana_1
+              uuid: EC_4iu_SRhGvgE1F4itc5Q
               shard_count: 1
               replica_count: 0
+              doc_count: 0
+              doc_count_deleted: 0
+              store_size_bytes: 208
+              creation_timestamp: '2026-05-23T06:19:26.806Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: -opendistro_security
               kind: index
               name: .opendistro_security
+              uuid: __o30MqzS42FjwicBr6g9w
               shard_count: 1
               replica_count: 0
+              doc_count: 10
+              doc_count_deleted: 0
+              store_size_bytes: 80896
+              creation_timestamp: '2026-05-23T06:18:55.684Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: -opensearch-observability
               kind: index
               name: .opensearch-observability
+              uuid: pU8SYLDESSeeZ06nIVJxug
               shard_count: 1
               replica_count: 0
+              doc_count: 0
+              doc_count_deleted: 0
+              store_size_bytes: 208
+              creation_timestamp: '2026-05-23T06:18:54.639Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: -plugins-ml-config
               kind: index
               name: .plugins-ml-config
+              uuid: 31QbTXSUTw2U_neEErngNA
               shard_count: 1
               replica_count: 0
+              doc_count: 1
+              doc_count_deleted: 0
+              store_size_bytes: 4096
+              creation_timestamp: '2026-05-23T06:19:14.512Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-23
               kind: index
               name: wazuh-alerts-4.x-2026.05.23
+              uuid: YSYUSnR7Tp-r1AUlWjxsUw
               shard_count: 3
               replica_count: 0
+              doc_count: 4535
+              doc_count_deleted: 0
+              store_size_bytes: 2202010
+              creation_timestamp: '2026-05-23T06:19:23.113Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-24
               kind: index
               name: wazuh-alerts-4.x-2026.05.24
+              uuid: 4cWoaAslQJyknAUME_cFIQ
               shard_count: 3
               replica_count: 0
+              doc_count: 5916
+              doc_count_deleted: 0
+              store_size_bytes: 2306867
+              creation_timestamp: '2026-05-24T00:09:22.443Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-25
               kind: index
               name: wazuh-alerts-4.x-2026.05.25
+              uuid: Q6q0BPldQbSCpIse7MBWLg
               shard_count: 3
               replica_count: 0
+              doc_count: 5936
+              doc_count_deleted: 0
+              store_size_bytes: 2202010
+              creation_timestamp: '2026-05-25T00:09:42.950Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-26
               kind: index
               name: wazuh-alerts-4.x-2026.05.26
+              uuid: cxrifan_RzKEkXwVvSUc8w
               shard_count: 3
               replica_count: 0
+              doc_count: 5866
+              doc_count_deleted: 0
+              store_size_bytes: 2306867
+              creation_timestamp: '2026-05-26T00:09:55.304Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-27
               kind: index
               name: wazuh-alerts-4.x-2026.05.27
+              uuid: Nv9ZEvzXRBa53WeZW__uEA
               shard_count: 3
               replica_count: 0
+              doc_count: 5854
+              doc_count_deleted: 0
+              store_size_bytes: 2202010
+              creation_timestamp: '2026-05-27T00:00:08.900Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-28
               kind: index
               name: wazuh-alerts-4.x-2026.05.28
+              uuid: SDOLdMGwT52IStajlLmnvA
               shard_count: 3
               replica_count: 0
+              doc_count: 5905
+              doc_count_deleted: 0
+              store_size_bytes: 2306867
+              creation_timestamp: '2026-05-28T00:00:23.157Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-29
               kind: index
               name: wazuh-alerts-4.x-2026.05.29
+              uuid: 84x7RJzRSW2AkMGBTqU3sw
               shard_count: 3
               replica_count: 0
+              doc_count: 5928
+              doc_count_deleted: 0
+              store_size_bytes: 2306867
+              creation_timestamp: '2026-05-29T00:00:44.590Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-30
               kind: index
               name: wazuh-alerts-4.x-2026.05.30
+              uuid: 85aB4EltSK6RRI-FOY2Uhg
               shard_count: 3
               replica_count: 0
+              doc_count: 5861
+              doc_count_deleted: 0
+              store_size_bytes: 1992294
+              creation_timestamp: '2026-05-30T00:00:55.085Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-05-31
               kind: index
               name: wazuh-alerts-4.x-2026.05.31
+              uuid: rF4CcRT2RSu9FPAd4619Tg
               shard_count: 3
               replica_count: 0
+              doc_count: 5887
+              doc_count_deleted: 0
+              store_size_bytes: 2202010
+              creation_timestamp: '2026-05-31T00:01:12.911Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-06-01
               kind: index
               name: wazuh-alerts-4.x-2026.06.01
+              uuid: Rut6_oHjSJ2wbkDzz3PGJA
               shard_count: 3
               replica_count: 0
+              doc_count: 5853
+              doc_count_deleted: 0
+              store_size_bytes: 2097152
+              creation_timestamp: '2026-06-01T00:01:33.375Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-06-02
               kind: index
               name: wazuh-alerts-4.x-2026.06.02
+              uuid: IgMtywQ_TqSNuxQnzOVK0g
               shard_count: 3
               replica_count: 0
+              doc_count: 5845
+              doc_count_deleted: 0
+              store_size_bytes: 2097152
+              creation_timestamp: '2026-06-02T00:01:45.801Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-06-03
               kind: index
               name: wazuh-alerts-4.x-2026.06.03
+              uuid: iKeB9X4qQM6LAk81FCTuMA
               shard_count: 3
               replica_count: 0
+              doc_count: 5858
+              doc_count_deleted: 0
+              store_size_bytes: 2202010
+              creation_timestamp: '2026-06-03T00:01:57.347Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-06-04
               kind: index
               name: wazuh-alerts-4.x-2026.06.04
+              uuid: HOr15VrvQ8-Tah_GbM7uqg
               shard_count: 3
               replica_count: 0
+              doc_count: 5844
+              doc_count_deleted: 0
+              store_size_bytes: 1992294
+              creation_timestamp: '2026-06-04T00:02:17.948Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-06-05
               kind: index
               name: wazuh-alerts-4.x-2026.06.05
+              uuid: Q_Z8vrqpROy3unfcUXxlMw
               shard_count: 3
               replica_count: 0
+              doc_count: 5865
+              doc_count_deleted: 0
+              store_size_bytes: 2097152
+              creation_timestamp: '2026-06-05T00:02:29.600Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-alerts-4-x-2026-06-06
               kind: index
               name: wazuh-alerts-4.x-2026.06.06
+              uuid: sKm3DX1dSHyIMvEZsnMm7Q
               shard_count: 3
               replica_count: 0
+              doc_count: 938
+              doc_count_deleted: 0
+              store_size_bytes: 663859
+              creation_timestamp: '2026-06-06T00:02:52.076Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-23
               kind: index
               name: wazuh-archives-4.x-2026.05.23
+              uuid: di3r6LvvR7eQbv1lpmgpJA
               shard_count: 3
               replica_count: 0
+              doc_count: 50946
+              doc_count_deleted: 0
+              store_size_bytes: 72142029
+              creation_timestamp: '2026-05-23T06:19:21.940Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-24
               kind: index
               name: wazuh-archives-4.x-2026.05.24
+              uuid: 4g5uomPoSeeG_84zL2wq_Q
               shard_count: 3
               replica_count: 0
+              doc_count: 68616
+              doc_count_deleted: 0
+              store_size_bytes: 96993280
+              creation_timestamp: '2026-05-24T00:00:03.573Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-25
               kind: index
               name: wazuh-archives-4.x-2026.05.25
+              uuid: kBkGQmPwTdSPVwgH9E0FGg
               shard_count: 3
               replica_count: 0
+              doc_count: 68832
+              doc_count_deleted: 0
+              store_size_bytes: 96888422
+              creation_timestamp: '2026-05-25T00:00:02.298Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-26
               kind: index
               name: wazuh-archives-4.x-2026.05.26
+              uuid: llyudOQxSjmdhLR9MMOHXA
               shard_count: 3
               replica_count: 0
+              doc_count: 68937
+              doc_count_deleted: 0
+              store_size_bytes: 96573850
+              creation_timestamp: '2026-05-26T00:00:06.631Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-27
               kind: index
               name: wazuh-archives-4.x-2026.05.27
+              uuid: 29_RK7fOQkKy1OeOWChh-w
               shard_count: 3
               replica_count: 0
+              doc_count: 68408
+              doc_count_deleted: 0
+              store_size_bytes: 96049562
+              creation_timestamp: '2026-05-27T00:00:07.718Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-28
               kind: index
               name: wazuh-archives-4.x-2026.05.28
+              uuid: s0fv6XlzTEuJNcP4RikTQg
               shard_count: 3
               replica_count: 0
+              doc_count: 68993
+              doc_count_deleted: 0
+              store_size_bytes: 96888422
+              creation_timestamp: '2026-05-28T00:00:05.253Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-29
               kind: index
               name: wazuh-archives-4.x-2026.05.29
+              uuid: tmU2NL6HQpS8O_F3lOevJA
               shard_count: 3
               replica_count: 0
+              doc_count: 68703
+              doc_count_deleted: 0
+              store_size_bytes: 96783565
+              creation_timestamp: '2026-05-29T00:00:05.080Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-30
               kind: index
               name: wazuh-archives-4.x-2026.05.30
+              uuid: BoJqRQ_STr2cKHqTKiz1ig
               shard_count: 3
               replica_count: 0
+              doc_count: 68880
+              doc_count_deleted: 0
+              store_size_bytes: 97832141
+              creation_timestamp: '2026-05-30T00:00:05.342Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-05-31
               kind: index
               name: wazuh-archives-4.x-2026.05.31
+              uuid: DZSYlg6kTxGWWwcLCoQ3HQ
               shard_count: 3
               replica_count: 0
+              doc_count: 68615
+              doc_count_deleted: 0
+              store_size_bytes: 95630131
+              creation_timestamp: '2026-05-31T00:00:04.274Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-06-01
               kind: index
               name: wazuh-archives-4.x-2026.06.01
+              uuid: EnfroEm0SWG7AL2VwocQcQ
               shard_count: 3
               replica_count: 0
+              doc_count: 68354
+              doc_count_deleted: 0
+              store_size_bytes: 97727283
+              creation_timestamp: '2026-06-01T00:00:01.847Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-06-02
               kind: index
               name: wazuh-archives-4.x-2026.06.02
+              uuid: 7suuqLuRSfmBRuPl5mCPBQ
               shard_count: 3
               replica_count: 0
+              doc_count: 68305
+              doc_count_deleted: 0
+              store_size_bytes: 95839846
+              creation_timestamp: '2026-06-02T00:00:03.726Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-06-03
               kind: index
               name: wazuh-archives-4.x-2026.06.03
+              uuid: RjLohu1mQJ-lUW6C--buuQ
               shard_count: 3
               replica_count: 0
+              doc_count: 68386
+              doc_count_deleted: 0
+              store_size_bytes: 98880717
+              creation_timestamp: '2026-06-03T00:00:07.540Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-06-04
               kind: index
               name: wazuh-archives-4.x-2026.06.04
+              uuid: ASI9um4JSiS_Tejkm__7jw
               shard_count: 3
               replica_count: 0
+              doc_count: 68316
+              doc_count_deleted: 0
+              store_size_bytes: 97202995
+              creation_timestamp: '2026-06-04T00:00:13.923Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-06-05
               kind: index
               name: wazuh-archives-4.x-2026.06.05
+              uuid: Y1S6FI35RXabEJUbxksUAg
               shard_count: 3
               replica_count: 0
+              doc_count: 68920
+              doc_count_deleted: 0
+              store_size_bytes: 96259277
+              creation_timestamp: '2026-06-05T00:00:02.536Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-archives-4-x-2026-06-06
               kind: index
               name: wazuh-archives-4.x-2026.06.06
+              uuid: RaFQxuBuQfOok4aoLewJBg
               shard_count: 3
               replica_count: 0
+              doc_count: 10956
+              doc_count_deleted: 0
+              store_size_bytes: 18140365
+              creation_timestamp: '2026-06-06T00:00:05.498Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-monitoring-2026-21w
               kind: index
               name: wazuh-monitoring-2026.21w
+              uuid: Y2BXYIFYTbiRxwXtFBg-rg
               shard_count: 1
               replica_count: 0
+              doc_count: 1168
+              doc_count_deleted: 0
+              store_size_bytes: 825754
+              creation_timestamp: '2026-05-23T06:19:28.720Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-monitoring-2026-22w
               kind: index
               name: wazuh-monitoring-2026.22w
+              uuid: 6BYEAIs_QeuZJFqN5dvoAg
               shard_count: 1
               replica_count: 0
+              doc_count: 4704
+              doc_count_deleted: 0
+              store_size_bytes: 1363149
+              creation_timestamp: '2026-05-25T00:00:01.170Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-monitoring-2026-23w
               kind: index
               name: wazuh-monitoring-2026.23w
+              uuid: YkRkznUAQX2aAA24fTQ5mQ
               shard_count: 1
               replica_count: 0
+              doc_count: 3465
+              doc_count_deleted: 0
+              store_size_bytes: 1468006
+              creation_timestamp: '2026-06-01T00:00:00.517Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-states-vulnerabilities-wazuh-manager
               kind: index
               name: wazuh-states-vulnerabilities-wazuh.manager
+              uuid: OSRyQnz1RF-E0R-f8hHnPg
               shard_count: 1
               replica_count: 0
+              doc_count: 0
+              doc_count_deleted: 0
+              store_size_bytes: 208
+              creation_timestamp: '2026-05-23T06:19:18.580Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-statistics-2026-21w
               kind: index
               name: wazuh-statistics-2026.21w
+              uuid: 9rLKEO2_Sw2-ImbyClK3jA
               shard_count: 1
               replica_count: 0
+              doc_count: 995
+              doc_count_deleted: 0
+              store_size_bytes: 706867
+              creation_timestamp: '2026-05-23T06:20:00.548Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-statistics-2026-22w
               kind: index
               name: wazuh-statistics-2026.22w
+              uuid: Rf7ev6YvRlGvmcwBPY7aaA
               shard_count: 1
               replica_count: 0
+              doc_count: 4026
+              doc_count_deleted: 0
+              store_size_bytes: 1468006
+              creation_timestamp: '2026-05-25T00:00:01.031Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
             - partition_id: wazuh-statistics-2026-23w
               kind: index
               name: wazuh-statistics-2026.23w
+              uuid: 4mUg72JATim5mYghmQtAuw
               shard_count: 1
               replica_count: 0
+              doc_count: 2960
+              doc_count_deleted: 0
+              store_size_bytes: 2621440
+              creation_timestamp: '2026-06-01T00:00:00.361Z'
+              open_closed_status: open
               health: green
-              description: OpenSearch index partition; cardinality/size/identity (uuid, doc count, store size, creation date,
-                open/closed status) blocked on Brad-Edwards/aces#468, structured field mapping blocked on Brad-Edwards/aces#469;
-                both observed in evidence.
+              description: OpenSearch index partition; per-index cardinality/size/identity from _cat/indices (store_size_bytes derived
+                from the human-rounded _cat size).
+          mappings:
+            - mapping_id: mapping-kibana-1
+              name: .kibana_1
+              top_level_field_count: 28
+              leaf_field_count: 132
+              schema_digest: sha256:9fc02cd7cc7b3a37a685f8e6a61749130be1c0ac5a5ddb824b4e7579354a10f1
+              evidence_refs:
+                - evidence/wazuh-indexer-family-mappings.json.gz
+                - evidence/wazuh-indexer-index-mappings-census.json
+              dynamic_policy: strict
+              field_type_census:
+                boolean: 5
+                date: 9
+                integer: 20
+                keyword: 21
+                long: 6
+                object: 50
+                text: 65
+              dynamic_template_count: 0
+              description: Structured field mapping for the .kibana_1 index group (1 index/indices, 1 distinct schema digest(s) across
+                members; geometry and field-type census from the representative .kibana_1).
+            - mapping_id: mapping-opendistro-security
+              name: .opendistro_security
+              top_level_field_count: 10
+              leaf_field_count: 10
+              schema_digest: sha256:6305dcadfd446ae17438672fa7f4aaa37683d148fc31dbd800e1b7accad23df0
+              evidence_refs:
+                - evidence/wazuh-indexer-family-mappings.json.gz
+                - evidence/wazuh-indexer-index-mappings-census.json
+              field_type_census:
+                keyword: 10
+                text: 10
+              dynamic_template_count: 0
+              description: Structured field mapping for the .opendistro_security index group (1 index/indices, 1 distinct schema digest(s)
+                across members; geometry and field-type census from the representative .opendistro_security).
+            - mapping_id: mapping-opensearch-observability
+              name: .opensearch-observability
+              top_level_field_count: 11
+              leaf_field_count: 11
+              schema_digest: sha256:7670e53e3cf743bb8376dd4dfdd57e04444890825e5b543bcdf91b8a205dea74
+              evidence_refs:
+                - evidence/wazuh-indexer-index-mappings-census.json
+              dynamic_policy: 'false'
+              description: Structured field mapping for the .opensearch-observability index group (1 index/indices, 1 distinct schema
+                digest(s) across members; geometry and field-type census from the representative .opensearch-observability).
+            - mapping_id: mapping-plugins-ml-config
+              name: .plugins-ml-config
+              top_level_field_count: 6
+              leaf_field_count: 6
+              schema_digest: sha256:7862e83ff2faeee75a3750f54cde2f8ddcd50f937774ecc7162ad05f43ada37e
+              evidence_refs:
+                - evidence/wazuh-indexer-index-mappings-census.json
+              description: Structured field mapping for the .plugins-ml-config index group (1 index/indices, 1 distinct schema digest(s)
+                across members; geometry and field-type census from the representative .plugins-ml-config).
+            - mapping_id: mapping-wazuh-alerts-4-x
+              name: wazuh-alerts-4.x-*
+              top_level_field_count: 25
+              leaf_field_count: 670
+              schema_digest: sha256:130c3a42ef1c56e9192533f1cccb4889770838801100c49671d3637dfcd4f09e
+              evidence_refs:
+                - evidence/wazuh-indexer-family-mappings.json.gz
+                - evidence/wazuh-indexer-index-mappings-census.json
+              field_type_census:
+                boolean: 1
+                date: 30
+                double: 5
+                geo_point: 2
+                integer: 4
+                ip: 8
+                keyword: 547
+                long: 58
+                object: 101
+                text: 15
+              dynamic_template_count: 1
+              date_detection: false
+              description: Structured field mapping for the wazuh-alerts-4.x-* index group (15 index/indices, 2 distinct schema digest(s)
+                across members; geometry and field-type census from the representative wazuh-alerts-4.x-2026.05.23).
+            - mapping_id: mapping-wazuh-archives-4-x
+              name: wazuh-archives-4.x-*
+              top_level_field_count: 25
+              leaf_field_count: 947
+              schema_digest: sha256:a05cd0f83be2f809b600f692c52a253d59aa05cd8fad5498b0dbc761b93d0ac8
+              evidence_refs:
+                - evidence/wazuh-indexer-family-mappings.json.gz
+                - evidence/wazuh-indexer-index-mappings-census.json
+              field_type_census:
+                boolean: 1
+                date: 30
+                double: 5
+                geo_point: 2
+                integer: 4
+                ip: 8
+                keyword: 824
+                long: 58
+                object: 143
+                text: 15
+              dynamic_template_count: 1
+              date_detection: false
+              description: Structured field mapping for the wazuh-archives-4.x-* index group (15 index/indices, 3 distinct schema
+                digest(s) across members; geometry and field-type census from the representative wazuh-archives-4.x-2026.05.23).
+            - mapping_id: mapping-wazuh-monitoring
+              name: wazuh-monitoring-*
+              top_level_field_count: 20
+              leaf_field_count: 27
+              schema_digest: sha256:342c4b01d51d75ef017e33800aa4d14d059ca061488dc932b0e5d544e2b7f796
+              evidence_refs:
+                - evidence/wazuh-indexer-family-mappings.json.gz
+                - evidence/wazuh-indexer-index-mappings-census.json
+              field_type_census:
+                date: 4
+                keyword: 22
+                long: 1
+                object: 2
+                text: 16
+              dynamic_template_count: 0
+              description: Structured field mapping for the wazuh-monitoring-* index group (3 index/indices, 2 distinct schema digest(s)
+                across members; geometry and field-type census from the representative wazuh-monitoring-2026.21w).
+            - mapping_id: mapping-wazuh-states-vulnerabilities-wazuh-manager
+              name: wazuh-states-vulnerabilities-wazuh.manager
+              top_level_field_count: 5
+              leaf_field_count: 47
+              schema_digest: sha256:d587876a152590882a62698d10f916818db43b6e99be2164a3ec3af5c8d9943e
+              evidence_refs:
+                - evidence/wazuh-indexer-family-mappings.json.gz
+                - evidence/wazuh-indexer-index-mappings-census.json
+              dynamic_policy: strict
+              field_type_census:
+                boolean: 1
+                date: 3
+                float: 3
+                keyword: 39
+                long: 1
+                object: 11
+              dynamic_template_count: 0
+              date_detection: false
+              description: Structured field mapping for the wazuh-states-vulnerabilities-wazuh.manager index group (1 index/indices,
+                1 distinct schema digest(s) across members; geometry and field-type census from the representative wazuh-states-vulnerabilities-wazuh.manager).
+            - mapping_id: mapping-wazuh-statistics
+              name: wazuh-statistics-*
+              top_level_field_count: 8
+              leaf_field_count: 68
+              schema_digest: sha256:2b679216aac4c25efdd661f3bb98a9681e41066acc4338fe3d8fd1823bdfc146
+              evidence_refs:
+                - evidence/wazuh-indexer-family-mappings.json.gz
+                - evidence/wazuh-indexer-index-mappings-census.json
+              field_type_census:
+                date: 1
+                keyword: 6
+                long: 61
+                object: 2
+                text: 3
+              dynamic_template_count: 1
+              description: Structured field mapping for the wazuh-statistics-* index group (3 index/indices, 1 distinct schema digest(s)
+                across members; geometry and field-type census from the representative wazuh-statistics-2026.21w).
           templates:
-            - wazuh
-            - wazuh-agent
-            - wazuh-states-vulnerabilities-wazuh.manager_template
-            - wazuh-statistics
-          engine_plugins:
-            - opensearch-alerting
-            - opensearch-anomaly-detection
-            - opensearch-asynchronous-search
-            - opensearch-cross-cluster-replication
-            - opensearch-geospatial
-            - opensearch-index-management
-            - opensearch-job-scheduler
-            - opensearch-knn
-            - opensearch-ml
-            - opensearch-neural-search
-            - opensearch-notifications
-            - opensearch-notifications-core
-            - opensearch-observability
-            - opensearch-performance-analyzer
-            - opensearch-reports-scheduler
-            - opensearch-security
-            - opensearch-security-analytics
-            - opensearch-sql
+            - template_id: wazuh
+              name: wazuh
+              index_patterns:
+                - wazuh-alerts-4.x-*
+                - wazuh-archives-4.x-*
+              evidence_refs:
+                - evidence/wazuh-indexer-templates.json.gz
+              settings_summary:
+                number_of_shards: '3'
+                number_of_replicas: '0'
+                refresh_interval: 5s
+              template_digest: sha256:8019cfb7ef5f3118992d0804352aae414b6f8f924d6d5bef94aeb4c1e13597a1
+              description: Index template wazuh seeding wazuh-alerts-4.x-*, wazuh-archives-4.x-*.
+            - template_id: wazuh-agent
+              name: wazuh-agent
+              index_patterns:
+                - wazuh-monitoring-*
+              evidence_refs:
+                - evidence/wazuh-indexer-templates.json.gz
+              settings_summary:
+                refresh_interval: 5s
+              template_digest: sha256:48cb682b14bc855c1ca36d513294f98f1f0f89dbae788b6bf37fa5f6860cb7d1
+              description: Index template wazuh-agent seeding wazuh-monitoring-*.
+            - template_id: wazuh-states-vulnerabilities-wazuh-manager_template
+              name: wazuh-states-vulnerabilities-wazuh.manager_template
+              index_patterns:
+                - wazuh-states-vulnerabilities-*
+              evidence_refs:
+                - evidence/wazuh-indexer-templates.json.gz
+              description: Index template wazuh-states-vulnerabilities-wazuh.manager_template seeding wazuh-states-vulnerabilities-*.
+            - template_id: wazuh-statistics
+              name: wazuh-statistics
+              index_patterns:
+                - wazuh-statistics-*
+              evidence_refs:
+                - evidence/wazuh-indexer-templates.json.gz
+              settings_summary:
+                refresh_interval: 5s
+              template_digest: sha256:4367638ad1385ce5acb7a887afc3f009ddf59ccd6bae18ddad200f8725e32189
+              description: Index template wazuh-statistics seeding wazuh-statistics-*.
           transport_security:
             transport_security_id: techvault-wazuh-indexer-mtls
             mode: mutual_tls
             client_verification: true
             node_verification: false
-            description: OpenSearch Security mutual-TLS using bind-mounted PEM material under /usr/share/wazuh-indexer/certs/;
-              transport hostname verification disabled per Wazuh-indexer default. Admin DN allowlist 'CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US'
+            description: OpenSearch Security mutual-TLS using bind-mounted PEM material under /usr/share/wazuh-indexer/certs/; transport
+              hostname verification disabled per Wazuh-indexer default. Admin DN allowlist 'CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US'
               encoded under the OpenSearch Security identity authority.
           settings:
             - setting_id: discovery-type
@@ -14245,12 +14699,11 @@ nodes:
               provenance: operator_override
               classification: plain
               description: Only persistent cluster setting observed via _cluster/settings.
-          description: 'Wazuh indexer (OpenSearch 2.19.1 fork) datastore service for the steady-state TechVault lab; persistence
-            mounted at /var/lib/wazuh-indexer via the wazuh-indexer-data named volume. Encoded: cluster identity (typed fields),
-            node membership/roles, per-index partition geometry (shard/replica/health), transport mutual-TLS, settings, plugin
-            + template NAMES. Blocked on ACES gaps: per-index/cluster cardinality+size+identity (Brad-Edwards/aces#468), structured
-            index mapping + template bodies (Brad-Edwards/aces#469), node engine provenance + per-plugin versions (Brad-Edwards/aces#470).
-            Blocked dimensions live in the evidence bundle and the mapping ledger, not in this prose.'
+          description: Wazuh indexer (OpenSearch 2.19.1 fork) datastore service for the steady-state TechVault lab; persistence mounted
+            at /var/lib/wazuh-indexer via the wazuh-indexer-data named volume. Encodes cluster identity + aggregate cardinality, node
+            membership/roles + engine provenance + per-plugin versions + endpoint topology, per-index partition geometry + cardinality,
+            per-family structured mappings + template bodies, transport mutual-TLS, and settings. All observed in evidence/wazuh-indexer-state.txt
+            and the mapping/template/census evidence.
       packages:
         - manager: generic
           name: openjdk

--- a/tests/test_wazuh_indexer_inventory.py
+++ b/tests/test_wazuh_indexer_inventory.py
@@ -155,18 +155,16 @@ def test_wazuh_indexer_inventory_note_declares_scope_and_evidence():
         "runtime.identity_authorities",
         "mapping-ledger.yaml",
         "aptl aces-inventory validate",
-        # The note must honestly disclose the blocked surfaces + their ACES
-        # issues, and that the inventory issue stays open until ACES lands them.
-        "Blocked surfaces (open ACES expressivity gaps)",
+        # ACES #468/#469/#470 shipped; the note records that every surface is
+        # now encoded with no remaining expressivity gap, still crediting the
+        # ACES issues that unblocked them.
+        "No known ACES expressivity gap remains",
         "Brad-Edwards/aces#468",
         "Brad-Edwards/aces#469",
         "Brad-Edwards/aces#470",
-        "stays open until these ACES surfaces land",
     )
     missing = [needle for needle in required if needle not in text]
     assert not missing, f"Wazuh indexer inventory note missing scope markers: {missing}"
-    # The over-claim the original pass shipped must never come back.
-    assert "No known ACES expressivity gap remains" not in text
 
 
 def test_wazuh_indexer_capture_script_pins_toolchain_and_redaction():
@@ -216,61 +214,43 @@ def test_wazuh_indexer_capture_stream_redaction_is_key_aware():
     assert "<REDACTED-INDEXER-INTERNAL-USER-HASH>" in redacted
 
 
-def test_wazuh_indexer_mapping_ledger_validates_with_recorded_aces_gaps():
+def test_wazuh_indexer_mapping_ledger_validates_without_gaps():
     result = validate_mapping_ledger(INDEXER_DIR)
     assert result.ok, result.errors
-    # No untriaged rows, but the OpenSearch cardinality/size, structured
-    # mapping, and node-provenance surfaces are honestly recorded as blocked
-    # on filed ACES expressivity issues rather than forced into SDL prose.
+    # ACES #468/#469/#470 shipped, so the OpenSearch cardinality/size, structured
+    # mapping, and node-provenance surfaces are now encoded from the captured
+    # evidence; no surface remains blocked on an ACES expressivity gap.
     assert result.triage_count == 0
-    assert result.blocked_count == 4
-    assert set(result.gap_issues) == {
-        "Brad-Edwards/aces #468",
-        "Brad-Edwards/aces #469",
-        "Brad-Edwards/aces #470",
-    }
+    assert result.blocked_count == 0
+    assert set(result.gap_issues) == set()
 
     ledger = load_mapping_ledger(LEDGER_PATH)
     assert ledger["asset"]["aptl_issue"] == 341
     assert IMAGE_DIGEST_RE.match(ledger["provenance"]["image_digest"])
     dispositions = {fact["id"]: fact["aces"]["disposition"] for fact in ledger["facts"]}
-    # Encoded surfaces: cluster identity, partition geometry, internal users.
-    assert dispositions["wazuh-indexer.datastore.cluster-identity"] == "encoded_with_caveat"
-    assert dispositions["wazuh-indexer.datastore.partition-geometry"] == "encoded_with_caveat"
-    assert dispositions["wazuh-indexer.identity.internal-users"] == "encoded"
-    # Plugin names encoded, per-plugin version blocked → caveat.
-    assert dispositions["wazuh-indexer.datastore.plugins"] == "encoded_with_caveat"
-    # Blocked surfaces: cardinality/size/identity, structured mappings, node provenance.
-    assert dispositions["wazuh-indexer.datastore.cluster-cardinality"] == "blocked_by_aces_gap"
-    assert dispositions["wazuh-indexer.datastore.partition-cardinality"] == "blocked_by_aces_gap"
-    assert dispositions["wazuh-indexer.datastore.index-mappings"] == "blocked_by_aces_gap"
-    assert dispositions["wazuh-indexer.datastore.node-provenance"] == "blocked_by_aces_gap"
+    # Every datastore surface formerly blocked or caveated on #468/#469/#470 is
+    # now fully encoded from typed fields.
+    for fact_id in (
+        "wazuh-indexer.datastore.cluster-identity",
+        "wazuh-indexer.datastore.cluster-cardinality",
+        "wazuh-indexer.datastore.node-membership",
+        "wazuh-indexer.datastore.node-provenance",
+        "wazuh-indexer.datastore.partition-geometry",
+        "wazuh-indexer.datastore.partition-cardinality",
+        "wazuh-indexer.datastore.index-mappings",
+        "wazuh-indexer.datastore.plugins",
+        "wazuh-indexer.identity.internal-users",
+    ):
+        assert dispositions[fact_id] == "encoded", fact_id
     assert len(ledger["facts"]) >= 30
 
 
-def test_wazuh_indexer_gap_report_records_blocked_surfaces_with_linked_issues():
+def test_wazuh_indexer_gap_report_records_no_blocked_surfaces():
     report = gap_report(INDEXER_DIR)
     assert report["triage_needed"] == []
-    gaps = report["gaps"]
-    by_fact = {g["fact_id"]: g for g in gaps}
-    expected = {
-        "wazuh-indexer.datastore.cluster-cardinality": 468,
-        "wazuh-indexer.datastore.partition-cardinality": 468,
-        "wazuh-indexer.datastore.index-mappings": 469,
-        "wazuh-indexer.datastore.node-provenance": 470,
-    }
-    assert set(by_fact) == set(expected), f"unexpected blocked-fact set: {sorted(by_fact)}"
-    for fact_id, issue_number in expected.items():
-        gap = by_fact[fact_id]
-        assert gap["gap_issue"]["tracker"] == "Brad-Edwards/aces"
-        assert gap["gap_issue"]["number"] == issue_number
-        assert gap["gap_issue"]["url"].endswith(f"/issues/{issue_number}")
-        assert gap["why_not_current_surfaces"]
-    # The structured-mapping gap must point at the real captured evidence,
-    # not at SDL prose.
-    mapping_evidence = {e["path"] for e in by_fact["wazuh-indexer.datastore.index-mappings"]["evidence"]}
-    assert "evidence/wazuh-indexer-index-mappings-census.json" in mapping_evidence
-    assert "evidence/wazuh-indexer-templates.json.gz" in mapping_evidence
+    # ACES #468/#469/#470 shipped and every formerly-blocked surface is encoded;
+    # the gap report is now empty.
+    assert report["gaps"] == []
 
 
 def test_wazuh_indexer_evidence_bundle_files_are_present_and_non_empty():
@@ -450,32 +430,34 @@ def test_techvault_sdl_encodes_wazuh_indexer_datastore_surface():
     assert {"discovery.type", "network.host", "http.port", "transport.tcp.port"} <= setting_names
     assert ds["transport_security"]["mode"] == "mutual_tls"
     assert ds["transport_security"]["client_verification"] is True
-    # Plugin + template NAMES have a typed home and are encoded.
-    assert len(ds["engine_plugins"]) >= 18
-    template_names = set(ds.get("templates", []))
+    # Plugins (with per-plugin versions) and structured templates are encoded.
+    plugins = {p["plugin_id"]: p for p in node_member["plugins"]}
+    assert len(plugins) >= 18
+    assert plugins["opensearch-security"]["version"] == "2.19.1.0"
+    template_names = {t["name"] for t in ds["templates"]}
     assert {"wazuh", "wazuh-agent", "wazuh-statistics"} <= template_names
 
-    # Honesty guard (the bug this re-encode fixes): blocked structured
-    # observables must NOT be forced back into SDL prose. The datastore
-    # service must carry zero per-index/cluster cardinality-size values and
-    # zero engine build provenance in any description string; those live in
-    # evidence + the blocked_by_aces_gap ledger facts.
-    ds_blob = json.dumps(ds)
-    forbidden_prose = [
-        "u-vGl1n0Q7e",            # cluster uuid
-        "docs.count",             # per-index doc count label
-        "store.size",             # per-index store size label
-        "store bytes",
-        "dae2bfc93896",           # node build hash
-        "1053842",                # aggregate doc count
-        "1391460626",             # aggregate store bytes
-    ]
-    leaked = [needle for needle in forbidden_prose if needle in ds_blob]
-    assert not leaked, f"blocked structured values leaked back into SDL prose: {leaked}"
-    # The descriptions must instead reference the ACES blocker issues.
-    assert "Brad-Edwards/aces#468" in ds_blob
-    assert "Brad-Edwards/aces#469" in ds_blob
-    assert "Brad-Edwards/aces#470" in ds_blob
+    # ACES #468/#469/#470 shipped: cluster cardinality, node engine provenance,
+    # per-index cardinality, and structured mappings now have typed homes and are
+    # encoded as field values (no longer blocked, no longer withheld to evidence).
+    assert ds["cluster"]["uuid"] == "u-vGl1n0Q7e-SKz1tWvb-w"
+    assert ds["cluster"]["doc_count"] == 1053842
+    assert ds["cluster"]["store_size_bytes"] == 1391460626
+    assert ds["cluster"]["shard_total"] == 102
+    assert node_member["engine_version"] == "2.19.1"
+    assert node_member["build_hash"] == "dae2bfc93896178873b43cdf4781f183c72b238f"
+    assert node_member["heap_max_bytes"] == 1073741824
+    assert {"client", "peer"} <= {e["role"] for e in node_member["endpoints"]}
+    by_name = {p["name"]: p for p in ds["partitions"]}
+    archive = by_name["wazuh-archives-4.x-2026.05.28"]
+    assert archive["uuid"] == "s0fv6XlzTEuJNcP4RikTQg"
+    assert archive["doc_count"] == 68993
+    assert archive["open_closed_status"] == "open"
+    mapping_names = {m["name"] for m in ds["mappings"]}
+    assert "wazuh-archives-4.x-*" in mapping_names
+    archives_mapping = next(m for m in ds["mappings"] if m["name"] == "wazuh-archives-4.x-*")
+    assert archives_mapping["leaf_field_count"] == 947
+    assert archives_mapping["schema_digest"].startswith("sha256:")
 
     authorities = runtime["identity_authorities"]
     assert len(authorities) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -5,7 +5,7 @@ requires-python = ">=3.11"
 [[package]]
 name = "aces-sdl"
 version = "0.2.0"
-source = { git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev#526ae02901a3c898f1f7750144048d87cc886ec5" }
+source = { git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev#ac5279a11e994e06524a8e5935e81e233cd29fe6" }
 dependencies = [
     { name = "asyncssh" },
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

ACES **#468** (datastore cardinality), **#469** (structured mappings + template bodies), and **#470** (node engine provenance) merged to aces `dev` (`ac5279a1`), giving typed homes to the four surfaces the SCN-010 wazuh.indexer inventory (#341) had honestly recorded as `blocked_by_aces_gap`. This bumps `aces-sdl` to `ac5279a1` and encodes all four from the already-captured evidence — **no known ACES expressivity gap remains** for this node.

## What changed

- **cluster** (#468): `uuid`, `node_count`, `shard_total`/`shard_primaries`, `doc_count` (1,053,842), `store_size_bytes` (1,391,460,626) on `RuntimeDatastoreCluster`.
- **node provenance** (#470): `engine_version`/`build_hash`/`build_type`, JVM heap bounds, `memory_locked`, typed per-plugin versions (18× `RuntimeDatastoreEnginePlugin`), and client/peer publish endpoints (`RuntimeDatastoreNodeEndpoint`).
- **partitions** (#468): per-index `uuid`/`doc_count`/`doc_count_deleted`/`store_size_bytes`/`creation_timestamp`/`open_closed_status` across all 41 indices.
- **mappings + templates** (#469): per-family `RuntimeDatastoreMapping` (schema geometry, field-type census, dynamic policy, schema digest) and structured `RuntimeDatastoreTemplate` bodies.
- **misp-redis**: the new schema removed the name-only `RuntimeDatastoreService.engine_plugins` (plugins are per-node now), so the empty `engine_plugins` is dropped.
- **ledger / README / tests**: the 4 blocked + 4 caveated datastore facts are now `encoded` (0 blocked, 0 gap issues); the prose-leak honesty guard inverts to assert the typed values are present.

## Validation

- Full composed SDL parses (24 nodes) against `aces-sdl@ac5279a1`.
- `tests/test_wazuh_indexer_inventory.py` (14) pass; `misp-redis` + `parity` + `classification-audit` (40) pass; mapping ledger validates with 0 gaps.
- Pre-commit clean (incl. `detect private key`).

## Open question before closing #341

The OpenSearch Security **internal-user bcrypt hashes** are still redacted in the identity-authority (`<REDACTED-INDEXER-INTERNAL-USER-HASH>`), enforced by `redact_stream` in the capture script. This is a *separate* concern from #468/#469/#470 (those are now fully encoded), but per the "capture all scenario secrets" bar it may want capturing too. Doing so means re-capturing `internal_users.yml`, relaxing `redact_stream` for those hashes, and updating the two redaction tests. **Flagging for your call** — happy to add it to this branch before merge, or track separately.
