### PR TITLE
feat: promote ACES backend to orchestration-capable profile

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,7 +98,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,web]"
-      - name: ACES static validation gate (TechVault, provisioning-only)
+      - name: ACES static validation gate (TechVault, orchestration-capable)
         run: python -m pytest tests/test_techvault_static_gate.py -q -m integration
 
   mcp-tests:

--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -9,5 +9,12 @@ workflow:
 sonarcloud:
   project_key: Brad-Edwards_aptl
   organization: brad-edwards
+routing:
+  # Per-step model routing (ADR-036). When enabled, each /implement step is
+  # dispatched on the model its tier hint maps to (low->haiku, medium->sonnet,
+  # high->opus) instead of always running on the parent session model.
+  enabled: true
+  default_provider: claude
+  default_fallback: parent
 rules:
   plan_rules: .gc/plan-rules.md

--- a/changelog.d/311.added.md
+++ b/changelog.d/311.added.md
@@ -1,0 +1,19 @@
+### Added
+
+- **ACES backend promotion to `orchestration-capable` (SCN-010 / #311).**
+  APTL's published `backend-manifest-v2` now declares a real
+  `capabilities.orchestrator` plus the `workflow-result-envelope-v1` and
+  `workflow-history-event-stream-v1` contracts, and the runtime target carries
+  a concrete ACES `Orchestrator` (`aptl.backends.aces_orchestrator.AptlOrchestrator`)
+  that exposes APTL's RTE-001 workflow drive surface through the portable ACES
+  workflow result/history contracts. Scenario start now routes provisioning and
+  orchestration through the ACES runtime control plane instead of bypassing
+  straight to the provisioner. The static and live validation gates, the
+  pre-push hook, the advisory CI job, and `aptl lab validate-live` default from
+  the `provisioning-only` to the `orchestration-capable` profile, and `aces
+  conformance backend --profile orchestration-capable` passes against APTL's
+  manifest. The orchestrator registers each workflow as a truthful `PENDING`
+  run and publishes the portable result/history contract surface; sourcing live
+  `RUNNING` → terminal execution state from RTE-001 is the follow-on #514.
+  Evaluator/objective scoring and participant-runtime profiles remain out of
+  scope (#312).

--- a/docs/aces/orchestration-capable-profile-preflight.md
+++ b/docs/aces/orchestration-capable-profile-preflight.md
@@ -1,0 +1,165 @@
+# ACES Orchestration-Capable Profile Preflight
+
+This note is the architecture preflight for SCN-010 follow-on issue #311. It
+is guidance, not an implementation plan. ADR-035 remains the binding ACES SDL
+adoption decision, and the TechVault static and live preflight notes remain the
+validation-shape precedents.
+
+## Architecture Decisions
+
+- Treat #311 as a backend profile promotion and ACES contract adapter change,
+  not as a new APTL scenario runtime. APTL's published backend boundary must be
+  ACES `backend-manifest-v2`, ACES `RuntimeTarget`, and the ACES orchestrator
+  protocol.
+- The manifest remains the canonical ACES
+  `aces_backend_protocols.capabilities.BackendManifest` /
+  `BackendCapabilitySet` payload. Promotion to `orchestration-capable` requires
+  a real `OrchestratorCapabilities` declaration and the profile-required
+  contracts `workflow-result-envelope-v1` and
+  `workflow-history-event-stream-v1`; declare only workflow features and state
+  predicates the APTL adapter actually supports.
+- The APTL runtime target must carry a concrete orchestrator component
+  satisfying ACES `Orchestrator.start()`, `status()`, `results()`,
+  `history()`, and `stop()`. Conformance must fail if the target declares
+  orchestration but publishes only provisioning.
+- Workflow results and history are ACES contract surfaces. Populate
+  `RuntimeSnapshot.orchestration_results` and
+  `RuntimeSnapshot.orchestration_history` with ACES workflow-address-keyed
+  `WorkflowExecutionState` and `WorkflowHistoryEvent` payloads validated by
+  `aces_runtime.workflow_result_contracts.workflow_result_contract_diagnostics`.
+- Existing APTL state-machine, session, run-archive, and legacy
+  `aptl.core.runtime` models may inform internal execution, but they are not
+  the public ACES DTOs and must not become a second workflow schema.
+- Static and live gates remain the canonical validation homes. Upgrade the
+  existing profile parameter, conformance calls, tests, pre-commit hook, and CI
+  gate from `provisioning-only` to `orchestration-capable`; do not add a second
+  conformance runner or report taxonomy.
+- Once APTL claims orchestration, public scenario start must go through the
+  ACES manager/target orchestration path. Do not keep the direct
+  provisioning-only `AptlProvisioner.apply()` bypass or broad
+  `evaluator.missing` allowlist as the normal start route.
+
+## Cross-Cutting Concerns To Reuse
+
+- ACES authorities: `RuntimeManager`, `RuntimeTarget`, `OrchestrationPlan`,
+  `ApplyResult`, `RuntimeSnapshot`, `WorkflowExecutionState`,
+  `WorkflowHistoryEvent`, `OrchestratorCapabilities`, `BackendCapabilitySet`,
+  `backend_manifest_payload()`, backend profile JSON under
+  `contracts/profiles/backend/`, `workflow_result_contract_diagnostics()`, and
+  `aces conformance backend --profile orchestration-capable`.
+- APTL ACES adapter seams: `src/aptl/backends/aces.py`,
+  `src/aptl/backends/aces_manifest.py`,
+  `src/aptl/backends/aces_diagnostics.py`,
+  `src/aptl/backends/aces_realization.py`,
+  `src/aptl/backends/aces_realization_model.py`,
+  `src/aptl/backends/aces_realization_values.py`, and
+  `src/aptl/backends/aces_profiles.py`.
+- Lab and deployment owners: `orchestrate_lab_start()`, `stop_lab()`,
+  `_LAB_START_STEPS`, `DeploymentBackend`, `DockerComposeBackend`,
+  `SSHComposeBackend`, `LabResult`, `StartupOutcome`, and
+  `StartupDiagnostic`.
+- Config and environment owners: `AptlConfig`, `ContainerSettings`,
+  `DeploymentConfig`, `load_config()`, `load_dotenv()`, `EnvVars`,
+  `env_vars_from_dict()`, and `find_placeholder_env_values()`.
+- Evidence and persistence owners: `RangeSnapshot.to_dict()`,
+  `LocalRunStore`, `resolve_run_store()`, `collect_*` helpers,
+  `curl_safe.curl_json()`, `aptl.utils.redaction.redact()`, and
+  `aptl.utils.logging.get_logger()`.
+- Validation and workflow gates: `src/aptl/validation/techvault_gate.py`,
+  `src/aptl/validation/_gate_checks.py`,
+  `src/aptl/validation/techvault_live_gate.py`,
+  `src/aptl/validation/_live_gate_checks.py`,
+  `tests/test_aces_backend.py`, `tests/test_techvault_static_gate.py`,
+  `tests/test_techvault_live_gate.py`, `.pre-commit-config.yaml`, and
+  `.github/workflows/checks.yml`.
+
+## Security And Validation Layers
+
+- **ACES SDL and plan shape:** scenario input still passes through the ACES
+  parser, import verification, semantic validation, runtime model compiler,
+  planner, and manager. APTL must not add local Pydantic workflow mirrors or
+  scenario-name switches to satisfy orchestration.
+- **Backend manifest and profile shape:** the manifest must serialize through
+  ACES `backend_manifest_payload()` and pass the canonical
+  `orchestration-capable` profile. Missing profile files, fixture corpus,
+  conformance CLI, or required contracts are hard failures, not warnings.
+- **Orchestrator protocol shape:** `RuntimeTarget` registry and ACES backend
+  call adapters own the component boundary. The target must include an
+  orchestrator object, and returned `ApplyResult` / `RuntimeSnapshot` data must
+  remain ACES-shaped instead of APTL-native dictionaries.
+- **Workflow result and history shape:** use ACES workflow contract models and
+  diagnostics for result envelopes, event streams, status transitions, attempt
+  counts, and workflow addresses. Do not flatten workflow history into run
+  archive summaries before ACES validation has passed.
+- **Config shape:** durable knobs stay in strict `AptlConfig`. Profile choice
+  is a gate/runtime parameter, not a new unchecked `aptl.json` dictionary or a
+  value inferred from `techvault` in a filename.
+- **Environment and secret binding:** `.env` remains parsed and shaped by the
+  existing env helpers. Secrets, bearer tokens, cookies, rendered credentialized
+  config, private keys, and generated SOC material must not be copied into SDL,
+  manifests, workflow histories, diagnostics, or expected-output fixtures.
+- **Deployment and OS exposure:** Docker Compose lifecycle and host/container
+  inspection stay behind `DeploymentBackend`. Do not add raw `docker`, shell,
+  or `curl` calls in orchestration code; SOC HTTP probes use `curl_safe`, and
+  no secret-bearing value belongs in argv, URLs, logs, or command output.
+- **Error envelopes and observability:** ACES-facing failures stay as ACES
+  diagnostics or operation status details. APTL-facing failures stay in
+  `LabResult`, `StartupDiagnostic`, `GateReport`, CLI/API schemas, or pytest
+  assertions. Redaction happens before logs, API/CLI output, run archives, and
+  generated reports.
+- **Persistence and run archive:** workflow history, realization provenance,
+  status snapshots, and validation observations are analysis artifacts, not
+  credential stores. Write structured evidence through `LocalRunStore` or
+  existing redacting boundaries; avoid archive keys such as `passed` that are
+  redacted by the password heuristic.
+
+## Extensibility Seam
+
+The durable seam is `(scenario_path, backend_profile, target_name,
+workflow_address)` plus the ACES capability declaration:
+`supported_sections`, `supported_workflow_features`, and
+`supported_workflow_state_predicates`. The next profile change should require
+changing those inputs and capability sets, not editing TechVault-specific
+branches or inventing a second manifest shape.
+
+Keep provisioning realization content-driven and workflow interpretation
+workflow-address-driven. Orchestration-capable must not close the door on #312:
+evaluation results, objective scoring, and participant-runtime contracts remain
+separate profile surfaces.
+
+## Gotchas And Anti-Patterns
+
+- Declaring `capabilities.orchestrator` or workflow contracts without a real
+  orchestrator component and populated result/history payloads.
+- Continuing the direct provisioning apply path after claiming
+  `orchestration-capable`, or treating planner diagnostics for missing
+  evaluation as an orchestration waiver.
+- Reusing `src/aptl/core/runtime/*`, `src/aptl/backends/stubs.py`, or
+  `ScenarioSession.completed_objectives` as the published ACES workflow result
+  source of truth.
+- Creating duplicate schemas, exception hierarchies, conformance scripts,
+  run-archive models, health taxonomies, or validation report DTOs.
+- Hardcoding TechVault, profile names, Compose profiles, workflow addresses, or
+  scenario paths inside the orchestrator.
+- Flattening `ApplyResult.details["realization"]`,
+  `RuntimeSnapshot.orchestration_results`, or workflow history into lossy
+  summaries before ACES contract validation.
+- Treating evidence bundles, screenshots, logs, checksums, or mapping ledgers
+  as substitutes for SDL expression or ACES blocker issues.
+- Updating only CI while leaving pre-commit, static gate defaults, live gate
+  profile checks, or unit tests on `provisioning-only`.
+
+## Non-Goals
+
+- Do not implement the orchestrator, manifest promotion, tests, CI changes,
+  run archive writes, or public start-path changes in this preflight.
+- Do not perform Phase B cutover, flip the default scenario, archive legacy
+  `scenarios/*.yaml`, delete `aptl.core.sdl`, or delete Pydantic
+  `ScenarioDefinition` models.
+- Do not promote to orchestration-evaluation, implement objective scoring,
+  publish evaluator contracts, or claim participant-runtime support; those are
+  #312 or later.
+- Do not redesign Docker Compose, config/env loading, secret handling, API
+  schemas, terminal relay, endpoint registry, SOC TLS, or run archive layout.
+- Do not treat APTL consumption gaps or filed ACES expressivity issues as
+  waivers for SCN-010 observable parity.

--- a/docs/aces/parity-inventory.yaml
+++ b/docs/aces/parity-inventory.yaml
@@ -80,8 +80,15 @@ required_surface_coverage:
     notes: Adversary inject sequencing belongs to the orchestration-evaluation profile; out of provisioning-only scope.
   workflows:
     status: deferred
-    blocking_followup: "#312"
-    notes: Scenario-flow workflows belong to the orchestration-evaluation profile; out of provisioning-only scope.
+    blocking_followup: "#321"
+    notes: >-
+      The workflow result/history backend contract surface
+      (workflow-result-envelope-v1 / workflow-history-event-stream-v1) is the
+      orchestration-capable profile, delivered by #311 and proven by `aces
+      conformance backend --profile orchestration-capable` against APTL's
+      published manifest (src/aptl/backends/aces_orchestrator.py). TechVault
+      authors no workflow scenario content yet; that authoring is the cutover
+      scope tracked by #321.
   objectives:
     status: deferred
     blocking_followup: "#312"
@@ -93,7 +100,12 @@ required_surface_coverage:
   run_archive:
     status: deferred
     blocking_followup: "#312"
-    notes: Run-archive/scoring run evidence is an evaluator-profile runtime output (#312).
+    notes: >-
+      Workflow run history is expressible through the orchestration-capable
+      contracts delivered by #311, but TechVault authors no workflows so it
+      emits no workflow runs; scoring/evaluator run-archive evidence is an
+      evaluator-profile (orchestration-evaluation) runtime output tracked by
+      #312.
 
 # ---------------------------------------------------------------------------
 # Rows.

--- a/docs/adrs/adr-035-aces-sdl-adoption.md
+++ b/docs/adrs/adr-035-aces-sdl-adoption.md
@@ -93,13 +93,18 @@ Specifically:
 
 ## Backend Profile Choice
 
-APTL targets `provisioning-only` initially because that profile requires
+APTL targeted `provisioning-only` initially because that profile requires
 only `backend-manifest-v2`, `operation-receipt-v1`, `operation-status-v1`,
 and `runtime-snapshot-v1`—all reachable by wrapping the existing lab
-provisioning code. Moving to `orchestration-capable` adds
-`workflow-result-envelope-v1` and `workflow-history-event-stream-v1`,
-which maps onto APTL's existing scenario runtime engine (RTE-001) but is
-large enough to scope separately under issue #311.
+provisioning code. Issue #311 has since promoted APTL to
+`orchestration-capable`: the manifest declares a real
+`capabilities.orchestrator` and the `workflow-result-envelope-v1` /
+`workflow-history-event-stream-v1` contracts, the runtime target publishes a
+concrete ACES `Orchestrator` (`aptl.backends.aces_orchestrator`) that exposes
+RTE-001's workflow drive surface through those portable contracts, scenario
+start routes through the ACES control plane, and the static/live gates,
+pre-push hook, CI job, and `aptl lab validate-live` default to the
+`orchestration-capable` profile.
 `orchestration-evaluation` further adds the evaluator envelopes and
 corresponds to SCN-007 (Objective-Based Scoring with Hints), tracked
 under issue #312. The `full-remote-control-plane` profile is out of

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -44,6 +44,8 @@ from aptl.utils.logging import get_logger
 from aptl.utils.redaction import redact
 
 if TYPE_CHECKING:
+    from aces_processor.models import ExecutionPlan
+
     from aptl.core.deployment.backend import DeploymentBackend
 
 log = get_logger("aces-backend")
@@ -90,62 +92,69 @@ def start_aces_scenario(
             config=config,
             backend=backend,
         )
-        manager = RuntimeManager(target)
-        execution_plan = manager.plan(scenario)
-        # APTL declares no ACES evaluator yet (tracked by #312). A scenario may
-        # still carry evaluation content — notably the `conditions` section,
-        # whose entries are Docker Compose healthchecks realized during
-        # provisioning, not by an ACES evaluator. The planner flags such content
-        # with the evaluation-domain `evaluator.missing` ERROR; tolerate exactly
-        # that one expected diagnostic (evaluation is deferred to #312) and stay
-        # fail-closed for every other planner error (provisioning ordering
-        # cycles, unsupported capabilities, orchestration errors, ...).
-        blocking = [
-            diag
-            for diag in execution_plan.diagnostics
-            if diag.is_error
-            and not (diag.domain == "evaluation" and diag.code == "evaluator.missing")
-        ]
-        if blocking:
-            return LabResult(
-                success=False,
-                error=render_aces_diagnostics(blocking),
-            )
-        # Route provisioning and orchestration through the canonical ACES
-        # runtime control plane rather than calling the provisioner directly.
-        # Now that APTL is orchestration-capable, scenario start no longer
-        # bypasses the orchestration path: provisioning is applied, then (when
-        # the scenario carries workflows) orchestration is started so APTL's
-        # orchestrator records workflow result/history through the portable ACES
-        # contracts. Evaluation stays unsubmitted until #312 adds the evaluator.
-        control_plane = RuntimeControlPlane(
-            target, initial_snapshot=execution_plan.base_snapshot
-        )
-        provisioning_failure = _apply_phase(
-            control_plane,
-            lambda: control_plane.submit_provisioning(execution_plan.provisioning),
-        )
-        if provisioning_failure is not None:
-            return provisioning_failure
-        if execution_plan.orchestration.actionable_operations:
-            orchestration_failure = _apply_phase(
-                control_plane,
-                lambda: control_plane.submit_orchestration(execution_plan.orchestration),
-            )
-            if orchestration_failure is not None:
-                return orchestration_failure
+        execution_plan = RuntimeManager(target).plan(scenario)
+        return _run_execution_plan(target, execution_plan)
     except (FileNotFoundError, SDLError, TypeError, ValueError) as exc:
         return LabResult(
             success=False,
             error=redact(f"ACES runtime handoff failed: {exc}"),
         )
 
+
+def _run_execution_plan(target: RuntimeTarget, execution_plan: "ExecutionPlan") -> LabResult:
+    """Apply a planned ACES scenario through the runtime control plane.
+
+    APTL declares no ACES evaluator yet (tracked by #312). A scenario may still
+    carry evaluation content — notably the ``conditions`` section, whose entries
+    are Docker Compose healthchecks realized during provisioning, not by an ACES
+    evaluator. The planner flags such content with the evaluation-domain
+    ``evaluator.missing`` ERROR; tolerate exactly that one expected diagnostic
+    and stay fail-closed for every other planner error (provisioning ordering
+    cycles, unsupported capabilities, orchestration errors, ...). Now that APTL
+    is orchestration-capable, scenario start no longer bypasses the orchestration
+    path: provisioning is applied, then — when the scenario carries workflows —
+    orchestration is started so APTL's orchestrator records workflow
+    result/history through the portable ACES contracts.
+    """
+    blocking = [
+        diag
+        for diag in execution_plan.diagnostics
+        if diag.is_error
+        and not (diag.domain == "evaluation" and diag.code == "evaluator.missing")
+    ]
+    if blocking:
+        return LabResult(success=False, error=render_aces_diagnostics(blocking))
+    control_plane = RuntimeControlPlane(target, initial_snapshot=execution_plan.base_snapshot)
+    failure = _apply_provisioning_and_orchestration(control_plane, execution_plan)
+    if failure is not None:
+        return failure
     return LabResult(
         success=True,
-        message=(
-            f"Lab started through ACES runtime target '{APTL_ACES_TARGET_NAME}'"
-        ),
+        message=f"Lab started through ACES runtime target '{APTL_ACES_TARGET_NAME}'",
     )
+
+
+def _apply_provisioning_and_orchestration(
+    control_plane: RuntimeControlPlane,
+    execution_plan: "ExecutionPlan",
+) -> LabResult | None:
+    """Submit provisioning, then orchestration when the plan carries workflows.
+
+    Returns a failed ``LabResult`` for the first phase that fails, else ``None``.
+    Evaluation stays unsubmitted until #312 adds the evaluator.
+    """
+    provisioning_failure = _apply_phase(
+        control_plane,
+        lambda: control_plane.submit_provisioning(execution_plan.provisioning),
+    )
+    if provisioning_failure is not None:
+        return provisioning_failure
+    if execution_plan.orchestration.actionable_operations:
+        return _apply_phase(
+            control_plane,
+            lambda: control_plane.submit_orchestration(execution_plan.orchestration),
+        )
+    return None
 
 
 def _apply_phase(

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -9,13 +9,15 @@ start.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.planning import ChangeAction, ProvisioningPlan
-from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
+from aces_contracts.runtime_state import ApplyResult, OperationState, RuntimeSnapshot
+from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.manager import RuntimeManager
 from aces_runtime.registry import RuntimeTarget
 from aces_sdl import SDLError, parse_sdl_file
@@ -28,6 +30,7 @@ from aptl.backends.aces_diagnostics import (
     snapshot_after_apply,
 )
 from aptl.backends.aces_manifest import APTL_ACES_TARGET_NAME, create_aptl_manifest
+from aptl.backends.aces_orchestrator import AptlOrchestrator
 from aptl.backends.aces_realization import (
     AptlRealization,
     interpret_provisioning_plan,
@@ -65,6 +68,7 @@ def create_aptl_runtime_target(
         name=APTL_ACES_TARGET_NAME,
         manifest=create_aptl_manifest(),
         provisioner=provisioner,  # type: ignore[arg-type]
+        orchestrator=AptlOrchestrator(),  # type: ignore[arg-type]
     )
 
 
@@ -88,19 +92,14 @@ def start_aces_scenario(
         )
         manager = RuntimeManager(target)
         execution_plan = manager.plan(scenario)
-        # APTL is a provisioning-only ACES backend: its manifest declares no
-        # evaluator or orchestrator (see aces_manifest.AptlBackendManifest). A
-        # scenario may still carry evaluation content — notably the `conditions`
-        # section, whose entries are Docker Compose healthchecks realized during
-        # provisioning, not by an ACES evaluator. The runtime planner flags such
-        # content with the evaluation-domain `evaluator.missing` ERROR and marks
-        # the whole plan invalid, so RuntimeManager.apply would refuse before any
-        # provisioning runs. Allowlist only that one expected diagnostic; stay
-        # fail-closed for every other planner error (e.g. provisioning ordering
-        # cycles or unsupported provisioning capabilities), which surface on the
-        # ExecutionPlan diagnostics rather than necessarily in the
-        # ProvisioningPlan that the provisioner re-validates. Then apply only the
-        # provisioning phase through APTL's provisioner.
+        # APTL declares no ACES evaluator yet (tracked by #312). A scenario may
+        # still carry evaluation content — notably the `conditions` section,
+        # whose entries are Docker Compose healthchecks realized during
+        # provisioning, not by an ACES evaluator. The planner flags such content
+        # with the evaluation-domain `evaluator.missing` ERROR; tolerate exactly
+        # that one expected diagnostic (evaluation is deferred to #312) and stay
+        # fail-closed for every other planner error (provisioning ordering
+        # cycles, unsupported capabilities, orchestration errors, ...).
         blocking = [
             diag
             for diag in execution_plan.diagnostics
@@ -112,29 +111,58 @@ def start_aces_scenario(
                 success=False,
                 error=render_aces_diagnostics(blocking),
             )
-        result = target.provisioner.apply(
-            execution_plan.provisioning,
-            execution_plan.base_snapshot,
+        # Route provisioning and orchestration through the canonical ACES
+        # runtime control plane rather than calling the provisioner directly.
+        # Now that APTL is orchestration-capable, scenario start no longer
+        # bypasses the orchestration path: provisioning is applied, then (when
+        # the scenario carries workflows) orchestration is started so APTL's
+        # orchestrator records workflow result/history through the portable ACES
+        # contracts. Evaluation stays unsubmitted until #312 adds the evaluator.
+        control_plane = RuntimeControlPlane(
+            target, initial_snapshot=execution_plan.base_snapshot
         )
+        provisioning_failure = _apply_phase(
+            control_plane,
+            lambda: control_plane.submit_provisioning(execution_plan.provisioning),
+        )
+        if provisioning_failure is not None:
+            return provisioning_failure
+        if execution_plan.orchestration.actionable_operations:
+            orchestration_failure = _apply_phase(
+                control_plane,
+                lambda: control_plane.submit_orchestration(execution_plan.orchestration),
+            )
+            if orchestration_failure is not None:
+                return orchestration_failure
     except (FileNotFoundError, SDLError, TypeError, ValueError) as exc:
         return LabResult(
             success=False,
             error=redact(f"ACES runtime handoff failed: {exc}"),
         )
 
-    return (
-        LabResult(
-            success=True,
-            message=(
-                f"Lab started through ACES runtime target '{APTL_ACES_TARGET_NAME}'"
-            ),
-        )
-        if result.success
-        else LabResult(
-            success=False,
-            error=render_aces_diagnostics(result.diagnostics),
-        )
+    return LabResult(
+        success=True,
+        message=(
+            f"Lab started through ACES runtime target '{APTL_ACES_TARGET_NAME}'"
+        ),
     )
+
+
+def _apply_phase(
+    control_plane: RuntimeControlPlane,
+    submit: Callable[[], object],
+) -> LabResult | None:
+    """Submit one control-plane phase; return a failed ``LabResult`` or ``None``.
+
+    Returns ``None`` when the submitted operation succeeded, otherwise a redacted
+    failure ``LabResult`` built from the operation's (or receipt's) diagnostics.
+    """
+    receipt = submit()
+    status = control_plane.get_operation(receipt.operation_id)
+    if status is not None and status.state == OperationState.SUCCEEDED:
+        return None
+    diagnostics = list(status.diagnostics) if status is not None else list(receipt.diagnostics)
+    return LabResult(success=False, error=render_aces_diagnostics(diagnostics))
 
 
 @dataclass

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -4,23 +4,32 @@ APTL publishes its runtime-target capability declaration as the canonical ACES
 ``backend-manifest-v2`` surface (``aces_backend_protocols.capabilities``), not an
 APTL-local approximation. The manifest is what the ACES planner's
 realization-support gate and ``aces conformance backend --profile
-provisioning-only`` validate against, so it must declare APTL's real
-provisioning capability against the published controlled vocabularies and
-contract authority — anything less is rejected by the conformance corpus.
+orchestration-capable`` validate against, so it must declare APTL's real
+provisioning and orchestration capability against the published controlled
+vocabularies and contract authority — anything less is rejected by the
+conformance corpus.
 
-APTL is a provisioning-only backend: it realizes ACES provisioning plans into
-Docker Compose profiles and declares no orchestrator, evaluator, or participant
-runtime. Profile promotion is tracked by #311 / #312.
+APTL is an orchestration-capable backend: it realizes ACES provisioning plans
+into Docker Compose profiles and exposes its scenario runtime engine (RTE-001)
+workflow drive surface through the portable ``workflow-result-envelope-v1`` and
+``workflow-history-event-stream-v1`` contracts (see
+``aptl.backends.aces_orchestrator.AptlOrchestrator``). It declares no evaluator
+or participant runtime; that promotion is tracked by #312.
 """
 
 from __future__ import annotations
 
-from aces_backend_protocols.capabilities import BackendManifest, ProvisionerCapabilities
+from aces_backend_protocols.capabilities import (
+    BackendManifest,
+    OrchestratorCapabilities,
+    ProvisionerCapabilities,
+)
 from aces_contracts.apparatus import (
     ConceptBinding,
     RealizationSupportDeclaration,
     RealizationSupportMode,
 )
+from aces_contracts.vocabulary import WorkflowFeature, WorkflowStatePredicateFeature
 
 APTL_ACES_TARGET_NAME = "aptl"
 APTL_ACES_TARGET_VERSION = "0.1.0"
@@ -28,10 +37,12 @@ APTL_ACES_TARGET_VERSION = "0.1.0"
 # The reference ACES processor whose provisioning-plan output APTL realizes.
 _COMPATIBLE_PROCESSORS = frozenset({"aces-reference-processor"})
 
-# Provisioning-only contract surface. The provisioning-only backend profile
-# (contracts/profiles/backend/provisioning-only.json) requires backend-manifest-v2,
-# operation-receipt-v1, operation-status-v1, and runtime-snapshot-v1; APTL also
-# declares provisioning-plan-v1 because it consumes ACES provisioning plans.
+# Orchestration-capable contract surface. The orchestration-capable backend
+# profile (contracts/profiles/backend/orchestration-capable.json) requires
+# backend-manifest-v2, operation-receipt-v1, operation-status-v1,
+# runtime-snapshot-v1, workflow-result-envelope-v1, and
+# workflow-history-event-stream-v1; APTL also declares provisioning-plan-v1
+# because it consumes ACES provisioning plans.
 _SUPPORTED_CONTRACT_VERSIONS = frozenset(
     {
         "backend-manifest-v2",
@@ -39,7 +50,33 @@ _SUPPORTED_CONTRACT_VERSIONS = frozenset(
         "operation-receipt-v1",
         "operation-status-v1",
         "runtime-snapshot-v1",
+        "workflow-result-envelope-v1",
+        "workflow-history-event-stream-v1",
     }
+)
+
+# Orchestrator capability declaration. APTL's RTE-001 runtime engine drives
+# workflows with objective, branching (`if` -> decision), parallel
+# (-> parallel-barrier), and `on-error` (-> failure-transitions) control flow,
+# with step-outcome predicates (-> outcome-matching). Those are the workflow
+# control features APTL can faithfully realize and report through the portable
+# workflow result/history contracts, so the manifest declares exactly that set
+# — not the switch/retry/call/cancellation/timeouts/compensation features APTL
+# does not drive (scenarios using those get an explicit planner diagnostic).
+_ORCHESTRATOR = OrchestratorCapabilities(
+    name="aptl-rte-orchestrator",
+    supported_sections=frozenset({"workflows"}),
+    supports_workflows=True,
+    supported_workflow_features=frozenset(
+        {
+            WorkflowFeature.DECISION,
+            WorkflowFeature.PARALLEL_BARRIER,
+            WorkflowFeature.FAILURE_TRANSITIONS,
+        }
+    ),
+    supported_workflow_state_predicates=frozenset(
+        {WorkflowStatePredicateFeature.OUTCOME_MATCHING}
+    ),
 )
 
 # Provisioner capability declaration, using only published controlled-vocabulary
@@ -91,7 +128,7 @@ _CONCEPT_BINDINGS = (
 
 
 def create_aptl_manifest() -> BackendManifest:
-    """Return APTL's provisioning-only canonical ACES ``backend-manifest-v2``."""
+    """Return APTL's orchestration-capable canonical ACES ``backend-manifest-v2``."""
     return BackendManifest(
         name=APTL_ACES_TARGET_NAME,
         version=APTL_ACES_TARGET_VERSION,
@@ -100,4 +137,5 @@ def create_aptl_manifest() -> BackendManifest:
         realization_support=_REALIZATION_SUPPORT,
         concept_bindings=_CONCEPT_BINDINGS,
         provisioner=_PROVISIONER,
+        orchestrator=_ORCHESTRATOR,
     )

--- a/src/aptl/backends/aces_orchestrator.py
+++ b/src/aptl/backends/aces_orchestrator.py
@@ -1,0 +1,238 @@
+"""APTL ACES orchestration adapter.
+
+Promotes APTL's ACES backend from ``provisioning-only`` to
+``orchestration-capable`` (SCN-010 follow-on #311). APTL's scenario runtime
+engine (RTE-001) already drives scenario steps with state-machine semantics;
+this adapter exposes that drive surface through the *portable* ACES contracts
+``workflow-result-envelope-v1`` and ``workflow-history-event-stream-v1`` rather
+than APTL-native run-archive shapes.
+
+The adapter is the ACES ``Orchestrator`` component published on APTL's
+``RuntimeTarget``. ``start()`` loads an ACES ``OrchestrationPlan`` into runtime
+state: it registers every orchestration resource as an ACES ``SnapshotEntry``
+and, for each workflow, records a truthful ``WorkflowExecutionState`` — the run
+is ``PENDING`` (registered and awaiting execution) with every observable step in
+the ``pending`` lifecycle and no history events, because no step has executed
+yet. The step lifecycle is *not* fabricated: the adapter never reports a
+workflow as ``RUNNING``/``SUCCEEDED`` or invents step outcomes. Step execution
+and lifecycle progression are driven out-of-band by RTE-001 and the in-range
+agents; when that execution-state integration lands (tracked by #514), the same
+``results()`` / ``history()`` surface will report the real ``RUNNING`` →
+terminal transitions and ``WorkflowHistoryEvent`` streams. ``stop()`` clears
+orchestration state.
+
+This keeps the orchestration-capable claim honest: APTL publishes the workflow
+result/history *contract* surface and the loaded/registered run state, not a
+synthetic in-memory run that never progresses. The ACES
+``WorkflowExecutionState`` / ``WorkflowHistoryEvent`` dataclasses are the public
+DTOs — APTL's internal ``aptl.core.runtime`` and run-archive models are never
+the published workflow schema. Workflow interpretation is workflow-address
+driven; nothing here hardcodes TechVault, a profile, a compose profile, or a
+workflow address.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.planning import ChangeAction, OrchestrationPlan, RuntimeDomain
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
+from aces_contracts.workflow import (
+    WorkflowExecutionState,
+    WorkflowResultContract,
+    WorkflowStatus,
+    WorkflowStepExecutionState,
+    WorkflowStepLifecycle,
+)
+
+from aptl.utils.redaction import redact
+
+ORCHESTRATION_ADDRESS = "runtime.apply.orchestration"
+_WORKFLOW_RESOURCE_TYPE = "workflow"
+
+
+def _orchestration_diagnostic(code: str, address: str, message: str) -> Diagnostic:
+    """Build a redacted orchestration-domain ACES error diagnostic."""
+    return Diagnostic(
+        code=code,
+        domain=RuntimeDomain.ORCHESTRATION.value,
+        address=address,
+        message=redact(message),
+        severity=Severity.ERROR,
+    )
+
+
+def _utc_now() -> str:
+    """Return the current UTC instant as an ISO-8601 ``...Z`` string."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class AptlOrchestrator(object):
+    """``orchestration-capable`` ACES backend adapter for APTL."""
+
+    # Last observed portable orchestration state, keyed by workflow address.
+    # Holds the ACES contract payloads so the no-argument ``results()`` /
+    # ``history()`` / ``status()` observation methods report the runtime state
+    # produced by the most recent ``start()``.
+    _results: dict[str, dict[str, object]] = field(default_factory=dict, init=False)
+    _history: dict[str, list[dict[str, object]]] = field(default_factory=dict, init=False)
+
+    def start(self, plan: object, snapshot: object) -> ApplyResult:
+        """Load an ACES orchestration plan and register its workflows.
+
+        Each workflow is recorded as a ``PENDING`` run (registered, awaiting
+        execution); no step lifecycle or history is fabricated. Returns the
+        snapshot extended with the orchestration entries and result payloads.
+        """
+        working_snapshot = snapshot if isinstance(snapshot, RuntimeSnapshot) else RuntimeSnapshot()
+        if not isinstance(plan, OrchestrationPlan):
+            return ApplyResult(
+                success=False,
+                snapshot=working_snapshot,
+                diagnostics=[
+                    _orchestration_diagnostic(
+                        "aptl.orchestrator.invalid-plan",
+                        ORCHESTRATION_ADDRESS,
+                        "APTL orchestrator expected an ACES OrchestrationPlan.",
+                    )
+                ],
+            )
+
+        entries = dict(working_snapshot.entries)
+        results = dict(working_snapshot.orchestration_results)
+        history = {address: list(events) for address, events in working_snapshot.orchestration_history.items()}
+        diagnostics: list[Diagnostic] = []
+        changed: list[str] = []
+        registered_at = _utc_now()
+
+        for op in plan.actionable_operations:
+            if op.action == ChangeAction.DELETE:
+                entries.pop(op.address, None)
+                results.pop(op.address, None)
+                history.pop(op.address, None)
+                changed.append(op.address)
+                continue
+            entries[op.address] = SnapshotEntry(
+                address=op.address,
+                domain=RuntimeDomain.ORCHESTRATION,
+                resource_type=op.resource_type,
+                payload=op.payload,
+                ordering_dependencies=op.ordering_dependencies,
+                refresh_dependencies=op.refresh_dependencies,
+                status="ready",
+            )
+            changed.append(op.address)
+            if op.resource_type == _WORKFLOW_RESOURCE_TYPE:
+                workflow_diagnostics = self._register_workflow(op.address, op.payload, registered_at, results)
+                diagnostics.extend(workflow_diagnostics)
+
+        if diagnostics:
+            return ApplyResult(
+                success=False,
+                snapshot=working_snapshot,
+                diagnostics=diagnostics,
+            )
+
+        self._results = {address: dict(result) for address, result in results.items()}
+        self._history = {address: [dict(event) for event in events] for address, events in history.items()}
+        return ApplyResult(
+            success=True,
+            snapshot=working_snapshot.with_entries(
+                entries,
+                orchestration_results=results,
+                orchestration_history=history,
+            ),
+            changed_addresses=changed,
+        )
+
+    def _register_workflow(
+        self,
+        workflow_address: str,
+        payload: dict[str, object],
+        registered_at: str,
+        results: dict[str, dict[str, object]],
+    ) -> list[Diagnostic]:
+        """Record the truthful initial (``PENDING``) portable state for a run.
+
+        The workflow is registered with every observable step in the ``pending``
+        lifecycle and no history events. Nothing is reported as executing,
+        succeeding, or failing — RTE-001 drives those transitions out-of-band
+        and reporting them is wired by #514.
+        """
+        result_contract_payload = payload.get("result_contract")
+        if not isinstance(result_contract_payload, dict):
+            return [
+                _orchestration_diagnostic(
+                    "aptl.orchestrator.workflow-contract-missing",
+                    workflow_address,
+                    "ACES workflow resource is missing its compiled result_contract.",
+                )
+            ]
+        try:
+            result_contract = WorkflowResultContract.from_mapping(result_contract_payload)
+        except (TypeError, ValueError) as exc:
+            return [
+                _orchestration_diagnostic(
+                    "aptl.orchestrator.workflow-contract-invalid",
+                    workflow_address,
+                    f"ACES workflow result_contract is invalid: {exc}",
+                )
+            ]
+
+        steps = {
+            step_name: WorkflowStepExecutionState(lifecycle=WorkflowStepLifecycle.PENDING)
+            for step_name in result_contract.observable_steps
+        }
+        # The ACES contract requires a non-empty started_at; it marks when the
+        # run *record* was created. The PENDING status (not RUNNING) is what
+        # truthfully says no step has executed yet.
+        state = WorkflowExecutionState(
+            state_schema_version=result_contract.state_schema_version,
+            workflow_status=WorkflowStatus.PENDING,
+            run_id=uuid4().hex,
+            started_at=registered_at,
+            updated_at=registered_at,
+            steps=steps,
+        )
+        results[workflow_address] = state.to_payload()
+        return []
+
+    def status(self) -> dict[str, object]:
+        """Return current orchestration status (registered, pending-execution runs)."""
+        return {
+            "backend": "aptl",
+            "registered_workflows": sorted(self._results),
+        }
+
+    def results(self) -> dict[str, dict[str, object]]:
+        """Return the most recent workflow execution state envelopes."""
+        return {address: dict(result) for address, result in self._results.items()}
+
+    def history(self) -> dict[str, list[dict[str, object]]]:
+        """Return the workflow execution history event streams."""
+        return {address: [dict(event) for event in events] for address, events in self._history.items()}
+
+    def stop(self, snapshot: object) -> ApplyResult:
+        """Stop orchestration and clear orchestration state."""
+        working_snapshot = snapshot if isinstance(snapshot, RuntimeSnapshot) else RuntimeSnapshot()
+        retained_entries = {
+            address: entry
+            for address, entry in working_snapshot.entries.items()
+            if entry.domain != RuntimeDomain.ORCHESTRATION
+        }
+        changed = sorted(set(working_snapshot.entries) - set(retained_entries))
+        self._results = {}
+        self._history = {}
+        return ApplyResult(
+            success=True,
+            snapshot=working_snapshot.with_entries(
+                retained_entries,
+                orchestration_results={},
+                orchestration_history={},
+            ),
+            changed_addresses=changed,
+        )

--- a/src/aptl/backends/aces_orchestrator.py
+++ b/src/aptl/backends/aces_orchestrator.py
@@ -70,6 +70,58 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+def _register_workflow(
+    workflow_address: str,
+    payload: dict[str, object],
+    registered_at: str,
+    results: dict[str, dict[str, object]],
+) -> list[Diagnostic]:
+    """Record the truthful initial (``PENDING``) portable state for a run.
+
+    The workflow is registered with every observable step in the ``pending``
+    lifecycle and no history events. Nothing is reported as executing,
+    succeeding, or failing — RTE-001 drives those transitions out-of-band and
+    reporting them is wired by #514.
+    """
+    result_contract_payload = payload.get("result_contract")
+    if not isinstance(result_contract_payload, dict):
+        return [
+            _orchestration_diagnostic(
+                "aptl.orchestrator.workflow-contract-missing",
+                workflow_address,
+                "ACES workflow resource is missing its compiled result_contract.",
+            )
+        ]
+    try:
+        result_contract = WorkflowResultContract.from_mapping(result_contract_payload)
+    except (TypeError, ValueError) as exc:
+        return [
+            _orchestration_diagnostic(
+                "aptl.orchestrator.workflow-contract-invalid",
+                workflow_address,
+                f"ACES workflow result_contract is invalid: {exc}",
+            )
+        ]
+
+    steps = {
+        step_name: WorkflowStepExecutionState(lifecycle=WorkflowStepLifecycle.PENDING)
+        for step_name in result_contract.observable_steps
+    }
+    # The ACES contract requires a non-empty started_at; it marks when the run
+    # *record* was created. The PENDING status (not RUNNING) is what truthfully
+    # says no step has executed yet.
+    state = WorkflowExecutionState(
+        state_schema_version=result_contract.state_schema_version,
+        workflow_status=WorkflowStatus.PENDING,
+        run_id=uuid4().hex,
+        started_at=registered_at,
+        updated_at=registered_at,
+        steps=steps,
+    )
+    results[workflow_address] = state.to_payload()
+    return []
+
+
 @dataclass
 class AptlOrchestrator(object):
     """``orchestration-capable`` ACES backend adapter for APTL."""
@@ -127,7 +179,7 @@ class AptlOrchestrator(object):
             )
             changed.append(op.address)
             if op.resource_type == _WORKFLOW_RESOURCE_TYPE:
-                workflow_diagnostics = self._register_workflow(op.address, op.payload, registered_at, results)
+                workflow_diagnostics = _register_workflow(op.address, op.payload, registered_at, results)
                 diagnostics.extend(workflow_diagnostics)
 
         if diagnostics:
@@ -148,58 +200,6 @@ class AptlOrchestrator(object):
             ),
             changed_addresses=changed,
         )
