### PR TITLE
changed: generalize ACES provisioning realization

### DIFF
--- a/changelog.d/324.changed.md
+++ b/changelog.d/324.changed.md
@@ -1,0 +1,4 @@
+**Generalized the ACES provisioning backend realization path.** APTL now
+validates ACES provisioning plans through a resource-kind interpreter, reports
+realization details, and fails missing or unsupported declared content with
+explicit diagnostics instead of relying on scenario metadata.

--- a/docs/sdl/runtime-architecture.md
+++ b/docs/sdl/runtime-architecture.md
@@ -170,6 +170,40 @@ snapshot than the one it was reconciled against.
 exceptions and invalid lifecycle return payloads are converted into structured
 runtime diagnostics instead of surfacing as unhandled crashes.
 
+## APTL ACES Provisioning Realization Contract
+
+The APTL ACES target is a provisioning-only backend. It interprets the ACES
+`ProvisioningPlan` emitted by the reference runtime compiler rather than
+dispatching on scenario name, path, or metadata. The supported provisioning
+resource kinds are:
+
+- `network`
+- `node`
+- `feature-binding`
+- `content-placement`
+- `account-placement`
+
+Node resources are realized into existing APTL Docker Compose profiles by
+matching declared ACES node payload values and explicit backend profile hints
+against the Compose profile index. Network and placement resources are retained
+in the realization details so static and live gates can audit which ACES
+declarations drove the backend decision. Feature, content, and account
+placements must target a declared node by address or node name; missing targets
+fail with ACES diagnostics instead of falling back to TechVault defaults.
+
+`ApplyResult.details["realization"]` is the stable audit surface for the
+provisioning target. It includes sorted selected profile inputs, resource
+counts, node services/config/evidence/telemetry hints, declared networks, and
+node-scoped placements. Unsupported provisioning resource kinds, malformed
+payloads, missing node/profile bindings, and configured-profile mismatches are
+reported as `aptl.provisioner.*` diagnostics.
+
+Orchestration and evaluation remain capability-gated by the ACES target
+manifest and `RuntimeManager` preconditions. Scenarios that require workflows,
+inject execution, scoring, or objectives need an orchestration/evaluation
+capable target before apply; the provisioning interpreter must not treat those
+sections as hidden TechVault presets.
+
 ## RTE-001 Guardrails
 
 The scenario runtime engine must extend the SDL-native runtime described here.

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -207,7 +207,8 @@ class AptlProvisioner(object):
             config=self.config,
         )
 
