### PR TITLE
security: move kali captures into a tamper-resistant sidecar (ADR-041)

### DIFF
--- a/changelog.d/305.security.md
+++ b/changelog.d/305.security.md
@@ -1,0 +1,3 @@
+### Security
+
+- Privileged capture writer: move all Kali-side capture writes (PTY transcript, per-session pcap, auditd, process accounting) into a dedicated `aptl-kali-capture` sidecar container that solely owns the `kali_captures` volume. The volume is no longer mounted in the Kali workload at all, so a sudo-capable agent can no longer read, list, delete, or modify any session's capture evidence — including other sessions' (ADR-041, issue #305).

--- a/containers/kali-capture/Dockerfile
+++ b/containers/kali-capture/Dockerfile
@@ -1,0 +1,26 @@
+# APTL Kali Capture Sidecar (ADR-041 / issue #305)
+#
+# Owns the kali_captures volume read-write.  The Kali workload mounts
+# the same volume read-only, so the kali user (including after sudo su -)
+# cannot delete or modify capture evidence.
+#
+# The aptl.rules file is bind-mounted at runtime via docker-compose.yml
+# (kali-capture service volumes:) so the canonical rule text is never
+# duplicated between the kali and kali-capture images.
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        auditd \
+        acct \
+        tcpdump \
+        libcap2-bin \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY writer.py /usr/local/bin/writer.py
+RUN chmod 0755 /usr/local/bin/entrypoint.sh /usr/local/bin/writer.py
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/containers/kali-capture/entrypoint.sh
+++ b/containers/kali-capture/entrypoint.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# APTL Kali Capture Sidecar entrypoint (ADR-041 / issue #305).
+#
+# Starts auditd (with the APTL ruleset mounted from the kali image),
+# process accounting, and the writer daemon.  All capture subsystem
+# boot outcomes are written to /run/aptl-kali-capture-ready.
+set -e
+
+auditd_status=degraded
+procacct_status=degraded
+
+mkdir -p /var/log/aptl/captures/_audit /var/log/aptl/captures/_proc-acct
+chmod 0700 /var/log/aptl/captures/_audit /var/log/aptl/captures/_proc-acct
+
+# Start auditd with APTL ruleset
+if command -v auditctl >/dev/null 2>&1 && [ -f /etc/audit/rules.d/aptl.rules ]; then
+    if [ -f /etc/audit/auditd.conf ]; then
+        sed -i 's|^log_file *=.*|log_file = /var/log/aptl/captures/_audit/audit.log|' \
+            /etc/audit/auditd.conf || true
+    fi
+    # touch (create-if-missing) — NOT truncate — preserves prior events on restart
+    touch /var/log/aptl/captures/_audit/audit.log
+    chmod 0600 /var/log/aptl/captures/_audit/audit.log
+    if auditctl -R /etc/audit/rules.d/aptl.rules >/dev/null 2>&1 && \
+       auditd >/dev/null 2>&1; then
+        auditd_status=ok
+        echo "[kali-capture] auditd started with APTL rules"
+    else
+        echo "[kali-capture] auditd start failed (missing AUDIT_CONTROL?); continuing"
+    fi
+else
+    echo "[kali-capture] auditctl or aptl.rules missing; auditd skipped"
+fi
+
+# Start process accounting
+if command -v accton >/dev/null 2>&1; then
+    touch /var/log/aptl/captures/_proc-acct/pacct
+    chown root:root /var/log/aptl/captures/_proc-acct/pacct
+    chmod 0600 /var/log/aptl/captures/_proc-acct/pacct
+    if accton /var/log/aptl/captures/_proc-acct/pacct; then
+        procacct_status=ok
+        echo "[kali-capture] process accounting active"
+    else
+        echo "[kali-capture] accton failed (missing SYS_PACCT?); continuing"
+    fi
+fi
+
+# Write sidecar readiness marker
+mkdir -p /run
+{
+    echo "ready_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "auditd=${auditd_status}"
+    echo "procacct=${procacct_status}"
+} > /run/aptl-kali-capture-ready
+
+echo "=== APTL Kali Capture Sidecar Ready ==="
+echo "auditd=${auditd_status} procacct=${procacct_status}"
+
+exec python3 /usr/local/bin/writer.py

--- a/containers/kali-capture/writer.py
+++ b/containers/kali-capture/writer.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""APTL kali-capture sidecar writer daemon (ADR-041 / issue #305).
+
+Binds an abstract Unix socket ``\x00aptl-capture-ctrl`` and handles
+JSON-framed newline-delimited messages from the Kali workload wrapper.
+All capture paths are derived from validated run/session IDs and a fixed
+capture root — the RPC never accepts absolute paths, shell commands,
+chmod/chown modes, delete or truncate requests.
+
+Session lifecycle is **owned by a single connection** (codex pre-push
+findings F1/F3): the connection that opens a session with ``session_start`` is
+the only one allowed to feed it ``pty_chunk`` frames or end it, and the session
+is finalized when that connection closes (EOF). A second connection cannot
+inject bytes into, end, or clobber another connection's session — at worst it
+starts its own. ``SO_PEERCRED`` is read and logged for forensics.
+
+Capability requirements (on the sidecar, NOT the Kali workload):
+  AUDIT_CONTROL, AUDIT_WRITE — auditd + auditctl
+  SYS_PACCT                  — accton / process accounting
+  NET_RAW                    — per-session tcpdump
+
+Python 3.11+ is assumed.  The module is also importable from tests
+(no ``__main__`` side-effects when imported).
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import socket
+import struct
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+_log = logging.getLogger("aptl.capture.writer")
+
+# ---------------------------------------------------------------------------
+# ID validation — must match the canonical OBS-003 contract:
+#   src/aptl/core/runstore.py  _ID_RE
+#   mcp/aptl-mcp-common/src/runs.ts  ID_RE
+#   containers/kali/scripts/aptl-wrap-shell.sh  valid_id()
+# ---------------------------------------------------------------------------
+_ID_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]*$")
+
+
+def validate_id(value: str, kind: str) -> str:
+    """Validate *value* as a run or session id.
+
+    Raises :class:`ValueError` on any violation.  Returns *value* unchanged
+    when valid so callers can use ``session_id = validate_id(raw, "session_id")``.
+    """
+    if not value:
+        raise ValueError(f"{kind}: id must not be empty")
+    if value.startswith("."):
+        raise ValueError(f"{kind}: id must not start with '.' (got {value!r})")
+    if ".." in value:
+        raise ValueError(f"{kind}: id contains '..', which is forbidden (path traversal)")
+    if "/" in value:
+        raise ValueError(f"{kind}: id contains invalid character '/' (got {value!r})")
+    if not _ID_RE.match(value):
+        raise ValueError(
+            f"{kind}: id {value!r} is invalid — must match {_ID_RE.pattern}"
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Forbidden frame types and fields (RPC contract, ADR-041 §RPC Contract)
+# ---------------------------------------------------------------------------
+_FORBIDDEN_TYPES: frozenset[str] = frozenset(
+    {"delete", "truncate", "chmod", "chown", "shell"}
+)
+_FORBIDDEN_FIELDS: frozenset[str] = frozenset(
+    {"output_path", "path", "chmod", "chown", "shell", "cmd", "command", "delete", "truncate"}
+)
+
+
+def validate_frame(frame: dict[str, Any]) -> None:
+    """Validate a decoded RPC frame.
+
+    Raises :class:`ValueError` with a message containing ``"forbidden"``
+    for any disallowed type or field so tests can ``match="forbidden"``.
+    """
+    msg_type = frame.get("type", "")
+    if msg_type in _FORBIDDEN_TYPES:
+        raise ValueError(
+            f"forbidden frame type {msg_type!r} — the sidecar RPC does not "
+            "accept delete, truncate, chmod, chown, or shell requests"
+        )
+    for field in _FORBIDDEN_FIELDS:
+        if field in frame:
+            raise ValueError(
+                f"forbidden field {field!r} in frame — the sidecar RPC must not "
+                "carry paths, shell commands, chmod/chown modes, or delete/truncate requests"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Per-session pcap (tcpdump) — runs in the sidecar, which shares the Kali
+# network namespace (docker-compose `network_mode: service:kali`).  The Kali
+# workload never runs tcpdump for capture, so a sudo-capable agent cannot stop
+# it or delete the pcap.  Rotation (-C 100MB, -W 10) caps one session at ~1GB.
+# ---------------------------------------------------------------------------
+_PCAP_ROTATE_MB = 100
+_PCAP_ROTATE_FILES = 10
+# `not port 22` drops the MCP control SSH noise so the pcap stays tractable;
+# mirrors the filter the in-Kali wrapper used before ADR-041.
+_PCAP_FILTER = "not port 22"
+
+
+def default_pcap_command(pcap_path: Path) -> list[str]:
+    """Build the tcpdump argv for a per-session capture.
+
+    Fixed recorder arguments only — never interpolates a user-controlled
+    filter or path fragment (ADR-041 §Security Layers / Process argv).
+    """
+    return [
+        "tcpdump",
+        "-i", "any",
+        "-w", str(pcap_path),
+        "-C", str(_PCAP_ROTATE_MB),
+        "-W", str(_PCAP_ROTATE_FILES),
+        "-U",
+        _PCAP_FILTER,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# WriterState — per-session capture lifecycle
+# ---------------------------------------------------------------------------
+
+class WriterState:
+    """Manage the set of active capture sessions, keyed by session_id.
+
+    Each session is **owned** by the opaque ``owner`` token passed to
+    ``handle_session_start`` (the connection handler passes a unique token per
+    socket connection).  ``handle_pty_chunk`` / ``handle_session_end`` are
+    no-ops unless the caller presents the owning token, and a ``session_start``
+    for an already-active session from a different owner is rejected rather
+    than clobbering the live capture (codex F1/F3).  ``finalize_owner`` closes
+    every session a departing connection owned (EOF-driven finalization).
+
+    ``enable_pcap`` defaults to ``False`` so unit tests that only exercise the
+    typescript/dir behaviour never spawn a real ``tcpdump``.  Production
+    (``_main``) sets it ``True``.  ``pcap_spawn`` is injectable so tests can
+    assert the tcpdump lifecycle with a fake process.
+    """
+
+    def __init__(
+        self,
+        capture_root: str,
+        *,
+        enable_pcap: bool = False,
+        pcap_spawn: Any = None,
+    ) -> None:
+        self.capture_root = Path(capture_root)
+        self.active_sessions: dict[str, dict] = {}
+        # Every session id ever started in this writer's lifetime. A session id
+        # is single-use: once finalized it must never be reopened for append,
+        # or a Kali process could re-`session_start` a finalized id and tack
+        # forged bytes onto harvested evidence (codex cycle 2 F3). Session ids
+        # are unique per MCP session, so this never blocks a legitimate start.
+        self._seen_session_ids: set[str] = set()
+        self._lock = threading.Lock()
+        self._owner_seq = 0
+        self.enable_pcap = enable_pcap
+        # Default to subprocess.Popen; injectable for tests.
+        self._pcap_spawn = pcap_spawn if pcap_spawn is not None else subprocess.Popen
+
+    def new_owner(self) -> int:
+        """Return a process-unique owner token for a freshly-accepted connection."""
+        with self._lock:
+            self._owner_seq += 1
+            return self._owner_seq
+
+    def _start_pcap(self, pcap_dir: Path, session_id: str) -> Any:
+        """Start a per-session tcpdump.  Best-effort: a failure (tcpdump
+        missing, no NET_RAW) logs and returns ``None`` rather than breaking
+        the session — the typescript and audit captures still proceed.
+        """
+        if not self.enable_pcap:
+            return None
+        pcap_path = pcap_dir / "session.pcap"
+        argv = default_pcap_command(pcap_path)
+        try:
+            proc = self._pcap_spawn(
+                argv,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            _log.info("session=%s: tcpdump started -> %s", session_id, pcap_path)
+            return proc
+        except Exception as exc:
+            _log.warning("session=%s: tcpdump start failed (degraded): %s", session_id, exc)
+            return None
+
+    def _stop_pcap(self, sess: dict, session_id: str) -> None:
+        """Terminate the per-session tcpdump and chmod the pcap files 0600."""
+        proc = sess.get("pcap_proc")
+        if proc is not None:
+            try:
+                proc.terminate()
+                proc.wait(timeout=5)
+            except Exception as exc:
+                _log.warning("session=%s: error stopping tcpdump: %s", session_id, exc)
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+        pcap_dir = sess.get("pcap_dir")
+        if pcap_dir is not None:
+            for pcap_file in Path(pcap_dir).glob("session.pcap*"):
+                try:
+                    os.chmod(pcap_file, 0o600)
+                except Exception as exc:
+                    _log.warning("session=%s: chmod pcap failed: %s", session_id, exc)
+
+    def handle_session_start(self, run_id: str, session_id: str, owner: Any) -> bool:
+        """Validate IDs, create 0700 dirs, open typescript file, start pcap.
+
+        Returns ``True`` when the session is owned by ``owner`` after the call
+        (freshly created, or already owned by the same connection — idempotent).
+        Returns ``False`` without touching anything when the session is already
+        active under a DIFFERENT owner: a second connection must not clobber a
+        live capture or hijack its ownership.
+        """
+        run_id = validate_id(run_id, "run_id")
+        session_id = validate_id(session_id, "session_id")
+
+        with self._lock:
+            existing = self.active_sessions.get(session_id)
+            if existing is not None:
+                if existing["owner"] == owner:
+                    return True  # idempotent re-start on the same connection
+                _log.warning(
+                    "session=%s: session_start rejected — already owned by another "
+                    "connection (refusing to clobber live capture)", session_id,
+                )
+                return False
+            if session_id in self._seen_session_ids:
+                # Already started (and since finalized) — refuse to reopen the
+                # typescript for append (codex cycle 2 F3).
+                _log.warning(
+                    "session=%s: session_start rejected — id already used; "
+                    "refusing to reopen a finalized session for append", session_id,
+                )
+                return False
+            # Reserve the id now (under the lock) so a racing connection can't
+            # double-create it during the unlocked file I/O below.
+            self._seen_session_ids.add(session_id)
+
+        sess_dir = self.capture_root / run_id / session_id
+        pty_dir = sess_dir / "pty"
+        pcap_dir = sess_dir / "pcap"
+
+        for d in (pty_dir, pcap_dir):
+            d.mkdir(mode=0o700, parents=True, exist_ok=True)
+            os.chmod(d, 0o700)
+
+        typescript_path = pty_dir / "typescript"
+        ts_file = typescript_path.open("ab")
+
+        pcap_proc = self._start_pcap(pcap_dir, session_id)
+
+        with self._lock:
+            # Re-check under the lock in case a racing connection won the create.
+            if session_id in self.active_sessions:
+                ts_file.close()
+                if pcap_proc is not None:
+                    try:
+                        pcap_proc.terminate()
+                    except Exception:
+                        pass
+                return self.active_sessions[session_id]["owner"] == owner
+            self.active_sessions[session_id] = {
+                "run_id": run_id,
+                "owner": owner,
+                "typescript_path": typescript_path,
+                "ts_file": ts_file,
+                "pcap_dir": pcap_dir,
+                "pcap_proc": pcap_proc,
+            }
+        _log.info("session_start run=%s session=%s owner=%s", run_id, session_id, owner)
+        return True
+
+    def handle_pty_chunk(self, session_id: str, b64_data: str, owner: Any) -> None:
+        """Append decoded bytes to the session typescript.
+
+        Silently ignores unknown sessions and frames from a non-owning
+        connection (codex F3 — a different connection must not forge bytes
+        into another session's transcript).
+        """
+        with self._lock:
+            sess = self.active_sessions.get(session_id)
+            if sess is None or sess["owner"] != owner:
+                return
+            ts_file = sess["ts_file"]
+        try:
+            raw = base64.b64decode(b64_data)
+        except Exception:
+            _log.warning("session=%s: invalid b64 chunk (discarded)", session_id)
+            return
+        ts_file.write(raw)
+        ts_file.flush()
+
+    def handle_session_end(self, session_id: str, owner: Any) -> None:
+        """Finalize the session if ``owner`` owns it: close + chmod the
+        typescript, stop tcpdump, remove from active sessions.
+
+        A session_end from a non-owning connection is ignored (codex F3 — a
+        different connection must not end another session's capture early).
+        """
+        with self._lock:
+            sess = self.active_sessions.get(session_id)
+            if sess is None or sess["owner"] != owner:
+                return
+            del self.active_sessions[session_id]
+        self._finalize(sess, session_id)
+
+    def finalize_owner(self, owner: Any) -> None:
+        """Finalize every session owned by ``owner`` (EOF/disconnect cleanup).
+
+        This is the EOF-driven finalization (codex F1): a wrapper that is
+        killed or disconnects without a clean session_end still gets its
+        typescript closed and its tcpdump stopped.
+        """
+        with self._lock:
+            owned = [
+                (sid, sess)
+                for sid, sess in self.active_sessions.items()
+                if sess["owner"] == owner
+            ]
+            for sid, _ in owned:
+                del self.active_sessions[sid]
+        for sid, sess in owned:
+            self._finalize(sess, sid)
+
+    def _finalize(self, sess: dict, session_id: str) -> None:
+        """Close the typescript (chmod 0600) and stop tcpdump. No lock held."""
+        ts_file = sess["ts_file"]
+        ts_path: Path = sess["typescript_path"]
+        try:
+            ts_file.close()
+        except Exception as exc:
+            _log.warning("session=%s: error closing typescript: %s", session_id, exc)
+        if ts_path.exists():
+            try:
+                os.chmod(ts_path, 0o600)
+            except Exception as exc:
+                _log.warning("session=%s: chmod 0600 failed: %s", session_id, exc)
+        self._stop_pcap(sess, session_id)
+        _log.info("session_end session=%s owner=%s", session_id, sess.get("owner"))
+
+
+# ---------------------------------------------------------------------------
+# Peer credentials (SO_PEERCRED) — forensic record of who opened a connection
+# ---------------------------------------------------------------------------
+
+def peer_credentials(conn: socket.socket) -> tuple[int, int, int] | None:
+    """Return ``(pid, uid, gid)`` of the connecting peer, or ``None``.
+
+    Read for forensics/logging; the authoritative authorization is
+    connection-ownership (a session is bound to the connection that started
+    it), which holds even when an attacker can become any uid via sudo.
+    """
+    try:
+        data = conn.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+        pid, uid, gid = struct.unpack("3i", data)
+        return pid, uid, gid
+    except Exception:
+        return None
+
+
+def _allowed_uids() -> set[int] | None:
+    """Optional uid allowlist from ``APTL_CAPTURE_ALLOWED_UIDS`` (comma-sep).
+
+    Returns ``None`` when unset (accept any peer; ownership is the boundary).
+    """
+    raw = os.environ.get("APTL_CAPTURE_ALLOWED_UIDS", "").strip()
+    if not raw:
+        return None
+    out: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if part:
+            try:
+                out.add(int(part))
+            except ValueError:
+                _log.warning("ignoring non-integer uid in APTL_CAPTURE_ALLOWED_UIDS: %r", part)
+    return out or None
+
+
+# ---------------------------------------------------------------------------
+# Connection handler
+# ---------------------------------------------------------------------------
+
+def _handle_connection(
+    conn: socket.socket,
+    state: WriterState,
+    allowed_uids: set[int] | None = None,
+) -> None:
+    """Handle one client connection.
+
+    The connection owns every session it starts.  Newline-delimited JSON
+    frames are dispatched; data/state frames for a session are honored only
+    while this connection owns it.  When the connection closes (EOF), every
+    session it owns is finalized.
+    """
+    owner = state.new_owner()
+    cred = peer_credentials(conn)
+    if cred is not None:
+        _log.info("connection owner=%s peer pid=%s uid=%s gid=%s", owner, *cred)
+        if allowed_uids is not None and cred[1] not in allowed_uids:
+            _log.warning(
+                "connection owner=%s rejected — peer uid=%s not in allowlist %s",
+                owner, cred[1], sorted(allowed_uids),
+            )
+            try:
+                conn.close()
+            except Exception:
+                pass
+            return
+
+    buf = b""
+    try:
+        while True:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    frame = json.loads(line.decode("utf-8", errors="replace"))
+                except Exception as exc:
+                    _log.warning("malformed JSON frame: %s", exc)
+                    continue
+                if not isinstance(frame, dict):
+                    _log.warning("frame is not an object; discarded")
+                    continue
+                try:
+                    validate_frame(frame)
+                except ValueError as exc:
+                    _log.warning("rejected frame: %s", exc)
+                    continue
+                _dispatch_frame(frame, state, owner)
+    except Exception as exc:
+        _log.warning("connection error: %s", exc)
+    finally:
+        # EOF/disconnect: finalize every session this connection owned so a
+        # killed/disconnected wrapper never leaks an open file or tcpdump.
+        state.finalize_owner(owner)
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def _dispatch_frame(frame: dict[str, Any], state: WriterState, owner: Any) -> None:
+    """Dispatch a single validated frame for the connection identified by *owner*."""
+    msg_type = frame.get("type", "")
+    try:
+        if msg_type == "ping":
+            return  # reachability probe (the wrapper's wrapped-vs-unwrapped check)
+        if msg_type == "session_start":
+            state.handle_session_start(
+                frame.get("run_id", ""),
+                frame.get("session_id", ""),
+                owner,
+            )
+        elif msg_type == "pty_chunk":
+            state.handle_pty_chunk(
+                frame.get("session_id", ""),
+                frame.get("b64", ""),
+                owner,
+            )
+        elif msg_type == "session_end":
+            state.handle_session_end(frame.get("session_id", ""), owner)
+        else:
+            _log.debug("unhandled frame type: %s", msg_type)
+    except Exception as exc:
+        _log.warning("error handling frame type=%s: %s", msg_type, exc)
+
+
+# ---------------------------------------------------------------------------
+# Main server
+# ---------------------------------------------------------------------------
+#
+# auditd, process accounting, and the readiness marker are owned by the
+# sidecar's entrypoint.sh (which runs before this daemon). Doing it there too
+# would start auditd twice — the second start fails and falsely reports the
+# subsystem degraded. This module is solely the per-session capture writer.
+
+_CAPTURE_ROOT = os.environ.get("APTL_CAPTURE_ROOT", "/var/log/aptl/captures")
+_SOCKET_NAME = os.environ.get("APTL_CAPTURE_SOCKET", "\x00aptl-capture-ctrl")
+
+
+def _main() -> None:
+    capture_root = _CAPTURE_ROOT
+    socket_name = _SOCKET_NAME
+    allowed_uids = _allowed_uids()
+
+    Path(capture_root).mkdir(mode=0o755, parents=True, exist_ok=True)
+
+    print("=== APTL Kali Capture Writer listening ===", flush=True)
+    if allowed_uids is not None:
+        _log.info("peer uid allowlist active: %s", sorted(allowed_uids))
+
+    state = WriterState(capture_root=capture_root, enable_pcap=True)
+
+    # Bind abstract Unix socket
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(socket_name)
+    srv.listen(64)
+    _log.info("capture writer listening on %r", socket_name)
+
+    while True:
+        try:
+            conn, _ = srv.accept()
+        except KeyboardInterrupt:
+            _log.info("capture writer shutting down")
+            break
+        except Exception as exc:
+            _log.error("accept error: %s", exc)
+            continue
+        t = threading.Thread(
+            target=_handle_connection,
+            args=(conn, state, allowed_uids),
+            daemon=True,
+        )
+        t.start()
+
+
+if __name__ == "__main__":
+    _main()

--- a/containers/kali/Dockerfile
+++ b/containers/kali/Dockerfile
@@ -16,23 +16,22 @@ RUN apt-get update && \
         kali-tools-top10 \
         openssh-server \
         iputils-ping \
-        # OBS-003 behavioural capture (ADR-033):
-        #   auditd        — syscall / process / file events
-        #   acct          — process accounting (accton + pacct)
-        #   tcpdump       — per-session pcap
-        #   bsdmainutils  — provides script(1) for full PTY recording
-        #   libcap2-bin   — provides capsh (drops CAP_AUDIT_CONTROL
-        #                   before spawning sshd so the kali user
-        #                   can't disable audit via sudo)
-        #   acl           — provides setfacl (entrypoint grants kali
-        #                   user write access to the captures volume
-        #                   root without widening for everyone)
+        # OBS-003 behavioural capture tooling (ADR-033 / ADR-041):
+        #   auditd        — auditctl binary needed to check rule state
+        #   acct          — accton/lastcomm binaries for red-team use
+        #   tcpdump       — available for manual red-team packet capture
+        #   bsdmainutils  — provides script(1) for PTY recording pipe
+        #   libcap2-bin   — capsh: drops CAP_AUDIT_CONTROL before sshd
+        #   python3       — aptl-capture-client is a Python 3 script
+        # NOTE: acl (setfacl) removed — kali_captures is no longer mounted
+        # in this container at all (ADR-041); the sidecar owns the volume,
+        # so there is nothing here for setfacl to grant.
         auditd \
         acct \
         tcpdump \
         bsdmainutils \
         libcap2-bin \
-        acl && \
+        python3 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # AD/Enterprise attack tools for TechVault scenario
@@ -104,6 +103,9 @@ COPY --chown=kali:kali scripts/ /home/kali/
 # pattern for dumpcap above.
 RUN install -m 0755 /home/kali/aptl-wrap-shell.sh /usr/local/bin/aptl-wrap-shell.sh && \
     rm -f /home/kali/aptl-wrap-shell.sh && \
+    # ADR-041: install the capture client that delegates writes to the sidecar.
+    install -m 0755 /home/kali/aptl-capture-client /usr/local/bin/aptl-capture-client && \
+    rm -f /home/kali/aptl-capture-client && \
     setcap cap_net_raw,cap_net_admin+eip /usr/bin/tcpdump
 COPY audit/aptl.rules /etc/audit/rules.d/aptl.rules
 RUN chmod 0640 /etc/audit/rules.d/aptl.rules && \

--- a/containers/kali/entrypoint.sh
+++ b/containers/kali/entrypoint.sh
@@ -1,32 +1,20 @@
 #!/bin/bash
-# APTL Kali entrypoint (OBS-003 / ADR-033 revision, hardened against
-# codex pre-push cycle 1 findings).
+# APTL Kali entrypoint (OBS-003 / ADR-033 / ADR-041 revision).
 #
-# Brings up the Kali container with the OBS-003 capture surface:
-#   - sshd, spawned with CAP_AUDIT_CONTROL dropped via capsh so the
-#     kali user (passwordless sudo) cannot run `auditctl -D` to
-#     disable audit mid-scenario (codex finding-12).
-#   - auditd loaded with the APTL ruleset BEFORE sshd, so audit is
-#     active by the time the agent connects.
-#   - process accounting (accton) writing into the kali_captures
-#     named volume so events survive container restart and harvest
-#     out alongside per-session pcaps and PTY recordings (codex
-#     finding-5).
+# ADR-041: auditd, process accounting, and all capture writes have moved
+# to the aptl-kali-capture sidecar.  This entrypoint no longer starts
+# those subsystems.  The kali_captures volume is NOT mounted in this
+# container at all (not even read-only), so the kali user (passwordless
+# sudo) cannot read, list, delete, or modify any session's evidence.
 #
-# Wazuh agent installation and rsyslog forwarding to the SIEM,
-# present in prior revisions, were removed under the
-# non-contamination principle: red activity must not bleed into the
-# blue defensive stack's awareness. See ADR-033.
+# Remaining responsibilities:
+#   - SSH key setup
+#   - sshd, spawned with CAP_AUDIT_CONTROL dropped via capsh
+#   - OBS-003 ForceCommand wrapper presence check
+#   - Boot-readiness marker (sshd + wrapper status only)
 set -e
 
-# ADR-033 §2 / issue #293: per-subsystem boot outcomes. Each starts
-# `degraded` and is promoted to `ok` once its boot step succeeds. The
-# values are written into the readiness marker at the end of boot so
-# the healthcheck (aptl-healthcheck.sh) can surface a degraded
-# capture surface instead of masking it behind an open port 22.
 sshd_status=degraded
-auditd_status=degraded
-procacct_status=degraded
 wrapper_status=degraded
 
 # Set up SSH keys from host.
@@ -39,10 +27,7 @@ if [ -f "/host-ssh-keys/authorized_keys" ]; then
     echo "SSH keys configured for kali user"
 fi
 
-# SEC #417: the dedicated pivot private key is bind-mounted 0600 and owned by the
-# host UID, so the unprivileged `kali` login user cannot read it directly. Copy
-# it into the kali user's home with kali ownership and 0600 so kali-to-target
-# SSH works for the real operator path (not just root).
+# SEC #417: copy pivot private key into kali's home with correct ownership.
 if [ -f "/host-ssh-keys/kali_pivot_key" ]; then
     mkdir -p /home/kali/.ssh
     cp /host-ssh-keys/kali_pivot_key /home/kali/.ssh/kali_pivot_key
@@ -52,100 +37,17 @@ if [ -f "/host-ssh-keys/kali_pivot_key" ]; then
     echo "Kali pivot key configured for kali user"
 fi
 
-# OBS-003: prepare the captures volume mount. /var/log/aptl/captures
-# is a docker NAMED VOLUME (see docker-compose.yml). We chown only
-# the captures root + its container-wide audit/proc-acct subdirs so
-# the kali user can write per-session subdirs — NOT recursive into
-# any prior run's MCP-side records (codex finding-4: the prior
-# `chown -R /var/log/aptl` would have mutated host-side data when
-# bound to a host filesystem; the named volume approach + scoped
-# chown closes both issues).
-mkdir -p /var/log/aptl/captures \
-         /var/log/aptl/captures/_audit \
-         /var/log/aptl/captures/_proc-acct
-chown root:root /var/log/aptl /var/log/aptl/captures \
-                /var/log/aptl/captures/_audit \
-                /var/log/aptl/captures/_proc-acct
-chmod 0755 /var/log/aptl
-# 0701 on the captures root lets the kali user `cd` into per-run
-# subdirs (created by the wrapper as kali) without granting `ls`
-# access to siblings — protects against cross-session snooping
-# inside the same lab run.
-chmod 0701 /var/log/aptl/captures
-chmod 0700 /var/log/aptl/captures/_audit /var/log/aptl/captures/_proc-acct
-# Give kali write access to the captures root so the per-session
-# wrapper can mkdir its run_id/session_id subdirs.
-setfacl -m u:kali:rwx /var/log/aptl/captures 2>/dev/null \
-  || chmod 0707 /var/log/aptl/captures  # fallback if setfacl missing
+# ADR-041: no captures volume is mounted here, so there is nothing to
+# create or chown under /var/log/aptl — the sidecar owns the sink.
 
-# OBS-003: process accounting → captures volume. pacct accumulates
-# every process that exits; restart-survival comes from the volume.
-# Use `touch` (create-if-missing) — NOT `: >` (truncate) — so a
-# container restart mid-run doesn't erase the persisted accounting
-# evidence (codex cycle 2 finding-3).
-if command -v accton >/dev/null 2>&1; then
-    touch /var/log/aptl/captures/_proc-acct/pacct
-    chown root:root /var/log/aptl/captures/_proc-acct/pacct
-    chmod 0600 /var/log/aptl/captures/_proc-acct/pacct
-    if accton /var/log/aptl/captures/_proc-acct/pacct; then
-        procacct_status=ok
-        echo "Process accounting active"
-    else
-        echo "[entrypoint] accton failed (best-effort)"
-    fi
-fi
-
-# OBS-003: auditd. Load rules with full CAP_AUDIT_CONTROL (we have it
-# at entrypoint), then start the daemon. Subsequent sshd spawn drops
-# the capability so the kali user can't modify the loaded ruleset.
-audit_loaded=0
-if command -v auditctl >/dev/null 2>&1 && [ -f /etc/audit/rules.d/aptl.rules ]; then
-    if auditctl -R /etc/audit/rules.d/aptl.rules >/dev/null 2>&1; then
-        echo "auditd rules loaded"
-        audit_loaded=1
-    else
-        echo "[entrypoint] auditctl -R failed; auditd disabled"
-    fi
-fi
-if [ "$audit_loaded" = "1" ] && command -v auditd >/dev/null 2>&1; then
-    # Redirect auditd's log into the captures named volume so the
-    # events survive container restart and are pulled out by the
-    # MCP-side harvest alongside per-session pcaps/PTYs (codex
-    # finding-5). Without this, /var/log/audit lives in the overlay
-    # fs and is lost on `docker compose down -v`.
-    if [ -f /etc/audit/auditd.conf ]; then
-        sed -i 's|^log_file *=.*|log_file = /var/log/aptl/captures/_audit/audit.log|' \
-            /etc/audit/auditd.conf || true
-    fi
-    # `touch` (create-if-missing), NOT truncate — preserves prior
-    # audit events on container restart (codex cycle 2 finding-3).
-    touch /var/log/aptl/captures/_audit/audit.log
-    chmod 0600 /var/log/aptl/captures/_audit/audit.log
-    if auditd >/dev/null 2>&1; then
-        auditd_status=ok
-    else
-        echo "[entrypoint] auditd start failed (missing CAP_AUDIT_*?)"
-    fi
-fi
-
-# Final ownership repair on home dir (cheap, idempotent — NOT the
-# captures volume; that one is scoped above).
+# Final ownership repair on home dir (idempotent).
 chown -R kali:kali /home/kali/
 
-# Spawn sshd with CAP_AUDIT_CONTROL DROPPED (codex finding-12). The
-# kali user with passwordless sudo can otherwise run `sudo
-# auditctl -D` and erase the audit trail mid-scenario. capsh runs
-# the program in a child process with the bounding set masked, so
-# sudo (which queries the bounding set, not just the file caps)
-# inherits the restriction transitively.
+# Spawn sshd with CAP_AUDIT_CONTROL DROPPED (codex finding-12).
+# The kali user with passwordless sudo can otherwise run
+# `sudo auditctl -D` and erase the audit trail mid-scenario.
 mkdir -p /run/sshd
 if command -v capsh >/dev/null 2>&1; then
-    # `--drop=cap_audit_control` removes only the dangerous capability;
-    # sshd retains everything else it needs. If capsh fails (unlikely
-    # — it's in libcap2-bin which is in the kali base), fall back to
-    # unwrapped sshd so the lab still works, but log loudly. The `if`
-    # guards keep a sshd failure from tripping `set -e` so the boot
-    # still reaches the readiness marker (issue #293).
     if capsh --drop=cap_audit_control -- -c '/usr/sbin/sshd'; then
         sshd_status=ok
     else
@@ -153,7 +55,7 @@ if command -v capsh >/dev/null 2>&1; then
         if /usr/sbin/sshd; then sshd_status=ok; fi
     fi
 else
-    echo "[entrypoint] capsh missing; sshd running with full caps (auditd disable risk)" >&2
+    echo "[entrypoint] capsh missing; sshd running with full caps" >&2
     if /usr/sbin/sshd; then sshd_status=ok; fi
 fi
 if [ "$sshd_status" = "ok" ]; then
@@ -162,40 +64,25 @@ else
     echo "[entrypoint] WARNING: sshd failed to start" >&2
 fi
 
-# OBS-003 ForceCommand wrapper presence — the per-session capture
-# wiring sshd hands every kali login to. A missing/non-executable
-# wrapper means logins fall back to an unwrapped shell with no
-# capture, so it is part of the usable surface the healthcheck gates.
+# OBS-003 ForceCommand wrapper presence check.
 if [ -x /usr/local/bin/aptl-wrap-shell.sh ]; then
     wrapper_status=ok
 else
     echo "[entrypoint] WARNING: OBS-003 ForceCommand wrapper missing/not executable" >&2
 fi
 
-# ADR-033 §2 / issue #293: boot-readiness marker. Written only after
-# every boot step above — `set -e` aborts the entrypoint before this
-# point on any hard failure, so the marker's presence proves a
-# complete boot. aptl-healthcheck.sh treats a missing marker as
-# unhealthy and surfaces any `=degraded` subsystem in its health log.
+# Boot-readiness marker.  sshd and wrapper are the only managed
+# subsystems in this container; capture subsystems are in the sidecar.
 mkdir -p /run
 {
     echo "ready_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "sshd=${sshd_status}"
     echo "wrapper=${wrapper_status}"
-    echo "auditd=${auditd_status}"
-    echo "procacct=${procacct_status}"
 } > /run/aptl-kali-ready
 
 echo "=== APTL Kali Red Team Container Ready ==="
 echo "SSH: ssh kali@<container_ip>"
-echo "Working directory: /home/kali/operations"
-echo "Per-session captures: /var/log/aptl/captures/<run_id>/<session_id>/ (in named volume)"
-echo "Harvest target on host: .aptl/runs/<run_id>/kali-side/<session_id>/"
-echo "Boot readiness: sshd=${sshd_status} wrapper=${wrapper_status} auditd=${auditd_status} procacct=${procacct_status}"
+echo "Boot readiness: sshd=${sshd_status} wrapper=${wrapper_status}"
+echo "Capture subsystems: managed by aptl-kali-capture sidecar (ADR-041)"
 
-# ADR-033 §2 / issue #293: terminal keepalive. The kali service sets
-# `init: true` (docker-compose.yml), so PID 1 is Docker's bundled
-# init (docker-init / tini) — it reaps orphaned children and forwards
-# signals. This `sleep` is a child of that init, NOT PID 1, so it no
-# longer needs to (and could not) reap anything itself.
 exec sleep infinity

--- a/containers/kali/scripts/aptl-capture-client
+++ b/containers/kali/scripts/aptl-capture-client
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""APTL kali-side capture client (ADR-041 / issue #305).
+
+Talks to the aptl-kali-capture sidecar writer daemon over an abstract Unix
+socket.  Installed at /usr/local/bin/aptl-capture-client inside the Kali
+container.
+
+Subcommands:
+  aptl-capture-client ping
+      Reachability probe. Connects, sends a no-op ping frame, exits 0 if the
+      sidecar is up, 1 otherwise. The wrapper uses this to decide wrapped vs.
+      unwrapped before committing to capture.
+
+  aptl-capture-client stream RUN_ID SESSION_ID
+      Open ONE connection that owns the whole session: send session_start,
+      read stdin in chunks and forward as pty_chunk frames, then send
+      session_end on EOF and close. Because session_start, every pty_chunk,
+      and session_end all travel over this single connection, the sidecar
+      treats it as the session's owner — no other process can inject bytes
+      into or end this session, and the byte order is preserved with no race
+      against a separate "end" call (codex pre-push F1/F3).
+
+On connection failure the client prints a one-line warning to stderr and exits
+non-zero so the wrapper can detect sidecar unavailability and continue
+unwrapped.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import sys
+import time
+from typing import NoReturn
+
+_SOCKET_NAME = os.environ.get("APTL_CAPTURE_SOCKET", "\x00aptl-capture-ctrl")
+_CONNECT_TIMEOUT = 2.0  # seconds
+# Bound per-send blocking so a stuck/overwhelmed sidecar cannot hang the
+# wrapper's `wait` (and thus SSH session close) indefinitely. Best-effort: on
+# timeout the client gives up streaming for this session.
+_STREAM_TIMEOUT = 10.0  # seconds
+_CHUNK_SIZE = 4096
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _send_frame(sock: socket.socket, frame: dict) -> None:
+    data = json.dumps(frame, separators=(",", ":")).encode("utf-8") + b"\n"
+    sock.sendall(data)
+
+
+def _connect() -> socket.socket:
+    """Connect to the sidecar abstract socket.
+
+    Raises OSError on failure (caller handles with a warning + non-zero exit).
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(_CONNECT_TIMEOUT)
+    sock.connect(_SOCKET_NAME)
+    sock.settimeout(None)
+    return sock
+
+
+def _warn_unavailable(detail: str) -> None:
+    print(
+        f"[aptl-capture-client] WARNING: sidecar unavailable ({detail}); "
+        "capture disabled for this session",
+        file=sys.stderr,
+    )
+
+
+def cmd_ping() -> None:
+    """Reachability probe: exit 0 if the sidecar accepts a connection."""
+    try:
+        sock = _connect()
+    except OSError as exc:
+        _warn_unavailable(str(exc))
+        sys.exit(1)
+    try:
+        _send_frame(sock, {"type": "ping", "ts": _now_ms()})
+    except OSError:
+        # Connected but could not write — treat as unavailable.
+        sys.exit(1)
+    finally:
+        sock.close()
+
+
+def cmd_stream(run_id: str, session_id: str) -> None:
+    """Own the session on one connection: session_start, pty_chunks, session_end.
+
+    CRITICAL (codex cycle 2 F1): this process is the ONLY reader of the FIFO
+    that `script(1)` writes to. It must drain stdin to EOF no matter what — even
+    if the sidecar is unreachable or dies mid-stream — or `script` blocks on a
+    full pipe and the user's command/session hangs. A dead sidecar must degrade
+    capture, never break the shell. So a connect/send failure sets `failed` and
+    we keep reading stdin (discarding) until EOF rather than exiting early.
+    """
+    sock = None
+    failed = False
+    try:
+        sock = _connect()
+        sock.settimeout(_STREAM_TIMEOUT)
+        _send_frame(sock, {
+            "type": "session_start",
+            "run_id": run_id,
+            "session_id": session_id,
+            "ts": _now_ms(),
+        })
+    except OSError as exc:
+        _warn_stream(exc)
+        failed = True
+
+    stdin_fd = sys.stdin.buffer
+    while True:
+        chunk = stdin_fd.read(_CHUNK_SIZE)
+        if not chunk:
+            break
+        if failed:
+            continue  # drain only: keep `script` unblocked
+        try:
+            _send_frame(sock, {
+                "type": "pty_chunk",
+                "session_id": session_id,
+                "ts": _now_ms(),
+                "b64": base64.b64encode(chunk).decode("ascii"),
+            })
+        except OSError as exc:
+            _warn_stream(exc)
+            failed = True
+
+    # session_end travels on the SAME connection after every pty_chunk, so the
+    # sidecar finalizes only once the full transcript is in (no tail loss). Even
+    # if this frame is lost, the writer finalizes on connection close.
+    if sock is not None:
+        if not failed:
+            try:
+                _send_frame(sock, {
+                    "type": "session_end",
+                    "session_id": session_id,
+                    "ts": _now_ms(),
+                })
+            except OSError:
+                pass
+        sock.close()
+
+
+def _warn_stream(exc: Exception) -> None:
+    print(
+        f"[aptl-capture-client] WARNING: stream interrupted ({exc}); "
+        "capture may be partial (shell session continues)",
+        file=sys.stderr,
+    )
+
+
+def _usage() -> NoReturn:
+    print(
+        "Usage:\n"
+        "  aptl-capture-client ping\n"
+        "  aptl-capture-client stream RUN_ID SESSION_ID",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def main() -> None:
+    argv = sys.argv[1:]
+    if not argv:
+        _usage()
+    subcommand = argv[0]
+    if subcommand == "ping":
+        if len(argv) != 1:
+            _usage()
+        cmd_ping()
+    elif subcommand == "stream":
+        if len(argv) != 3:
+            _usage()
+        cmd_stream(argv[1], argv[2])
+    else:
+        _usage()
+
+
+if __name__ == "__main__":
+    main()

--- a/containers/kali/scripts/aptl-wrap-shell.sh
+++ b/containers/kali/scripts/aptl-wrap-shell.sh
@@ -1,47 +1,35 @@
 #!/bin/bash
-# OBS-003 / ADR-033 per-session shell wrapper invoked by sshd's
-# ForceCommand. Captures the full PTY (every keystroke + every byte of
-# output, with timing) via script(1), starts a per-session tcpdump,
-# then runs the agent's command (or an interactive bash). All
-# captures land under
-#   /var/log/aptl/captures/<run_id>/<session_id>/
-# inside the container. The MCP server harvests them out via
-# `docker cp` on session close (see captures.ts) into the host's
-# `.aptl/runs/<run_id>/kali-side/<session_id>/`. The container holds
-# captures in a docker named volume (not a host bind mount), so the
-# kali user cannot read or tamper with prior runs' MCP-side records
-# (codex pre-push cycle 1 finding-10).
+# OBS-003 / ADR-033 / ADR-041 per-session shell wrapper invoked by sshd's
+# ForceCommand.  Delegates all capture file writes to the aptl-kali-capture
+# sidecar daemon via `aptl-capture-client` so the kali user (passwordless
+# sudo) cannot delete or modify capture evidence.
 #
-# Hardening notes addressed in this revision:
-#   - cycle 1 finding-7: do NOT `exec` script — run it as a child so
-#     the EXIT trap still fires and kills tcpdump.
-#   - cycle 1 finding-11: enforce 0700 dirs / 0600 files via umask.
-#   - cycle 1 finding-13: reject IDs containing `.` `..` or any
-#     character outside [A-Za-z0-9_-]; fall back to a generated safe
-#     ID rather than absorbing the value.
+# Capture lifecycle (single owning connection — codex pre-push F1/F3):
+#   1. aptl-capture-client ping
+#      → best-effort reachability probe; decides wrapped vs unwrapped.
+#   2. aptl-capture-client stream RUN_ID SESSION_ID (one connection)
+#      → sends session_start, forwards script(1)'s --log-io transcript as
+#        pty_chunk frames, then session_end on EOF. The sidecar binds the
+#        session to this connection and finalizes it (typescript chmod 0600,
+#        tcpdump stop) on session_end OR connection close.
 #
-# Best-effort: if setup fails (missing script/tcpdump, capture dir
-# can't be created), log a warning and exec the requested shell
-# unwrapped rather than break SSH login.
+# The Kali container does NOT mount the captures volume (ADR-041) and does NOT
+# share the sidecar's PID namespace: all writes happen in the sidecar, so a
+# sudo-capable agent cannot read, delete, or alter any session's evidence.
+# This wrapper never touches a capture file directly.
+#
+# If the sidecar is unreachable (client exits non-zero), a warning is
+# logged to stderr and the session runs unwrapped rather than failing
+# the SSH login (ADR-041 §Security Layers: best-effort).
+#
+# ID validation:
+#   Canonical rule: `^[A-Za-z0-9_][A-Za-z0-9._-]*$` AND no `..`.
+#   Must match src/aptl/core/runstore.py _ID_RE and
+#   mcp/aptl-mcp-common/src/runs.ts ID_RE.
 
 set -u
 umask 077
 
-# ID validation MUST match the canonical contract used by the
-# Python `src/aptl/core/runstore.py` `_ID_RE` and the TypeScript
-# `mcp/aptl-mcp-common/src/runs.ts` `ID_RE` (codex pre-push cycle 2
-# finding-4 + finding-10): any divergence causes the wrapper to
-# silently re-route an MCP-allowed id (e.g. `_unbound`, `foo.bar`)
-# into `anon-...`, and the MCP-side `harvestSession()` then looks
-# under the originally-requested path, finds nothing, and reports
-# success — silently losing all Kali-side captures for that session
-# (also turns into a tampering primitive if an agent picks
-# `evade.harvest` as their session id).
-#
-# Canonical rule: `^[A-Za-z0-9_][A-Za-z0-9._-]*$` AND must not
-# contain `..`. Leading `_` permitted so the `_unbound` sentinel
-# round-trips; `.` permitted so version-shaped ids like `sess-1.0`
-# round-trip; `..` rejected as the only real path-traversal vector.
 valid_id() {
   case "$1" in
     *..* | */* | "" ) return 1 ;;
@@ -62,8 +50,6 @@ safe_id() {
 SESSION_ID="$(safe_id "${APTL_SESSION_ID:-}")"
 RUN_ID="$(safe_id "${APTL_RUN_ID:-_unbound}")"
 
-SESS_DIR="/var/log/aptl/captures/${RUN_ID}/${SESSION_ID}"
-
 run_unwrapped() {
   if [ -n "${SSH_ORIGINAL_COMMAND:-}" ]; then
     exec /bin/bash -c "$SSH_ORIGINAL_COMMAND"
@@ -71,43 +57,19 @@ run_unwrapped() {
   exec /bin/bash --login
 }
 
-if ! mkdir -p "$SESS_DIR/pty" "$SESS_DIR/pcap" 2>/dev/null; then
-  echo "[aptl-wrap-shell] capture dir setup failed; running unwrapped" >&2
+# Reachability probe: decide wrapped vs unwrapped WITHOUT committing to
+# capture. If the sidecar is unavailable, run the shell unwrapped rather than
+# break SSH login (ADR-041 best-effort).
+if ! aptl-capture-client ping 2>/dev/null; then
+  echo "[aptl-wrap-shell] capture sidecar unavailable; running unwrapped" >&2
   run_unwrapped
 fi
-# Tighten perms on the per-session subtree (umask covered new
-# directories, but be explicit so a re-run after a chmod doesn't
-# leave a wider parent).
-chmod 0700 "$SESS_DIR" "$SESS_DIR/pty" "$SESS_DIR/pcap" 2>/dev/null || true
 
-PTY_TS="$SESS_DIR/pty/typescript"
-PTY_TIMING="$SESS_DIR/pty/timing"
-PCAP="$SESS_DIR/pcap/session.pcap"
-
-TCPDUMP_PID=""
-if command -v tcpdump >/dev/null 2>&1; then
-  # -C 100M, -W 10 → rolling 1GB max per session so an agent cannot
-  # fill the host disk with one long-running session. tcpdump runs
-  # with cap_net_raw+cap_net_admin via file capabilities applied in
-  # the Dockerfile (codex cycle 1 finding-6), so no sudo / no root.
-  # `not port 22` filters out SSH noise so the pcap is small enough
-  # to be tractable per session.
-  tcpdump -i any -w "$PCAP" -C 100 -W 10 -U \
-    not port 22 \
-    >/dev/null 2>&1 &
-  TCPDUMP_PID=$!
-fi
-
+# Clean up the spool FIFO on every exit path.
+SPOOL=""
 cleanup() {
-  if [ -n "$TCPDUMP_PID" ]; then
-    kill "$TCPDUMP_PID" 2>/dev/null || true
-    wait "$TCPDUMP_PID" 2>/dev/null || true
-  fi
-  # Repair file modes one more time at exit — script writes the
-  # typescript / timing files with the wrapper's umask, but a
-  # bare-metal `chmod` here closes any residual race window.
-  chmod 0600 "$PTY_TS" "$PTY_TIMING" 2>/dev/null || true
-  find "$SESS_DIR/pcap" -type f -name '*.pcap*' -exec chmod 0600 {} + 2>/dev/null || true
+  [ -n "$SPOOL" ] && rm -f "$SPOOL" 2>/dev/null
+  return 0
 }
 trap cleanup EXIT TERM INT
 
@@ -116,25 +78,45 @@ if ! command -v script >/dev/null 2>&1; then
   run_unwrapped
 fi
 
-# `script -q` suppresses the "Script started" banner; `-f` flushes
-# after each write so a killed session preserves the tail; `--timing`
-# writes a side file so playback is possible later. `--return` makes
-# script(1) propagate the wrapped command's exit status — without it
-# script returns its own status (0 on clean disconnect) and a failing
-# command like `false` would close the SSH channel with rc=0,
-# breaking `kali_run_command` result semantics and OCSF outcome
-# derivation (codex cycle 2 finding-1). `--log-io` writes a single
-# combined input+output transcript (replaces `--command`'s
-# output-only capture) so non-echoed input (passwords, `read -s`)
-# is recorded too (codex cycle 2 finding-5).
+# Route script(1)'s --log-io transcript to the sidecar through a private FIFO.
+# `script`'s own stdout/stdin stay wired to the SSH channel so the agent sees
+# output and `kali_run_command` returns the real result — only the transcript
+# is forwarded. (Piping script's stdout into the client instead would send all
+# output to the sidecar and return an EMPTY result to the caller.)
 #
-# Run script as a CHILD (not `exec`) so the wrapper survives to fire
-# the EXIT trap and kill tcpdump (codex cycle 1 finding-7). Forward
-# script's exit status via $? so SSH sees the right return code.
-SCRIPT_ARGS=( -q -f --return --log-io "$PTY_TS" --log-timing "$PTY_TIMING" )
+# One `stream` client owns the whole session on a SINGLE connection
+# (session_start -> pty_chunks -> session_end), so finalization cannot race a
+# separate "end" call and a killed wrapper still gets EOF-driven finalization
+# in the sidecar (codex pre-push F1/F3). We `wait` for the client so every
+# pty_chunk is flushed before the wrapper exits (no tail loss). The FIFO only
+# carries this session's own bytes in transit; the written evidence lives in
+# the sidecar, out of this container's mount namespace.
+#
+# `script -q` suppresses the banner; `-f` flushes each write; `--return`
+# propagates the wrapped command's exit status (correct result semantics + OCSF
+# outcome); `--log-io` records combined input+output (non-echoed input such as
+# `read -s` passwords included).
+SPOOL="$(mktemp -u "${TMPDIR:-/tmp}/aptl-cap-XXXXXX")"
+if ! mkfifo -m 0600 "$SPOOL" 2>/dev/null; then
+  echo "[aptl-wrap-shell] could not create capture spool; running unwrapped" >&2
+  run_unwrapped
+fi
+
+# Start the reader (stream client) first so script's open-for-write rendezvous
+# on the FIFO succeeds; it forwards FIFO bytes to the sidecar until EOF.
+aptl-capture-client stream "$RUN_ID" "$SESSION_ID" < "$SPOOL" &
+CLIENT_PID=$!
+
+SCRIPT_ARGS=( -q -f --return --log-io "$SPOOL" )
 if [ -n "${SSH_ORIGINAL_COMMAND:-}" ]; then
   script "${SCRIPT_ARGS[@]}" --command "$SSH_ORIGINAL_COMMAND"
 else
   script "${SCRIPT_ARGS[@]}" --command "/bin/bash --login"
 fi
-exit $?
+RC=$?
+
+# script closed the FIFO write end on exit → the client sees EOF, flushes the
+# tail, sends session_end, and exits. Wait so finalization completes before we
+# return the command's exit status to sshd.
+wait "$CLIENT_PID" 2>/dev/null
+exit "$RC"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1198,35 +1198,21 @@ services:
       - ./keys/authorized_keys:/host-ssh-keys/authorized_keys:ro
       - ./config/lab-ssh/kali_pivot_key:/host-ssh-keys/kali_pivot_key:ro
       - kali_operations:/home/kali/operations
-      # OBS-003 / ADR-033: per-session captures land in a docker
-      # NAMED VOLUME (not a host bind mount). The named volume is
-      # not visible on the host filesystem to other containers or
-      # to the kali workload's snooping, and an attacker who escalates
-      # to container root cannot read or tamper with prior runs'
-      # MCP-side records (codex pre-push cycle 1 finding-10). The
-      # MCP-red server harvests captures out via `docker cp` on
-      # session close into `.aptl/runs/<run_id>/kali-side/<session_id>/`
-      # on the host with 0600 perms — see `captures.ts` in
-      # aptl-mcp-common.
-      - kali_captures:/var/log/aptl/captures
+      # ADR-041 / issue #305: the kali_captures volume is NOT mounted in this
+      # container at all — not even read-only. A read-only mount would still
+      # let a `sudo`-capable agent READ sibling sessions' evidence (ro blocks
+      # writes, not reads); the only way to deny read/list/modify to a
+      # sudo-root shell is to keep the capture sink out of this container's
+      # mount namespace entirely. All capture writes and the harvest source
+      # live in the aptl-kali-capture sidecar; this workload reaches the
+      # sidecar only over the abstract Unix socket (shared netns).
     cap_add:
-      - NET_RAW       # tcpdump / packet capture
-      - NET_ADMIN     # network manipulation tools
-      # OBS-003: AUDIT_CONTROL and AUDIT_WRITE are granted to the
-      # container so entrypoint.sh (running as root, before sshd is
-      # exposed) can load the APTL audit ruleset. The entrypoint
-      # then drops CAP_AUDIT_CONTROL from the sshd-spawning process
-      # via `capsh --drop=cap_audit_control` so the kali user
-      # (passwordless sudo) cannot run `auditctl -D` to disable
-      # the audit trail mid-scenario (codex cycle 1 finding-12).
-      - AUDIT_CONTROL
-      - AUDIT_WRITE
-      # OBS-003 / codex cycle 3 finding-1: SYS_PACCT is required for
-      # `accton` to enable kernel process accounting. Docker's default
-      # cap set excludes it, so without this the entrypoint's
-      # `accton /var/log/aptl/captures/_proc-acct/pacct` silently
-      # fails and the advertised pacct capture is empty.
-      - SYS_PACCT
+      - NET_RAW       # tcpdump / packet capture (red-team tooling)
+      - NET_ADMIN     # network manipulation tools (red-team tooling)
+      # ADR-041: AUDIT_CONTROL, AUDIT_WRITE, and SYS_PACCT have moved
+      # to the kali-capture sidecar.  The Kali workload no longer needs
+      # them — capture-only capabilities must not be on the workload
+      # service.
     security_opt:
       - seccomp:unconfined  # Required for some red team tools
     # ADR-033 §2 / issue #293: the healthcheck verifies the usable
@@ -1244,6 +1230,62 @@ services:
       resources:
         limits:
           memory: 1g
+
+  # ---------------------------------------------------------------------------
+  # ADR-041 / issue #305: Kali Capture Sidecar
+  #
+  # The SOLE owner of the kali_captures volume (read-write). The Kali workload
+  # does not mount the volume at all, so a sudo-capable agent cannot read,
+  # list, delete, or modify any session's evidence. The sidecar receives PTY
+  # bytes over an abstract Unix socket, runs the per-session tcpdump, and hosts
+  # auditd + process accounting. The MCP-red server harvests captures via
+  # `docker cp aptl-kali-capture:...` (see capture_container_name in
+  # mcp/mcp-red/docker-lab-config.json).
+  #
+  # Shares ONLY the Kali network namespace, so tcpdump observes Kali's traffic
+  # and the abstract Unix socket is mutually reachable. It must NOT share the
+  # PID namespace: with a shared PID namespace a sudo-root Kali shell can see
+  # the sidecar's PIDs and traverse `/proc/<sidecar-pid>/root/var/log/aptl/
+  # captures` into the sidecar's mount namespace, reading or deleting the
+  # evidence the sidecar owns — defeating the whole boundary (codex pre-push
+  # cycle 1 finding F2). auditd and process accounting are kernel-wide and do
+  # not need PID sharing to observe Kali's processes. NOTE: `network_mode:
+  # service:kali` forbids hostname/ports/networks/extra_hosts on this service —
+  # Docker rejects the combination at `up` time. Do not re-add a `hostname:`.
+  # ---------------------------------------------------------------------------
+  kali-capture:
+    profiles: ["kali"]
+    build:
+      context: ./containers/kali-capture
+      dockerfile: Dockerfile
+    container_name: aptl-kali-capture
+    restart: unless-stopped
+    # ADR-033 §2 pattern: run under Docker's bundled init so the per-session
+    # tcpdump / auditd / accton children are reaped rather than zombified.
+    init: true
+    # Share ONLY Kali's network namespace (abstract socket + tcpdump). PID
+    # namespace is deliberately NOT shared (codex F2 — /proc traversal).
+    network_mode: "service:kali"
+    depends_on:
+      - kali
+    volumes:
+      # Read-write owner of the captures volume (ADR-041 security boundary).
+      - kali_captures:/var/log/aptl/captures
+      # Bind-mount the canonical APTL audit ruleset from the kali image's
+      # build context so rule text is never duplicated (ADR-041 §Maintainability).
+      - ./containers/kali/audit/aptl.rules:/etc/audit/rules.d/aptl.rules:ro
+    cap_add:
+      # ADR-041: capture-only capabilities live here, never on the kali workload.
+      - AUDIT_CONTROL  # auditctl — load rules, start/stop auditd
+      - AUDIT_WRITE    # write audit events
+      - SYS_PACCT      # accton — enable process accounting
+      - NET_RAW        # tcpdump on the shared (Kali) network namespace
+    # No host ports: the only new control surface is the abstract Unix socket
+    # which is local to the shared PID/network namespace (ADR-041 §Security).
+    deploy:
+      resources:
+        limits:
+          memory: 256m
 
   # Reverse Engineering Container
   reverse:

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -62,3 +62,4 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [038](adr-038-docs-style-lint-and-published-site.md) | Documentation Style Lint and Published Docs Site | accepted | 2026-06-11 |
 | [039](adr-039-web-control-plane-authentication.md) | Web Control Plane Authentication and Loopback Exposure | accepted | 2026-06-14 |
 | [040](adr-040-terminal-ssh-host-key-verification.md) | Terminal SSH Host-Key Verification Boundary | accepted | 2026-06-13 |
+| [041](adr-041-kali-capture-sidecar-ownership-boundary.md) | Kali Capture Sidecar Ownership Boundary | accepted | 2026-06-20 |

--- a/docs/adrs/adr-033-agent-reasoning-trace-boundary.md
+++ b/docs/adrs/adr-033-agent-reasoning-trace-boundary.md
@@ -261,34 +261,36 @@ agent CLI ships.
   entrypoint that stays PID 1 and waits on the children it starts. A
   keepalive process that only sleeps is not a lifecycle boundary and
   must not be used to hide failed boot work.
-- **Capture integrity from a sudo-capable kali user** (residual
-  risk, codex pre-push cycle 2 finding-9; tracked in
+- **Capture integrity from a sudo-capable kali user** (superseded by
+  [ADR-041](adr-041-kali-capture-sidecar-ownership-boundary.md) for
   [issue #305](https://github.com/Brad-Edwards/aptl/issues/305)):
-  the kali user has passwordless sudo (required for legitimate
-  red-team tooling). Per-session capture files are owned by kali
-  and writable by kali; the agent can `rm -rf` its own session
-  subtree before close, or `sudo` to root and modify the global
-  `_audit` / `_proc-acct` files. The `CAP_AUDIT_CONTROL` drop
-  prevents `auditctl -D` (the most surgical attack), but file
-  deletion remains. Mitigations in place:
-  - The MCP-side PTY tee writes to `.aptl/runs/<run>/mcp-side/sessions/`
-    in a process the kali user cannot touch—this is the
-    authoritative tamper-resistant record for keystrokes and output.
-  - `harvestSession()` reports failure (not silent success) when the
-    per-session source directory is missing on the container side,
-    so deletion is observable rather than invisible.
-  - Per-session captures use 0700 dirs / 0600 files inside the
-    container so cross-session snooping by *other* sessions is
-    blocked even when the originating session's own files are
-    rewriteable.
+  the original ADR-033 implementation left the capture volume writable
+  from inside the Kali workload container. Because the `kali` user has
+  passwordless sudo for legitimate red-team tooling, root-owned files,
+  ACLs, setuid helpers, or a dedicated in-container capture user are not
+  sufficient tamper-resistance boundaries inside the same writable mount
+  namespace.
 
-  Closing this fully requires a privileged in-container daemon or
-  capture sidecar that owns capture writes outside the kali user's
-  reach. Tracked as
-  [#305 "Privileged capture writer: take Kali captures out of the
-  kali user's reach"](https://github.com/Brad-Edwards/aptl/issues/305)
-—a separate ADR will record the writer-ownership design
-  decision when that issue lands.
+  ADR-041 selects a capture sidecar as the ownership boundary: the
+  sidecar shares ONLY Kali's network namespace (not its PID namespace,
+  which would expose `/proc/<pid>/root` traversal), mounts
+  `kali_captures` read-write, and owns per-session PTY, pcap, auditd,
+  and process-accounting writes. Kali does NOT mount `kali_captures`
+  at all (not even read-only, since a read-only mount still lets a
+  sudo-root shell `cat` sibling sessions' evidence). With the sink
+  absent from Kali's mount namespace, `sudo` read/list/rm/truncate/
+  chmod/chown/rewrite attempts from Kali have no path to it. The
+  wrapper's role narrows to validated session metadata RPC and
+  best-effort shell continuation. (PTY transcript bytes are still
+  supplied by the workload, so the Kali-side typescript is not
+  tamper-resistant for the workload's own session; the authoritative
+  keystroke/output record remains the MCP-side PTY tee.)
+
+  Until the ADR-041 implementation lands, the current code still carries
+  the residual risk described above. The implementation must preserve the
+  existing mitigations that remain valid: MCP-side PTY tee outside the
+  container, fail-loud `harvestSession()` missing-source reporting, and
+  restrictive harvested host-side modes.
 - **Harvest race window** (closed by
   [issue #304](https://github.com/Brad-Edwards/aptl/issues/304)):
   `PersistentSession.close()` now resolves only after the SSH stream's

--- a/docs/adrs/adr-041-kali-capture-sidecar-ownership-boundary.md
+++ b/docs/adrs/adr-041-kali-capture-sidecar-ownership-boundary.md
@@ -1,0 +1,317 @@
+# ADR-041: Kali Capture Sidecar Ownership Boundary
+
+## Status
+
+accepted
+
+## Date
+
+2026-06-20
+
+## Context
+
+ADR-033 moved red-side behavioural capture out of the SIEM and into
+per-run artifacts. The current Kali-side writers still run in the Kali
+container:
+
+- `containers/kali/scripts/aptl-wrap-shell.sh` creates per-session
+  directories and runs `script(1)` plus `tcpdump`.
+- `containers/kali/entrypoint.sh` starts `auditd` and process accounting
+  against `/var/log/aptl/captures/_audit` and `_proc-acct`.
+- `mcp/aptl-mcp-common/src/captures.ts` harvests the named volume with
+  `docker cp` into `.aptl/runs/<run_id>/kali-side/<session_id>/`.
+
+The workload user is `kali` and intentionally has passwordless sudo for
+legitimate red-team tooling. That means ordinary Unix ownership inside the
+same container is not a sufficient capture-integrity boundary: after
+`sudo su -`, the workload can remove or truncate root-owned files under the
+same writable mount. Making a helper daemon root-owned inside Kali, or writing
+as a dedicated capture user inside the same mount namespace, does not satisfy
+the issue #305 acceptance criteria by itself.
+
+## Decision
+
+Use a dedicated capture sidecar service, `aptl-kali-capture`, as the
+Kali-side capture writer. The sidecar is part of the `kali` profile, shares
+ONLY the Kali container's network namespace (so tcpdump sees Kali's traffic
+and the abstract socket is mutually reachable), and mounts the `kali_captures`
+volume read-write. It deliberately does NOT share Kali's PID namespace: a
+shared PID namespace would let a sudo-root Kali shell traverse
+`/proc/<sidecar-pid>/root` into the sidecar's mount namespace and reach the
+evidence. auditd and process accounting are kernel-wide and need no PID
+sharing to observe Kali's processes.
+
+**The Kali workload container does not mount `kali_captures` at all, not even
+read-only.** A read-only mount blocks writes but not reads: a `sudo`-capable
+agent can still `cat` a sibling session's `pty/typescript` or pcap on an `ro`
+mount, which would leave issue #305's cross-session-disclosure criterion
+(added in the issue thread) unmet. The only way to deny *read, list, and
+modify* to a sudo-root shell is to keep the capture sink out of the workload
+container's mount namespace entirely. The `kali` user, including after
+`sudo su -`, therefore has no filesystem path to any capture evidence,
+neither its own session's nor any other's.
+
+The host-side harvest runs `docker cp` against the **sidecar**
+(`aptl-kali-capture`), not the workload container, since the sidecar is where
+the volume is mounted. This is wired through the existing capture-container
+configuration path (`capture_container_name` in the MCP lab config; see
+`resolveCaptureContainer`), so no second harvester is introduced.
+
+The Kali ForceCommand wrapper remains the single SSH session ingress point, but
+it stops writing capture files directly. Its responsibility becomes:
+
+- validate/fallback `APTL_RUN_ID` and `APTL_SESSION_ID` with the canonical
+  OBS-003 identifier contract;
+- open a local Unix-domain control connection to the capture sidecar;
+- notify the sidecar of session start and session exit;
+- continue the shell session if the sidecar is unavailable, logging a narrow
+  warning rather than rejecting SSH login.
+
+The sidecar owns all paths below `/var/log/aptl/captures`:
+
+- per-session PTY transcript/timing artifacts;
+- per-session pcap rotation;
+- `_audit/audit.log`;
+- `_proc-acct/pacct`.
+
+The sidecar also owns `auditd` and `accton` startup. Move
+`AUDIT_CONTROL`, `AUDIT_WRITE`, and `SYS_PACCT` capability requirements from
+the Kali workload service to the sidecar wherever Docker permits. Kali keeps
+only capabilities required by red-team tooling, such as `NET_RAW` and
+`NET_ADMIN`; it must not retain capabilities whose only purpose is starting,
+stopping, or reconfiguring the capture subsystems.
+
+## RPC Contract
+
+The sidecar RPC is a small local control protocol, not a file API.
+
+- Transport: Unix-domain socket only. Prefer an abstract socket, or a socket
+  path made available to Kali through a read-only mount, so sudo-root in Kali
+  cannot unlink or replace the endpoint.
+- Authentication/authority: use kernel peer credentials and a per-session
+  control connection. Do not use an env-var token, argv token, shared secret,
+  or file token that the Kali workload can read after sudo.
+- Messages: bounded JSON frames with a version, event type, run id, session id,
+  timestamp, and minimal process metadata. If the chosen PTY recorder needs
+  byte frames from the wrapper, those frames are append-only data events on
+  the same session connection.
+- Path derivation: the sidecar derives all filesystem paths from validated
+  run/session ids and fixed capture-root constants. RPC messages must never
+  carry absolute output paths, relative path fragments, shell commands, chmod
+  modes, delete requests, truncate requests, or arbitrary tcpdump arguments.
+- Lifecycle: start is idempotent for a session; exit/EOF finalizes the
+  per-session capture. A stop/finalize frame is accepted only from the same
+  registered peer connection or registered peer pid. Other Kali processes,
+  including sudo-root shells, may at most cause an observable denial-of-service;
+  they must not gain a write/delete primitive over capture files.
+
+`script(1)` is not magic by itself in a sidecar. The implementation must make
+the sidecar the owner of the PTY transcript data path. Running `script(1)` in
+the sidecar is acceptable only if it actually owns the wrapped PTY/session
+recording. Otherwise, the sidecar should write script-compatible
+typescript/timing artifacts from a wrapper-to-sidecar byte stream. Do not leave
+`script(1)` writing in the Kali container and call the result protected.
+
+## Security Layers
+
+- **Auth surface:** no host-published port and no remote API. The only new
+  control surface is local to the Kali network namespace (the abstract socket).
+  It accepts only the bounded capture-control contract above and never exposes
+  command execution or filesystem mutation operations.
+- **Secret handling:** the RPC carries correlation ids and capture metadata,
+  not secrets. Captured PTY, pcap, audit, and pacct content may contain
+  secret-shaped target data by design; treat these files as raw evidence with
+  restrictive modes. Do not log transcript bytes, pcap payloads, command lines
+  with credentials, or raw audit records from the sidecar on failures.
+- **Identifier validation:** reuse the canonical OBS-003 id rule already
+  mirrored by `src/aptl/core/runstore.py`, `mcp/aptl-mcp-common/src/runs.ts`,
+  MCP ingress session checks, and the Bash wrapper: `^[A-Za-z0-9_][A-Za-z0-9._-]*$`
+  and no `..`. Do not add a looser sidecar-only schema.
+- **Config shape:** the sidecar is part of the existing Compose `kali` profile,
+  not a new durable `aptl.json` feature flag. If implementation needs runtime
+  knobs for socket name, capture root, enabled capture classes, or pcap
+  rotation limits, define them as sidecar environment variables with explicit
+  parser/shape checks and safe defaults. Add `AptlConfig` fields only for
+  durable first-party user configuration.
+- **OS and mount exposure:** the capture volume is mounted read-write only in
+  the sidecar and is **not mounted in the Kali workload at all**. The barrier
+  is the absence of the sink from Kali's mount namespace, not `0700
+  root:root`, `chattr`, setuid helpers, a non-sudo capture user, or an `ro`
+  mount (all of which a `sudo`-capable agent reads through or around).
+- **Process argv:** do not pass secrets, full command lines, or user-controlled
+  tcpdump expressions through shell strings. Prefer argv arrays and fixed
+  recorder arguments such as the existing pcap rotation policy.
+- **Error envelopes:** writer unavailability is best-effort: wrapper logs and
+  continues; MCP close handlers preserve the existing `harvest_warning`
+  behavior; startup/readiness surfaces may report degraded capture state using
+  the existing health/readiness pattern. Do not introduce a new exception
+  hierarchy or make capture startup a hard precondition for opening a shell.
+- **Persistence and harvest:** keep the host-side run layout owned by
+  `LocalRunStore` and `mcp/aptl-mcp-common/src/runs.ts`. Keep
+  `mcp/aptl-mcp-common/src/captures.ts` as the harvest/chmod boundary and
+  preserve its no-PATH Docker binary resolution. Harvest runs against the
+  sidecar (`aptl-kali-capture`), resolved through the existing
+  container-name configuration path: a `capture_container_name` field on the
+  MCP lab config that `resolveCaptureContainer` returns in preference to the
+  workload `container_name`. No second harvester is introduced; `docker cp`
+  reads the same volume from whichever container mounts it.
+
+## Maintainability
+
+Implementations must build on the existing incumbents:
+
+- `containers/kali/scripts/aptl-wrap-shell.sh`: the single ForceCommand entry
+  point and the existing Bash id fallback contract.
+- `containers/kali/audit/aptl.rules`: the canonical audit rule set. Copy or
+  mount this into the sidecar; do not duplicate rule text.
+- `mcp/aptl-mcp-common/src/ssh.ts`: `APTL_SESSION_ID`, `APTL_RUN_ID`, bound
+  run id, remote-close await, and best-effort PTY tee semantics.
+- `mcp/aptl-mcp-common/src/tools/handlers.ts`: close-session and close-all
+  harvest warning envelopes.
+- `mcp/aptl-mcp-common/src/captures.ts`: docker-copy harvest, global
+  `_audit` / `_proc-acct` collection, destination chmod repair, and
+  fail-loud missing-source behavior.
+- `src/aptl/core/runstore.py` and `mcp/aptl-mcp-common/src/runs.ts`: per-run
+  directory and id contracts.
+- ADR-033 non-contamination: do not reintroduce Wazuh, rsyslog, SIEM dispatch,
+  or a blue-visible red telemetry feed from Kali.
+- ADR-028, ADR-029, ADR-030, ADR-031, and ADR-037 for generated state,
+  secret handling, degraded readiness, lifecycle envelopes, and Docker/Compose
+  boundary discipline.
+
+Static and live tests should pin the boundary, not just the happy path:
+
+- Compose consistency: `kali_captures` is NOT mounted in the Kali workload at
+  all, read-write in `aptl-kali-capture`; sidecar shares Kali pid/net
+  namespaces; sidecar has no host ports and no `hostname` (which conflicts
+  with `network_mode: service:`); capture-only caps are not on the Kali
+  workload service.
+- OBS-003 live tests: `sudo su -` in Kali cannot read, list, remove,
+  truncate, or modify the capture sink (the volume is absent from Kali's mount
+  namespace); per-session PTY, pcap, auditd, and pacct survive a
+  `sudo rm -rf /var/log/aptl/captures/*` attempt; a Kali shell in session N
+  cannot read session M's captures.
+- RPC unit tests: invalid ids, path-bearing messages, delete/truncate frames,
+  spoofed stop/finalize attempts, and writer-unavailable paths.
+- Existing MCP tests: harvest remains best-effort and surfaces warnings rather
+  than breaking command/session results.
+
+## Extensibility
+
+The extensibility seam is the sidecar-owned capture writer contract:
+
+- socket endpoint;
+- capture root;
+- enabled capture classes;
+- pcap rotation limits;
+- future session-scoped capture subdirectories under
+  `<state>/runs/<run_id>/kali-side/<session_id>/`.
+
+Add the next capture source by extending the sidecar writer and adding a new
+subdirectory under the existing per-session or `_global` layout. Do not change
+the run archive root, duplicate the harvester, or add another MCP session id
+concept.
+
+## PTY transcript authenticity (residual)
+
+This boundary makes capture evidence **undeletable and unreadable** by the
+Kali workload, and makes the genuinely Kali-side witnesses (per-session
+**pcap**, **auditd**, and **process accounting**) **tamper-resistant**,
+because the sidecar produces them from kernel sources the workload does not
+feed. It does **not** make the Kali-side PTY *typescript* tamper-proof for the
+workload's own session.
+
+The reason is fundamental: a shell transcript is generated by the shell, which
+runs in the Kali container. Any capture of it that the workload can feed or
+write (here, `script(1)` to a wrapper FIFO to `aptl-capture-client` to the
+sidecar RPC) can be forged by a sudo-capable workload for its own session: it
+can type fake output, run the client by hand, or write to the FIFO/fds of its
+own wrapper. Connection ownership stops one session from forging *another*
+session's transcript and the single-use session-id rule stops reopening a
+*finalized* session for append, but neither prevents a session from forging
+*its own* in-flight transcript.
+
+The authoritative, tamper-resistant keystroke/output record is therefore the
+**MCP-side PTY tee** (`createPtyTeeWriter` in `mcp/aptl-mcp-common/src/runs.ts`),
+which runs in the MCP server process outside every container and which the Kali
+workload cannot reach, exactly as issue #305's own framing states. The
+Kali-side typescript is a convenience secondary to it.
+
+Fully tamper-proofing the Kali-side typescript would require the sidecar to own
+the PTY master itself (moving sshd / PTY proxying into the sidecar), a much
+larger rearchitecture that changes the SSH/shell execution model and is out of
+scope for this boundary. It would be its own ADR if pursued.
+
+## Consequences
+
+### Positive
+
+- The capture sink is outside the Kali workload's write authority, including
+  sudo-root inside the Kali container.
+- The red workload remains operational when the writer is degraded.
+- The architecture preserves ADR-033 non-contamination by keeping observation
+  outside the blue defensive stack.
+- MCP-side PTY tee, tool-call JSONL, OCSF JSONL, and Kali-side artifacts keep
+  the same correlation keys and host-side run layout.
+
+### Negative
+
+- The lab gains another container in the `kali` profile.
+- Session capture now has an RPC lifecycle that must be tested for ordering,
+  spoofing, and unavailable-writer behavior.
+- PTY transcript capture needs deliberate design; sharing the network
+  namespace alone does not make sidecar `script(1)` observe a shell. The
+  Kali-side transcript is therefore supplied by the workload over the RPC and
+  is NOT tamper-resistant against a sudo-capable Kali user (see "PTY transcript
+  authenticity" below); the authoritative keystroke/output record is the
+  MCP-side PTY tee, and the tamper-resistant Kali-side witnesses are the
+  sidecar-produced pcap, auditd, and process-accounting streams.
+
+### Risks
+
+- A sudo-root Kali workload can still attempt denial-of-service against the
+  session, wrapper, network namespace, or capture sidecar. This ADR prevents
+  read, delete, alter, and truncate of capture evidence from Kali; it does
+  not make the workload incapable of noisy self-sabotage.
+- Docker/runtime differences around auditd, process accounting, and Unix
+  socket mounts can degrade capture on some hosts. That degradation must be
+  visible through the existing readiness/logging surfaces.
+- If implementation mounts the volume in Kali at all (even read-only), the
+  design fails the cross-session read-isolation acceptance criterion regardless
+  of daemon code quality: `ro` blocks writes, not a sudo-root `cat`.
+
+## Non-Goals
+
+- Do not remove Kali passwordless sudo or reduce legitimate red-team tooling.
+- Do not redesign MCP command execution, session queues, OCSF schemas,
+  redaction helpers, runstore layout, or export/archive semantics.
+- Do not make capture writer availability a hard gate for SSH login.
+- Do not add a database, broker, remote service, or SIEM transport for the
+  capture path.
+- Do not solve complete anti-evasion or anti-DoS against a sudo-capable
+  workload in this issue.
+
+## Anti-Patterns
+
+- Treating root-owned files, setuid helpers, ACLs, or a dedicated capture user
+  inside the same writable Kali container as tamper-resistant against
+  `sudo su -`.
+- Mounting `kali_captures` into Kali at all (read-write or read-only) for
+  wrapper or harvest compatibility. A read-only mount still exposes every
+  session's evidence to a sudo-root `cat`.
+- Letting the wrapper create, chmod, truncate, rotate, or delete files under
+  `/var/log/aptl/captures`.
+- Adding a second id regex, second run directory layout, second harvester, or
+  second capture-warning envelope.
+- Accepting arbitrary paths, shell commands, tcpdump filters, delete requests,
+  or chmod/chown requests over the sidecar RPC.
+- Authenticating the RPC with a token in environment variables, argv, a file in
+  Kali, or any material readable by the workload after sudo.
+- Reintroducing any red-to-SIEM pipe as a shortcut for durable capture.
+
+## Related
+
+- [Issue #305](https://github.com/Brad-Edwards/aptl/issues/305)
+- [ADR-033: Red-Side Behavioural Capture and Non-Contamination Boundary](adr-033-agent-reasoning-trace-boundary.md)
+- [ADR-029: Control-Plane Secret Handling in Run Data and Local State](adr-029-control-plane-secret-handling.md)
+- [ADR-037: Docker Compose Backend Cohesion](adr-037-docker-compose-backend-cohesion.md)

--- a/mcp/aptl-mcp-common/src/captures.ts
+++ b/mcp/aptl-mcp-common/src/captures.ts
@@ -1,19 +1,21 @@
 /**
- * Per-session capture harvest from the Kali container.
+ * Per-session capture harvest from the Kali capture sidecar.
  *
- * OBS-003 / ADR-033 design: the Kali container writes per-session
- * captures (PTY typescript+timing, pcap, audit/proc-acct snapshots)
- * into a docker named volume at `/var/log/aptl/captures/<run_id>/<session_id>/`.
- * The volume is invisible to the host filesystem to prevent cross-
- * scenario tampering by the kali user (codex pre-push cycle 1
- * finding-10).
+ * OBS-003 / ADR-033 / ADR-041 design: the `aptl-kali-capture` sidecar (not the
+ * Kali workload) writes per-session captures (PTY typescript, pcap,
+ * audit/proc-acct snapshots) into a docker named volume at
+ * `/var/log/aptl/captures/<run_id>/<session_id>/`. The Kali workload does not
+ * mount the volume at all, so a sudo-capable agent cannot read or tamper with
+ * evidence (ADR-041). The volume is invisible to the host filesystem to
+ * prevent cross-scenario tampering (codex pre-push cycle 1 finding-10).
  *
- * When an SSH session closes, the MCP server invokes
- * `harvestSession()` which runs `docker cp` to copy the per-session
- * subtree out into `.aptl/runs/<run_id>/kali-side/<session_id>/`
- * on the host, then sets 0600 permissions on every file. The
- * harvest is best-effort — a missing container / docker / missing
- * subdir logs to stderr but does not throw out of the close path.
+ * When an SSH session closes, the MCP server invokes `harvestSession()` which
+ * runs `docker cp` against the capture container (the sidecar — see
+ * `resolveCaptureContainer` / `capture_container_name`) to copy the
+ * per-session subtree out into `.aptl/runs/<run_id>/kali-side/<session_id>/`
+ * on the host, then sets 0600 permissions on every file. The harvest is
+ * best-effort — a missing container / docker / missing subdir logs to stderr
+ * but does not throw out of the close path.
  */
 
 import { spawn } from 'node:child_process';
@@ -23,7 +25,8 @@ import { join } from 'node:path';
 import { kaliSideSessionDir, loadActiveTraceId } from './runs.js';
 
 export interface HarvestOptions {
-  /** Docker container to harvest from (e.g. `aptl-kali`). */
+  /** Docker container to harvest from. Per ADR-041 this is the capture
+   * sidecar (e.g. `aptl-kali-capture`), which owns the captures volume. */
   containerName: string;
   /** Path inside the container that holds per-run capture subdirs.
    * Defaults to `/var/log/aptl/captures` to match the wrapper. */

--- a/mcp/aptl-mcp-common/src/config.ts
+++ b/mcp/aptl-mcp-common/src/config.ts
@@ -28,6 +28,14 @@ export interface LabConfig {
       ssh_port: number;
       enabled: boolean;
       shell?: 'bash' | 'sh' | 'powershell' | 'cmd';
+      /**
+       * ADR-041 / issue #305: container to harvest per-session captures from,
+       * when it differs from the workload container. The Kali capture sidecar
+       * (`aptl-kali-capture`) owns the captures volume; the workload container
+       * does not mount it, so harvest must target the sidecar. Defaults to
+       * `container_name` when unset (workload also owns its captures).
+       */
+      capture_container_name?: string;
     };
   };
   api?: {

--- a/mcp/aptl-mcp-common/src/tools/handlers.ts
+++ b/mcp/aptl-mcp-common/src/tools/handlers.ts
@@ -9,6 +9,13 @@ import { harvestSession } from '../captures.js';
  * the literal otherwise repeats in every handler's catch block). */
 const UNKNOWN_ERROR = 'Unknown error';
 
+/** Normalize a caught value to a message string for the failure envelope.
+ * Centralizes the `instanceof Error` narrowing so it is defined and covered
+ * once instead of duplicated across every handler's catch block. */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : UNKNOWN_ERROR;
+}
+
 /**
  * Reject session ids whose JSON-schema pattern admits them but which
  * still contain the `..` path-traversal token (the schema regex
@@ -242,7 +249,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             text: JSON.stringify({
               command,
               success: false,
-              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+              error: errorMessage(error),
             }, null, 2),
           },
         ],
@@ -300,7 +307,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             type: 'text',
             text: JSON.stringify({
               success: false,
-              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+              error: errorMessage(error),
             }, null, 2),
           },
         ],
@@ -359,7 +366,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             type: 'text',
             text: JSON.stringify({
               success: false,
-              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+              error: errorMessage(error),
             }, null, 2),
           },
         ],
@@ -403,7 +410,7 @@ const baseHandlers: Record<string, ToolHandler> = {
               success: false,
               session_id,
               command,
-              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+              error: errorMessage(error),
             }, null, 2),
           },
         ],
@@ -444,7 +451,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             type: 'text',
             text: JSON.stringify({
               success: false,
-              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+              error: errorMessage(error),
             }, null, 2),
           },
         ],
@@ -503,7 +510,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             text: JSON.stringify({
               success: false,
               session_id,
-              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+              error: errorMessage(error),
             }, null, 2),
           },
         ],
@@ -545,7 +552,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             text: JSON.stringify({
               success: false,
               session_id,
-              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+              error: errorMessage(error),
             }, null, 2),
           },
         ],
@@ -605,7 +612,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             type: 'text',
             text: JSON.stringify({
               success: false,
-              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+              error: errorMessage(error),
             }, null, 2),
           },
         ],

--- a/mcp/aptl-mcp-common/src/tools/handlers.ts
+++ b/mcp/aptl-mcp-common/src/tools/handlers.ts
@@ -5,6 +5,10 @@ import { LabConfig, getTargetCredentials } from '../config.js';
 import { ShellType } from '../shells.js';
 import { harvestSession } from '../captures.js';
 
+/** Fallback message when a caught value is not an Error (SonarCloud S1192 —
+ * the literal otherwise repeats in every handler's catch block). */
+const UNKNOWN_ERROR = 'Unknown error';
+
 /**
  * Reject session ids whose JSON-schema pattern admits them but which
  * still contain the `..` path-traversal token (the schema regex
@@ -238,7 +242,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             text: JSON.stringify({
               command,
               success: false,
-              error: error instanceof Error ? error.message : 'Unknown error',
+              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
             }, null, 2),
           },
         ],
@@ -296,7 +300,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             type: 'text',
             text: JSON.stringify({
               success: false,
-              error: error instanceof Error ? error.message : 'Unknown error',
+              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
             }, null, 2),
           },
         ],
@@ -355,7 +359,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             type: 'text',
             text: JSON.stringify({
               success: false,
-              error: error instanceof Error ? error.message : 'Unknown error',
+              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
             }, null, 2),
           },
         ],
@@ -399,7 +403,7 @@ const baseHandlers: Record<string, ToolHandler> = {
               success: false,
               session_id,
               command,
-              error: error instanceof Error ? error.message : 'Unknown error',
+              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
             }, null, 2),
           },
         ],
@@ -440,7 +444,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             type: 'text',
             text: JSON.stringify({
               success: false,
-              error: error instanceof Error ? error.message : 'Unknown error',
+              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
             }, null, 2),
           },
         ],
@@ -499,7 +503,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             text: JSON.stringify({
               success: false,
               session_id,
-              error: error instanceof Error ? error.message : 'Unknown error',
+              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
             }, null, 2),
           },
         ],
@@ -541,7 +545,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             text: JSON.stringify({
               success: false,
               session_id,
-              error: error instanceof Error ? error.message : 'Unknown error',
+              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
             }, null, 2),
           },
         ],
@@ -601,7 +605,7 @@ const baseHandlers: Record<string, ToolHandler> = {
             type: 'text',
             text: JSON.stringify({
               success: false,
-              error: error instanceof Error ? error.message : 'Unknown error',
+              error: error instanceof Error ? error.message : UNKNOWN_ERROR,
             }, null, 2),
           },
         ],

--- a/mcp/aptl-mcp-common/src/tools/handlers.ts
+++ b/mcp/aptl-mcp-common/src/tools/handlers.ts
@@ -24,20 +24,26 @@ function assertSessionIdContract(value: unknown): asserts value is string {
 }
 
 /**
- * OBS-003 / ADR-033: resolve the docker container name that backs
- * the SSH target for this MCP server, so the close_session /
- * close_all_sessions handlers can harvest per-session captures out
- * of the `kali_captures` (or analogous) named volume into
- * `.aptl/runs/<run_id>/kali-side/<session_id>/` on the host.
+ * OBS-003 / ADR-033 / ADR-041: resolve the docker container the
+ * close_session / close_all_sessions handlers harvest per-session captures
+ * from, into `.aptl/runs/<run_id>/kali-side/<session_id>/` on the host.
  *
- * Returns `undefined` when the lab is configured for an API-only
- * target (no container) or when the configKey is missing — those
- * MCP servers don't ship captures and harvest is a no-op.
+ * Per ADR-041 the capture sink may be owned by a dedicated sidecar that the
+ * workload container does not mount (so a sudo-capable agent cannot read or
+ * tamper with evidence). When `capture_container_name` is set, harvest targets
+ * it (e.g. `aptl-kali-capture`); otherwise it falls back to the workload's own
+ * `container_name`.
+ *
+ * Returns `undefined` when the lab is configured for an API-only target (no
+ * container) or when the configKey is missing — those MCP servers don't ship
+ * captures and harvest is a no-op.
  */
-function resolveCaptureContainer(labConfig: LabConfig): string | undefined {
+export function resolveCaptureContainer(labConfig: LabConfig): string | undefined {
   const key = labConfig.server.configKey;
   if (!key || !labConfig.containers) return undefined;
-  return labConfig.containers[key]?.container_name;
+  const container = labConfig.containers[key];
+  if (!container) return undefined;
+  return container.capture_container_name ?? container.container_name;
 }
 
 /**

--- a/mcp/aptl-mcp-common/tests/tools-handlers.test.ts
+++ b/mcp/aptl-mcp-common/tests/tools-handlers.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
-import { generateToolHandlers, resolveCaptureContainer } from '../src/tools/handlers.js';
+import { generateToolHandlers, resolveCaptureContainer, errorMessage } from '../src/tools/handlers.js';
+
+describe('errorMessage', () => {
+  it('returns the message of an Error', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('falls back to "Unknown error" for a non-Error value', () => {
+    // Covers the false branch of the instanceof narrowing — the catch blocks
+    // only ever throw Errors, so this is the only place the fallback runs.
+    expect(errorMessage('a thrown string')).toBe('Unknown error');
+    expect(errorMessage(undefined)).toBe('Unknown error');
+  });
+});
 
 // Partial mock: keep SSHError as a real Error subclass so
 // `assertSessionIdContract` in handlers.ts throws an object whose `.message`
@@ -286,6 +299,16 @@ describe('resolveCaptureContainer (ADR-041 harvest target)', () => {
 
   it('returns undefined for an API-only target (no containers)', () => {
     const labConfig = { ...base, server: { configKey: '' } } as any;
+    expect(resolveCaptureContainer(labConfig)).toBeUndefined();
+  });
+
+  it('returns undefined when configKey is set but containers is absent', () => {
+    const labConfig = { ...base } as any; // no `containers` key
+    expect(resolveCaptureContainer(labConfig)).toBeUndefined();
+  });
+
+  it('returns undefined when the configKey container is missing', () => {
+    const labConfig = { ...base, containers: { other: { container_name: 'x' } } } as any;
     expect(resolveCaptureContainer(labConfig)).toBeUndefined();
   });
 });

--- a/mcp/aptl-mcp-common/tests/tools-handlers.test.ts
+++ b/mcp/aptl-mcp-common/tests/tools-handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { generateToolHandlers } from '../src/tools/handlers.js';
+import { generateToolHandlers, resolveCaptureContainer } from '../src/tools/handlers.js';
 
 // Partial mock: keep SSHError as a real Error subclass so
 // `assertSessionIdContract` in handlers.ts throws an object whose `.message`
@@ -169,7 +169,15 @@ describe('assertSessionIdContract — canonical session_id at MCP ingress', () =
       { session_id: '', command: 'whoami' },
       ctx,
     );
-    expect(result.content[0].text.toLowerCase()).toContain('session_id');
+    // Assert on the assertSessionIdContract message specifically, NOT just the
+    // presence of "session_id" — the JSON envelope always carries a
+    // `"session_id"` key, so a mere `toContain('session_id')` would also pass
+    // if the contract were removed and a downstream TypeError were caught
+    // instead (test-quality review cycle 1). The "must be a non-empty string"
+    // phrasing only appears in the SSHError the contract throws.
+    const body = JSON.parse(result.content[0].text);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('must be a non-empty string');
   });
 
   it.each([
@@ -193,6 +201,41 @@ describe('assertSessionIdContract — canonical session_id at MCP ingress', () =
       ctx,
     );
     expect(result.content[0].text.toLowerCase()).toContain("'..'");
+  });
+});
+
+describe('resolveCaptureContainer (ADR-041 harvest target)', () => {
+  const base = {
+    server: { configKey: 'kali', targetName: 'Kali' },
+    lab: { name: 'aptl-local', network_subnet: '172.20.0.0/16' },
+  };
+
+  it('harvests from capture_container_name when set (sidecar)', () => {
+    const labConfig = {
+      ...base,
+      containers: {
+        kali: {
+          container_name: 'aptl-kali',
+          capture_container_name: 'aptl-kali-capture',
+        },
+      },
+    } as any;
+    // ADR-041: captures live in the sidecar, not the workload container, so a
+    // sudo-capable agent cannot read or tamper with them.
+    expect(resolveCaptureContainer(labConfig)).toBe('aptl-kali-capture');
+  });
+
+  it('falls back to container_name when capture_container_name is unset', () => {
+    const labConfig = {
+      ...base,
+      containers: { kali: { container_name: 'aptl-kali' } },
+    } as any;
+    expect(resolveCaptureContainer(labConfig)).toBe('aptl-kali');
+  });
+
+  it('returns undefined for an API-only target (no containers)', () => {
+    const labConfig = { ...base, server: { configKey: '' } } as any;
+    expect(resolveCaptureContainer(labConfig)).toBeUndefined();
   });
 });
 

--- a/mcp/aptl-mcp-common/tests/tools-handlers.test.ts
+++ b/mcp/aptl-mcp-common/tests/tools-handlers.test.ts
@@ -204,6 +204,57 @@ describe('assertSessionIdContract — canonical session_id at MCP ingress', () =
   });
 });
 
+describe('handler error paths return a failure envelope', () => {
+  // Every session/command handler wraps its body in try/catch and returns
+  // `{ success: false, error: <message | UNKNOWN_ERROR> }`. Drive each handler
+  // through its catch with an sshManager that throws on any call, so the
+  // failure-envelope line is exercised (and the UNKNOWN_ERROR fallback line is
+  // not dead code). Args use a VALID session id so the handler passes ingress
+  // validation and reaches the throwing dependency.
+  const handlers = generateToolHandlers({
+    toolPrefix: 'test',
+    targetName: 'Test',
+    configKey: 'test-container',
+  });
+  const throwingCtx = {
+    sshManager: new Proxy(
+      {},
+      { get: () => () => { throw new Error('boom'); } },
+    ) as any,
+    labConfig: {
+      server: { configKey: 'test-container', targetName: 'Test' },
+      lab: { name: 'test-lab', network_subnet: '172.20.0.0/16' },
+      containers: {
+        'test-container': {
+          container_name: 'aptl-test',
+          container_ip: '172.20.0.50',
+          ssh_key: '/tmp/nonexistent-key',
+          ssh_user: 'testuser',
+          ssh_port: 2022,
+          enabled: true,
+        },
+      },
+    } as any,
+  };
+
+  it.each([
+    ['run_command', 'test_run_command', { command: 'whoami' }],
+    ['interactive_session', 'test_interactive_session', { session_id: 'sess-1' }],
+    ['background_session', 'test_background_session', { session_id: 'sess-1' }],
+    ['session_command', 'test_session_command', { session_id: 'sess-1', command: 'whoami' }],
+    ['list_sessions', 'test_list_sessions', {}],
+    ['close_session', 'test_close_session', { session_id: 'sess-1' }],
+    ['get_session_output', 'test_get_session_output', { session_id: 'sess-1' }],
+    ['close_all_sessions', 'test_close_all_sessions', {}],
+  ])('%s returns a failure envelope when its dependency throws', async (_label, handlerName, args) => {
+    const result = await handlers[handlerName](args as any, throwingCtx);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.success).toBe(false);
+    expect(typeof body.error).toBe('string');
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+});
+
 describe('resolveCaptureContainer (ADR-041 harvest target)', () => {
   const base = {
     server: { configKey: 'kali', targetName: 'Kali' },

--- a/mcp/mcp-red/docker-lab-config.json
+++ b/mcp/mcp-red/docker-lab-config.json
@@ -15,6 +15,7 @@
   "containers": {
     "kali": {
       "container_name": "aptl-kali",
+      "capture_container_name": "aptl-kali-capture",
       "container_ip": "172.20.4.30",
       "ssh_key": "~/.ssh/aptl_lab_key",
       "ssh_user": "kali",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -411,6 +411,15 @@ def kali_exec(cmd: str, timeout: int = 60) -> subprocess.CompletedProcess:
     return docker_exec("aptl-kali", cmd, timeout=timeout)
 
 
+def kali_capture_exec(cmd: str, timeout: int = 60) -> subprocess.CompletedProcess:
+    """Run a command inside the Kali capture sidecar (ADR-041).
+
+    The sidecar owns the kali_captures volume read-write; the Kali workload
+    does not mount it, so capture-evidence assertions must run here.
+    """
+    return docker_exec("aptl-kali-capture", cmd, timeout=timeout)
+
+
 def workstation_exec(
     cmd: str, timeout: int = 60,
 ) -> subprocess.CompletedProcess:

--- a/tests/test_kali_capture_compose.py
+++ b/tests/test_kali_capture_compose.py
@@ -1,0 +1,171 @@
+"""Compose consistency tests for the ADR-041 Kali capture sidecar boundary.
+
+These tests parse docker-compose.yml directly and do NOT require a running
+lab (no APTL_SMOKE / LIVE_LAB gate).  They run in every CI unit-test pass.
+
+Issue #305 / ADR-041.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Helper: load docker-compose.yml once for compose-consistency tests
+# ---------------------------------------------------------------------------
+_COMPOSE_PATH = Path(__file__).parent.parent / "docker-compose.yml"
+
+
+def _load_compose() -> dict:
+    with _COMPOSE_PATH.open() as fh:
+        return yaml.safe_load(fh)
+
+
+class TestComposeConsistency:
+    """Static assertions about docker-compose.yml that pin the ADR-041 boundary."""
+
+    def test_kali_has_no_captures_mount(self):
+        """kali service must NOT mount kali_captures at all (ADR-041).
+
+        A read-only mount would still let a sudo-capable agent READ sibling
+        sessions' evidence (ro blocks writes, not reads). The only way to deny
+        read/list/modify to a sudo-root shell is to keep the capture sink out
+        of the workload container's mount namespace entirely — the sidecar
+        owns it and harvest runs against the sidecar.
+        """
+        compose = _load_compose()
+        kali_volumes = compose["services"]["kali"].get("volumes", [])
+        # Catch BOTH short-form ("kali_captures:/path[:ro]") and long-form
+        # ({type: volume, source: kali_captures, ...}) entries — a dict-form
+        # mount would otherwise slip past a str-only filter and re-expose the
+        # volume to a sudo-capable agent (test-quality review cycle 1).
+        captures_entries = [
+            v for v in kali_volumes
+            if (isinstance(v, str) and "kali_captures" in v)
+            or (isinstance(v, dict) and v.get("source") == "kali_captures")
+        ]
+        assert not captures_entries, (
+            "kali service must NOT mount kali_captures (ADR-041 read-isolation); "
+            f"found: {captures_entries!r}"
+        )
+
+    def test_kali_capture_service_mounts_captures_rw(self):
+        """kali-capture sidecar must mount kali_captures read-write (no :ro)."""
+        compose = _load_compose()
+        services = compose.get("services", {})
+        assert "kali-capture" in services, (
+            "kali-capture service must exist in docker-compose.yml (ADR-041)"
+        )
+        sidecar_volumes = services["kali-capture"].get("volumes", [])
+        str_entries = [
+            v for v in sidecar_volumes
+            if isinstance(v, str) and "kali_captures" in v
+        ]
+        dict_entries = [
+            v for v in sidecar_volumes
+            if isinstance(v, dict) and v.get("source") == "kali_captures"
+        ]
+        assert str_entries or dict_entries, (
+            "kali-capture service must have a kali_captures volume entry"
+        )
+        for entry in str_entries:
+            assert not entry.endswith(":ro"), (
+                f"kali_captures must NOT be :ro in kali-capture sidecar; got: {entry!r}"
+            )
+        for entry in dict_entries:
+            assert not entry.get("read_only"), (
+                f"kali_captures must NOT be read_only in kali-capture sidecar; got: {entry!r}"
+            )
+
+    def test_audit_caps_removed_from_kali(self):
+        """AUDIT_CONTROL, AUDIT_WRITE, SYS_PACCT must NOT be in kali.cap_add."""
+        compose = _load_compose()
+        kali_caps = compose["services"]["kali"].get("cap_add", [])
+        for cap in ("AUDIT_CONTROL", "AUDIT_WRITE", "SYS_PACCT"):
+            assert cap not in kali_caps, (
+                f"{cap} must be removed from kali service cap_add (ADR-041); "
+                f"these caps belong to the kali-capture sidecar only"
+            )
+
+    def test_audit_caps_present_on_sidecar(self):
+        """AUDIT_CONTROL, AUDIT_WRITE, SYS_PACCT must be in kali-capture.cap_add."""
+        compose = _load_compose()
+        services = compose.get("services", {})
+        assert "kali-capture" in services, (
+            "kali-capture service must exist in docker-compose.yml"
+        )
+        sidecar_caps = services["kali-capture"].get("cap_add", [])
+        for cap in ("AUDIT_CONTROL", "AUDIT_WRITE", "SYS_PACCT"):
+            assert cap in sidecar_caps, (
+                f"{cap} must be in kali-capture sidecar cap_add (ADR-041)"
+            )
+
+    def test_sidecar_no_host_ports(self):
+        """kali-capture sidecar must publish no host ports."""
+        compose = _load_compose()
+        services = compose.get("services", {})
+        assert "kali-capture" in services, (
+            "kali-capture service must exist in docker-compose.yml"
+        )
+        ports = services["kali-capture"].get("ports", [])
+        assert not ports, (
+            f"kali-capture sidecar must have no host ports (ADR-041 auth surface); "
+            f"got: {ports}"
+        )
+
+    def test_sidecar_in_kali_profile(self):
+        """kali-capture must be in the kali profile."""
+        compose = _load_compose()
+        services = compose.get("services", {})
+        assert "kali-capture" in services, (
+            "kali-capture service must exist in docker-compose.yml"
+        )
+        profiles = services["kali-capture"].get("profiles", [])
+        assert "kali" in profiles, (
+            f"kali-capture sidecar must have profiles: [kali]; got: {profiles}"
+        )
+
+    def test_sidecar_has_net_raw(self):
+        """kali-capture needs NET_RAW to run tcpdump in the shared netns."""
+        compose = _load_compose()
+        sidecar_caps = compose["services"]["kali-capture"].get("cap_add", [])
+        assert "NET_RAW" in sidecar_caps, (
+            "kali-capture sidecar must have NET_RAW for per-session tcpdump "
+            f"(ADR-041); got: {sidecar_caps}"
+        )
+
+    def test_sidecar_shares_only_network_namespace(self):
+        """kali-capture shares Kali's NETWORK namespace but NOT its PID namespace.
+
+        A shared PID namespace would let a sudo-root Kali shell traverse
+        `/proc/<sidecar-pid>/root/var/log/aptl/captures` into the sidecar's
+        mount namespace and read/delete evidence (codex F2). tcpdump needs only
+        the network namespace; auditd/accton are kernel-wide.
+        """
+        compose = _load_compose()
+        sidecar = compose["services"]["kali-capture"]
+        assert sidecar.get("network_mode") == "service:kali", (
+            f"kali-capture must use network_mode service:kali; got: "
+            f"{sidecar.get('network_mode')!r}"
+        )
+        assert "pid" not in sidecar, (
+            "kali-capture must NOT share Kali's PID namespace — it opens a "
+            f"/proc/<pid>/root traversal to the capture volume (codex F2); "
+            f"got pid: {sidecar.get('pid')!r}"
+        )
+
+    def test_sidecar_has_no_hostname(self):
+        """`hostname` conflicts with `network_mode: service:` at `up` time.
+
+        Docker rejects the combination when creating the container, so a stray
+        hostname here would break a clean `aptl lab start`.
+        """
+        compose = _load_compose()
+        sidecar = compose["services"]["kali-capture"]
+        assert "hostname" not in sidecar, (
+            "kali-capture must not set hostname — it conflicts with "
+            "network_mode: service:kali and fails at container create"
+        )

--- a/tests/test_kali_capture_writer.py
+++ b/tests/test_kali_capture_writer.py
@@ -1,0 +1,342 @@
+"""Unit tests for the kali-capture sidecar writer daemon (ADR-041 / issue #305)."""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import stat
+from pathlib import Path
+
+import pytest
+
+# Load writer module from containers/kali-capture/writer.py
+_WRITER_PATH = Path(__file__).parent.parent / "containers/kali-capture/writer.py"
+
+# Opaque connection-owner tokens (the writer treats them as hashable handles).
+_OWNER_A = 1
+_OWNER_B = 2
+
+
+def _load_writer():
+    if not _WRITER_PATH.exists():
+        pytest.skip("containers/kali-capture/writer.py not yet written")
+    spec = importlib.util.spec_from_file_location("kali_capture_writer", _WRITER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def writer_mod():
+    return _load_writer()
+
+
+class TestIdValidation:
+    def test_valid_simple(self, writer_mod):
+        assert writer_mod.validate_id("abc123", "x") == "abc123"
+
+    def test_valid_underscore_prefix(self, writer_mod):
+        assert writer_mod.validate_id("_unbound", "x") == "_unbound"
+
+    def test_valid_dot_dash(self, writer_mod):
+        assert writer_mod.validate_id("run-1.0", "x") == "run-1.0"
+
+    def test_dotdot_rejected(self, writer_mod):
+        with pytest.raises(ValueError, match=".."):
+            writer_mod.validate_id("../evil", "x")
+
+    def test_slash_rejected(self, writer_mod):
+        with pytest.raises(ValueError, match="invalid"):
+            writer_mod.validate_id("a/b", "x")
+
+    def test_empty_rejected(self, writer_mod):
+        with pytest.raises(ValueError):
+            writer_mod.validate_id("", "x")
+
+    def test_leading_dot_rejected(self, writer_mod):
+        with pytest.raises(ValueError):
+            writer_mod.validate_id(".hidden", "x")
+
+
+class TestMessageParsing:
+    def test_path_bearing_message_rejected(self, writer_mod):
+        frame = {"type": "session_start", "run_id": "r1", "session_id": "s1", "output_path": "/evil"}
+        with pytest.raises(ValueError, match="forbidden"):
+            writer_mod.validate_frame(frame)
+
+    def test_delete_message_rejected(self, writer_mod):
+        frame = {"type": "delete", "run_id": "r1", "session_id": "s1"}
+        with pytest.raises(ValueError, match="forbidden"):
+            writer_mod.validate_frame(frame)
+
+    def test_truncate_message_rejected(self, writer_mod):
+        frame = {"type": "truncate", "run_id": "r1", "session_id": "s1"}
+        with pytest.raises(ValueError, match="forbidden"):
+            writer_mod.validate_frame(frame)
+
+    def test_chmod_field_rejected(self, writer_mod):
+        frame = {"type": "session_start", "run_id": "r1", "session_id": "s1", "chmod": "777"}
+        with pytest.raises(ValueError, match="forbidden"):
+            writer_mod.validate_frame(frame)
+
+    def test_valid_session_start_accepted(self, writer_mod):
+        frame = {"type": "session_start", "run_id": "r1", "session_id": "s1", "ts": 1}
+        writer_mod.validate_frame(frame)  # should not raise
+
+    def test_valid_pty_chunk_accepted(self, writer_mod):
+        frame = {
+            "type": "pty_chunk",
+            "session_id": "s1",
+            "ts": 1,
+            "b64": base64.b64encode(b"hello").decode(),
+        }
+        writer_mod.validate_frame(frame)  # should not raise
+
+    def test_valid_session_end_accepted(self, writer_mod):
+        frame = {"type": "session_end", "session_id": "s1", "ts": 1}
+        writer_mod.validate_frame(frame)  # should not raise
+
+
+class TestSessionDirs:
+    def test_session_start_creates_dirs(self, writer_mod, tmp_path):
+        capture_root = str(tmp_path / "captures")
+        state = writer_mod.WriterState(capture_root=capture_root)
+        assert state.handle_session_start("runA", "sessB", _OWNER_A) is True
+        pty_dir = tmp_path / "captures" / "runA" / "sessB" / "pty"
+        pcap_dir = tmp_path / "captures" / "runA" / "sessB" / "pcap"
+        assert pty_dir.is_dir()
+        assert pcap_dir.is_dir()
+        assert (stat.S_IMODE(pty_dir.stat().st_mode) & 0o777) == 0o700
+        assert (stat.S_IMODE(pcap_dir.stat().st_mode) & 0o777) == 0o700
+
+    def test_pty_chunk_appends_bytes(self, writer_mod, tmp_path):
+        capture_root = str(tmp_path / "captures")
+        state = writer_mod.WriterState(capture_root=capture_root)
+        state.handle_session_start("runA", "sessB", _OWNER_A)
+        raw = b"hello world"
+        state.handle_pty_chunk("sessB", base64.b64encode(raw).decode(), _OWNER_A)
+        ts_file = tmp_path / "captures" / "runA" / "sessB" / "pty" / "typescript"
+        assert ts_file.read_bytes() == raw
+
+    def test_pty_chunk_appends_multiple(self, writer_mod, tmp_path):
+        capture_root = str(tmp_path / "captures")
+        state = writer_mod.WriterState(capture_root=capture_root)
+        state.handle_session_start("runX", "sessY", _OWNER_A)
+        state.handle_pty_chunk("sessY", base64.b64encode(b"foo").decode(), _OWNER_A)
+        state.handle_pty_chunk("sessY", base64.b64encode(b"bar").decode(), _OWNER_A)
+        ts_file = tmp_path / "captures" / "runX" / "sessY" / "pty" / "typescript"
+        assert ts_file.read_bytes() == b"foobar"
+
+    def test_pty_chunk_unknown_session_ignored(self, writer_mod, tmp_path):
+        capture_root = str(tmp_path / "captures")
+        state = writer_mod.WriterState(capture_root=capture_root)
+        # No session started — should not crash
+        state.handle_pty_chunk("no_such_session", base64.b64encode(b"x").decode(), _OWNER_A)
+
+    def test_session_end_marks_closed(self, writer_mod, tmp_path):
+        capture_root = str(tmp_path / "captures")
+        state = writer_mod.WriterState(capture_root=capture_root)
+        state.handle_session_start("runA", "sessC", _OWNER_A)
+        state.handle_session_end("sessC", _OWNER_A)
+        assert "sessC" not in state.active_sessions
+
+    def test_typescript_file_mode_0600(self, writer_mod, tmp_path):
+        capture_root = str(tmp_path / "captures")
+        state = writer_mod.WriterState(capture_root=capture_root)
+        state.handle_session_start("runA", "sessD", _OWNER_A)
+        state.handle_pty_chunk("sessD", base64.b64encode(b"x").decode(), _OWNER_A)
+        state.handle_session_end("sessD", _OWNER_A)
+        ts_file = tmp_path / "captures" / "runA" / "sessD" / "pty" / "typescript"
+        if ts_file.exists():
+            assert (stat.S_IMODE(ts_file.stat().st_mode) & 0o777) == 0o600
+
+
+class TestConnectionOwnership:
+    """Codex pre-push F1/F3: a session is owned by the connection that started
+    it. Other connections cannot inject bytes into it, end it, or clobber it,
+    and a dropped connection finalizes the sessions it owned.
+    """
+
+    def test_pty_chunk_from_non_owner_ignored(self, writer_mod, tmp_path):
+        state = writer_mod.WriterState(capture_root=str(tmp_path / "captures"))
+        state.handle_session_start("runA", "sess1", _OWNER_A)
+        # Owner B tries to forge bytes into owner A's session — must be ignored.
+        state.handle_pty_chunk("sess1", base64.b64encode(b"FORGED").decode(), _OWNER_B)
+        # Owner A's legit bytes land.
+        state.handle_pty_chunk("sess1", base64.b64encode(b"real").decode(), _OWNER_A)
+        ts = tmp_path / "captures" / "runA" / "sess1" / "pty" / "typescript"
+        assert ts.read_bytes() == b"real"
+
+    def test_session_end_from_non_owner_ignored(self, writer_mod, tmp_path):
+        state = writer_mod.WriterState(capture_root=str(tmp_path / "captures"))
+        state.handle_session_start("runA", "sess2", _OWNER_A)
+        # Owner B tries to end owner A's session early — must be ignored.
+        state.handle_session_end("sess2", _OWNER_B)
+        assert "sess2" in state.active_sessions
+        # The real owner can still end it.
+        state.handle_session_end("sess2", _OWNER_A)
+        assert "sess2" not in state.active_sessions
+
+    def test_duplicate_start_different_owner_rejected(self, writer_mod, tmp_path):
+        state = writer_mod.WriterState(capture_root=str(tmp_path / "captures"))
+        state.handle_session_start("runA", "sess3", _OWNER_A)
+        state.handle_pty_chunk("sess3", base64.b64encode(b"keep").decode(), _OWNER_A)
+        # Owner B re-starts the same session id: must be rejected, not clobber.
+        assert state.handle_session_start("runA", "sess3", _OWNER_B) is False
+        assert state.active_sessions["sess3"]["owner"] == _OWNER_A
+        # Owner A's data is intact (no truncating re-open).
+        state.handle_pty_chunk("sess3", base64.b64encode(b"more").decode(), _OWNER_A)
+        ts = tmp_path / "captures" / "runA" / "sess3" / "pty" / "typescript"
+        assert ts.read_bytes() == b"keepmore"
+
+    def test_duplicate_start_same_owner_idempotent(self, writer_mod, tmp_path):
+        state = writer_mod.WriterState(capture_root=str(tmp_path / "captures"))
+        assert state.handle_session_start("runA", "sess4", _OWNER_A) is True
+        assert state.handle_session_start("runA", "sess4", _OWNER_A) is True
+
+    def test_reopen_after_finalize_rejected(self, writer_mod, tmp_path):
+        # A session id is single-use: once finalized it must not be reopened for
+        # append, or forged bytes could be tacked onto harvested evidence
+        # (codex cycle 2 F3).
+        state = writer_mod.WriterState(capture_root=str(tmp_path / "captures"))
+        state.handle_session_start("runA", "sess5", _OWNER_A)
+        state.handle_pty_chunk("sess5", base64.b64encode(b"original").decode(), _OWNER_A)
+        state.handle_session_end("sess5", _OWNER_A)
+        # A fresh connection tries to reopen the same id — must be rejected.
+        assert state.handle_session_start("runA", "sess5", _OWNER_B) is False
+        # And the post-finalize append is dropped (session is not active).
+        state.handle_pty_chunk("sess5", base64.b64encode(b"FORGED").decode(), _OWNER_B)
+        ts = tmp_path / "captures" / "runA" / "sess5" / "pty" / "typescript"
+        assert ts.read_bytes() == b"original"
+
+    def test_finalize_owner_closes_owned_sessions(self, writer_mod, tmp_path):
+        state = writer_mod.WriterState(capture_root=str(tmp_path / "captures"))
+        state.handle_session_start("runA", "sessE", _OWNER_A)
+        state.handle_session_start("runA", "sessF", _OWNER_A)
+        state.handle_session_start("runA", "sessG", _OWNER_B)
+        # Connection A drops: only its sessions finalize; B's stays.
+        state.finalize_owner(_OWNER_A)
+        assert "sessE" not in state.active_sessions
+        assert "sessF" not in state.active_sessions
+        assert "sessG" in state.active_sessions
+
+    def test_ping_and_peercred_helpers_exist(self, writer_mod):
+        # The connection handler reads SO_PEERCRED for forensics; the helper
+        # must be present and tolerate a non-socket gracefully.
+        assert hasattr(writer_mod, "peer_credentials")
+        assert writer_mod.peer_credentials(object()) is None
+
+
+class _FakeProc:
+    """Stand-in for a tcpdump subprocess.Popen handle."""
+
+    def __init__(self):
+        self.terminated = False
+        self.killed = False
+        self.waited = False
+
+    def terminate(self):
+        self.terminated = True
+
+    def wait(self, timeout=None):
+        self.waited = True
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
+class TestPcapLifecycle:
+    """tcpdump per-session lifecycle (ADR-041): the sidecar owns pcap.
+
+    The real tcpdump is never spawned in unit tests — ``pcap_spawn`` is
+    injected so the lifecycle (start on session_start, terminate on
+    session_end) is asserted without NET_RAW or a packet source.
+    """
+
+    def test_pcap_disabled_by_default(self, writer_mod, tmp_path):
+        # Default WriterState must NOT spawn tcpdump, so the bare unit tests
+        # above never launch a real capture.
+        calls = []
+
+        def spy_spawn(argv, **kwargs):
+            calls.append(argv)
+            return _FakeProc()
+
+        state = writer_mod.WriterState(
+            capture_root=str(tmp_path / "captures"), pcap_spawn=spy_spawn
+        )
+        state.handle_session_start("runA", "sessP", _OWNER_A)
+        assert calls == [], "tcpdump must not spawn when enable_pcap is False"
+
+    def test_session_start_launches_pcap(self, writer_mod, tmp_path):
+        calls = []
+
+        def spy_spawn(argv, **kwargs):
+            calls.append(argv)
+            return _FakeProc()
+
+        state = writer_mod.WriterState(
+            capture_root=str(tmp_path / "captures"),
+            enable_pcap=True,
+            pcap_spawn=spy_spawn,
+        )
+        state.handle_session_start("runA", "sessP", _OWNER_A)
+        assert len(calls) == 1, "tcpdump should be spawned once on session_start"
+        argv = calls[0]
+        assert argv[0] == "tcpdump"
+        # Writes into the per-session pcap dir.
+        pcap_path = str(tmp_path / "captures" / "runA" / "sessP" / "pcap" / "session.pcap")
+        assert pcap_path in argv, f"tcpdump should target {pcap_path}; got {argv}"
+        # Drops the SSH control noise.
+        assert "not port 22" in argv
+
+    def test_session_end_kills_pcap(self, writer_mod, tmp_path):
+        fake = _FakeProc()
+
+        def spy_spawn(argv, **kwargs):
+            return fake
+
+        state = writer_mod.WriterState(
+            capture_root=str(tmp_path / "captures"),
+            enable_pcap=True,
+            pcap_spawn=spy_spawn,
+        )
+        state.handle_session_start("runA", "sessQ", _OWNER_A)
+        assert not fake.terminated
+        state.handle_session_end("sessQ", _OWNER_A)
+        assert fake.terminated, "tcpdump must be terminated on session_end"
+
+    def test_finalize_owner_kills_pcap(self, writer_mod, tmp_path):
+        fake = _FakeProc()
+        state = writer_mod.WriterState(
+            capture_root=str(tmp_path / "captures"),
+            enable_pcap=True,
+            pcap_spawn=lambda argv, **kw: fake,
+        )
+        state.handle_session_start("runA", "sessQ2", _OWNER_A)
+        # Connection drop (EOF) must stop the tcpdump too.
+        state.finalize_owner(_OWNER_A)
+        assert fake.terminated, "tcpdump must be terminated on connection drop"
+
+    def test_pcap_command_uses_fixed_rotation(self, writer_mod, tmp_path):
+        argv = writer_mod.default_pcap_command(tmp_path / "session.pcap")
+        # Rotation flags cap a single session's pcap footprint.
+        assert "-C" in argv and "100" in argv
+        assert "-W" in argv and "10" in argv
+
+    def test_pcap_start_failure_is_best_effort(self, writer_mod, tmp_path):
+        # A tcpdump that fails to spawn must not break the session — the
+        # typescript still records.
+        def boom_spawn(argv, **kwargs):
+            raise FileNotFoundError("tcpdump not installed")
+
+        state = writer_mod.WriterState(
+            capture_root=str(tmp_path / "captures"),
+            enable_pcap=True,
+            pcap_spawn=boom_spawn,
+        )
+        state.handle_session_start("runA", "sessR", _OWNER_A)  # must not raise
+        state.handle_pty_chunk("sessR", base64.b64encode(b"data").decode(), _OWNER_A)
+        state.handle_session_end("sessR", _OWNER_A)
+        ts_file = tmp_path / "captures" / "runA" / "sessR" / "pty" / "typescript"
+        assert ts_file.read_bytes() == b"data"

--- a/tests/test_obs003_kali_capture.py
+++ b/tests/test_obs003_kali_capture.py
@@ -15,9 +15,28 @@ because the container's runtime doesn't grant audit caps).
 
 from __future__ import annotations
 
-import pytest
+import re
+from pathlib import Path
 
-from tests.helpers import LIVE_LAB, container_running, kali_exec
+import pytest
+import yaml
+
+from tests.helpers import (
+    LIVE_LAB,
+    container_running,
+    kali_capture_exec,
+    kali_exec,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: load docker-compose.yml once for compose-consistency tests
+# ---------------------------------------------------------------------------
+_COMPOSE_PATH = Path(__file__).parent.parent / "docker-compose.yml"
+
+
+def _load_compose() -> dict:
+    with _COMPOSE_PATH.open() as fh:
+        return yaml.safe_load(fh)
 
 pytestmark = [
     LIVE_LAB,
@@ -127,14 +146,17 @@ class TestCaptureSurface:
             "sshd_config Match User kali should ForceCommand the OBS-003 wrapper"
         )
 
-    def test_per_run_capture_root_writable_by_kali(self):
-        # /var/log/aptl/captures (named volume mount target) must be
-        # kali-writable so the wrapper can mkdir per-session subdirs.
+    def test_capture_volume_readonly_in_kali(self):
+        # ADR-041 / issue #305: kali_captures is mounted read-only in the
+        # kali container so the kali user (including after `sudo su -`)
+        # cannot delete or modify capture evidence. A write attempt must
+        # fail regardless of Unix ownership or ACLs.
         r = kali_exec(
-            "sudo -u kali test -w /var/log/aptl/captures && echo ok || echo not_writable"
+            "touch /var/log/aptl/captures/_probe 2>&1; echo EXIT=$?"
         )
-        assert r.stdout.strip() == "ok", (
-            "/var/log/aptl/captures must be writable by the kali user"
+        assert "EXIT=0" not in r.stdout, (
+            "/var/log/aptl/captures must be read-only in the kali container "
+            "(ADR-041); touch succeeded when it should have been blocked"
         )
 
     def test_audit_control_cap_dropped_for_sshd(self):
@@ -242,21 +264,34 @@ class TestEndToEndCapture:
         # Run a command through the wrapped shell.
         self._ssh_with_env(run_id, session_id, f"echo {marker}")
 
-        # Confirm the per-session capture dir was created and contains
-        # the PTY typescript with the marker.
+        # ADR-041: captures land in the SIDECAR, which owns the volume — they
+        # are NOT visible in the kali workload container at all.
         sess_path = f"/var/log/aptl/captures/{run_id}/{session_id}"
-        r = kali_exec(f"test -d {sess_path}/pty && echo ok || echo missing")
-        assert r.stdout.strip() == "ok", f"PTY dir missing under {sess_path}"
-
-        ts = kali_exec(f"cat {sess_path}/pty/typescript 2>/dev/null || true").stdout
-        assert marker in ts, (
-            f"PTY typescript at {sess_path}/pty/typescript should contain {marker!r}; got {ts!r}"
+        r = kali_capture_exec(f"test -d {sess_path}/pty && echo ok || echo missing")
+        assert r.stdout.strip() == "ok", (
+            f"PTY dir missing under {sess_path} in the capture sidecar"
         )
 
-        # Confirm a pcap was started (presence; rotated file naming
-        # depends on tcpdump's -C behaviour, so check the dir).
-        r = kali_exec(f"ls {sess_path}/pcap 2>/dev/null | head -1").stdout.strip()
+        ts = kali_capture_exec(
+            f"cat {sess_path}/pty/typescript 2>/dev/null || true"
+        ).stdout
+        assert marker in ts, (
+            f"PTY typescript at {sess_path}/pty/typescript should contain "
+            f"{marker!r}; got {ts!r}"
+        )
+
+        # Confirm a pcap was started (presence; rotated file naming depends on
+        # tcpdump's -C behaviour, so check the dir in the sidecar).
+        r = kali_capture_exec(f"ls {sess_path}/pcap 2>/dev/null | head -1").stdout.strip()
         assert r, f"pcap directory under {sess_path}/pcap should be non-empty"
+
+        # The captures must NOT be reachable from inside the kali workload —
+        # not even with sudo (the volume is not mounted there at all).
+        r = kali_exec(f"sudo ls {sess_path} 2>&1; echo EXIT=$?")
+        assert "EXIT=0" not in r.stdout, (
+            f"capture path {sess_path} must not be readable inside aptl-kali "
+            f"(ADR-041 read-isolation); got: {r.stdout!r}"
+        )
 
     def test_session_dir_permissions_are_restrictive(self):
         import uuid as _uuid
@@ -266,9 +301,10 @@ class TestEndToEndCapture:
 
         self._ssh_with_env(run_id, session_id, "true")
 
-        # 0700 dirs, 0600 files inside the per-session subtree.
+        # 0700 dirs, 0600 files inside the per-session subtree (checked in the
+        # sidecar, which owns the volume — ADR-041).
         sess_path = f"/var/log/aptl/captures/{run_id}/{session_id}"
-        modes = kali_exec(
+        modes = kali_capture_exec(
             f"find {sess_path} -mindepth 1 -printf '%m %p\\n' 2>/dev/null | head -20"
         ).stdout
         # Pre-condition: without this, a silently-failed SSH session (or a
@@ -286,7 +322,9 @@ class TestEndToEndCapture:
             if len(parts) < 2:
                 continue
             mode, path = parts
-            r = kali_exec(f"test -d {path} && echo dir || echo file").stdout.strip()
+            r = kali_capture_exec(
+                f"test -d {path} && echo dir || echo file"
+            ).stdout.strip()
             if r == "dir":
                 assert mode in ("700", "0700"), f"{path} dir mode {mode}, expected 0700"
             else:
@@ -339,15 +377,23 @@ class TestProcessLifecycle:
             for line in marker.splitlines()
             if "=" in line
         )
-        for required in ("ready_at", "sshd", "wrapper", "auditd", "procacct"):
+        # ADR-041: auditd / process accounting moved to the kali-capture
+        # sidecar, so the kali readiness marker only tracks sshd + wrapper.
+        for required in ("ready_at", "sshd", "wrapper"):
             assert required in keys, (
                 f"readiness marker missing `{required}`; got keys {sorted(keys)}"
             )
-        for subsystem in ("sshd", "wrapper", "auditd", "procacct"):
+        for subsystem in ("sshd", "wrapper"):
             assert keys[subsystem] in ("ok", "degraded"), (
                 f"readiness marker `{subsystem}` should be ok|degraded; "
                 f"got {keys[subsystem]!r}"
             )
+        # The capture subsystems must NOT be reported here anymore — they
+        # belong to the sidecar's own readiness marker.
+        assert "auditd" not in keys and "procacct" not in keys, (
+            "kali readiness marker must not report auditd/procacct after "
+            f"ADR-041 (those moved to the sidecar); got keys {sorted(keys)}"
+        )
         # sshd and the ForceCommand wrapper are the usable surface —
         # in a healthy lab they must not be degraded.
         assert keys["sshd"] == "ok", "sshd recorded degraded in readiness marker"
@@ -385,4 +431,110 @@ class TestProcessLifecycle:
         )
         assert "healthy" in r.stdout, (
             f"aptl-healthcheck.sh should report healthy; got {r.stdout!r}"
+        )
+
+
+# TestComposeConsistency lives in tests/test_kali_capture_compose.py to avoid
+# inheriting the module-level LIVE_LAB + kali skipif pytestmark (class-level
+# pytestmark in pytest adds to — not replaces — module-level marks).
+
+# ---------------------------------------------------------------------------
+# ADR-041 / issue #305: live ownership boundary tests (LIVE_LAB only)
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarOwnershipBoundary:
+    """Live tests that verify the kali workload cannot read, list, delete, or
+    modify capture evidence even after `sudo su -`. The capture sink is not in
+    the kali container's mount namespace at all (ADR-041), so a sudo-capable
+    agent has no path to it. Requires APTL_SMOKE=1 and both containers running.
+    """
+
+    pytestmark = [
+        LIVE_LAB,
+        pytest.mark.skipif(
+            not container_running("aptl-kali"),
+            reason="aptl-kali container is not running",
+        ),
+    ]
+
+    def test_captures_not_mounted_in_kali(self):
+        """The captures volume must be absent from the kali mount table."""
+        r = kali_exec(
+            "grep -F '/var/log/aptl/captures' /proc/self/mounts || echo NONE"
+        )
+        assert r.stdout.strip() == "NONE", (
+            "kali_captures must NOT be mounted in aptl-kali (ADR-041); "
+            f"found mount: {r.stdout!r}"
+        )
+
+    def test_sudo_cannot_write_captures_path(self):
+        """Even `sudo` cannot create files under the capture path in kali —
+        the path is not a writable mount here."""
+        r = kali_exec(
+            "sudo mkdir -p /var/log/aptl/captures 2>/dev/null; "
+            "sudo touch /var/log/aptl/captures/_probe 2>&1; echo EXIT=$?; "
+            "sudo rm -f /var/log/aptl/captures/_probe 2>/dev/null || true"
+        )
+        # The captures dir is owned by the sidecar; in kali it is at most an
+        # empty stub on the container's own overlay fs (not the named volume),
+        # so even if a write 'succeeds' it never touches real evidence. Assert
+        # the sidecar's evidence is unaffected below.
+        sidecar = kali_capture_exec(
+            "test -e /var/log/aptl/captures/_probe && echo LEAKED || echo SAFE"
+        )
+        assert sidecar.stdout.strip() == "SAFE", (
+            "a kali-side write must never reach the sidecar-owned captures "
+            f"volume (ADR-041); kali output: {r.stdout!r}"
+        )
+
+    def test_sudo_rm_cannot_delete_sidecar_captures(self):
+        """A sudo rm -rf attempt in kali must not destroy sidecar evidence."""
+        # Seed an audit log in the sidecar (the entrypoint already does this on
+        # boot; assert it exists, then attempt destruction from kali).
+        before = kali_capture_exec(
+            "test -f /var/log/aptl/captures/_audit/audit.log && echo ok || echo missing"
+        ).stdout.strip()
+        if before != "ok":
+            pytest.skip("sidecar audit log not present (auditd may be degraded)")
+        kali_exec("sudo rm -rf /var/log/aptl/captures/* 2>/dev/null || true")
+        after = kali_capture_exec(
+            "test -f /var/log/aptl/captures/_audit/audit.log && echo ok || echo missing"
+        ).stdout.strip()
+        assert after == "ok", (
+            "sidecar audit evidence was destroyed by a kali-side sudo rm -rf "
+            "(ADR-041 acceptance criterion #2)"
+        )
+
+    def test_cross_session_read_isolation(self):
+        """A kali shell (even sudo) cannot READ another session's captures.
+
+        This is issue #305's cross-session-disclosure criterion: with the
+        volume entirely outside kali's mount namespace, there is no path for a
+        sudo-root shell to cat a sibling session's typescript/pcap.
+        """
+        import uuid
+
+        run_id = f"iso-{uuid.uuid4().hex[:8]}"
+        session_v = f"sess-victim-{uuid.uuid4().hex[:6]}"
+        marker = f"SECRET_{uuid.uuid4().hex[:8]}"
+
+        # Produce a victim session's capture via the wrapped shell.
+        TestEndToEndCapture()._ssh_with_env(run_id, session_v, f"echo {marker}")
+
+        victim_ts = f"/var/log/aptl/captures/{run_id}/{session_v}/pty/typescript"
+        # Sanity: the sidecar has it.
+        s = kali_capture_exec(f"cat {victim_ts} 2>/dev/null || true").stdout
+        if marker not in s:
+            pytest.skip("victim capture not produced; cannot assert isolation")
+
+        # An authenticated kali shell, even with sudo, must not be able to read
+        # it — the path does not exist in kali's mount namespace.
+        r = kali_exec(f"sudo cat {victim_ts} 2>&1; echo EXIT=$?")
+        assert marker not in r.stdout, (
+            f"kali read a sibling session's capture ({victim_ts}); "
+            f"cross-session disclosure not closed (ADR-041 / #305): {r.stdout!r}"
+        )
+        assert "EXIT=0" not in r.stdout, (
+            "sudo cat of a sibling session's capture should fail in kali"
         )


### PR DESCRIPTION
## Summary

Moves all Kali-side capture writes (PTY transcript, per-session pcap, auditd, process accounting) into a dedicated `aptl-kali-capture` sidecar that solely owns the `kali_captures` volume. The Kali workload no longer mounts the volume and does not share the sidecar's PID namespace, so a sudo-capable agent has no filesystem path to any session's evidence — it cannot read, list, delete, or modify it, including other sessions'. The wrapper streams the transcript over a single connection-owned RPC (one connection owns a session end-to-end; the writer honors data/state frames only from the owning connection, refuses reopening finalized sessions, and finalizes on EOF), and is strictly best-effort: if the sidecar is unavailable the shell runs unwrapped and never blocks. Harvest is redirected to the sidecar via a new `capture_container_name` config field. One residual (a workload can forge its own session's PTY typescript) is an accepted, documented wontfix — the authoritative record is the MCP-side PTY tee and the tamper-proof sidecar witnesses (pcap/auditd/pacct); the PTY-ownership rearchitecture is tracked in #516.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #305

## ADR Impact

- ADR-041
- ADR-033 (amended)
- ADR-021

## Changes

- New `aptl-kali-capture` sidecar: Dockerfile, root entrypoint (auditd + accton + readiness), and a connection-owned Unix-socket writer daemon (writer.py) that owns per-session typescript + tcpdump
- `docker-compose.yml`: add the sidecar (network_mode service:kali only — NOT pid, to close /proc/<pid>/root traversal; NET_RAW/AUDIT_*/SYS_PACCT moved off the kali workload); remove the kali_captures mount from the kali service entirely
- `aptl-wrap-shell.sh` + new `aptl-capture-client`: ping-gate then stream the script(1) --log-io transcript to the sidecar over one owning connection; client always drains to EOF so a dead sidecar degrades capture without blocking the shell
- `containers/kali/entrypoint.sh` + Dockerfile: drop auditd/accton/setfacl and the captures mount handling; install the capture client; readiness marker tracks sshd+wrapper only
- Harvest: add `capture_container_name` to the MCP lab config + `resolveCaptureContainer`, pointing harvest at `aptl-kali-capture`
- ADR-041 (new) records the boundary incl. the PTY-transcript-authenticity residual; ADR-033 capture-integrity entry amended
- Tests: writer unit tests (id/frame validation, connection ownership, reopen-refuse, pcap lifecycle), compose-consistency tests (no kali mount, sidecar caps/namespaces/ports), live ownership + cross-session read-isolation tests, resolveCaptureContainer vitest

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Unit/static tiers run in CI: writer (42) + compose-consistency + resolveCaptureContainer vitest + full aptl-mcp-common vitest (430). Live ownership/cross-session tests are APTL_SMOKE-gated and require the kali profile (kali + kali-capture). Sidecar image build + end-to-end RPC behavior (EOF finalization, cross-connection forgery rejection, reopen-after-finalize rejection, drain-on-sidecar-down) verified locally.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-041 ← containers/kali-capture/writer.py, ADR-041 ← docker-compose.yml, ADR-041 ← mcp/aptl-mcp-common/src/tools/handlers.ts
- TESTS: ADR-041 ← tests/test_kali_capture_writer.py, ADR-041 ← tests/test_kali_capture_compose.py, ADR-041 ← tests/test_obs003_kali_capture.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/305.security.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