-
-    def _register_workflow(
-        self,
-        workflow_address: str,
-        payload: dict[str, object],
-        registered_at: str,
-        results: dict[str, dict[str, object]],
-    ) -> list[Diagnostic]:
-        """Record the truthful initial (``PENDING``) portable state for a run.
-
-        The workflow is registered with every observable step in the ``pending``
-        lifecycle and no history events. Nothing is reported as executing,
-        succeeding, or failing — RTE-001 drives those transitions out-of-band
-        and reporting them is wired by #514.
-        """
-        result_contract_payload = payload.get("result_contract")
-        if not isinstance(result_contract_payload, dict):
-            return [
-                _orchestration_diagnostic(
-                    "aptl.orchestrator.workflow-contract-missing",
-                    workflow_address,
-                    "ACES workflow resource is missing its compiled result_contract.",
-                )
-            ]
-        try:
-            result_contract = WorkflowResultContract.from_mapping(result_contract_payload)
-        except (TypeError, ValueError) as exc:
-            return [
-                _orchestration_diagnostic(
-                    "aptl.orchestrator.workflow-contract-invalid",
-                    workflow_address,
-                    f"ACES workflow result_contract is invalid: {exc}",
-                )
-            ]
-
-        steps = {
-            step_name: WorkflowStepExecutionState(lifecycle=WorkflowStepLifecycle.PENDING)
-            for step_name in result_contract.observable_steps
-        }
-        # The ACES contract requires a non-empty started_at; it marks when the
-        # run *record* was created. The PENDING status (not RUNNING) is what
-        # truthfully says no step has executed yet.
-        state = WorkflowExecutionState(
-            state_schema_version=result_contract.state_schema_version,
-            workflow_status=WorkflowStatus.PENDING,
-            run_id=uuid4().hex,
-            started_at=registered_at,
-            updated_at=registered_at,
-            steps=steps,
-        )
-        results[workflow_address] = state.to_payload()
-        return []
 
     def status(self) -> dict[str, object]:
         """Return current orchestration status (registered, pending-execution runs)."""

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -248,7 +248,7 @@ def validate_live(
         help="ACES SDL scenario (default: scenarios/techvault.sdl.yaml).",
     ),
     profile: str = typer.Option(
-        "provisioning-only",
+        "orchestration-capable",
         "--profile",
         help="ACES backend capability profile to validate against.",
     ),

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -139,7 +139,7 @@ def check_boot_inputs_match_public_path(
     The gate computes the expected realization from ``scenario_path`` and
     ``options.profile``, but the public boot path it exercises
     (``orchestrate_lab_start`` → ``start_aces_scenario``) is hardwired to
-    ``DEFAULT_ACES_SCENARIO`` and the ``provisioning-only`` capability profile;
+    ``DEFAULT_ACES_SCENARIO`` and the ``orchestration-capable`` capability profile;
     it ignores any caller-supplied scenario/profile. Booting one model while
     validating another would silently produce false pass/fail results, so a
     mismatch is a hard ``backend_instantiation`` failure raised *before* any

--- a/src/aptl/validation/techvault_gate.py
+++ b/src/aptl/validation/techvault_gate.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from aptl.core.config import AptlConfig
 
-DEFAULT_PROFILE = "provisioning-only"
+DEFAULT_PROFILE = "orchestration-capable"
 DEFAULT_SCENARIO = Path("scenarios") / "techvault.sdl.yaml"
 DEFAULT_PARITY_INVENTORY = Path("docs") / "aces" / "parity-inventory.yaml"
 

--- a/src/aptl/validation/techvault_live_gate.py
+++ b/src/aptl/validation/techvault_live_gate.py
@@ -12,7 +12,7 @@ archive.
 Like the static gate, it is scenario-generic and parameterized by scenario
 path, backend profile, and project directory: TechVault is the proving input,
 never a hardcoded branch (ADR-035). The next scenario in APTL's
-``provisioning-only`` expressivity class passes through by changing inputs.
+``orchestration-capable`` expressivity class passes through by changing inputs.
 
 The gate is inherently integration / live-run work: it requires Docker, the SOC
 stack's resources, real ``.env`` secrets, and minutes-long startup. It is wired
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from aptl.core.config import AptlConfig
     from aptl.core.runstore import RunStorageBackend
 
-DEFAULT_PROFILE = "provisioning-only"
+DEFAULT_PROFILE = "orchestration-capable"
 
 # Stable failure categories (issue #323 acceptance: a failure must identify the
 # layer that broke). These map onto existing ACES diagnostics and APTL startup
@@ -142,7 +142,7 @@ class LiveGateReport(object):
 class LiveGateOptions(object):
     """Tunable inputs for the live validation gate.
 
-    ``profile`` selects the backend capability profile (``provisioning-only``).
+    ``profile`` selects the backend capability profile (``orchestration-capable``).
     ``clean_volumes`` runs the data-destroying ``stop -v`` cleanup before the
     boot; ``skip_clean_boot`` validates against an already-running lab without
     the destructive cleanup (operator opt-in for a non-destructive check). The
@@ -228,7 +228,7 @@ def validate_live_deployment(
     static_passed = scenario is not None and static_check.passed
 
     # 2a. Input/boot-path agreement — the public start path is hardwired to the
-    #     default scenario + provisioning-only profile, so a scenario/profile
+    #     default scenario + orchestration-capable profile, so a scenario/profile
     #     the boot path will not honor must fail loud BEFORE any destructive
     #     boot, not silently validate one model while booting another.
     inputs_passed = False

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 
 from aces_contracts.planning import (
     ChangeAction,
+    EvaluationPlan,
+    OrchestrationPlan,
     PlannedResource,
     ProvisioningPlan,
     ProvisionOp,
@@ -104,8 +106,18 @@ def test_create_runtime_target_accepts_aptl_manifest_shape(tmp_path):
 class _FakeExecutionPlan:
     """Minimal ExecutionPlan stand-in exposing the fields the handoff reads."""
 
-    def __init__(self, provisioning, *, is_valid=True, diagnostics=None):
+    def __init__(
+        self,
+        provisioning,
+        *,
+        is_valid=True,
+        diagnostics=None,
+        orchestration=None,
+        evaluation=None,
+    ):
         self.provisioning = provisioning
+        self.orchestration = orchestration or OrchestrationPlan()
+        self.evaluation = evaluation or EvaluationPlan()
         self.base_snapshot = RuntimeSnapshot()
         self.is_valid = is_valid
         self.diagnostics = diagnostics or []
@@ -127,10 +139,13 @@ def test_create_aptl_manifest_is_canonical_backend_manifest_v2():
         "operation-receipt-v1",
         "operation-status-v1",
         "runtime-snapshot-v1",
+        "workflow-result-envelope-v1",
+        "workflow-history-event-stream-v1",
     }
     assert required <= set(payload["supported_contract_versions"])
-    # provisioning-only: no orchestration / evaluation / participant surfaces.
-    assert manifest.has_orchestrator is False
+    # orchestration-capable: orchestrator declared; evaluator / participant
+    # runtime remain out of scope (#312).
+    assert manifest.has_orchestrator is True
     assert manifest.has_evaluator is False
     assert manifest.has_participant_runtime is False
 
@@ -153,6 +168,34 @@ def test_aptl_target_passes_provisioning_only_conformance(tmp_path):
     assert report.passed is True, [d.code for d in report.diagnostics]
     assert report.unsupported_contract_gaps == ()
     assert report.unsupported_capability_gaps == ()
+
+
+def test_aptl_target_passes_orchestration_capable_conformance(tmp_path):
+    from aces_conformance.conformance import run_target_conformance
+
+    from aptl.backends.aces import create_aptl_runtime_target
+
+    backend = MagicMock()
+    config = AptlConfig(lab={"name": "test"})
+    target = create_aptl_runtime_target(
+        project_dir=tmp_path,
+        config=config,
+        backend=backend,
+    )
+
+    report = run_target_conformance(target, profile="orchestration-capable")
+
+    assert report.passed is True, [d.code for d in report.diagnostics]
+    assert report.unsupported_contract_gaps == ()
+    assert report.unsupported_capability_gaps == ()
+    # The live probe submits a workflow scenario through the control plane and
+    # validates the resulting orchestration snapshot; assert APTL's orchestrator
+    # produced a contract-clean run-archive surface.
+    assert all(case.passed for case in report.cases), [
+        (case.name, [d.message for d in case.diagnostics])
+        for case in report.cases
+        if not case.passed
+    ]
 
 
 def test_start_aces_scenario_uses_parser_runtime_manager_and_backend(
@@ -199,9 +242,148 @@ def test_start_aces_scenario_uses_parser_runtime_manager_and_backend(
     backend.start.assert_called_once_with(["wazuh", "kali", "otel"])
 
 
+def _workflow_orchestration_plan():
+    """Compile a minimal workflow scenario into its ACES orchestration plan."""
+    from textwrap import dedent
+
+    from aces_processor.compiler import compile_runtime_model
+    from aces_processor.planner import plan as aces_plan
+    from aces_sdl.parser import parse_sdl
+
+    from aptl.backends.aces_manifest import create_aptl_manifest
+
+    scenario = parse_sdl(
+        dedent(
+            """
+            name: wf
+            nodes:
+              vm:
+                type: vm
+                os: linux
+                resources: {ram: 1 gib, cpu: 1}
+                conditions: {health: ops}
+                roles: {ops: operator}
+            conditions:
+              health: {command: /bin/true, interval: 15}
+            entities:
+              blue: {role: blue}
+            objectives:
+              validate:
+                entity: blue
+                success: {conditions: [health]}
+            workflows:
+              response:
+                start: run
+                steps:
+                  run: {type: objective, objective: validate, on-success: finish}
+                  finish: {type: end}
+            """
+        )
+    )
+    return aces_plan(compile_runtime_model(scenario), create_aptl_manifest()).orchestration
+
+
+def test_start_aces_scenario_submits_orchestration_for_workflow_scenario(mocker, tmp_path):
+    """A scenario carrying workflows routes through the control plane's
+    orchestration submission (not just provisioning), and the lab still starts."""
+    from aptl.backends import aces
+
+    _write_compose(tmp_path, {"victim": ["victim"]})
+    mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=object())
+    orchestration = _workflow_orchestration_plan()
+    assert orchestration.actionable_operations  # guard: the plan really carries workflows
+
+    class FakeRuntimeManager:
+        def __init__(self, target):
+            self.target = target
+
+        def plan(self, parsed_scenario):
+            return _FakeExecutionPlan(
+                _plan_for_nodes("techvault.victim"), orchestration=orchestration
+            )
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
+
+    result = aces.start_aces_scenario(tmp_path, config, backend)
+
+    assert result.success is True
+    backend.start.assert_called_once_with(["victim", "otel"])
+
+
+def test_start_aces_scenario_fails_when_provisioning_backend_fails(mocker, tmp_path):
+    """A deployment-backend failure surfaces as a failed control-plane phase."""
+    from aptl.backends import aces
+
+    _write_compose(tmp_path, {"victim": ["victim"]})
+    mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=object())
+
+    class FakeRuntimeManager:
+        def __init__(self, target):
+            self.target = target
+
+        def plan(self, parsed_scenario):
+            return _FakeExecutionPlan(_plan_for_nodes("techvault.victim"))
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=False, error="backend boom")
+    config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
+
+    result = aces.start_aces_scenario(tmp_path, config, backend)
+
+    assert result.success is False
+    assert result.error
+
+
+def test_start_aces_scenario_fails_when_orchestration_fails(mocker, tmp_path):
+    """An orchestration-phase failure (provisioning already applied) surfaces as
+    a failed lab start, not a silent success."""
+    from aces_contracts.planning import ChangeAction, OrchestrationOp, OrchestrationPlan
+
+    from aptl.backends import aces
+
+    _write_compose(tmp_path, {"victim": ["victim"]})
+    mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=object())
+    # A workflow op with no compiled result_contract makes AptlOrchestrator.start
+    # fail closed, which the control plane reports as a failed operation.
+    bad_orchestration = OrchestrationPlan(
+        resources={},
+        operations=[
+            OrchestrationOp(
+                action=ChangeAction.CREATE,
+                address="orchestration.workflow.bad",
+                resource_type="workflow",
+                payload={"name": "bad"},
+            )
+        ],
+    )
+
+    class FakeRuntimeManager:
+        def __init__(self, target):
+            self.target = target
+
+        def plan(self, parsed_scenario):
+            return _FakeExecutionPlan(
+                _plan_for_nodes("techvault.victim"), orchestration=bad_orchestration
+            )
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
+
+    result = aces.start_aces_scenario(tmp_path, config, backend)
+
+    assert result.success is False
+    assert result.error
+
+
 def test_start_aces_scenario_provisions_despite_evaluation_content(mocker, tmp_path):
     """A scenario carrying evaluation content (e.g. the `conditions` healthcheck
-    section) must still provision. APTL is a provisioning-only ACES backend, so
+    section) must still provision. APTL declares no ACES evaluator yet (#312), so
     the planner's `evaluator.missing` error and the resulting invalid plan must
     not block lab standup."""
     from aces_contracts.diagnostics import Diagnostic, Severity
@@ -244,8 +426,8 @@ def test_start_aces_scenario_provisions_despite_evaluation_content(mocker, tmp_p
 def test_start_aces_scenario_fails_closed_on_non_evaluator_plan_error(mocker, tmp_path):
     """A planner error that is NOT the expected evaluation-domain
     `evaluator.missing` (e.g. a provisioning ordering cycle) must fail closed:
-    the provisioning-only handoff must refuse to start Compose on an otherwise
-    invalid execution plan rather than bypass the gate for every plan."""
+    the ACES handoff must refuse to start Compose on an otherwise invalid
+    execution plan rather than bypass the gate for every plan."""
     from aces_contracts.diagnostics import Diagnostic, Severity
 
     from aptl.backends import aces

--- a/tests/test_aces_orchestrator.py
+++ b/tests/test_aces_orchestrator.py
@@ -1,0 +1,201 @@
+"""Tests for the APTL ACES orchestration adapter (issue #311)."""
+
+from textwrap import dedent
+
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
+from aces_contracts.workflow import WorkflowExecutionState, WorkflowStatus, WorkflowStepLifecycle
+from aces_processor.compiler import compile_runtime_model
+from aces_processor.planner import plan
+from aces_runtime.workflow_result_contracts import workflow_result_contract_diagnostics
+from aces_sdl.parser import parse_sdl
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.backends.aces_orchestrator import AptlOrchestrator
+
+_WORKFLOW_SCENARIO = dedent(
+    """
+    name: orchestrator-test
+    nodes:
+      vm:
+        type: vm
+        os: linux
+        resources: {ram: 1 gib, cpu: 1}
+        conditions: {health: ops}
+        roles: {ops: operator}
+    conditions:
+      health: {command: /bin/true, interval: 15}
+    entities:
+      blue: {role: blue}
+    objectives:
+      validate:
+        entity: blue
+        success: {conditions: [health]}
+    workflows:
+      response:
+        start: run
+        steps:
+          run:
+            type: objective
+            objective: validate
+            on-success: finish
+          finish: {type: end}
+    """
+)
+
+
+def _orchestration_plan():
+    scenario = parse_sdl(_WORKFLOW_SCENARIO)
+    execution_plan = plan(compile_runtime_model(scenario), create_aptl_manifest())
+    return execution_plan.orchestration
+
+
+def test_start_registers_workflows_as_pending_with_pending_steps():
+    orchestrator = AptlOrchestrator()
+    result = orchestrator.start(_orchestration_plan(), RuntimeSnapshot())
+
+    assert isinstance(result, ApplyResult)
+    assert result.success is True
+    assert result.snapshot.orchestration_results, "expected at least one workflow run recorded"
+
+    for payload in result.snapshot.orchestration_results.values():
+        state = WorkflowExecutionState.from_payload(payload)
+        # PENDING, not RUNNING: the run is registered but no step has executed,
+        # and the adapter never fabricates execution progress.
+        assert state.workflow_status == WorkflowStatus.PENDING
+        assert state.run_id
+        assert state.steps, "workflow must report its observable steps"
+        assert all(step.lifecycle == WorkflowStepLifecycle.PENDING for step in state.steps.values())
+    # No history events are invented for a not-yet-executed workflow.
+    assert result.snapshot.orchestration_history == {}
+
+
+def test_start_output_is_workflow_contract_clean():
+    orchestrator = AptlOrchestrator()
+    result = orchestrator.start(_orchestration_plan(), RuntimeSnapshot())
+
+    diagnostics = workflow_result_contract_diagnostics(result.snapshot)
+    assert diagnostics == [], [d.message for d in diagnostics]
+
+
+def test_results_and_status_reflect_registered_workflows():
+    orchestrator = AptlOrchestrator()
+    assert orchestrator.results() == {}
+    assert orchestrator.history() == {}
+
+    orchestrator.start(_orchestration_plan(), RuntimeSnapshot())
+
+    assert orchestrator.results()
+    # No history until real execution-state integration lands.
+    assert orchestrator.history() == {}
+    assert orchestrator.status()["registered_workflows"] == sorted(orchestrator.results())
+
+
+def test_start_preserves_existing_provisioning_entries():
+    from aces_contracts.planning import RuntimeDomain
+    from aces_contracts.runtime_state import SnapshotEntry
+
+    base = RuntimeSnapshot(
+        entries={
+            "provision.node.vm": SnapshotEntry(
+                address="provision.node.vm",
+                domain=RuntimeDomain.PROVISIONING,
+                resource_type="node",
+                payload={"name": "vm"},
+            )
+        }
+    )
+    orchestrator = AptlOrchestrator()
+    result = orchestrator.start(_orchestration_plan(), base)
+
+    assert "provision.node.vm" in result.snapshot.entries
+    assert any(
+        entry.domain == RuntimeDomain.ORCHESTRATION for entry in result.snapshot.entries.values()
+    )
+
+
+def test_stop_clears_orchestration_state():
+    orchestrator = AptlOrchestrator()
+    started = orchestrator.start(_orchestration_plan(), RuntimeSnapshot())
+
+    stopped = orchestrator.stop(started.snapshot)
+
+    assert stopped.success is True
+    assert stopped.snapshot.orchestration_results == {}
+    assert stopped.snapshot.orchestration_history == {}
+    assert orchestrator.results() == {}
+    assert orchestrator.history() == {}
+
+
+def test_start_rejects_non_orchestration_plan():
+    orchestrator = AptlOrchestrator()
+    result = orchestrator.start(object(), RuntimeSnapshot())
+
+    assert result.success is False
+    assert any(d.code == "aptl.orchestrator.invalid-plan" for d in result.diagnostics)
+
+
+def _workflow_op(address, payload, *, action=None):
+    from aces_contracts.planning import ChangeAction, OrchestrationOp
+
+    return OrchestrationOp(
+        action=action or ChangeAction.CREATE,
+        address=address,
+        resource_type="workflow",
+        payload=payload,
+    )
+
+
+def test_start_fails_closed_on_workflow_missing_result_contract():
+    from aces_contracts.planning import OrchestrationPlan
+
+    op = _workflow_op("orchestration.workflow.broken", {"name": "broken"})
+    result = AptlOrchestrator().start(
+        OrchestrationPlan(resources={}, operations=[op]), RuntimeSnapshot()
+    )
+
+    assert result.success is False
+    assert any(d.code == "aptl.orchestrator.workflow-contract-missing" for d in result.diagnostics)
+
+
+def test_start_fails_closed_on_invalid_result_contract():
+    from aces_contracts.planning import OrchestrationPlan
+
+    op = _workflow_op(
+        "orchestration.workflow.broken",
+        {"name": "broken", "result_contract": {"observable_steps": "not-a-dict"}},
+    )
+    result = AptlOrchestrator().start(
+        OrchestrationPlan(resources={}, operations=[op]), RuntimeSnapshot()
+    )
+
+    assert result.success is False
+    assert any(d.code == "aptl.orchestrator.workflow-contract-invalid" for d in result.diagnostics)
+
+
+def test_start_handles_delete_operation():
+    from aces_contracts.planning import ChangeAction, OrchestrationPlan, RuntimeDomain
+    from aces_contracts.runtime_state import SnapshotEntry
+
+    address = "orchestration.workflow.gone"
+    base = RuntimeSnapshot(
+        entries={
+            address: SnapshotEntry(
+                address=address,
+                domain=RuntimeDomain.ORCHESTRATION,
+                resource_type="workflow",
+                payload={"name": "gone"},
+            )
+        },
+        orchestration_results={address: {"workflow_status": "running"}},
+        orchestration_history={address: [{"event_type": "workflow_started"}]},
+    )
+    op = _workflow_op(address, {"name": "gone"}, action=ChangeAction.DELETE)
+
+    result = AptlOrchestrator().start(
+        OrchestrationPlan(resources={}, operations=[op]), base
+    )
+
+    assert result.success is True
+    assert address not in result.snapshot.entries
+    assert address not in result.snapshot.orchestration_results
+    assert address not in result.snapshot.orchestration_history

--- a/tests/test_techvault_static_gate.py
+++ b/tests/test_techvault_static_gate.py
@@ -128,7 +128,7 @@ def test_target_conformance_fails_loudly_on_missing_corpus(tmp_path):
         project_dir=PROJECT_ROOT, config=config, backend=_NoStartBackend()
     )
     report = run_target_conformance(
-        target, profile="provisioning-only", root=tmp_path, profiles_root=tmp_path
+        target, profile="orchestration-capable", root=tmp_path, profiles_root=tmp_path
     )
     assert not report.passed
 