-    def _invalid_plan_diagnostics(self, plan: object) -> list[Diagnostic]:
+    @staticmethod
+    def _invalid_plan_diagnostics(plan: object) -> list[Diagnostic]:
         if isinstance(plan, ProvisioningPlan):
             return []
         return [

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -13,8 +13,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import yaml
-
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.planning import ChangeAction, ProvisioningPlan
 from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
@@ -28,14 +26,13 @@ from aptl.backends.aces_diagnostics import (
     has_error,
     render_aces_diagnostics,
     snapshot_after_apply,
-    unsupported_resource_diagnostics,
 )
 from aptl.backends.aces_manifest import APTL_ACES_TARGET_NAME, create_aptl_manifest
+from aptl.backends.aces_realization import (
+    AptlRealization,
+    interpret_provisioning_plan,
+)
 from aptl.backends.aces_profiles import (
-    configured_profiles,
-    explicit_compose_profile_hints,
-    load_compose_profile_index,
-    node_aliases,
     select_backend_profiles,
 )
 from aptl.core.config import AptlConfig
@@ -102,8 +99,7 @@ def start_aces_scenario(
         return LabResult(
             success=True,
             message=(
-                "Lab started through ACES runtime target "
-                f"'{APTL_ACES_TARGET_NAME}'"
+                f"Lab started through ACES runtime target '{APTL_ACES_TARGET_NAME}'"
             ),
         )
     return LabResult(
@@ -132,25 +128,7 @@ class AptlProvisioner(object):
                 )
             ]
 
-        diagnostics: list[Diagnostic] = []
-        diagnostics.extend(unsupported_resource_diagnostics(plan))
-
-        profiles, profile_diagnostics = self._profiles_from_plan(plan)
-        diagnostics.extend(profile_diagnostics)
-        configured = configured_profiles(self.config)
-        if configured and not (set(configured) & set(profiles)):
-            diagnostics.append(
-                diagnostic(
-                    "aptl.provisioner.no-configured-profile-matches",
-                    PROVISIONING_ADDRESS,
-                    (
-                        "ACES provisioning plan did not declare any node "
-                        "that maps to an enabled APTL compose profile."
-                    ),
-                )
-            )
-
-        return diagnostics
+        return list(self._realize_plan(plan).diagnostics)
 
     def apply(self, plan: object, snapshot: object) -> ApplyResult:
         """Apply an ACES provisioning plan via APTL's deployment backend."""
@@ -158,14 +136,29 @@ class AptlProvisioner(object):
         working_snapshot = (
             snapshot if isinstance(snapshot, RuntimeSnapshot) else RuntimeSnapshot()
         )
-        diagnostics = self.validate(plan)
+        diagnostics = self._invalid_plan_diagnostics(plan)
         result = ApplyResult(
             success=False,
             snapshot=working_snapshot,
             diagnostics=diagnostics,
         )
-        if isinstance(plan, ProvisioningPlan) and not has_error(diagnostics):
-            result = self._apply_valid_plan(plan, working_snapshot, diagnostics)
+        if isinstance(plan, ProvisioningPlan):
+            realization = self._realize_plan(plan)
+            diagnostics = list(realization.diagnostics)
+            if not has_error(diagnostics):
+                result = self._apply_valid_plan(
+                    plan,
+                    working_snapshot,
+                    diagnostics,
+                    realization,
+                )
+            else:
+                result = ApplyResult(
+                    success=False,
+                    snapshot=working_snapshot,
+                    diagnostics=diagnostics,
+                    details={"realization": realization.details()},
+                )
         return result
 
     def _apply_valid_plan(
@@ -173,18 +166,10 @@ class AptlProvisioner(object):
         plan: ProvisioningPlan,
         snapshot: RuntimeSnapshot,
         diagnostics: list[Diagnostic],
+        realization: AptlRealization,
     ) -> ApplyResult:
         """Apply a validated ACES plan to the deployment backend."""
-        profiles, profile_diagnostics = self._profiles_from_plan(plan)
-        diagnostics.extend(profile_diagnostics)
-        if has_error(diagnostics):
-            return ApplyResult(
-                success=False,
-                snapshot=snapshot,
-                diagnostics=diagnostics,
-            )
-
-        selected_profiles = select_backend_profiles(self.config, profiles)
+        selected_profiles = select_backend_profiles(self.config, realization.profiles)
         start_result = self.deployment_backend.start(selected_profiles)
         if not start_result.success:
             diagnostics.append(
@@ -198,66 +183,42 @@ class AptlProvisioner(object):
                 success=False,
                 snapshot=snapshot,
                 diagnostics=diagnostics,
-                details={"profiles": selected_profiles},
+                details={
+                    "profiles": selected_profiles,
+                    "realization": realization.details(),
+                },
             )
         return ApplyResult(
             success=True,
             snapshot=snapshot_after_apply(plan, snapshot),
             diagnostics=diagnostics,
             changed_addresses=_changed_addresses(plan),
-            details={"profiles": selected_profiles},
+            details={
+                "profiles": selected_profiles,
+                "realization": realization.details(),
+            },
         )
 
-    def _profiles_from_plan(
-        self,
-        plan: ProvisioningPlan,
-    ) -> tuple[frozenset[str], list[Diagnostic]]:
-        """Resolve APTL Compose profiles from ACES node resources."""
-        diagnostics: list[Diagnostic] = []
-        try:
-            profile_index = load_compose_profile_index(self.project_dir)
-        except (OSError, ValueError, yaml.YAMLError) as exc:
-            return (
-                frozenset(),
-                [
-                    diagnostic(
-                        "aptl.provisioner.compose-profile-index-failed",
-                        PROVISIONING_ADDRESS,
-                        redact(str(exc)),
-                    )
-                ],
-            )
+    def _realize_plan(self, plan: ProvisioningPlan) -> AptlRealization:
+        """Interpret an ACES plan against APTL's supported contract."""
+        return interpret_provisioning_plan(
+            plan=plan,
+            project_dir=self.project_dir,
+            config=self.config,
+        )
 
-        profiles: set[str] = set()
-        for resource in plan.resources.values():
-            if resource.resource_type != "node":
-                continue
-            payload = resource.payload
-            profiles.update(explicit_compose_profile_hints(payload))
-            profiles.update(
-                profile_index.profiles_for_aliases(
-                    node_aliases(resource.address, payload)
-                )
+    def _invalid_plan_diagnostics(self, plan: object) -> list[Diagnostic]:
+        if isinstance(plan, ProvisioningPlan):
+            return []
+        return [
+            diagnostic(
+                "aptl.provisioner.invalid-plan",
+                PROVISIONING_ADDRESS,
+                "APTL provisioner expected an ACES ProvisioningPlan.",
             )
-
-        if not profiles:
-            diagnostics.append(
-                diagnostic(
-                    "aptl.provisioner.profile-resolution-failed",
-                    PROVISIONING_ADDRESS,
-                    (
-                        "ACES provisioning plan contained no node resources "
-                        "that map to APTL compose profiles."
-                    ),
-                )
-            )
-        return frozenset(profiles), diagnostics
+        ]
 
 
 def _changed_addresses(plan: ProvisioningPlan) -> list[str]:
     """Return addresses whose planned operation changes runtime state."""
-    return [
-        op.address
-        for op in plan.operations
-        if op.action != ChangeAction.UNCHANGED
-    ]
+    return [op.address for op in plan.operations if op.action != ChangeAction.UNCHANGED]

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -1,0 +1,516 @@
+"""APTL realization contract for ACES provisioning plans."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import PlannedResource, ProvisioningPlan
+
+from aptl.backends.aces_diagnostics import (
+    PROVISIONING_ADDRESS,
+    SUPPORTED_RESOURCE_TYPES,
+    diagnostic,
+    unsupported_resource_diagnostics,
+)
+from aptl.backends.aces_profiles import (
+    ComposeProfileIndex,
+    configured_profiles,
+    explicit_compose_profile_hints,
+    load_compose_profile_index,
+    node_aliases,
+    normalize_identifier,
+)
+from aptl.core.config import AptlConfig
+from aptl.utils.redaction import redact
+
+PLACEMENT_RESOURCE_TYPES = frozenset(
+    {"feature-binding", "content-placement", "account-placement"}
+)
+
+
+@dataclass(frozen=True)
+class NodeRealization(object):
+    """APTL realization data for one ACES node resource."""
+
+    address: str
+    name: str
+    aliases: tuple[str, ...]
+    profiles: tuple[str, ...]
+    services: tuple[str, ...]
+    rendered_configs: tuple[str, ...]
+    evidence_paths: tuple[str, ...]
+    telemetry_paths: tuple[str, ...]
+    networks: tuple[str, ...]
+    static_addresses: tuple[str, ...]
+
+    def details(self) -> dict[str, object]:
+        return {
+            "address": self.address,
+            "name": self.name,
+            "aliases": list(self.aliases),
+            "profiles": list(self.profiles),
+            "services": list(self.services),
+            "rendered_configs": list(self.rendered_configs),
+            "evidence_paths": list(self.evidence_paths),
+            "telemetry_paths": list(self.telemetry_paths),
+            "networks": list(self.networks),
+            "static_addresses": list(self.static_addresses),
+        }
+
+
+@dataclass(frozen=True)
+class NetworkRealization(object):
+    """APTL realization data for one ACES network resource."""
+
+    address: str
+    name: str
+    cidr: str | None
+    gateway: str | None
+    internal: bool | None
+
+    def details(self) -> dict[str, object]:
+        return {
+            "address": self.address,
+            "name": self.name,
+            "cidr": self.cidr,
+            "gateway": self.gateway,
+            "internal": self.internal,
+        }
+
+
+@dataclass(frozen=True)
+class PlacementRealization(object):
+    """APTL realization data for one node-scoped provisioning binding."""
+
+    address: str
+    resource_type: str
+    name: str
+    target_address: str
+    target_node: str | None
+
+    def details(self) -> dict[str, object]:
+        return {
+            "address": self.address,
+            "resource_type": self.resource_type,
+            "name": self.name,
+            "target_address": self.target_address,
+            "target_node": self.target_node,
+        }
+
+
+@dataclass(frozen=True)
+class AptlRealization(object):
+    """Result of interpreting ACES provisioning content for APTL."""
+
+    profiles: frozenset[str]
+    nodes: tuple[NodeRealization, ...]
+    networks: tuple[NetworkRealization, ...]
+    placements: tuple[PlacementRealization, ...]
+    diagnostics: tuple[Diagnostic, ...]
+
+    def details(self) -> dict[str, object]:
+        resource_counts = {
+            "account-placement": sum(
+                placement.resource_type == "account-placement"
+                for placement in self.placements
+            ),
+            "content-placement": sum(
+                placement.resource_type == "content-placement"
+                for placement in self.placements
+            ),
+            "feature-binding": sum(
+                placement.resource_type == "feature-binding"
+                for placement in self.placements
+            ),
+            "network": len(self.networks),
+            "node": len(self.nodes),
+        }
+        return {
+            "profiles": sorted(self.profiles),
+            "resource_counts": {
+                key: value for key, value in sorted(resource_counts.items()) if value
+            },
+            "nodes": [node.details() for node in self.nodes],
+            "networks": [network.details() for network in self.networks],
+            "placements": [placement.details() for placement in self.placements],
+        }
+
+
+def interpret_provisioning_plan(
+    *,
+    plan: ProvisioningPlan,
+    project_dir: Path,
+    config: AptlConfig,
+) -> AptlRealization:
+    """Interpret ACES provisioning resources as an APTL realization plan."""
+
+    diagnostics: list[Diagnostic] = []
+    diagnostics.extend(unsupported_resource_diagnostics(plan))
+    try:
+        profile_index = load_compose_profile_index(project_dir)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        return _empty_realization(
+            [
+                *diagnostics,
+                diagnostic(
+                    "aptl.provisioner.compose-profile-index-failed",
+                    PROVISIONING_ADDRESS,
+                    redact(str(exc)),
+                ),
+            ]
+        )
+
+    supported_resources = [
+        resource
+        for resource in plan.resources.values()
+        if resource.resource_type in SUPPORTED_RESOURCE_TYPES
+    ]
+    invalid_payloads = _invalid_payload_diagnostics(supported_resources)
+    diagnostics.extend(invalid_payloads)
+    payload_resources = [
+        resource
+        for resource in supported_resources
+        if isinstance(resource.payload, Mapping)
+    ]
+
+    nodes: list[NodeRealization] = []
+    networks: list[NetworkRealization] = []
+    placements: list[PlacementRealization] = []
+    profiles: set[str] = set()
+
+    for resource in payload_resources:
+        payload = resource.payload
+        if resource.resource_type == "node":
+            node = _realize_node(resource, payload, profile_index)
+            nodes.append(node)
+            profiles.update(node.profiles)
+            if not node.profiles:
+                diagnostics.append(
+                    diagnostic(
+                        "aptl.provisioner.node-profile-unresolved",
+                        resource.address,
+                        (
+                            "ACES node resource does not declare content that "
+                            "maps to an APTL compose profile."
+                        ),
+                    )
+                )
+        elif resource.resource_type == "network":
+            networks.append(_realize_network(resource, payload))
+
+    node_lookup = _node_lookup(nodes)
+    for resource in payload_resources:
+        if resource.resource_type in PLACEMENT_RESOURCE_TYPES:
+            placement, placement_diagnostics = _realize_placement(
+                resource,
+                resource.payload,
+                node_lookup,
+            )
+            diagnostics.extend(placement_diagnostics)
+            if placement is not None:
+                placements.append(placement)
+
+    if not profiles:
+        diagnostics.append(
+            diagnostic(
+                "aptl.provisioner.profile-resolution-failed",
+                PROVISIONING_ADDRESS,
+                (
+                    "ACES provisioning plan contained no node resources "
+                    "that map to APTL compose profiles."
+                ),
+            )
+        )
+
+    enabled_profiles = configured_profiles(config)
+    if enabled_profiles and not (set(enabled_profiles) & profiles):
+        diagnostics.append(
+            diagnostic(
+                "aptl.provisioner.no-configured-profile-matches",
+                PROVISIONING_ADDRESS,
+                (
+                    "ACES provisioning plan did not declare any node "
+                    "that maps to an enabled APTL compose profile."
+                ),
+            )
+        )
+
+    return AptlRealization(
+        profiles=frozenset(profiles),
+        nodes=tuple(sorted(nodes, key=lambda item: item.address)),
+        networks=tuple(sorted(networks, key=lambda item: item.address)),
+        placements=tuple(sorted(placements, key=lambda item: item.address)),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def _empty_realization(diagnostics: list[Diagnostic]) -> AptlRealization:
+    return AptlRealization(
+        profiles=frozenset(),
+        nodes=(),
+        networks=(),
+        placements=(),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def _invalid_payload_diagnostics(
+    resources: list[PlannedResource],
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    for resource in resources:
+        if isinstance(resource.payload, Mapping):
+            continue
+        diagnostics.append(
+            diagnostic(
+                "aptl.provisioner.invalid-resource-payload",
+                resource.address,
+                (
+                    "APTL provisioner expected ACES resource payload "
+                    f"'{resource.resource_type}' to be a mapping."
+                ),
+            )
+        )
+    return diagnostics
+
+
+def _realize_node(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+    profile_index: ComposeProfileIndex,
+) -> NodeRealization:
+    aliases = node_aliases(resource.address, payload)
+    profile_hints = explicit_compose_profile_hints(payload)
+    profiles = profile_hints | profile_index.profiles_for_aliases(aliases)
+    spec = _mapping(payload.get("spec"))
+    node_spec = _mapping(spec.get("node")) if spec else None
+    infra_spec = _mapping(spec.get("infrastructure")) if spec else None
+    runtime_spec = _runtime_spec(payload, spec)
+    return NodeRealization(
+        address=resource.address,
+        name=_resource_name(resource.address, payload),
+        aliases=tuple(sorted(aliases)),
+        profiles=tuple(sorted(profiles)),
+        services=tuple(sorted(_service_names(node_spec))),
+        rendered_configs=tuple(sorted(_string_list(runtime_spec, "rendered_configs"))),
+        evidence_paths=tuple(sorted(_string_list(runtime_spec, "evidence_paths"))),
+        telemetry_paths=tuple(sorted(_string_list(runtime_spec, "telemetry_paths"))),
+        networks=tuple(sorted(_network_names(infra_spec))),
+        static_addresses=tuple(sorted(_static_addresses(infra_spec))),
+    )
+
+
+def _realize_network(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+) -> NetworkRealization:
+    spec = _mapping(payload.get("spec"))
+    infra_spec = _mapping(spec.get("infrastructure")) if spec else None
+    properties = _mapping(infra_spec.get("properties")) if infra_spec else None
+    return NetworkRealization(
+        address=resource.address,
+        name=_resource_name(resource.address, payload),
+        cidr=_optional_string(properties, "cidr"),
+        gateway=_optional_string(properties, "gateway"),
+        internal=_optional_bool(properties, "internal"),
+    )
+
+
+def _realize_placement(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+    node_lookup: dict[str, str],
+) -> tuple[PlacementRealization | None, list[Diagnostic]]:
+    target_values = _placement_target_values(resource.resource_type, payload)
+    target_address = _resolve_target_address(target_values, node_lookup)
+    if target_address is None:
+        return (
+            None,
+            [
+                diagnostic(
+                    "aptl.provisioner.binding-target-unresolved",
+                    resource.address,
+                    (
+                        "ACES provisioning binding does not target a "
+                        "declared APTL-realizable node."
+                    ),
+                )
+            ],
+        )
+    return (
+        PlacementRealization(
+            address=resource.address,
+            resource_type=resource.resource_type,
+            name=_resource_name(resource.address, payload),
+            target_address=target_address,
+            target_node=_first_nonempty_string(target_values),
+        ),
+        [],
+    )
+
+
+def _node_lookup(nodes: list[NodeRealization]) -> dict[str, str]:
+    lookup: dict[str, str] = {}
+    for node in nodes:
+        values = {node.address, node.name, *node.aliases}
+        for value in values:
+            if not value:
+                continue
+            lookup[value] = node.address
+            normalized = normalize_identifier(value)
+            if normalized:
+                lookup[normalized] = node.address
+    return lookup
+
+
+def _placement_target_values(
+    resource_type: str,
+    payload: Mapping[str, Any],
+) -> tuple[str, ...]:
+    if resource_type == "feature-binding":
+        return _payload_string_values(payload, ("node_address", "node_name"))
+    if resource_type == "content-placement":
+        return _payload_string_values(payload, ("target_address", "target_node"))
+    if resource_type == "account-placement":
+        return _payload_string_values(payload, ("target_address", "node_name"))
+    return ()
+
+
+def _resolve_target_address(
+    target_values: tuple[str, ...],
+    node_lookup: dict[str, str],
+) -> str | None:
+    for value in target_values:
+        if value in node_lookup:
+            return node_lookup[value]
+        normalized = normalize_identifier(value)
+        if normalized in node_lookup:
+            return node_lookup[normalized]
+    return None
+
+
+def _resource_name(address: str, payload: Mapping[str, Any]) -> str:
+    return _first_nonempty_string(_payload_string_values(payload, ("name",))) or address
+
+
+def _runtime_spec(
+    payload: Mapping[str, Any],
+    spec: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    for container in (payload, spec):
+        if container is None:
+            continue
+        runtime = container.get("runtime")
+        if isinstance(runtime, Mapping):
+            return runtime
+        aptl = container.get("aptl")
+        if isinstance(aptl, Mapping):
+            return aptl
+    return None
+
+
+def _service_names(node_spec: Mapping[str, Any] | None) -> set[str]:
+    if node_spec is None:
+        return set()
+    services = node_spec.get("services")
+    if not isinstance(services, list):
+        return set()
+    names: set[str] = set()
+    for service in services:
+        if not isinstance(service, Mapping):
+            continue
+        name = service.get("name")
+        if isinstance(name, str) and name.strip():
+            names.add(name)
+    return names
+
+
+def _network_names(infra_spec: Mapping[str, Any] | None) -> set[str]:
+    if infra_spec is None:
+        return set()
+    return _string_values(infra_spec.get("links"))
+
+
+def _static_addresses(infra_spec: Mapping[str, Any] | None) -> set[str]:
+    if infra_spec is None:
+        return set()
+    properties = infra_spec.get("properties")
+    addresses: set[str] = set()
+    if isinstance(properties, list):
+        for item in properties:
+            if isinstance(item, Mapping):
+                addresses.update(_string_values(item.values()))
+    elif isinstance(properties, Mapping):
+        for key in ("address", "ip", "ipv4_address", "static_address"):
+            value = properties.get(key)
+            if isinstance(value, str) and value.strip():
+                addresses.add(value)
+    return addresses
+
+
+def _string_list(
+    payload: Mapping[str, Any] | None,
+    key: str,
+) -> set[str]:
+    if payload is None:
+        return set()
+    return _string_values(payload.get(key))
+
+
+def _string_values(raw: object) -> set[str]:
+    if isinstance(raw, str):
+        return {raw} if raw.strip() else set()
+    if isinstance(raw, Mapping):
+        raw = raw.values()
+    if isinstance(raw, list | tuple | set | frozenset):
+        return {str(value) for value in raw if str(value).strip()}
+    return set()
+
+
+def _payload_string_values(
+    payload: Mapping[str, Any],
+    keys: tuple[str, ...],
+) -> tuple[str, ...]:
+    values: list[str] = []
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            values.append(value)
+    return tuple(values)
+
+
+def _first_nonempty_string(values: tuple[str, ...]) -> str | None:
+    for value in values:
+        if value.strip():
+            return value
+    return None
+
+
+def _optional_string(
+    payload: Mapping[str, Any] | None,
+    key: str,
+) -> str | None:
+    if payload is None:
+        return None
+    value = payload.get(key)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _optional_bool(
+    payload: Mapping[str, Any] | None,
+    key: str,
+) -> bool | None:
+    if payload is None:
+        return None
+    value = payload.get(key)
+    return value if isinstance(value, bool) else None
+
+
+def _mapping(value: object) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -26,120 +25,32 @@ from aptl.backends.aces_profiles import (
     node_aliases,
     normalize_identifier,
 )
+from aptl.backends.aces_realization_model import (
+    AptlRealization,
+    NetworkRealization,
+    NodeRealization,
+    PlacementRealization,
+)
+from aptl.backends.aces_realization_values import (
+    first_nonempty_string as _first_nonempty_string,
+    mapping as _mapping,
+    network_names as _network_names,
+    optional_bool as _optional_bool,
+    optional_string as _optional_string,
+    placement_target_values as _placement_target_values,
+    resolve_target_address as _resolve_target_address,
+    resource_name as _resource_name,
+    runtime_spec as _runtime_spec,
+    service_names as _service_names,
+    static_addresses as _static_addresses,
+    string_list as _string_list,
+)
 from aptl.core.config import AptlConfig
 from aptl.utils.redaction import redact
 
 PLACEMENT_RESOURCE_TYPES = frozenset(
     {"feature-binding", "content-placement", "account-placement"}
 )
-
-
-@dataclass(frozen=True)
-class NodeRealization(object):
-    """APTL realization data for one ACES node resource."""
-
-    address: str
-    name: str
-    aliases: tuple[str, ...]
-    profiles: tuple[str, ...]
-    services: tuple[str, ...]
-    rendered_configs: tuple[str, ...]
-    evidence_paths: tuple[str, ...]
-    telemetry_paths: tuple[str, ...]
-    networks: tuple[str, ...]
-    static_addresses: tuple[str, ...]
-
-    def details(self) -> dict[str, object]:
-        return {
-            "address": self.address,
-            "name": self.name,
-            "aliases": list(self.aliases),
-            "profiles": list(self.profiles),
-            "services": list(self.services),
-            "rendered_configs": list(self.rendered_configs),
-            "evidence_paths": list(self.evidence_paths),
-            "telemetry_paths": list(self.telemetry_paths),
-            "networks": list(self.networks),
-            "static_addresses": list(self.static_addresses),
-        }
-
-
-@dataclass(frozen=True)
-class NetworkRealization(object):
-    """APTL realization data for one ACES network resource."""
-
-    address: str
-    name: str
-    cidr: str | None
-    gateway: str | None
-    internal: bool | None
-
-    def details(self) -> dict[str, object]:
-        return {
-            "address": self.address,
-            "name": self.name,
-            "cidr": self.cidr,
-            "gateway": self.gateway,
-            "internal": self.internal,
-        }
-
-
-@dataclass(frozen=True)
-class PlacementRealization(object):
-    """APTL realization data for one node-scoped provisioning binding."""
-
-    address: str
-    resource_type: str
-    name: str
-    target_address: str
-    target_node: str | None
-
-    def details(self) -> dict[str, object]:
-        return {
-            "address": self.address,
-            "resource_type": self.resource_type,
-            "name": self.name,
-            "target_address": self.target_address,
-            "target_node": self.target_node,
-        }
-
-
-@dataclass(frozen=True)
-class AptlRealization(object):
-    """Result of interpreting ACES provisioning content for APTL."""
-
-    profiles: frozenset[str]
-    nodes: tuple[NodeRealization, ...]
-    networks: tuple[NetworkRealization, ...]
-    placements: tuple[PlacementRealization, ...]
-    diagnostics: tuple[Diagnostic, ...]
-
-    def details(self) -> dict[str, object]:
-        resource_counts = {
-            "account-placement": sum(
-                placement.resource_type == "account-placement"
-                for placement in self.placements
-            ),
-            "content-placement": sum(
-                placement.resource_type == "content-placement"
-                for placement in self.placements
-            ),
-            "feature-binding": sum(
-                placement.resource_type == "feature-binding"
-                for placement in self.placements
-            ),
-            "network": len(self.networks),
-            "node": len(self.nodes),
-        }
-        return {
-            "profiles": sorted(self.profiles),
-            "resource_counts": {
-                key: value for key, value in sorted(resource_counts.items()) if value
-            },
-            "nodes": [node.details() for node in self.nodes],
-            "networks": [network.details() for network in self.networks],
-            "placements": [placement.details() for placement in self.placements],
-        }
 
 
 def interpret_provisioning_plan(
@@ -152,38 +63,70 @@ def interpret_provisioning_plan(
 
     diagnostics: list[Diagnostic] = []
     diagnostics.extend(unsupported_resource_diagnostics(plan))
+    profile_index = _load_profile_index(project_dir, diagnostics)
+    if profile_index is None:
+        return _empty_realization(diagnostics)
+
+    payload_resources = _payload_resources(plan, diagnostics)
+    nodes, networks, profiles = _realize_nodes_and_networks(
+        payload_resources,
+        profile_index,
+        diagnostics,
+    )
+    placements = _realize_placements(payload_resources, _node_lookup(nodes), diagnostics)
+    _append_profile_diagnostics(profiles, config, diagnostics)
+
+    return _realization_from_parts(nodes, networks, placements, profiles, diagnostics)
+
+
+def _load_profile_index(
+    project_dir: Path,
+    diagnostics: list[Diagnostic],
+) -> ComposeProfileIndex | None:
+    """Load the compose profile index and record redacted load failures."""
+
     try:
-        profile_index = load_compose_profile_index(project_dir)
+        return load_compose_profile_index(project_dir)
     except (OSError, ValueError, yaml.YAMLError) as exc:
-        return _empty_realization(
-            [
-                *diagnostics,
-                diagnostic(
-                    "aptl.provisioner.compose-profile-index-failed",
-                    PROVISIONING_ADDRESS,
-                    redact(str(exc)),
-                ),
-            ]
+        diagnostics.append(
+            diagnostic(
+                "aptl.provisioner.compose-profile-index-failed",
+                PROVISIONING_ADDRESS,
+                redact(str(exc)),
+            )
         )
+        return None
+
+
+def _payload_resources(
+    plan: ProvisioningPlan,
+    diagnostics: list[Diagnostic],
+) -> list[PlannedResource]:
+    """Return supported resources with mapping payloads and report invalid ones."""
 
     supported_resources = [
         resource
         for resource in plan.resources.values()
         if resource.resource_type in SUPPORTED_RESOURCE_TYPES
     ]
-    invalid_payloads = _invalid_payload_diagnostics(supported_resources)
-    diagnostics.extend(invalid_payloads)
-    payload_resources = [
+    diagnostics.extend(_invalid_payload_diagnostics(supported_resources))
+    return [
         resource
         for resource in supported_resources
         if isinstance(resource.payload, Mapping)
     ]
 
+
+def _realize_nodes_and_networks(
+    payload_resources: list[PlannedResource],
+    profile_index: ComposeProfileIndex,
+    diagnostics: list[Diagnostic],
+) -> tuple[list[NodeRealization], list[NetworkRealization], set[str]]:
+    """Realize node and network resources before resolving placements."""
+
     nodes: list[NodeRealization] = []
     networks: list[NetworkRealization] = []
-    placements: list[PlacementRealization] = []
     profiles: set[str] = set()
-
     for resource in payload_resources:
         payload = resource.payload
         if resource.resource_type == "node":
@@ -191,20 +134,38 @@ def interpret_provisioning_plan(
             nodes.append(node)
             profiles.update(node.profiles)
             if not node.profiles:
-                diagnostics.append(
-                    diagnostic(
-                        "aptl.provisioner.node-profile-unresolved",
-                        resource.address,
-                        (
-                            "ACES node resource does not declare content that "
-                            "maps to an APTL compose profile."
-                        ),
-                    )
-                )
+                _append_node_profile_diagnostic(resource, diagnostics)
         elif resource.resource_type == "network":
             networks.append(_realize_network(resource, payload))
+    return nodes, networks, profiles
 
-    node_lookup = _node_lookup(nodes)
+
+def _append_node_profile_diagnostic(
+    resource: PlannedResource,
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record a diagnostic for a node without an APTL profile mapping."""
+
+    diagnostics.append(
+        diagnostic(
+            "aptl.provisioner.node-profile-unresolved",
+            resource.address,
+            (
+                "ACES node resource does not declare content that "
+                "maps to an APTL compose profile."
+            ),
+        )
+    )
+
+
+def _realize_placements(
+    payload_resources: list[PlannedResource],
+    node_lookup: dict[str, str],
+    diagnostics: list[Diagnostic],
+) -> list[PlacementRealization]:
+    """Resolve supported placement resources against realized nodes."""
+
+    placements: list[PlacementRealization] = []
     for resource in payload_resources:
         if resource.resource_type in PLACEMENT_RESOURCE_TYPES:
             placement, placement_diagnostics = _realize_placement(
@@ -215,6 +176,15 @@ def interpret_provisioning_plan(
             diagnostics.extend(placement_diagnostics)
             if placement is not None:
                 placements.append(placement)
+    return placements
+
+
+def _append_profile_diagnostics(
+    profiles: set[str],
+    config: AptlConfig,
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record diagnostics for missing or disabled compose-profile matches."""
 
     if not profiles:
         diagnostics.append(
@@ -241,6 +211,16 @@ def interpret_provisioning_plan(
             )
         )
 
+
+def _realization_from_parts(
+    nodes: list[NodeRealization],
+    networks: list[NetworkRealization],
+    placements: list[PlacementRealization],
+    profiles: set[str],
+    diagnostics: list[Diagnostic],
+) -> AptlRealization:
+    """Build the stable realization value from collected resource parts."""
+
     return AptlRealization(
         profiles=frozenset(profiles),
         nodes=tuple(sorted(nodes, key=lambda item: item.address)),
@@ -251,6 +231,8 @@ def interpret_provisioning_plan(
 
 
 def _empty_realization(diagnostics: list[Diagnostic]) -> AptlRealization:
+    """Build an empty realization that carries validation diagnostics."""
+
     return AptlRealization(
         profiles=frozenset(),
         nodes=(),
@@ -263,6 +245,8 @@ def _empty_realization(diagnostics: list[Diagnostic]) -> AptlRealization:
 def _invalid_payload_diagnostics(
     resources: list[PlannedResource],
 ) -> list[Diagnostic]:
+    """Report supported resources whose payload cannot be interpreted."""
+
     diagnostics: list[Diagnostic] = []
     for resource in resources:
         if isinstance(resource.payload, Mapping):
@@ -285,6 +269,8 @@ def _realize_node(
     payload: Mapping[str, Any],
     profile_index: ComposeProfileIndex,
 ) -> NodeRealization:
+    """Realize a node resource into APTL profile and runtime details."""
+
     aliases = node_aliases(resource.address, payload)
     profile_hints = explicit_compose_profile_hints(payload)
     profiles = profile_hints | profile_index.profiles_for_aliases(aliases)
@@ -310,6 +296,8 @@ def _realize_network(
     resource: PlannedResource,
     payload: Mapping[str, Any],
 ) -> NetworkRealization:
+    """Realize a network resource into APTL network details."""
+
     spec = _mapping(payload.get("spec"))
     infra_spec = _mapping(spec.get("infrastructure")) if spec else None
     properties = _mapping(infra_spec.get("properties")) if infra_spec else None
@@ -327,6 +315,8 @@ def _realize_placement(
     payload: Mapping[str, Any],
     node_lookup: dict[str, str],
 ) -> tuple[PlacementRealization | None, list[Diagnostic]]:
+    """Realize a placement resource or return its diagnostics."""
+
     target_values = _placement_target_values(resource.resource_type, payload)
     target_address = _resolve_target_address(target_values, node_lookup)
     if target_address is None:
@@ -356,6 +346,8 @@ def _realize_placement(
 
 
 def _node_lookup(nodes: list[NodeRealization]) -> dict[str, str]:
+    """Index node addresses and aliases for placement target resolution."""
+
     lookup: dict[str, str] = {}
     for node in nodes:
         values = {node.address, node.name, *node.aliases}
@@ -367,150 +359,3 @@ def _node_lookup(nodes: list[NodeRealization]) -> dict[str, str]:
             if normalized:
                 lookup[normalized] = node.address
     return lookup
-
-
-def _placement_target_values(
-    resource_type: str,
-    payload: Mapping[str, Any],
-) -> tuple[str, ...]:
-    if resource_type == "feature-binding":
-        return _payload_string_values(payload, ("node_address", "node_name"))
-    if resource_type == "content-placement":
-        return _payload_string_values(payload, ("target_address", "target_node"))
-    if resource_type == "account-placement":
-        return _payload_string_values(payload, ("target_address", "node_name"))
-    return ()
-
-
-def _resolve_target_address(
-    target_values: tuple[str, ...],
-    node_lookup: dict[str, str],
-) -> str | None:
-    for value in target_values:
-        if value in node_lookup:
-            return node_lookup[value]
-        normalized = normalize_identifier(value)
-        if normalized in node_lookup:
-            return node_lookup[normalized]
-    return None
-
-
-def _resource_name(address: str, payload: Mapping[str, Any]) -> str:
-    return _first_nonempty_string(_payload_string_values(payload, ("name",))) or address
-
-
-def _runtime_spec(
-    payload: Mapping[str, Any],
-    spec: Mapping[str, Any] | None,
-) -> Mapping[str, Any] | None:
-    for container in (payload, spec):
-        if container is None:
-            continue
-        runtime = container.get("runtime")
-        if isinstance(runtime, Mapping):
-            return runtime
-        aptl = container.get("aptl")
-        if isinstance(aptl, Mapping):
-            return aptl
-    return None
-
-
-def _service_names(node_spec: Mapping[str, Any] | None) -> set[str]:
-    if node_spec is None:
-        return set()
-    services = node_spec.get("services")
-    if not isinstance(services, list):
-        return set()
-    names: set[str] = set()
-    for service in services:
-        if not isinstance(service, Mapping):
-            continue
-        name = service.get("name")
-        if isinstance(name, str) and name.strip():
-            names.add(name)
-    return names
-
-
-def _network_names(infra_spec: Mapping[str, Any] | None) -> set[str]:
-    if infra_spec is None:
-        return set()
-    return _string_values(infra_spec.get("links"))
-
-
-def _static_addresses(infra_spec: Mapping[str, Any] | None) -> set[str]:
-    if infra_spec is None:
-        return set()
-    properties = infra_spec.get("properties")
-    addresses: set[str] = set()
-    if isinstance(properties, list):
-        for item in properties:
-            if isinstance(item, Mapping):
-                addresses.update(_string_values(item.values()))
-    elif isinstance(properties, Mapping):
-        for key in ("address", "ip", "ipv4_address", "static_address"):
-            value = properties.get(key)
-            if isinstance(value, str) and value.strip():
-                addresses.add(value)
-    return addresses
-
-
-def _string_list(
-    payload: Mapping[str, Any] | None,
-    key: str,
-) -> set[str]:
-    if payload is None:
-        return set()
-    return _string_values(payload.get(key))
-
-
-def _string_values(raw: object) -> set[str]:
-    if isinstance(raw, str):
-        return {raw} if raw.strip() else set()
-    if isinstance(raw, Mapping):
-        raw = raw.values()
-    if isinstance(raw, list | tuple | set | frozenset):
-        return {str(value) for value in raw if str(value).strip()}
-    return set()
-
-
-def _payload_string_values(
-    payload: Mapping[str, Any],
-    keys: tuple[str, ...],
-) -> tuple[str, ...]:
-    values: list[str] = []
-    for key in keys:
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            values.append(value)
-    return tuple(values)
-
-
-def _first_nonempty_string(values: tuple[str, ...]) -> str | None:
-    for value in values:
-        if value.strip():
-            return value
-    return None
-
-
-def _optional_string(
-    payload: Mapping[str, Any] | None,
-    key: str,
-) -> str | None:
-    if payload is None:
-        return None
-    value = payload.get(key)
-    return value if isinstance(value, str) and value.strip() else None
-
-
-def _optional_bool(
-    payload: Mapping[str, Any] | None,
-    key: str,
-) -> bool | None:
-    if payload is None:
-        return None
-    value = payload.get(key)
-    return value if isinstance(value, bool) else None
-
-
-def _mapping(value: object) -> Mapping[str, Any] | None:
-    return value if isinstance(value, Mapping) else None

--- a/src/aptl/backends/aces_realization_model.py
+++ b/src/aptl/backends/aces_realization_model.py
@@ -8,7 +8,7 @@ from aces_contracts.diagnostics import Diagnostic
 
 
 @dataclass(frozen=True)
-class NodeRealization:
+class NodeRealization(object):
     """APTL realization data for one ACES node resource."""
 
     address: str
@@ -38,7 +38,7 @@ class NodeRealization:
 
 
 @dataclass(frozen=True)
-class NetworkRealization:
+class NetworkRealization(object):
     """APTL realization data for one ACES network resource."""
 
     address: str
@@ -58,7 +58,7 @@ class NetworkRealization:
 
 
 @dataclass(frozen=True)
-class PlacementRealization:
+class PlacementRealization(object):
     """APTL realization data for one node-scoped provisioning binding."""
 
     address: str
@@ -78,7 +78,7 @@ class PlacementRealization:
 
 
 @dataclass(frozen=True)
-class AptlRealization:
+class AptlRealization(object):
     """Result of interpreting ACES provisioning content for APTL."""
 
     profiles: frozenset[str]

--- a/src/aptl/backends/aces_realization_model.py
+++ b/src/aptl/backends/aces_realization_model.py
@@ -1,0 +1,115 @@
+"""Structured APTL realization data produced from ACES resources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aces_contracts.diagnostics import Diagnostic
+
+
+@dataclass(frozen=True)
+class NodeRealization:
+    """APTL realization data for one ACES node resource."""
+
+    address: str
+    name: str
+    aliases: tuple[str, ...]
+    profiles: tuple[str, ...]
+    services: tuple[str, ...]
+    rendered_configs: tuple[str, ...]
+    evidence_paths: tuple[str, ...]
+    telemetry_paths: tuple[str, ...]
+    networks: tuple[str, ...]
+    static_addresses: tuple[str, ...]
+
+    def details(self) -> dict[str, object]:
+        return {
+            "address": self.address,
+            "name": self.name,
+            "aliases": list(self.aliases),
+            "profiles": list(self.profiles),
+            "services": list(self.services),
+            "rendered_configs": list(self.rendered_configs),
+            "evidence_paths": list(self.evidence_paths),
+            "telemetry_paths": list(self.telemetry_paths),
+            "networks": list(self.networks),
+            "static_addresses": list(self.static_addresses),
+        }
+
+
+@dataclass(frozen=True)
+class NetworkRealization:
+    """APTL realization data for one ACES network resource."""
+
+    address: str
+    name: str
+    cidr: str | None
+    gateway: str | None
+    internal: bool | None
+
+    def details(self) -> dict[str, object]:
+        return {
+            "address": self.address,
+            "name": self.name,
+            "cidr": self.cidr,
+            "gateway": self.gateway,
+            "internal": self.internal,
+        }
+
+
+@dataclass(frozen=True)
+class PlacementRealization:
+    """APTL realization data for one node-scoped provisioning binding."""
+
+    address: str
+    resource_type: str
+    name: str
+    target_address: str
+    target_node: str | None
+
+    def details(self) -> dict[str, object]:
+        return {
+            "address": self.address,
+            "resource_type": self.resource_type,
+            "name": self.name,
+            "target_address": self.target_address,
+            "target_node": self.target_node,
+        }
+
+
+@dataclass(frozen=True)
+class AptlRealization:
+    """Result of interpreting ACES provisioning content for APTL."""
+
+    profiles: frozenset[str]
+    nodes: tuple[NodeRealization, ...]
+    networks: tuple[NetworkRealization, ...]
+    placements: tuple[PlacementRealization, ...]
+    diagnostics: tuple[Diagnostic, ...]
+
+    def details(self) -> dict[str, object]:
+        resource_counts = {
+            "account-placement": sum(
+                placement.resource_type == "account-placement"
+                for placement in self.placements
+            ),
+            "content-placement": sum(
+                placement.resource_type == "content-placement"
+                for placement in self.placements
+            ),
+            "feature-binding": sum(
+                placement.resource_type == "feature-binding"
+                for placement in self.placements
+            ),
+            "network": len(self.networks),
+            "node": len(self.nodes),
+        }
+        return {
+            "profiles": sorted(self.profiles),
+            "resource_counts": {
+                key: value for key, value in sorted(resource_counts.items()) if value
+            },
+            "nodes": [node.details() for node in self.nodes],
+            "networks": [network.details() for network in self.networks],
+            "placements": [placement.details() for placement in self.placements],
+        }

--- a/src/aptl/backends/aces_realization_values.py
+++ b/src/aptl/backends/aces_realization_values.py
@@ -1,0 +1,183 @@
+"""Field extraction helpers for ACES-to-APTL realization."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from aptl.backends.aces_profiles import normalize_identifier
+
+PLACEMENT_TARGET_KEYS = {
+    "account-placement": ("target_address", "node_name"),
+    "content-placement": ("target_address", "target_node"),
+    "feature-binding": ("node_address", "node_name"),
+}
+
+
+def placement_target_values(
+    resource_type: str,
+    payload: Mapping[str, Any],
+) -> tuple[str, ...]:
+    """Return candidate node reference values for a placement resource."""
+
+    return payload_string_values(payload, PLACEMENT_TARGET_KEYS.get(resource_type, ()))
+
+
+def resolve_target_address(
+    target_values: tuple[str, ...],
+    node_lookup: dict[str, str],
+) -> str | None:
+    """Resolve placement target text to a realized node address."""
+
+    for value in target_values:
+        if value in node_lookup:
+            return node_lookup[value]
+        normalized = normalize_identifier(value)
+        if normalized in node_lookup:
+            return node_lookup[normalized]
+    return None
+
+
+def resource_name(address: str, payload: Mapping[str, Any]) -> str:
+    """Return a resource display name, defaulting to its ACES address."""
+
+    return first_nonempty_string(payload_string_values(payload, ("name",))) or address
+
+
+def runtime_spec(
+    payload: Mapping[str, Any],
+    spec: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    """Return the runtime-specific payload block when present."""
+
+    for container in (payload, spec):
+        if container is None:
+            continue
+        runtime = container.get("runtime")
+        if isinstance(runtime, Mapping):
+            return runtime
+        aptl = container.get("aptl")
+        if isinstance(aptl, Mapping):
+            return aptl
+    return None
+
+
+def service_names(node_spec: Mapping[str, Any] | None) -> set[str]:
+    """Extract named services from a node specification."""
+
+    if node_spec is None:
+        return set()
+    services = node_spec.get("services")
+    if not isinstance(services, list):
+        return set()
+    names: set[str] = set()
+    for service in services:
+        if not isinstance(service, Mapping):
+            continue
+        name = service.get("name")
+        if isinstance(name, str) and name.strip():
+            names.add(name)
+    return names
+
+
+def network_names(infra_spec: Mapping[str, Any] | None) -> set[str]:
+    """Extract linked network names from infrastructure details."""
+
+    if infra_spec is None:
+        return set()
+    return string_values(infra_spec.get("links"))
+
+
+def static_addresses(infra_spec: Mapping[str, Any] | None) -> set[str]:
+    """Extract static host addresses from infrastructure details."""
+
+    if infra_spec is None:
+        return set()
+    properties = infra_spec.get("properties")
+    addresses: set[str] = set()
+    if isinstance(properties, list):
+        for item in properties:
+            if isinstance(item, Mapping):
+                addresses.update(string_values(item.values()))
+    elif isinstance(properties, Mapping):
+        for key in ("address", "ip", "ipv4_address", "static_address"):
+            value = properties.get(key)
+            if isinstance(value, str) and value.strip():
+                addresses.add(value)
+    return addresses
+
+
+def string_list(
+    payload: Mapping[str, Any] | None,
+    key: str,
+) -> set[str]:
+    """Extract a string set from an optional mapping key."""
+
+    if payload is None:
+        return set()
+    return string_values(payload.get(key))
+
+
+def string_values(raw: object) -> set[str]:
+    """Normalize scalar or collection values into non-empty strings."""
+
+    if isinstance(raw, str):
+        return {raw} if raw.strip() else set()
+    if isinstance(raw, Mapping):
+        raw = raw.values()
+    if isinstance(raw, list | tuple | set | frozenset):
+        return {str(value) for value in raw if str(value).strip()}
+    return set()
+
+
+def payload_string_values(
+    payload: Mapping[str, Any],
+    keys: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Return non-empty string values from payload keys in order."""
+
+    values: list[str] = []
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            values.append(value)
+    return tuple(values)
+
+
+def first_nonempty_string(values: tuple[str, ...]) -> str | None:
+    """Return the first non-empty string from a candidate tuple."""
+
+    for value in values:
+        if value.strip():
+            return value
+    return None
+
+
+def optional_string(
+    payload: Mapping[str, Any] | None,
+    key: str,
+) -> str | None:
+    """Return a non-empty string property from an optional mapping."""
+
+    if payload is None:
+        return None
+    value = payload.get(key)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def optional_bool(
+    payload: Mapping[str, Any] | None,
+    key: str,
+) -> bool | None:
+    """Return a boolean property from an optional mapping."""
+
+    if payload is None:
+        return None
+    value = payload.get(key)
+    return value if isinstance(value, bool) else None
+
+
+def mapping(value: object) -> Mapping[str, Any] | None:
+    """Return mapping values while rejecting scalar payload fragments."""
+
+    return value if isinstance(value, Mapping) else None

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -47,8 +47,8 @@ def _node_resource(node_name: str) -> PlannedResource:
     )
 
 
-def _plan_for_nodes(*node_names: str) -> ProvisioningPlan:
-    resources = {resource.address: resource for resource in map(_node_resource, node_names)}
+def _plan_for_resources(*resources: PlannedResource) -> ProvisioningPlan:
+    mapped = {resource.address: resource for resource in resources}
     operations = [
         ProvisionOp(
             action=ChangeAction.CREATE,
@@ -56,9 +56,13 @@ def _plan_for_nodes(*node_names: str) -> ProvisioningPlan:
             resource_type=resource.resource_type,
             payload=resource.payload,
         )
-        for resource in resources.values()
+        for resource in mapped.values()
     ]
-    return ProvisioningPlan(resources=resources, operations=operations)
+    return ProvisioningPlan(resources=mapped, operations=operations)
+
+
+def _plan_for_nodes(*node_names: str) -> ProvisioningPlan:
+    return _plan_for_resources(*map(_node_resource, node_names))
 
 
 def _plan_with_resource_type(resource_type: str) -> ProvisioningPlan:
@@ -179,6 +183,201 @@ def test_provisioner_profiles_are_derived_from_plan_content(tmp_path):
     assert backend.start.call_args_list[1].args == (["victim", "otel"],)
 
 
+def test_provisioner_realization_details_follow_distinct_plan_content(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose(
+        tmp_path,
+        {
+            "kali": ["kali"],
+            "victim": ["victim"],
+            "aptl-otel-collector": ["otel"],
+        },
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(
+        lab={"name": "test"},
+        containers={"kali": True, "victim": True, "wazuh": False},
+    )
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+    attacker = _node_resource("exercise-a.kali")
+    attacker.payload["spec"]["node"]["services"] = [
+        {"name": "ssh-control", "port": 22, "protocol": "tcp"}
+    ]
+    attacker.payload["spec"]["runtime"] = {
+        "rendered_configs": ["kali-operator.conf"],
+        "evidence_paths": ["runs/exercise-a/kali"],
+    }
+    target = _node_resource("exercise-b.victim")
+    target.payload["spec"]["node"]["services"] = [
+        {"name": "web-target", "port": 8080, "protocol": "tcp"}
+    ]
+    target.payload["spec"]["runtime"] = {
+        "rendered_configs": ["victim-web.conf"],
+        "evidence_paths": ["runs/exercise-b/victim"],
+    }
+
+    first = provisioner.apply(_plan_for_resources(attacker), RuntimeSnapshot())
+    second = provisioner.apply(_plan_for_resources(target), RuntimeSnapshot())
+
+    assert first.success is True
+    assert second.success is True
+    assert (
+        first.details["realization"]["nodes"] != second.details["realization"]["nodes"]
+    )
+    assert first.details["realization"]["nodes"][0]["services"] == ["ssh-control"]
+    assert second.details["realization"]["nodes"][0]["services"] == ["web-target"]
+    assert first.details["realization"]["nodes"][0]["rendered_configs"] == [
+        "kali-operator.conf"
+    ]
+    assert second.details["realization"]["nodes"][0]["rendered_configs"] == [
+        "victim-web.conf"
+    ]
+
+
+def test_provisioner_rejects_missing_node_realization_even_with_techvault_metadata(
+    tmp_path,
+):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose(tmp_path, {"kali": ["kali"]})
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "test"}),
+        deployment_backend=backend,
+    )
+    resource = PlannedResource(
+        address="provision.node.techvault",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload={
+            "name": "techvault",
+            "metadata": {"scenario": "techvault"},
+            "spec": {"node": {"description": "metadata-only node"}},
+        },
+    )
+
+    result = provisioner.apply(_plan_for_resources(resource), RuntimeSnapshot())
+
+    assert result.success is False
+    assert any(
+        diagnostic.code == "aptl.provisioner.node-profile-unresolved"
+        and diagnostic.address == resource.address
+        for diagnostic in result.diagnostics
+    )
+    backend.start.assert_not_called()
+
+
+def test_provisioner_rejects_supported_placement_without_declared_target(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose(tmp_path, {"kali": ["kali"]})
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "test"}),
+        deployment_backend=backend,
+    )
+    node = _node_resource("scenario.kali")
+    placement = PlannedResource(
+        address="provision.content-placement.payload",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="content-placement",
+        payload={
+            "name": "payload",
+            "content_name": "payload.exe",
+            "target_node": "missing-node",
+        },
+    )
+
+    result = provisioner.apply(_plan_for_resources(node, placement), RuntimeSnapshot())
+
+    assert result.success is False
+    assert any(
+        diagnostic.code == "aptl.provisioner.binding-target-unresolved"
+        and diagnostic.address == placement.address
+        for diagnostic in result.diagnostics
+    )
+    backend.start.assert_not_called()
+
+
+def test_provisioner_records_supported_placement_realizations(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose(
+        tmp_path,
+        {
+            "kali": ["kali"],
+            "aptl-otel-collector": ["otel"],
+        },
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "test"}),
+        deployment_backend=backend,
+    )
+    node = _node_resource("scenario.kali")
+    feature = PlannedResource(
+        address="provision.feature-binding.ssh",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="feature-binding",
+        payload={
+            "name": "ssh-feature",
+            "feature_name": "ssh",
+            "node_name": "scenario.kali",
+        },
+    )
+    content = PlannedResource(
+        address="provision.content-placement.payload",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="content-placement",
+        payload={
+            "name": "payload",
+            "content_name": "payload.exe",
+            "target_address": node.address,
+        },
+    )
+    account = PlannedResource(
+        address="provision.account-placement.operator",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="account-placement",
+        payload={
+            "name": "operator",
+            "account_name": "operator",
+            "node_name": "scenario.kali",
+        },
+    )
+
+    result = provisioner.apply(
+        _plan_for_resources(node, feature, content, account), RuntimeSnapshot()
+    )
+
+    assert result.success is True
+    placements = result.details["realization"]["placements"]
+    assert {placement["resource_type"] for placement in placements} == {
+        "account-placement",
+        "content-placement",
+        "feature-binding",
+    }
+    assert {placement["target_address"] for placement in placements} == {node.address}
+    assert result.details["realization"]["resource_counts"] == {
+        "account-placement": 1,
+        "content-placement": 1,
+        "feature-binding": 1,
+        "node": 1,
+    }
+
+
 def test_provisioner_rejects_unsupported_resource_type(tmp_path):
     from aptl.backends.aces import AptlProvisioner
 
