### PR TITLE
[codex] Update README conference acceptances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=Brad-Edwards_aptl&token=4dd88be3421d6d030a4615b86ac8ab0e3c9eb4d3)](https://sonarcloud.io/summary/new_code?id=Brad-Edwards_aptl)
 
-🎤 **Accepted to [Black Hat USA Arsenal 2026](https://blackhat.com/us-26/arsenal/schedule/#aptl-advanced-purple-team-labs-52322) and [SecTor Arsenal 2026](https://blackhat.com/sector/arsenal/schedule/index.html#aptl-advanced-purple-team-labs-54785).** Live demos at both conferences.
+🎤 **Accepted to [Black Hat USA Arsenal 2026](https://blackhat.com/us-26/arsenal/schedule/#aptl-advanced-purple-team-labs-52322), [SecTor Arsenal 2026](https://blackhat.com/sector/arsenal/schedule/index.html#aptl-advanced-purple-team-labs-54785), and SecTor 2026 Briefings.** Live Arsenal demos at both conferences, plus the SecTor Briefing talk **APTL for Agentic Purple Teaming**.
 
 # APTL—Advanced Purple Team Lab
 


### PR DESCRIPTION
## Summary

Updates the main README announcement to include APTL's 2026 conference acceptances:

- Black Hat USA Arsenal 2026
- SecTor Arsenal 2026
- SecTor 2026 Briefings talk: `APTL for Agentic Purple Teaming`

## Why

The README should reflect the newly accepted SecTor Briefing alongside the existing Arsenal appearances.

## Impact

Documentation-only change. No runtime behavior changes.

## Validation

- `pre-commit run --files README.md`

Closes #412