@@ -141,7 +141,7 @@ def test_backend_conformance_fails_loudly_on_missing_corpus(tmp_path):
     check = check_backend_conformance(
         project_dir=PROJECT_ROOT,
         config=config,
-        profile="provisioning-only",
+        profile="orchestration-capable",
         profiles_root=tmp_path,  # empty corpus root -> profile artifact not found
         fixtures_root=tmp_path,
     )


### PR DESCRIPTION
## Summary

Promotes APTL's ACES backend from the provisioning-only profile to orchestration-capable (SCN-010 follow-on). The published backend-manifest-v2 now declares a real capabilities.orchestrator plus the workflow-result-envelope-v1 and workflow-history-event-stream-v1 contracts, and the runtime target carries a concrete ACES Orchestrator (AptlOrchestrator) that registers each workflow from the OrchestrationPlan as a truthful PENDING run and exposes the portable workflow result/history contract surface. Scenario start now routes provisioning and orchestration through the ACES runtime control plane instead of bypassing straight to the provisioner. The static and live validation gates, the pre-commit hook, the advisory CI job, and `aptl lab validate-live` default from provisioning-only to orchestration-capable, and `aces conformance backend --profile orchestration-capable` passes against APTL's manifest. The orchestrator reports honest PENDING state with no fabricated execution; sourcing live RTE-001 RUNNING→terminal execution state is the follow-on #514, and evaluator/objective scoring and participant-runtime profiles remain #312.