@@ -191,7 +390,9 @@ def test_provisioner_rejects_unsupported_resource_type(tmp_path):
         deployment_backend=backend,
     )
 
-    result = provisioner.apply(_plan_with_resource_type("packet-capture"), RuntimeSnapshot())
+    result = provisioner.apply(
+        _plan_with_resource_type("packet-capture"), RuntimeSnapshot()
+    )
 
     assert result.success is False
     assert any(


### PR DESCRIPTION
## Summary

Generalizes the APTL ACES provisioning path into a resource-kind interpreter that derives compose profiles, placement bindings, and realization audit details from ACES provisioning-plan content instead of scenario metadata.

## Requirement UIDs

- `SCN-010`

## Related Issues

Closes #324

## ADR Impact

- ADR-035

## Changes

- Add an ACES provisioning realization module for nodes, networks, feature bindings, content placements, and account placements.
- Wire AptlProvisioner validation and apply through the single realization result, including explicit diagnostics and ApplyResult realization details.
- Cover distinct plan-content realizations, metadata-only negative cases, unsupported declarations, and placement success/failure paths in pytest.
- Document the provisioning realization contract and add the issue changelog fragment.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- `.venv/bin/python -m pytest` passed: 2277 passed, 181 skipped, 22 deselected, 1 xfailed.
- `pre-commit run --all-files` passed after the placement success-path test fix.
- Codex pre-push review cycle 1 was clean.
- Test-quality cycle 1 found missing placement success-path coverage; the test was added and locally verified. User instructed to continue without an over-cap review cycle.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SCN-010 ← src/aptl/backends/aces.py, SCN-010 ← src/aptl/backends/aces_realization.py, SCN-010 ← docs/sdl/runtime-architecture.md
- TESTS: SCN-010 ← tests/test_aces_backend.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/324.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
