### PR TITLE
changed: route lab start through ACES runtime

### DIFF
--- a/changelog.d/321.changed.md
+++ b/changelog.d/321.changed.md
@@ -1,0 +1,1 @@
+Route `aptl lab start` and `/api/lab/start` container startup through the ACES SDL parser, runtime planner, and APTL provisioning target before invoking the existing deployment backend.

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -1,0 +1,551 @@
+"""APTL ACES runtime target.
+
+This module is the handoff layer between the external ACES SDL/runtime
+packages and APTL's existing deployment primitives.  It intentionally keeps
+Docker/SSH details behind ``DeploymentBackend``; the ACES provisioner only
+translates a provisioning plan into the compose profiles APTL can already
+start.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.planning import ChangeAction, ProvisioningPlan, RuntimeDomain
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
+from aces_runtime.manager import RuntimeManager
+from aces_runtime.registry import RuntimeTarget
+from aces_sdl import SDLError, parse_sdl_file
+
+from aptl.core.config import AptlConfig
+from aptl.core.lab_types import LabResult
+from aptl.utils.logging import get_logger
+from aptl.utils.redaction import redact
+
+if TYPE_CHECKING:
+    from aptl.core.deployment.backend import DeploymentBackend
+
+log = get_logger("aces-backend")
+
+APTL_ACES_TARGET_NAME = "aptl"
+DEFAULT_ACES_SCENARIO = Path("scenarios") / "techvault.sdl.yaml"
+
+_SUPPORTED_RESOURCE_TYPES = frozenset(
+    {
+        "network",
+        "node",
+        "feature-binding",
+        "content-placement",
+        "account-placement",
+    }
+)
+_CORE_PROFILES = frozenset({"otel"})
+_IDENTIFIER_SEPARATORS = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class _AptlProvisionerCapabilities:
+    """Minimal capability shape consumed by the ACES planner."""
+
+    name: str = "aptl-docker-compose-provisioner"
+    supported_node_types: frozenset[str] = frozenset({"switch", "vm"})
+    supported_os_families: frozenset[str] = frozenset(
+        {"freebsd", "linux", "macos", "other", "windows"}
+    )
+    supported_content_types: frozenset[str] = frozenset(
+        {"dataset", "directory", "file"}
+    )
+    supported_account_features: frozenset[str] = frozenset(
+        {
+            "auth_method",
+            "disabled",
+            "groups",
+            "home",
+            "mail",
+            "other:password_strength",
+            "shell",
+            "spn",
+        }
+    )
+    max_total_nodes: int | None = None
+    supports_acls: bool = True
+    supports_accounts: bool = True
+    constraints: Mapping[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class _AptlBackendManifest:
+    """Runtime-target manifest shape used by ``RuntimeManager``.
+
+    The installed ACES package validates full manifests against the ACES
+    contract corpus.  APTL's direct-reference dependency does not vendor that
+    corpus into ``.venv/contracts``, so the runtime target uses the attributes
+    consumed by ``aces_processor.planner`` and ``aces_runtime.registry`` while
+    leaving full manifest conformance to the ACES package distribution.
+    """
+
+    name: str = APTL_ACES_TARGET_NAME
+    version: str = "0.1.0"
+    provisioner: _AptlProvisionerCapabilities = (
+        _AptlProvisionerCapabilities()
+    )
+    orchestrator: None = None
+    evaluator: None = None
+    participant_runtime: None = None
+
+    @property
+    def has_orchestrator(self) -> bool:
+        return False
+
+    @property
+    def has_evaluator(self) -> bool:
+        return False
+
+    @property
+    def has_participant_runtime(self) -> bool:
+        return False
+
+    @property
+    def evaluator_supported_sections(self) -> frozenset[str]:
+        return frozenset()
+
+    @property
+    def supports_scoring(self) -> bool:
+        return False
+
+    @property
+    def supports_objectives(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class _ComposeProfileIndex:
+    """Compose service aliases indexed to profile names."""
+
+    alias_to_profiles: dict[str, frozenset[str]]
+
+    def profiles_for_aliases(self, aliases: set[str]) -> frozenset[str]:
+        profiles: set[str] = set()
+        for alias in aliases:
+            profiles.update(self.alias_to_profiles.get(alias, frozenset()))
+        return frozenset(profiles)
+
+
+def create_aptl_manifest() -> _AptlBackendManifest:
+    """Return the APTL provisioning-only runtime manifest."""
+
+    return _AptlBackendManifest()
+
+
+def create_aptl_runtime_target(
+    *,
+    project_dir: Path,
+    config: AptlConfig,
+    backend: "DeploymentBackend",
+) -> RuntimeTarget:
+    """Build the ACES runtime target for APTL."""
+
+    provisioner = AptlProvisioner(
+        project_dir=project_dir,
+        config=config,
+        deployment_backend=backend,
+    )
+    return RuntimeTarget(
+        name=APTL_ACES_TARGET_NAME,
+        manifest=create_aptl_manifest(),  # type: ignore[arg-type]
+        provisioner=provisioner,  # type: ignore[arg-type]
+    )
+
+
+def start_aces_scenario(
+    project_dir: Path,
+    config: AptlConfig,
+    backend: "DeploymentBackend",
+    scenario_path: Path | None = None,
+) -> LabResult:
+    """Start an APTL lab by compiling and applying an ACES SDL scenario."""
+
+    resolved_scenario = scenario_path or DEFAULT_ACES_SCENARIO
+    if not resolved_scenario.is_absolute():
+        resolved_scenario = project_dir / resolved_scenario
+    try:
+        scenario = parse_sdl_file(resolved_scenario)
+        target = create_aptl_runtime_target(
+            project_dir=project_dir,
+            config=config,
+            backend=backend,
+        )
+        manager = RuntimeManager(target)
+        execution_plan = manager.plan(scenario)
+        result = manager.apply(execution_plan)
+    except (FileNotFoundError, SDLError, TypeError, ValueError) as exc:
+        return LabResult(
+            success=False,
+            error=redact(f"ACES runtime handoff failed: {exc}"),
+        )
+
+    if result.success:
+        return LabResult(
+            success=True,
+            message=(
+                "Lab started through ACES runtime target "
+                f"'{APTL_ACES_TARGET_NAME}'"
+            ),
+        )
+    return LabResult(
+        success=False,
+        error=_render_aces_diagnostics(result.diagnostics),
+    )
+
+
+@dataclass
+class AptlProvisioner:
+    """Provisioning-only ACES backend adapter for APTL."""
+
+    project_dir: Path
+    config: AptlConfig
+    deployment_backend: "DeploymentBackend"
+
+    def validate(self, plan: object) -> list[Diagnostic]:
+        """Validate that the ACES provisioning plan is APTL-realizable."""
+
+        if not isinstance(plan, ProvisioningPlan):
+            return [
+                _diagnostic(
+                    "aptl.provisioner.invalid-plan",
+                    "runtime.apply.provisioning",
+                    "APTL provisioner expected an ACES ProvisioningPlan.",
+                )
+            ]
+
+        diagnostics: list[Diagnostic] = []
+        diagnostics.extend(_unsupported_resource_diagnostics(plan))
+
+        profiles, profile_diagnostics = self._profiles_from_plan(plan)
+        diagnostics.extend(profile_diagnostics)
+        configured = _configured_profiles(self.config)
+        if configured and not (set(configured) & set(profiles)):
+            diagnostics.append(
+                _diagnostic(
+                    "aptl.provisioner.no-configured-profile-matches",
+                    "runtime.apply.provisioning",
+                    (
+                        "ACES provisioning plan did not declare any node "
+                        "that maps to an enabled APTL compose profile."
+                    ),
+                )
+            )
+
+        return diagnostics
+
+    def apply(self, plan: object, snapshot: object) -> ApplyResult:
+        """Apply an ACES provisioning plan via APTL's deployment backend."""
+
+        working_snapshot = (
+            snapshot if isinstance(snapshot, RuntimeSnapshot) else RuntimeSnapshot()
+        )
+        diagnostics = self.validate(plan)
+        if not isinstance(plan, ProvisioningPlan):
+            return ApplyResult(
+                success=False,
+                snapshot=working_snapshot,
+                diagnostics=diagnostics,
+            )
+        if _has_error(diagnostics):
+            return ApplyResult(
+                success=False,
+                snapshot=working_snapshot,
+                diagnostics=diagnostics,
+            )
+
+        profiles, profile_diagnostics = self._profiles_from_plan(plan)
+        diagnostics.extend(profile_diagnostics)
+        if _has_error(diagnostics):
+            return ApplyResult(
+                success=False,
+                snapshot=working_snapshot,
+                diagnostics=diagnostics,
+            )
+
+        selected_profiles = _select_backend_profiles(self.config, profiles)
+        start_result = self.deployment_backend.start(selected_profiles)
+        if not start_result.success:
+            diagnostics.append(
+                _diagnostic(
+                    "aptl.provisioner.backend-start-failed",
+                    "runtime.apply.provisioning",
+                    start_result.error or "APTL deployment backend failed.",
+                )
+            )
+            return ApplyResult(
+                success=False,
+                snapshot=working_snapshot,
+                diagnostics=diagnostics,
+                details={"profiles": selected_profiles},
+            )
+
+        next_snapshot = _snapshot_after_apply(plan, working_snapshot)
+        changed_addresses = [
+            op.address
+            for op in plan.operations
+            if op.action != ChangeAction.UNCHANGED
+        ]
+        return ApplyResult(
+            success=True,
+            snapshot=next_snapshot,
+            diagnostics=diagnostics,
+            changed_addresses=changed_addresses,
+            details={"profiles": selected_profiles},
+        )
+
+    def _profiles_from_plan(
+        self,
+        plan: ProvisioningPlan,
+    ) -> tuple[frozenset[str], list[Diagnostic]]:
+        diagnostics: list[Diagnostic] = []
+        try:
+            profile_index = _load_compose_profile_index(self.project_dir)
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            return (
+                frozenset(),
+                [
+                    _diagnostic(
+                        "aptl.provisioner.compose-profile-index-failed",
+                        "runtime.apply.provisioning",
+                        redact(str(exc)),
+                    )
+                ],
+            )
+
+        profiles: set[str] = set()
+        for resource in plan.resources.values():
+            if resource.resource_type != "node":
+                continue
+            payload = resource.payload
+            profiles.update(_explicit_compose_profile_hints(payload))
+            profiles.update(
+                profile_index.profiles_for_aliases(
+                    _node_aliases(resource.address, payload)
+                )
+            )
+
+        if not profiles:
+            diagnostics.append(
+                _diagnostic(
+                    "aptl.provisioner.profile-resolution-failed",
+                    "runtime.apply.provisioning",
+                    (
+                        "ACES provisioning plan contained no node resources "
+                        "that map to APTL compose profiles."
+                    ),
+                )
+            )
+        return frozenset(profiles), diagnostics
+
+
+def _load_compose_profile_index(project_dir: Path) -> _ComposeProfileIndex:
+    compose_path = project_dir / "docker-compose.yml"
+    if not compose_path.exists():
+        raise ValueError(f"docker-compose.yml not found under {project_dir}")
+    data = yaml.safe_load(compose_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, Mapping):
+        raise ValueError(f"{compose_path} must contain a YAML mapping")
+    services = data.get("services") or {}
+    if not isinstance(services, Mapping):
+        raise ValueError(f"{compose_path} services section must be a mapping")
+
+    alias_to_profiles: dict[str, set[str]] = {}
+    for service_name, service_def in services.items():
+        if not isinstance(service_def, Mapping):
+            continue
+        profiles = {
+            str(profile)
+            for profile in (service_def.get("profiles") or [])
+            if str(profile).strip()
+        }
+        if not profiles:
+            continue
+        aliases = {str(service_name)}
+        for alias_key in ("container_name", "hostname"):
+            alias = service_def.get(alias_key)
+            if isinstance(alias, str) and alias.strip():
+                aliases.add(alias)
+        for alias in aliases:
+            for normalized in _normalized_identifier_aliases(alias):
+                alias_to_profiles.setdefault(normalized, set()).update(profiles)
+
+    return _ComposeProfileIndex(
+        {
+            alias: frozenset(profiles)
+            for alias, profiles in alias_to_profiles.items()
+        }
+    )
+
+
+def _normalized_identifier_aliases(raw: str) -> set[str]:
+    normalized = _normalize_identifier(raw)
+    if not normalized:
+        return set()
+    aliases = {normalized}
+    if normalized.startswith("aptl-"):
+        aliases.add(normalized.removeprefix("aptl-"))
+    return {alias for alias in aliases if alias}
+
+
+def _normalize_identifier(raw: str) -> str:
+    lowered = raw.strip().lower()
+    normalized = _IDENTIFIER_SEPARATORS.sub("-", lowered).strip("-")
+    return normalized
+
+
+def _node_aliases(address: str, payload: Mapping[str, Any]) -> set[str]:
+    raw_values: set[str] = {address}
+    for key in ("name", "node_name", "target_node"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            raw_values.add(value)
+
+    spec = payload.get("spec")
+    if isinstance(spec, Mapping):
+        node_spec = spec.get("node")
+        if isinstance(node_spec, Mapping):
+            for key in ("name", "node_id", "hostname"):
+                value = node_spec.get(key)
+                if isinstance(value, str) and value.strip():
+                    raw_values.add(value)
+
+    aliases: set[str] = set()
+    for value in raw_values:
+        aliases.update(_normalized_identifier_aliases(value))
+        if "." in value:
+            aliases.update(_normalized_identifier_aliases(value.rsplit(".", 1)[-1]))
+    return aliases
+
+
+def _explicit_compose_profile_hints(payload: Mapping[str, Any]) -> frozenset[str]:
+    hints: set[str] = set()
+    for parent_key in ("runtime", "aptl"):
+        parent = payload.get(parent_key)
+        if isinstance(parent, Mapping):
+            hints.update(_profile_values(parent.get("compose_profiles")))
+            hints.update(_profile_values(parent.get("compose_profile")))
+
+    spec = payload.get("spec")
+    if isinstance(spec, Mapping):
+        for parent_key in ("runtime", "aptl"):
+            parent = spec.get(parent_key)
+            if isinstance(parent, Mapping):
+                hints.update(_profile_values(parent.get("compose_profiles")))
+                hints.update(_profile_values(parent.get("compose_profile")))
+    return frozenset(hints)
+
+
+def _profile_values(raw: object) -> set[str]:
+    if isinstance(raw, str):
+        return {raw} if raw.strip() else set()
+    if isinstance(raw, list | tuple | set | frozenset):
+        return {str(value) for value in raw if str(value).strip()}
+    return set()
+
+
+def _configured_profiles(config: AptlConfig) -> list[str]:
+    return list(config.containers.enabled_profiles())
+
+
+def _select_backend_profiles(
+    config: AptlConfig,
+    plan_profiles: frozenset[str],
+) -> list[str]:
+    selected = [
+        profile
+        for profile in _configured_profiles(config)
+        if profile in plan_profiles
+    ]
+    for profile in _CORE_PROFILES:
+        if profile not in selected:
+            selected.append(profile)
+    return selected
+
+
+def _unsupported_resource_diagnostics(
+    plan: ProvisioningPlan,
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    seen: set[tuple[str, str]] = set()
+    for resource in list(plan.resources.values()) + list(plan.operations):
+        resource_type = resource.resource_type
+        if resource_type in _SUPPORTED_RESOURCE_TYPES:
+            continue
+        key = (resource.address, resource_type)
+        if key in seen:
+            continue
+        seen.add(key)
+        diagnostics.append(
+            _diagnostic(
+                "aptl.provisioner.unsupported-resource-type",
+                resource.address,
+                (
+                    "APTL provisioning target does not support ACES "
+                    f"resource type '{resource_type}'."
+                ),
+            )
+        )
+    return diagnostics
+
+
+def _snapshot_after_apply(
+    plan: ProvisioningPlan,
+    snapshot: RuntimeSnapshot,
+) -> RuntimeSnapshot:
+    entries = dict(snapshot.entries)
+    for op in plan.operations:
+        if op.action == ChangeAction.DELETE:
+            entries.pop(op.address, None)
+    for address, resource in plan.resources.items():
+        entries[address] = SnapshotEntry(
+            address=address,
+            domain=RuntimeDomain.PROVISIONING,
+            resource_type=resource.resource_type,
+            payload=resource.payload,
+            ordering_dependencies=resource.ordering_dependencies,
+            refresh_dependencies=resource.refresh_dependencies,
+            status="ready",
+        )
+    return snapshot.with_entries(entries)
+
+
+def _diagnostic(code: str, address: str, message: str) -> Diagnostic:
+    return Diagnostic(
+        code=code,
+        domain=RuntimeDomain.PROVISIONING.value,
+        address=address,
+        message=redact(message),
+        severity=Severity.ERROR,
+    )
+
+
+def _has_error(diagnostics: list[Diagnostic]) -> bool:
+    return any(diagnostic.is_error for diagnostic in diagnostics)
+
+
+def _render_aces_diagnostics(diagnostics: list[Diagnostic]) -> str:
+    if not diagnostics:
+        return "ACES runtime handoff failed."
+    rendered = [
+        f"{diag.code} at {diag.address}: {diag.message}"
+        for diag in diagnostics
+        if diag.is_error
+    ]
+    if not rendered:
+        rendered = [
+            f"{diag.code} at {diag.address}: {diag.message}"
+            for diag in diagnostics
+        ]
+    return redact("ACES runtime handoff failed: " + "; ".join(rendered[:5]))

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Optional
 import icontract
 import yaml
 
+from aptl.backends.aces import start_aces_scenario
 from aptl.core.certs import ensure_ssl_certs
 from aptl.core.soc_ca import ensure_soc_certs
 from aptl.core.config import AptlConfig, find_config, load_config
@@ -801,9 +802,7 @@ def _step_pull_images(ctx: _LabStartContext) -> LabResult | None:
 def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
     log.info("Step 8: Starting containers...")
     assert ctx.config is not None and ctx.backend is not None  # runtime guards above
-    start_result = start_lab(
-        ctx.config, project_dir=ctx.project_dir, backend=ctx.backend
-    )
+    start_result = start_aces_scenario(ctx.project_dir, ctx.config, ctx.backend)
     if not start_result.success and ctx.config.containers.soc:
         log.warning(
             "Initial compose up failed (SOC dependencies may still be "
@@ -811,9 +810,7 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
         )
         import time
         time.sleep(60)
-        start_result = start_lab(
-            ctx.config, project_dir=ctx.project_dir, backend=ctx.backend
-        )
+        start_result = start_aces_scenario(ctx.project_dir, ctx.config, ctx.backend)
     if start_result.success:
         return None
     log.error("Lab start failed: %s", start_result.error)

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -72,7 +72,12 @@ def start_aces_scenario(
     backend: "DeploymentBackend",
 ) -> LabResult:
     """Lazy ACES handoff import for the public lab-start path."""
-    from aptl.backends.aces import start_aces_scenario as _start_aces_scenario
+    try:
+        from aptl.backends.aces import start_aces_scenario as _start_aces_scenario
+    except (ImportError, ModuleNotFoundError) as exc:
+        error = f"ACES runtime handoff unavailable: {redact(str(exc))}"
+        log.error(error)
+        return LabResult(success=False, error=error)
 
     return _start_aces_scenario(project_dir, config, backend)
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Optional
 import icontract
 import yaml
 
-from aptl.backends.aces import start_aces_scenario
 from aptl.core.certs import ensure_ssl_certs
 from aptl.core.soc_ca import ensure_soc_certs
 from aptl.core.config import AptlConfig, find_config, load_config
@@ -65,6 +64,17 @@ if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
 
 log = get_logger("lab")
+
+
+def start_aces_scenario(
+    project_dir: Path,
+    config: AptlConfig,
+    backend: "DeploymentBackend",
+) -> LabResult:
+    """Lazy ACES handoff import for the public lab-start path."""
+    from aptl.backends.aces import start_aces_scenario as _start_aces_scenario
+
+    return _start_aces_scenario(project_dir, config, backend)
 
 
 def _runtime_require(condition, description):

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -1,0 +1,208 @@
+"""Tests for the APTL ACES runtime handoff."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from aces_contracts.planning import (
+    ChangeAction,
+    PlannedResource,
+    ProvisioningPlan,
+    ProvisionOp,
+    RuntimeDomain,
+)
+from aces_contracts.runtime_state import RuntimeSnapshot
+
+from aptl.core.config import AptlConfig
+from aptl.core.lab_types import LabResult
+
+
+def _write_compose(project_dir: Path, services: dict[str, list[str]]) -> None:
+    lines = ["services:"]
+    for service_name, profiles in services.items():
+        rendered = ", ".join(f'"{profile}"' for profile in profiles)
+        lines.extend(
+            [
+                f"  {service_name}:",
+                f"    profiles: [{rendered}]",
+                "    image: example:latest",
+            ]
+        )
+    (project_dir / "docker-compose.yml").write_text("\n".join(lines))
+
+
+def _node_resource(node_name: str) -> PlannedResource:
+    address = f"provision.node.{node_name}"
+    payload = {
+        "name": node_name,
+        "node_name": node_name,
+        "node_type": "vm",
+        "os_family": "linux",
+        "spec": {"node": {"name": node_name}, "infrastructure": {}},
+    }
+    return PlannedResource(
+        address=address,
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload=payload,
+    )
+
+
+def _plan_for_nodes(*node_names: str) -> ProvisioningPlan:
+    resources = {resource.address: resource for resource in map(_node_resource, node_names)}
+    operations = [
+        ProvisionOp(
+            action=ChangeAction.CREATE,
+            address=resource.address,
+            resource_type=resource.resource_type,
+            payload=resource.payload,
+        )
+        for resource in resources.values()
+    ]
+    return ProvisioningPlan(resources=resources, operations=operations)
+
+
+def _plan_with_resource_type(resource_type: str) -> ProvisioningPlan:
+    resource = PlannedResource(
+        address=f"provision.{resource_type}.example",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type=resource_type,
+        payload={"name": "example"},
+    )
+    return ProvisioningPlan(
+        resources={resource.address: resource},
+        operations=[
+            ProvisionOp(
+                action=ChangeAction.CREATE,
+                address=resource.address,
+                resource_type=resource.resource_type,
+                payload=resource.payload,
+            )
+        ],
+    )
+
+
+def test_create_runtime_target_accepts_aptl_manifest_shape(tmp_path):
+    from aptl.backends.aces import create_aptl_runtime_target
+
+    backend = MagicMock()
+    config = AptlConfig(lab={"name": "test"})
+
+    target = create_aptl_runtime_target(
+        project_dir=tmp_path,
+        config=config,
+        backend=backend,
+    )
+
+    assert target.name == "aptl"
+    assert target.manifest.name == "aptl"
+
+
+def test_start_aces_scenario_uses_parser_runtime_manager_and_backend(
+    mocker,
+    tmp_path,
+):
+    from aptl.backends import aces
+
+    _write_compose(
+        tmp_path,
+        {
+            "wazuh.manager": ["wazuh"],
+            "kali": ["kali"],
+            "aptl-otel-collector": ["otel"],
+        },
+    )
+    scenario = object()
+    parser = mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=scenario)
+    calls: dict[str, object] = {}
+
+    class FakeRuntimeManager:
+        def __init__(self, target):
+            self.target = target
+
+        def plan(self, parsed_scenario):
+            calls["planned_scenario"] = parsed_scenario
+            return "execution-plan"
+
+        def apply(self, execution_plan):
+            calls["execution_plan"] = execution_plan
+            plan = _plan_for_nodes("techvault.wazuh-manager", "techvault.kali")
+            return self.target.provisioner.apply(plan, RuntimeSnapshot())
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(
+        lab={"name": "test"},
+        containers={"wazuh": True, "kali": True, "victim": False},
+    )
+
+    result = aces.start_aces_scenario(tmp_path, config, backend)
+
+    assert result.success is True
+    parser.assert_called_once_with(tmp_path / "scenarios" / "techvault.sdl.yaml")
+    assert calls == {
+        "planned_scenario": scenario,
+        "execution_plan": "execution-plan",
+    }
+    backend.start.assert_called_once_with(["wazuh", "kali", "otel"])
+
+
+def test_provisioner_profiles_are_derived_from_plan_content(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose(
+        tmp_path,
+        {
+            "kali": ["kali"],
+            "victim": ["victim"],
+            "aptl-otel-collector": ["otel"],
+        },
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(
+        lab={"name": "test"},
+        containers={"kali": True, "victim": True, "wazuh": False},
+    )
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+
+    first = provisioner.apply(_plan_for_nodes("scenario-a.kali"), RuntimeSnapshot())
+    second = provisioner.apply(_plan_for_nodes("scenario-b.victim"), RuntimeSnapshot())
+
+    assert first.success is True
+    assert second.success is True
+    assert backend.start.call_args_list[0].args == (["kali", "otel"],)
+    assert backend.start.call_args_list[1].args == (["victim", "otel"],)
+
+
+def test_provisioner_rejects_unsupported_resource_type(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose(tmp_path, {"kali": ["kali"]})
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "test"}),
+        deployment_backend=backend,
+    )
+
+    result = provisioner.apply(_plan_with_resource_type("packet-capture"), RuntimeSnapshot())
+
+    assert result.success is False
+    assert any(
+        diagnostic.code == "aptl.provisioner.unsupported-resource-type"
+        for diagnostic in result.diagnostics
+    )
+    backend.start.assert_not_called()
+
+
+def test_aces_backend_does_not_import_legacy_sdl_parser():
+    source = Path("src/aptl/backends/aces.py").read_text()
+
+    assert "aptl.core.sdl" not in source
+    assert "ScenarioDefinition" not in source

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -715,10 +715,10 @@ class TestOrchestrateLabStart:
             return_value=CertResult(success=True, generated=False, certs_dir=certs_dir),
         )
 
-        # Mock docker compose start
+        # Mock ACES runtime handoff start
         from aptl.core.lab import LabResult
         mocks["start"] = mocker.patch(
-            "aptl.core.lab.start_lab",
+            "aptl.core.lab.start_aces_scenario",
             return_value=LabResult(success=True, message="Lab started"),
         )
 
@@ -964,7 +964,7 @@ class TestOrchestrateLabStart:
             "containers": {"wazuh": False, "victim": False, "kali": False, "reverse": False},
         }))
 
-        # Re-mock start_lab and wait_for_service since config changes
+        # Re-mock ACES handoff and wait_for_service since config changes
         from aptl.core.lab import LabResult
         mocks["start"].return_value = LabResult(success=True, message="Lab started")
 
@@ -2042,6 +2042,22 @@ class TestLabOrchestrationContracts:
         # backend stays None
         with pytest.raises(icontract.ViolationError):
             _step_start_containers(ctx)
+
+    def test_start_containers_routes_through_aces_handoff(self, mocker, tmp_path):
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config()
+        ctx.backend = MagicMock()
+        start_aces = mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            return_value=LabResult(success=True, message="ok"),
+        )
+
+        result = _step_start_containers(ctx)
+
+        assert result is None
+        start_aces.assert_called_once_with(tmp_path, ctx.config, ctx.backend)
 
     # -- ssh_key_is_ready --------------------------------------------
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -14,6 +14,36 @@ import pytest
 class TestLabImportContracts:
     """Import contracts for core lab orchestration."""
 
+    def test_aces_handoff_import_failure_returns_failed_lab_result(
+        self, monkeypatch, tmp_path
+    ):
+        import builtins
+        import sys
+
+        import aptl.backends as backends
+        from aptl.core.config import AptlConfig
+        from aptl.core.lab import start_aces_scenario
+
+        real_import = builtins.__import__
+
+        def guarded_import(
+            name, global_vars=None, local_vars=None, fromlist=(), level=0
+        ):
+            if name == "aptl.backends.aces":
+                raise ModuleNotFoundError("No module named 'aces_sdl'")
+            return real_import(name, global_vars, local_vars, fromlist, level)
+
+        monkeypatch.delitem(sys.modules, "aptl.backends.aces", raising=False)
+        monkeypatch.delattr(backends, "aces", raising=False)
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+        backend = MagicMock()
+        result = start_aces_scenario(tmp_path, AptlConfig(), backend)
+
+        assert result.success is False
+        assert "ACES runtime handoff unavailable" in result.error
+        backend.start.assert_not_called()
+
     def test_import_does_not_eagerly_load_aces_backend(self):
         import subprocess
         import sys

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -11,6 +11,38 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 
+class TestLabImportContracts:
+    """Import contracts for core lab orchestration."""
+
+    def test_import_does_not_eagerly_load_aces_backend(self):
+        import subprocess
+        import sys
+
+        code = """
+import importlib.abc
+import sys
+
+
+class BlockAcesBackend(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "aptl.backends.aces":
+            raise RuntimeError("aptl.backends.aces imported eagerly")
+        return None
+
+
+sys.meta_path.insert(0, BlockAcesBackend())
+import aptl.core.lab
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+
 class TestComposeCommandBuilder:
     """Tests for building docker compose commands."""
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -984,9 +984,19 @@ class TestOrchestrateLabStart:
 
     def test_pre_pull_runs_before_compose_up(self, mocker, tmp_path):
         """Should call docker pull for images before compose up."""
-        from aptl.core.lab import orchestrate_lab_start
+        from aptl.core.lab import (
+            _LAB_START_STEPS,
+            _step_pull_images,
+            _step_start_containers,
+            orchestrate_lab_start,
+        )
 
         mocks = self._patch_all_steps(mocker, tmp_path)
+
+        step_names = [step.__name__ for step in _LAB_START_STEPS]
+        assert step_names.index(_step_pull_images.__name__) < step_names.index(
+            _step_start_containers.__name__
+        )
 
         result = orchestrate_lab_start(tmp_path)
 

--- a/tests/test_shuffle_orborus_inventory.py
+++ b/tests/test_shuffle_orborus_inventory.py
@@ -305,7 +305,7 @@ def test_techvault_sdl_encodes_shuffle_orborus_node(legacy_scenario):
     network = runtime["network"]
     endpoint = network["endpoints"][0]
     assert endpoint["network"] == "security-net"
-    assert endpoint["ip_address"] == "172.20.0.6"
+    assert endpoint["ip_address"] == "172.20.0.7"
     assert network["published_ports"] == []
 
     proc_names = {p["name"] for p in runtime["processes"]}


### PR DESCRIPTION
## Summary

Route the public APTL lab-start path through the external ACES SDL parser and RuntimeManager before invoking the existing deployment backend.

## Requirement UIDs

- `SCN-010`

## Related Issues

Closes #321

## ADR Impact

- ADR-035

## Changes

- Add an APTL ACES provisioning target that builds a provisioning-only RuntimeTarget, derives Compose profiles from ACES provisioning-plan nodes plus docker-compose service profiles, and applies the plan through the existing DeploymentBackend contract.
- Wire the orchestrated lab-start container step to start_aces_scenario while preserving the existing start_lab wrapper for compatibility.
- Add focused ACES handoff/provisioner tests and a lab-step regression proving the public start path uses the ACES handoff.
- Refresh the Shuffle Orborus inventory assertion to match its current captured DHCP address evidence.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

pre-commit run --all-files; uv run pytest tests/test_aces_backend.py; uv run pytest tests/test_shuffle_orborus_inventory.py::test_techvault_sdl_encodes_shuffle_orborus_node

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SCN-010 ← src/aptl/backends/aces.py, SCN-010 ← src/aptl/core/lab.py
- TESTS: SCN-010 ← tests/test_aces_backend.py, SCN-010 ← tests/test_lab.py, SCN-010 ← tests/test_shuffle_orborus_inventory.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/321.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