## Requirement UIDs

- `SCN-010`

## Related Issues

Closes #311

## ADR Impact

- ADR-035

## Changes

- aces_manifest.py: declare workflow-result-envelope-v1 + workflow-history-event-stream-v1 and OrchestratorCapabilities (supported workflow features grounded in RTE-001: decision, parallel-barrier, failure-transitions + outcome-matching predicate)
- aces_orchestrator.py (new): AptlOrchestrator implements the ACES Orchestrator protocol (start/status/results/history/stop), registering workflows as PENDING runs and producing workflow_result_contract-clean snapshots
- aces.py: wire the orchestrator onto the RuntimeTarget and route scenario start through RuntimeControlPlane (submit_provisioning + submit_orchestration), dropping the provisioning-only apply bypass; evaluation stays deferred to #312
- Flip DEFAULT_PROFILE to orchestration-capable in techvault_gate.py and techvault_live_gate.py; update the CI step label, the validate-live CLI default, and live-gate docstrings
- docs/aces/parity-inventory.yaml: correct the workflows/run_archive surface notes to attribute the workflow result/history contract surface to orchestration-capable (#311)
- ADR-035 + changelog fragment + .ground-control.yaml routing.enabled
- Tests: new tests/test_aces_orchestrator.py (100% module coverage) and orchestration-capable conformance + control-plane start-path tests in tests/test_aces_backend.py

## Test Plan

- [x] Full fast suite green (1874 passed, integration deselected)
- [x] orchestration-capable conformance verified non-vacuously (the orchestrator records a real PENDING run; an empty/crashed orchestrator would not)
- [x] No coverage regression; new orchestrator module at 100%

The integration static gate (tests/test_techvault_static_gate.py -m integration) runs in the advisory CI job and now exercises the orchestration-capable profile.

## Ground Control Checks

- [x] `pre-commit` (ruff complexity gate + Vale) passes on the diff
- [x] Quality gates evaluated (no project gates enabled) — unchanged by this repo-only change
- [x] Pre-push codex review + test-quality review run; codex design finding fixed (PENDING-honest orchestrator), follow-on filed as #514

## Traceability

- IMPLEMENTS: SCN-010 ← src/aptl/backends/aces_manifest.py, SCN-010 ← src/aptl/backends/aces_orchestrator.py, SCN-010 ← src/aptl/backends/aces.py, SCN-010 ← src/aptl/validation/techvault_gate.py
- TESTS: SCN-010 ← tests/test_aces_orchestrator.py, SCN-010 ← tests/test_aces_backend.py

## Checklist

- [x] Code follows project conventions (ruff complexity gate; matches surrounding style)
- [x] Changelog fragment added at `changelog.d/311.added.md`
- [x] Architectural docs updated (ADR-035, parity-inventory, preflight note)
