### PR TITLE
Clear the 3 open SonarCloud new-code findings on PR #508

### DIFF
--- a/src/aptl/core/deployment/_compose_queries.py
+++ b/src/aptl/core/deployment/_compose_queries.py
@@ -90,13 +90,15 @@ def _decode_compose_ps(stdout: str) -> list[dict[str, Any]]:
         return []
     try:
         if stripped.startswith("["):
-            return json.loads(stripped)
-        return [
-            json.loads(line) for line in stripped.splitlines() if line.strip()
-        ]
+            parsed = json.loads(stripped)
+        else:
+            parsed = [
+                json.loads(line) for line in stripped.splitlines() if line.strip()
+            ]
     except json.JSONDecodeError:
         log.warning("could not parse compose ps output")
         return []
+    return parsed
 
 
 class ComposeQueryMixin(object):

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -645,7 +645,7 @@ def _run_credential_sync(
     try:
         fn(*args)
     except PathContainmentError as exc:
-        log.error("%s containment violation: %s", label, exc)
+        log.exception("%s containment violation", label)
         return LabResult(success=False, error=f"{label}: {exc}")
     except Exception as exc:
         log.exception("Failed to render %s", label.lower())

--- a/src/aptl/core/ssh.py
+++ b/src/aptl/core/ssh.py
@@ -20,7 +20,7 @@ _PIVOT_KEY_NAME = "kali_pivot_key"
 
 
 @dataclass
-class SSHKeyResult:
+class SSHKeyResult(object):
     """Result of SSH key generation."""
 
     success: bool


### PR DESCRIPTION
PR #508 (dev → main) carries 3 open (non-accepted) SonarCloud new-code findings. This clears all three at the source so the next analysis on #508 reports them resolved.

| Rule | File | Fix |
|------|------|-----|
| `python:S1142` | `core/deployment/_compose_queries.py` | `_decode_compose_ps` had 4 returns (max 3). Collapse the two parse branches into one `parsed` assignment with a single trailing return — behaviour identical. |
| `python:S8572` | `core/lab.py` | The `PathContainmentError` handler in `_run_credential_sync` logged with `log.error()` inside an `except` block. Switch to `log.exception()` so the guardrail breach is logged with its traceback (matching the sibling generic-failure branch). The exception is still surfaced verbatim in the returned `LabResult.error`. |
| `python:S1722` | `core/ssh.py` | `SSHKeyResult` now inherits from `object`, matching the repo-wide convention already applied to every other dataclass/helper class. ruff enables only `C901`, so `UP004` does not fire. |

## Validation

- `ruff check src/` (C901 complexity gate): pass
- Targeted suites for all three touched areas — `test_ssh.py`, `test_api_integration.py`, `test_lab.py` (incl. the containment-breach tests, which assert on `LabResult.error`, not log level): 155 passed
- The pre-commit lint hooks (trailing-whitespace, end-of-file-fixer, ruff-complexity) pass on the changed files

The 4 Accepted SonarCloud issues on #508 are left untouched.