### PR TITLE
Guard docs-deploy jobs to main ref only

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -21,6 +21,11 @@ concurrency:
 
 jobs:
   build:
+    # Job-level main-only guard: `push.branches: [main]` constrains only
+    # push events, while workflow_dispatch can target any ref. Without
+    # this guard a collaborator could manually deploy a non-main
+    # branch's docs to Pages (codex finding on #408).
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -37,6 +42,7 @@ jobs:
           path: site
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Follow-up to #408 (issue #407, DOC-001). Fixes the codex security finding: `workflow_dispatch` can target any ref, so the `push.branches: [main]` trigger filter alone did not enforce the main-only Pages deploy policy — a collaborator could manually publish a non-main branch's docs using the workflow's `pages: write` / `id-token: write` permissions. Adds job-level `if: github.ref == 'refs/heads/main'` guards to both the build and deploy jobs, per the finding's recommendation: https://github.com/Brad-Edwards/aptl/pull/408#discussion_r3398832859