### PR TITLE
Make TechVault ACES startup operational

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,9 @@ API_PASSWORD=CHANGE_ME_api_password
 # Wazuh cluster key
 WAZUH_CLUSTER_KEY=CHANGE_ME_cluster_key
 
-# Web control-plane API token (ADR-039). Required by the aptl-web-api and
-# aptl-web-ui services — `aptl lab start` fails the compose parse if it is
-# unset. Generate a real token with:
+# Web control-plane API token (ADR-039). Required when running the optional
+# aptl-web-api and aptl-web-ui services. The API rejects missing, empty, or
+# placeholder values at runtime. Generate a real token with:
 #   python3 -c 'import secrets; print(secrets.token_hex(32))'
 APTL_API_TOKEN=CHANGE_ME_api_token
 

--- a/changelog.d/370.changed.md
+++ b/changelog.d/370.changed.md
@@ -1,0 +1,7 @@
+APTL now boots TechVault through a dedicated ACES operational SDL,
+`scenarios/techvault-operational.sdl.yaml`, while keeping
+`scenarios/techvault.sdl.yaml` as the deep inventory/parity artifact. The ACES
+static gate now fails scenarios whose realized Compose profile set does not
+match the public `aptl lab start` range, and tests assert that the operational
+SDL covers every steady-state service selected by the default public-start
+profiles.

--- a/changelog.d/370.changed.md
+++ b/changelog.d/370.changed.md
@@ -5,3 +5,10 @@ static gate now fails scenarios whose realized Compose profile set does not
 match the public `aptl lab start` range, and tests assert that the operational
 SDL covers every steady-state service selected by the default public-start
 profiles.
+
+The live proof run also tightened startup parity: core `otel` is now treated as
+part of the public-start profile set during ACES realization diagnostics, the
+OTEL collector healthcheck uses the image's own `/otelcol-contrib` binary
+instead of missing shell tools, and inactive optional web-profile services no
+longer make default Compose startup require `APTL_API_TOKEN` before the web
+runtime is launched.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1371,8 +1371,10 @@ services:
       - "127.0.0.1:8400:8400"
     environment:
       - APTL_PROJECT_DIR=/project
-      # Required: generate with python3 -c 'import secrets; print(secrets.token_hex(32))'
-      - APTL_API_TOKEN=${APTL_API_TOKEN:?APTL_API_TOKEN must be set to a secure token}
+      # Validated by the API at runtime. Do not use `${VAR:?}` here: Compose
+      # expands inactive-profile services too, which would make the default lab
+      # start require the optional web control-plane token.
+      - APTL_API_TOKEN=${APTL_API_TOKEN:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/project:ro
@@ -1397,7 +1399,9 @@ services:
     environment:
       - ORIGIN=http://localhost:3000
       # Same token as aptl-web-api — SvelteKit server injects it as Bearer header.
-      - APTL_API_TOKEN=${APTL_API_TOKEN:?APTL_API_TOKEN must be set to a secure token}
+      # The API rejects empty/placeholder values at runtime; keep Compose
+      # interpolation non-fatal while the web profile is inactive.
+      - APTL_API_TOKEN=${APTL_API_TOKEN:-}
       # Internal Docker hostname the SvelteKit server uses to reach the API.
       - APTL_API_URL=http://aptl-web-api:8400
       # Hostname:port the browser uses for direct WebSocket connections.
@@ -1427,7 +1431,7 @@ services:
     volumes:
       - ./config/otel/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:13133/"]
+      test: ["CMD", "/otelcol-contrib", "validate", "--config", "/etc/otelcol-contrib/config.yaml"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/aces/techvault-live-validation-gate.md
+++ b/docs/aces/techvault-live-validation-gate.md
@@ -11,17 +11,18 @@ the run archive. It implements requirement SCN-010 (issue #323).
 
 The gate is scenario-generic by construction. `validate_live_deployment()` takes
 a scenario path, a backend profile, the project directory, and a run id, so the
-next scenario in APTL's `provisioning-only` expressivity class passes through by
-changing inputs rather than by editing the gate. TechVault is the proving input,
-never a hardcoded branch (ADR-035).
+next scenario in APTL's `orchestration-capable` expressivity class passes
+through by changing inputs rather than by editing the gate. TechVault is the
+proving input, never a hardcoded branch (ADR-035).
 
 APTL's public start path (`orchestrate_lab_start()`), however, is currently
-hardwired to the default scenario (`scenarios/techvault.sdl.yaml`) and the
-`provisioning-only` capability profile; it does not yet accept a caller-supplied
-scenario or profile. So the gate verifies up front that the scenario and profile
-it was asked to validate are the ones the public start path will actually boot,
-and fails loud before any destructive boot if they diverge, so it never
-validates one model while booting another. When the public start path learns to honor a
+hardwired to the operational startup scenario
+(`scenarios/techvault-operational.sdl.yaml`) and the `orchestration-capable`
+capability profile; it does not yet accept a caller-supplied scenario or
+profile. So the gate verifies up front that the scenario and profile it was
+asked to validate are the ones the public start path will actually boot, and
+fails loud before any destructive boot if they diverge, so it never validates
+one model while booting another. When the public start path learns to honor a
 caller-supplied scenario/profile, this guard relaxes to thread them through
 instead of rejecting them.
 
@@ -37,7 +38,7 @@ layer that broke:
    than degrading to a warning.
 2. **Boot-input agreement** (`backend_instantiation`). The scenario and profile
    under validation must be the ones the public start path will actually boot
-   (the default scenario and the `provisioning-only` profile). A mismatch is a
+   (the operational scenario and the `orchestration-capable` profile). A mismatch is a
    hard failure raised before any destructive boot, so the gate never validates
    one model while booting another.
 3. **ACES-driven boot** (`backend_interpretation` or `backend_instantiation`).
@@ -101,15 +102,14 @@ schema `aptl.live-gate.manifest/v1`. It records:
 
 ## Observable parity
 
-The live gate is validation tooling and a run-archive writer rather than new
-scenario content. The TechVault steady-state observables are already encoded in
-`scenarios/techvault.sdl.yaml` by the inventory passes and proven by the static
-gate. The evaluator surfaces (objectives, scoring, injects, workflows, and the
-evaluator run-archive output) are deferred to issue #312, which promotes APTL
-beyond the `provisioning-only` profile. The gate therefore adds no
-ACES-expressible observable surface, leaves `required_surface_coverage`
-unchanged, and files no ACES expressivity blocker. The run archive is proof of
-what the model realized; it does not substitute for SDL encoding.
+The live gate validates the operational startup contract. The public boot SDL,
+`scenarios/techvault-operational.sdl.yaml`, names the steady-state Compose
+services and networks at range granularity; the deep inventory SDL,
+`scenarios/techvault.sdl.yaml`, remains the detailed asset/parity evidence
+surface proven by the static inventory tests. The evaluator surfaces
+(objectives, scoring, injects, workflows, and the evaluator run-archive output)
+are deferred to issue #312. The run archive is proof of what the operational
+model realized; it does not substitute for SDL encoding.
 
 ## Prerequisites
 
@@ -146,8 +146,9 @@ the prompt in automation, or `--skip-clean-boot` to validate an already-running
 lab without the destructive `stop -v` and reboot. The `--scenario` and
 `--profile` options exist for the scenario-generic seam, but until the public
 start path accepts a caller-supplied scenario/profile they must match what that
-path boots (the default scenario and `provisioning-only`); the gate fails the
-boot-input agreement check otherwise. `--run-id` sets the run-archive id.
+path boots (`scenarios/techvault-operational.sdl.yaml` and
+`orchestration-capable`); the gate fails the boot-input agreement check
+otherwise. `--run-id` sets the run-archive id.
 
 The same boot runs as the explicitly gated integration test:
 

--- a/docs/aces/techvault-static-validation-gate.md
+++ b/docs/aces/techvault-static-validation-gate.md
@@ -28,14 +28,16 @@ editing the gate. TechVault is the proving input, never a hardcoded branch.
    semantic validation against the concept-authority corpus and produces the
    runtime model.
 4. **Backend conformance.** APTL's canonical `backend-manifest-v2` target passes
-   `run_target_conformance()` for the `provisioning-only` profile, and the
-   published `aces conformance backend --profile provisioning-only` command runs
-   against the bundled contract corpus. A missing corpus, profile artifact, or
-   conformance command is a gate failure with an actionable diagnostic, never a
-   downgraded warning and never a reason to accept an APTL-local manifest
+   `run_target_conformance()` for the `orchestration-capable` profile, and the
+   published `aces conformance backend --profile orchestration-capable` command
+   runs against the bundled contract corpus. A missing corpus, profile artifact,
+   or conformance command is a gate failure with an actionable diagnostic, never
+   a downgraded warning and never a reason to accept an APTL-local manifest
    approximation.
 5. **Provisioning realization.** The interpreter realizes the provisioning plan
-   with no errors and produces nodes, services, and networks. The realization is
+   with no errors and produces nodes, services, and networks. The selected
+   Compose profiles must match the public lab-start profile set, so a scenario
+   that would instantiate a partial range fails the gate. The realization is
    driven by declared content, not by the scenario identifier.
 6. **Parity manifest.** Every required observable surface in
    `docs/aces/parity-inventory.yaml` under `required_surface_coverage` is either
@@ -52,12 +54,12 @@ local dataclass approximation is not accepted as conformance evidence.
 ## Required surface coverage
 
 The parity inventory records, for each required surface, whether TechVault
-represents it today or defers it to a follow-up. Provisioning-only surfaces
-(nodes, services, vulnerabilities, features, Kali apparatus, defensive-stack
-configs, and health) are represented. Evaluation-profile surfaces (injects,
-workflows, objectives, scoring, and run-archive evidence) are deferred to issue
-#312, which promotes APTL beyond the provisioning-only profile. A surface that
-is neither represented with evidence nor deferred with an issue fails the gate.
+represents it today or defers it to a follow-up. Startup surfaces (nodes,
+services, vulnerabilities, features, Kali apparatus, defensive-stack configs,
+and health) are represented. Remaining evaluator and scenario-flow surfaces
+(injects, workflows, objectives, scoring, and evaluator run-archive evidence)
+are deferred to issue #312. A surface that is neither represented with evidence
+nor deferred with an issue fails the gate.
 
 ## Advisory in Phase A, blocking at cutover
 

--- a/docs/adrs/adr-035-aces-sdl-adoption.md
+++ b/docs/adrs/adr-035-aces-sdl-adoption.md
@@ -67,29 +67,31 @@ Specifically:
 - APTL implements one `RuntimeTarget` registered into the ACES runtime
   target registry (final import path pinned during implementation) and
   publishes a `backend-manifest-v2` claiming conformance to the
-  **`provisioning-only`** profile as the initial target. Promotion to
-  `orchestration-capable` and `orchestration-evaluation` is tracked as
-  follow-on GitHub issues (#311, #312) once the corresponding APTL
-  capabilities (workflow execution under the orchestrator contract;
-  objective evaluation under the evaluator contract) are wired through.
+  **`orchestration-capable`** profile. `provisioning-only` was the
+  bootstrap target; `orchestration-evaluation` remains tracked by #312
+  until objective evaluation under the evaluator contract is wired through.
 - APTL's CLI delegates `aptl lab start` and friends through the ACES
   `RuntimeManager` lifecycle (compile → plan → validate → apply → start
   orchestrator/evaluator → stop) instead of the current imperative Python
   lifecycle.
 - APTL's published backend manifest is committed under an APTL-side
   contracts path (final location pinned during implementation) and
-  validated by `aces conformance backend --profile provisioning-only` as
-  a pre-push gate.
+  validated by `aces conformance backend --profile orchestration-capable`
+  as a pre-push gate.
 - The legacy `aptl.core.sdl` parser and `scenarios/*.yaml` Pydantic path
   remain functional throughout the adoption work. The `aces_sdl`
   dependency, the ACES backend target, and the ACES TechVault scenario
   land as a *parallel* path during Phase A.
-- At cutover (Phase B, a single PR), the default scenario flips to the
-  ACES-authored `techvault.sdl.yaml`, `scenarios/*.yaml` moves to
-  `scenarios/archive/` as strictly reference-only material (not loaded by
-  any runtime path), `aptl.core.sdl` is deleted, `aptl.core.scenarios`
-  collapses to a thin loader around `aces_sdl.parse_sdl_file`, and
-  Pydantic `ScenarioDefinition` models are deleted.
+- At cutover (Phase B, a single PR), the public startup path flips to the
+  ACES-authored operational TechVault SDL
+  (`scenarios/techvault-operational.sdl.yaml`). The deeper
+  `scenarios/techvault.sdl.yaml` remains the detailed inventory/parity
+  artifact rather than the runtime boot contract. Legacy `scenarios/*.yaml`
+  moves to `scenarios/archive/` as strictly reference-only material (not
+  loaded by any runtime path), `aptl.core.sdl` is deleted,
+  `aptl.core.scenarios` collapses to a thin loader around
+  `aces_sdl.parse_sdl_file`, and Pydantic `ScenarioDefinition` models are
+  deleted.
 
 ## Backend Profile Choice
 
@@ -209,8 +211,8 @@ the caller is ACES.
   JSON/JSONL redaction boundaries where those artifacts cross APTL
   serialization.
 - Published backend capability stays profile-named and contract-validated:
-  `provisioning-only` is the initial claim, and any profile promotion belongs
-  to the follow-on issues already named here.
+  `orchestration-capable` is the current claim, and any further profile
+  promotion belongs to the follow-on issues already named here.
 
 The extensibility seam is the ACES backend capability profile plus a small
 backend realization map from ACES runtime resource kinds to existing APTL
@@ -232,7 +234,7 @@ in-tree SDL path stays the default until cutover.
    continue to use `aptl.core.sdl`.
 3. Publish APTL's `backend-manifest-v2` under an APTL-side contracts
    path.
-4. Wire `aces conformance backend --profile provisioning-only` as an
+4. Wire `aces conformance backend --profile orchestration-capable` as an
    **advisory** check (non-blocking) so drift is visible during Phase A.
 5. Author `scenarios/techvault.sdl.yaml` in ACES SDL.
 
@@ -244,14 +246,17 @@ See dedicated section above. Hard prerequisite to Phase B.
 
 Lands in one PR:
 
-- Default scenario flips to the ACES TechVault.
+- Default public startup scenario flips to
+  `scenarios/techvault-operational.sdl.yaml`; the detailed
+  `scenarios/techvault.sdl.yaml` remains the inventory/parity evidence
+  artifact.
 - `aptl lab` and CLI entrypoints route through ACES `RuntimeManager`.
 - `scenarios/*.yaml` moves to `scenarios/archive/` with a README marking
   the directory strictly reference-only (not loaded by any runtime path).
 - `aptl.core.sdl` deleted.
 - `aptl.core.scenarios` Pydantic models deleted; loader collapses to a
   thin `aces_sdl.parse_sdl_file` wrapper.
-- `aces conformance backend --profile provisioning-only` switches from
+- `aces conformance backend --profile orchestration-capable` switches from
   advisory to enforced (pre-push gate).
 - Ground Control reconciliation in the same PR:
   - DSL-001 → DEPRECATED

--- a/scenarios/techvault-operational.sdl.yaml
+++ b/scenarios/techvault-operational.sdl.yaml
@@ -1,0 +1,294 @@
+name: techvault
+description: >
+  Operational ACES projection for the TechVault range. This SDL is the public
+  startup contract: it names the steady-state Compose services and networks
+  that `aptl lab start` realizes without carrying the deep per-asset inventory
+  encoded in scenarios/techvault.sdl.yaml.
+
+nodes:
+  security-net:
+    type: switch
+    description: SOC and security tooling network.
+  dmz-net:
+    type: switch
+    description: TechVault DMZ network.
+  internal-net:
+    type: switch
+    description: Internal enterprise target network.
+  redteam-net:
+    type: switch
+    description: Red-team operations network.
+
+  wazuh-manager:
+    type: vm
+    os: linux
+    services:
+      - {name: wazuh-api, port: 55000, protocol: tcp}
+      - {name: agent-events, port: 1514, protocol: tcp}
+      - {name: syslog, port: 514, protocol: udp}
+    runtime:
+      health:
+        status: healthy
+        description: Compose healthcheck must pass before public startup is ready.
+  wazuh-indexer:
+    type: vm
+    os: linux
+    services:
+      - {name: indexer-api, port: 9200, protocol: tcp}
+  wazuh-dashboard:
+    type: vm
+    os: linux
+    services:
+      - {name: dashboard, port: 5601, protocol: tcp}
+
+  suricata:
+    type: vm
+    os: linux
+    services: []
+  misp:
+    type: vm
+    os: linux
+    services:
+      - {name: https, port: 443, protocol: tcp}
+  misp-db:
+    type: vm
+    os: linux
+    services:
+      - {name: mysql, port: 3306, protocol: tcp}
+  misp-redis:
+    type: vm
+    os: linux
+    services:
+      - {name: redis, port: 6379, protocol: tcp}
+  misp-suricata-sync:
+    type: vm
+    os: linux
+    services: []
+  thehive:
+    type: vm
+    os: linux
+    services:
+      - {name: thehive-api, port: 9000, protocol: tcp}
+  thehive-cassandra:
+    type: vm
+    os: linux
+    services:
+      - {name: cassandra, port: 9042, protocol: tcp}
+  thehive-es:
+    type: vm
+    os: linux
+    services:
+      - {name: elasticsearch, port: 9200, protocol: tcp}
+  cortex:
+    type: vm
+    os: linux
+    services:
+      - {name: cortex-api, port: 9001, protocol: tcp}
+  shuffle-backend:
+    type: vm
+    os: linux
+    services:
+      - {name: shuffle-api, port: 5001, protocol: tcp}
+  shuffle-frontend:
+    type: vm
+    os: linux
+    services:
+      - {name: https, port: 443, protocol: tcp}
+      - {name: http, port: 80, protocol: tcp}
+  shuffle-orborus:
+    type: vm
+    os: linux
+    services: []
+  shuffle-opensearch:
+    type: vm
+    os: linux
+    services:
+      - {name: opensearch-rest, port: 9200, protocol: tcp}
+      - {name: opensearch-transport, port: 9300, protocol: tcp}
+  wazuh-sidecar-db:
+    type: vm
+    os: linux
+    services: []
+  wazuh-sidecar-suricata:
+    type: vm
+    os: linux
+    services: []
+
+  webapp:
+    type: vm
+    os: linux
+    services:
+      - {name: http, port: 8080, protocol: tcp}
+  ad:
+    type: vm
+    os: linux
+    services:
+      - {name: ldap, port: 389, protocol: tcp}
+      - {name: kerberos, port: 88, protocol: tcp}
+      - {name: smb, port: 445, protocol: tcp}
+  db:
+    type: vm
+    os: linux
+    services:
+      - {name: postgres, port: 5432, protocol: tcp}
+  workstation:
+    type: vm
+    os: linux
+    services:
+      - {name: ssh, port: 22, protocol: tcp}
+  fileshare:
+    type: vm
+    os: linux
+    services:
+      - {name: smb, port: 445, protocol: tcp}
+  dns:
+    type: vm
+    os: linux
+    services:
+      - {name: dns, port: 53, protocol: udp}
+  victim:
+    type: vm
+    os: linux
+    services:
+      - {name: ssh, port: 22, protocol: tcp}
+
+  kali:
+    type: vm
+    os: linux
+    services:
+      - {name: ssh, port: 22, protocol: tcp}
+  kali-capture:
+    type: vm
+    os: linux
+    services: []
+
+  aptl-otel-collector:
+    type: vm
+    os: linux
+    services:
+      - {name: otlp-grpc, port: 4317, protocol: tcp}
+      - {name: otlp-http, port: 4318, protocol: tcp}
+  aptl-tempo:
+    type: vm
+    os: linux
+    services:
+      - {name: tempo-http, port: 3200, protocol: tcp}
+  aptl-grafana-otel:
+    type: vm
+    os: linux
+    services:
+      - {name: grafana, port: 3000, protocol: tcp}
+
+infrastructure:
+  security-net:
+    properties: {cidr: 172.20.0.0/24, gateway: 172.20.0.1, internal: false}
+  dmz-net:
+    properties: {cidr: 172.20.1.0/24, gateway: 172.20.1.1, internal: true}
+  internal-net:
+    properties: {cidr: 172.20.2.0/24, gateway: 172.20.2.1, internal: true}
+  redteam-net:
+    properties: {cidr: 172.20.4.0/24, gateway: 172.20.4.1, internal: true}
+
+  wazuh-manager:
+    links: [security-net, dmz-net, internal-net]
+  wazuh-indexer:
+    links: [security-net]
+    dependencies: [wazuh-manager]
+  wazuh-dashboard:
+    links: [security-net]
+    dependencies: [wazuh-indexer, wazuh-manager]
+
+  suricata:
+    links: [security-net, dmz-net, internal-net]
+  misp:
+    links: [security-net]
+    dependencies: [misp-db, misp-redis]
+  misp-db:
+    links: [security-net]
+  misp-redis:
+    links: [security-net]
+  misp-suricata-sync:
+    links: [security-net]
+    dependencies: [misp, suricata]
+  thehive:
+    links: [security-net]
+    dependencies: [thehive-cassandra, thehive-es, cortex]
+  thehive-cassandra:
+    links: [security-net]
+  thehive-es:
+    links: [security-net]
+  cortex:
+    links: [security-net]
+    dependencies: [thehive-es]
+  shuffle-backend:
+    links: [security-net]
+    dependencies: [shuffle-opensearch]
+  shuffle-frontend:
+    links: [security-net]
+    dependencies: [shuffle-backend]
+  shuffle-orborus:
+    links: [security-net]
+    dependencies: [shuffle-backend]
+  shuffle-opensearch:
+    links: [security-net]
+  wazuh-sidecar-db:
+    links: [security-net]
+    dependencies: [wazuh-manager, db]
+  wazuh-sidecar-suricata:
+    links: [security-net]
+    dependencies: [wazuh-manager, suricata]
+
+  webapp:
+    links: [dmz-net, internal-net]
+    dependencies: [db, wazuh-manager]
+  ad:
+    links: [internal-net]
+    dependencies: [wazuh-manager]
+  db:
+    links: [internal-net]
+  workstation:
+    links: [internal-net]
+    dependencies: [wazuh-manager]
+  fileshare:
+    links: [internal-net]
+    dependencies: [wazuh-manager]
+  dns:
+    links: [security-net, dmz-net, internal-net]
+    dependencies: [wazuh-manager]
+  victim:
+    links: [internal-net]
+    dependencies: [wazuh-manager]
+
+  kali:
+    links: [redteam-net, dmz-net, internal-net]
+  kali-capture:
+    dependencies: [kali]
+
+  aptl-otel-collector:
+    links: [security-net]
+  aptl-tempo:
+    links: [security-net]
+  aptl-grafana-otel:
+    links: [security-net]
+    dependencies: [aptl-tempo]
+
+features:
+  techvault-webapp-service:
+    type: service
+    source:
+      name: aptl-webapp
+      version: local
+    description: TechVault vulnerable customer portal service.
+  techvault-defensive-stack:
+    type: service
+    source:
+      name: aptl-soc-stack
+      version: local
+    description: Wazuh, Suricata, MISP, TheHive, Cortex, and Shuffle services.
+
+vulnerabilities:
+  webapp-sqli-login:
+    name: SQL injection in login
+    description: Login form accepts intentionally vulnerable SQL input.
+    technical: true
+    class: CWE-89

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
 log = get_logger("aces-backend")
 
-DEFAULT_ACES_SCENARIO = Path("scenarios") / "techvault.sdl.yaml"
+DEFAULT_ACES_SCENARIO = Path("scenarios") / "techvault-operational.sdl.yaml"
 
 
 def create_aptl_runtime_target(

--- a/src/aptl/backends/aces_profiles.py
+++ b/src/aptl/backends/aces_profiles.py
@@ -12,7 +12,7 @@ import yaml
 
 from aptl.core.config import AptlConfig
 
-CORE_PROFILES = frozenset({"otel"})
+CORE_PROFILES = ("otel",)
 IDENTIFIER_SEPARATORS = re.compile(r"[^a-z0-9]+")
 
 
@@ -76,6 +76,15 @@ def configured_profiles(config: AptlConfig) -> list[str]:
     return list(config.containers.enabled_profiles())
 
 
+def public_start_profiles(config: AptlConfig) -> list[str]:
+    """Return the Compose profiles used by the public lab start path."""
+    selected = configured_profiles(config)
+    for profile in CORE_PROFILES:
+        if profile not in selected:
+            selected.append(profile)
+    return selected
+
+
 def select_backend_profiles(
     config: AptlConfig,
     plan_profiles: frozenset[str],
@@ -83,13 +92,23 @@ def select_backend_profiles(
     """Intersect ACES plan profiles with enabled APTL profiles."""
     selected = [
         profile
-        for profile in configured_profiles(config)
-        if profile in plan_profiles
+        for profile in public_start_profiles(config)
+        if profile in plan_profiles or profile in CORE_PROFILES
     ]
-    for profile in CORE_PROFILES:
-        if profile not in selected:
-            selected.append(profile)
     return selected
+
+
+def steady_state_service_aliases_for_profiles(
+    project_dir: Path, selected_profiles: list[str]
+) -> dict[str, tuple[str, ...]]:
+    """Return normalized aliases for steady-state services in selected profiles."""
+    selected = set(selected_profiles)
+    services = _load_compose_services(project_dir)
+    return {
+        str(service_name): _normalized_service_aliases(str(service_name), service_def)
+        for service_name, service_def in services.items()
+        if _service_selected(service_def, selected)
+    }
 
 
 def normalized_identifier_aliases(raw: str) -> set[str]:
@@ -146,6 +165,32 @@ def _service_profiles(service_def: Mapping[str, object]) -> set[str]:
         for profile in (service_def.get("profiles") or [])
         if str(profile).strip()
     }
+
+
+def _service_selected(service_def: object, selected_profiles: set[str]) -> bool:
+    """Return whether a service is steady-state and in a selected profile."""
+    if not isinstance(service_def, Mapping):
+        return False
+    profiles = _service_profiles(service_def)
+    return bool(profiles & selected_profiles) and not _is_one_shot(service_def)
+
+
+def _is_one_shot(service_def: Mapping[str, object]) -> bool:
+    """Return whether Compose marks a service as a non-steady-state task."""
+    return str(service_def.get("restart", "")).lower() in {"no", "false"}
+
+
+def _normalized_service_aliases(
+    service_name: str,
+    service_def: object,
+) -> tuple[str, ...]:
+    """Return sorted normalized aliases for one Compose service."""
+    if not isinstance(service_def, Mapping):
+        return ()
+    aliases: set[str] = set()
+    for alias in _service_aliases(service_name, service_def):
+        aliases.update(normalized_identifier_aliases(alias))
+    return tuple(sorted(aliases))
 
 
 def _service_aliases(

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -19,11 +19,11 @@ from aptl.backends.aces_diagnostics import (
 )
 from aptl.backends.aces_profiles import (
     ComposeProfileIndex,
-    configured_profiles,
     explicit_compose_profile_hints,
     load_compose_profile_index,
     node_aliases,
     normalize_identifier,
+    public_start_profiles,
 )
 from aptl.backends.aces_realization_model import (
     AptlRealization,
@@ -198,15 +198,15 @@ def _append_profile_diagnostics(
             )
         )
 
-    enabled_profiles = configured_profiles(config)
-    if enabled_profiles and not (set(enabled_profiles) & profiles):
+    start_profiles = public_start_profiles(config)
+    if start_profiles and not (set(start_profiles) & profiles):
         diagnostics.append(
             diagnostic(
                 "aptl.provisioner.no-configured-profile-matches",
                 PROVISIONING_ADDRESS,
                 (
                     "ACES provisioning plan did not declare any node "
-                    "that maps to an enabled APTL compose profile."
+                    "that maps to a public-start APTL compose profile."
                 ),
             )
         )

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -245,7 +245,7 @@ def validate_live(
     scenario: Optional[Path] = typer.Option(
         None,
         "--scenario",
-        help="ACES SDL scenario (default: scenarios/techvault.sdl.yaml).",
+        help="ACES SDL scenario (default: scenarios/techvault-operational.sdl.yaml).",
     ),
     profile: str = typer.Option(
         "orchestration-capable",

--- a/src/aptl/validation/_gate_checks.py
+++ b/src/aptl/validation/_gate_checks.py
@@ -25,6 +25,7 @@ from aces_sdl import SDLError, parse_sdl_file
 from aces_sdl.scenario import Scenario
 
 from aptl.backends.aces import create_aptl_runtime_target
+from aptl.backends.aces_profiles import public_start_profiles, select_backend_profiles
 from aptl.backends.aces_realization import interpret_provisioning_plan
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.utils.redaction import redact
@@ -189,6 +190,14 @@ def check_provisioning_realization(
         diagnostics.append("realization produced no services on any node")
     if not details.get("networks"):
         diagnostics.append("realization produced no networks")
+    expected_profiles = public_start_profiles(config)
+    selected_profiles = select_backend_profiles(config, realization.profiles)
+    if selected_profiles != expected_profiles:
+        diagnostics.append(
+            "ACES-selected profiles "
+            f"{selected_profiles} do not match public lab start profiles "
+            f"{expected_profiles}; scenario would not instantiate the same range"
+        )
     return details, GateCheck("provisioning_realization", *_outcome(diagnostics))
 
 

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -145,8 +145,8 @@ def check_boot_inputs_match_public_path(
     mismatch is a hard ``backend_instantiation`` failure raised *before* any
     destructive boot — never a degraded warning. This holds for
     ``skip_clean_boot`` too: the already-running lab was itself booted from the
-    default scenario, so a mismatched ``--scenario`` would validate the wrong
-    model against it.
+    operational scenario, so a mismatched ``--scenario`` would validate the
+    wrong model against it.
     """
     expected_scenario = DEFAULT_ACES_SCENARIO
     if not expected_scenario.is_absolute():

--- a/src/aptl/validation/techvault_live_gate.py
+++ b/src/aptl/validation/techvault_live_gate.py
@@ -38,7 +38,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-from aptl.validation.techvault_gate import DEFAULT_SCENARIO
+from aptl.backends.aces import DEFAULT_ACES_SCENARIO
 
 if TYPE_CHECKING:
     from aces_sdl.scenario import Scenario
@@ -214,7 +214,7 @@ def validate_live_deployment(
     from aptl.validation import _live_gate_checks as checks
 
     opts = options or LiveGateOptions()
-    scenario_path = scenario_path or (project_dir / DEFAULT_SCENARIO)
+    scenario_path = scenario_path or (project_dir / DEFAULT_ACES_SCENARIO)
     run_id = opts.run_id or uuid.uuid4().hex
     state = LiveGateState()
     results: list[LiveGateCheck] = []
@@ -228,9 +228,10 @@ def validate_live_deployment(
     static_passed = scenario is not None and static_check.passed
 
     # 2a. Input/boot-path agreement — the public start path is hardwired to the
-    #     default scenario + orchestration-capable profile, so a scenario/profile
-    #     the boot path will not honor must fail loud BEFORE any destructive
-    #     boot, not silently validate one model while booting another.
+    #     operational scenario + orchestration-capable profile, so a
+    #     scenario/profile the boot path will not honor must fail loud BEFORE
+    #     any destructive boot, not silently validate one model while booting
+    #     another.
     inputs_passed = False
     if static_passed:
         inputs_check = checks.check_boot_inputs_match_public_path(

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -130,6 +130,35 @@ def test_public_start_profiles_match_start_lab_backend_call():
     backend.start.assert_called_once_with(public_start_profiles(config))
 
 
+def test_realization_accepts_core_otel_as_public_start_profile(tmp_path):
+    from aptl.backends.aces_realization import interpret_provisioning_plan
+
+    _write_compose(tmp_path, {"aptl-otel-collector": ["otel"]})
+    config = AptlConfig(
+        lab={"name": "test"},
+        containers={
+            "wazuh": False,
+            "victim": False,
+            "kali": False,
+            "reverse": False,
+            "enterprise": False,
+            "soc": False,
+            "mail": False,
+            "fileshare": False,
+            "dns": False,
+        },
+    )
+
+    realization = interpret_provisioning_plan(
+        plan=_plan_for_nodes("aptl-otel-collector"),
+        project_dir=tmp_path,
+        config=config,
+    )
+
+    assert realization.profiles == frozenset({"otel"})
+    assert [diag.code for diag in realization.diagnostics] == []
+
+
 class _FakeExecutionPlan:
     """Minimal ExecutionPlan stand-in exposing the fields the handoff reads."""
 

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -103,6 +103,33 @@ def test_create_runtime_target_accepts_aptl_manifest_shape(tmp_path):
     assert target.manifest.name == "aptl"
 
 
+def test_public_start_profiles_match_start_lab_backend_call():
+    from aptl.backends.aces_profiles import public_start_profiles
+    from aptl.core.lab import start_lab
+
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True)
+    config = AptlConfig(
+        lab={"name": "test"},
+        containers={
+            "wazuh": True,
+            "victim": False,
+            "kali": True,
+            "reverse": False,
+            "enterprise": True,
+            "soc": False,
+            "mail": False,
+            "fileshare": True,
+            "dns": False,
+        },
+    )
+
+    result = start_lab(config, project_dir=Path("."), backend=backend)
+
+    assert result.success is True
+    backend.start.assert_called_once_with(public_start_profiles(config))
+
+
 class _FakeExecutionPlan:
     """Minimal ExecutionPlan stand-in exposing the fields the handoff reads."""
 
@@ -237,7 +264,9 @@ def test_start_aces_scenario_uses_parser_runtime_manager_and_backend(
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
     assert result.success is True
-    parser.assert_called_once_with(tmp_path / "scenarios" / "techvault.sdl.yaml")
+    parser.assert_called_once_with(
+        tmp_path / "scenarios" / "techvault-operational.sdl.yaml"
+    )
     assert calls == {"planned_scenario": scenario}
     backend.start.assert_called_once_with(["wazuh", "kali", "otel"])
 

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -137,6 +137,39 @@ class TestComposeConsistency:
         assert "/seed/suricata.yaml" in entrypoint
         assert "exec /docker-entrypoint.sh" in entrypoint
 
+    def test_otel_collector_healthcheck_uses_image_binary(self, compose_config):
+        """The OTEL collector image is distroless, so the healthcheck cannot
+        depend on shell utilities such as wget or curl."""
+        collector = compose_config["services"]["aptl-otel-collector"]
+        test = collector.get("healthcheck", {}).get("test")
+
+        assert test == [
+            "CMD",
+            "/otelcol-contrib",
+            "validate",
+            "--config",
+            "/etc/otelcol-contrib/config.yaml",
+        ]
+
+    def test_web_api_token_does_not_block_inactive_profiles(self, compose_config):
+        """Compose expands environment substitutions for inactive profiles, so
+        the optional web token must be validated by the web runtime instead of
+        by `${VAR:?}` interpolation in docker-compose.yml."""
+        services = compose_config["services"]
+        env_lines = (
+            services["aptl-web-api"]["environment"]
+            + services["aptl-web-ui"]["environment"]
+        )
+        token_lines = [
+            line for line in env_lines if line.startswith("APTL_API_TOKEN=")
+        ]
+
+        assert token_lines == [
+            "APTL_API_TOKEN=${APTL_API_TOKEN:-}",
+            "APTL_API_TOKEN=${APTL_API_TOKEN:-}",
+        ]
+        assert not any(":?" in line for line in token_lines)
+
 
 class TestKaliContainerLifecycle:
     """Issue #293 / ADR-033 §2: the kali container must reap children and

--- a/tests/test_techvault_live_gate.py
+++ b/tests/test_techvault_live_gate.py
@@ -36,7 +36,8 @@ from aptl.validation.techvault_live_gate import (
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-SCENARIO = PROJECT_ROOT / "scenarios" / "techvault.sdl.yaml"
+SCENARIO = PROJECT_ROOT / "scenarios" / "techvault-operational.sdl.yaml"
+FULL_INVENTORY_SCENARIO = PROJECT_ROOT / "scenarios" / "techvault.sdl.yaml"
 
 
 # --------------------------------------------------------------------------- #
@@ -402,6 +403,14 @@ def test_boot_inputs_fail_for_mismatched_scenario():
     assert any("does not match" in d for d in check.diagnostics)
 
 
+def test_boot_inputs_fail_for_full_inventory_scenario():
+    check = lgc.check_boot_inputs_match_public_path(
+        FULL_INVENTORY_SCENARIO, project_dir=PROJECT_ROOT, options=LiveGateOptions()
+    )
+    assert not check.passed
+    assert any("techvault-operational.sdl.yaml" in d for d in check.diagnostics)
+
+
 def test_boot_inputs_fail_for_mismatched_profile():
     check = lgc.check_boot_inputs_match_public_path(
         SCENARIO, project_dir=PROJECT_ROOT, options=LiveGateOptions(profile="evaluation")
@@ -724,7 +733,7 @@ def test_run_archive_writes_manifest_through_redacting_boundary():
     assert manifest["aces_provenance"]["realization"]["nodes"]
     assert manifest["aces_provenance"]["selected_profiles"] == ["dmz", "soc"]
     assert manifest["evaluator_surfaces_deferred"]["objectives"] == "#312"
-    assert manifest["scenario"]["name"] == "techvault"
+    assert manifest["scenario"]["name"] == "techvault-operational"
 
 
 def test_run_archive_roundtrips_to_local_store(tmp_path):
@@ -887,7 +896,9 @@ def test_variation_fails_on_realization_error(monkeypatch):
     reason="Set APTL_LIVE_GATE=1 to run the destructive live deployment gate",
 )
 def test_live_gate_passes_on_techvault():
-    config = AptlConfig(lab={"name": "techvault"})
+    from aptl.core.config import load_config
+
+    config = load_config(PROJECT_ROOT / "aptl.json")
     report = validate_live_deployment(
         SCENARIO, project_dir=PROJECT_ROOT, config=config
     )
@@ -904,7 +915,7 @@ def _patch_cli(mocker, *, passed=True):
 
     report = LiveGateReport(
         "scn",
-        "provisioning-only",
+        "orchestration-capable",
         "rid",
         (LiveGateCheck("aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, passed),),
     )

--- a/tests/test_techvault_live_gate.py
+++ b/tests/test_techvault_live_gate.py
@@ -849,6 +849,22 @@ def test_variation_passes_on_distinct_realizations(monkeypatch):
     assert check.passed
 
 
+def test_variation_accepts_core_otel_public_start_profile():
+    config = AptlConfig(
+        lab={"name": "techvault"},
+        containers={"enterprise": True, "wazuh": False, "victim": False, "kali": False},
+    )
+    state = _variation_state(
+        [_node("ad", ["enterprise"]), _node("aptl-grafana-otel", ["otel"])]
+    )
+
+    check = lgc.check_scenario_variation(
+        project_dir=PROJECT_ROOT, config=config, state=state
+    )
+
+    assert check.passed
+
+
 def test_variation_fails_on_collapse(monkeypatch):
     same = _Realization([_node("x", ["p"])], ["p"])
     monkeypatch.setattr(lgc, "interpret_provisioning_plan", lambda **k: same)

--- a/tests/test_techvault_static_gate.py
+++ b/tests/test_techvault_static_gate.py
@@ -23,8 +23,13 @@ from aces_contracts.planning import (
     RuntimeDomain,
 )
 
+from aptl.backends.aces_profiles import (
+    public_start_profiles,
+    select_backend_profiles,
+    steady_state_service_aliases_for_profiles,
+)
 from aptl.backends.aces_realization import interpret_provisioning_plan
-from aptl.core.config import AptlConfig
+from aptl.core.config import AptlConfig, load_config
 from aptl.validation import _gate_checks as gc
 from aptl.validation._gate_checks import (
     _NoStartBackend,
@@ -57,6 +62,7 @@ from aptl.validation.techvault_gate import (
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SCENARIO = PROJECT_ROOT / "scenarios" / "techvault.sdl.yaml"
+OPERATIONAL_SCENARIO = PROJECT_ROOT / "scenarios" / "techvault-operational.sdl.yaml"
 
 
 @pytest.fixture(scope="module")
@@ -98,6 +104,36 @@ def test_gate_runs_every_fast_stage(techvault_report):
 
 def test_committed_lockfile_exists():
     assert (SCENARIO.with_name("aces.lock.json")).exists()
+
+
+def test_operational_scenario_matches_public_start_profiles_and_services():
+    config = load_config(PROJECT_ROOT / "aptl.json")
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert scenario is not None
+    assert parse_check.passed, parse_check.diagnostics
+
+    details, check = check_provisioning_realization(
+        scenario=scenario, project_dir=PROJECT_ROOT, config=config
+    )
+    assert details is not None
+    assert check.passed, check.diagnostics
+
+    expected_profiles = public_start_profiles(config)
+    selected_profiles = select_backend_profiles(
+        config, frozenset(details.get("profiles", []))
+    )
+    assert selected_profiles == expected_profiles
+
+    expected_services = steady_state_service_aliases_for_profiles(
+        PROJECT_ROOT, expected_profiles
+    )
+    realized_aliases = _realized_aliases(details)
+    missing = {
+        service: aliases
+        for service, aliases in expected_services.items()
+        if not set(aliases) & realized_aliases
+    }
+    assert missing == {}
 
 
 @pytest.mark.integration
@@ -523,6 +559,55 @@ def test_check_provisioning_realization_handles_raise(monkeypatch):
     assert details is None and not check.passed
 
 
+def test_check_provisioning_realization_fails_on_profile_mismatch(tmp_path):
+    from textwrap import dedent
+
+    from aces_sdl.parser import parse_sdl
+
+    _write_compose(tmp_path, {"kali": ["kali"], "victim": ["victim"]})
+    scenario = parse_sdl(
+        dedent(
+            """
+            name: partial-range
+            nodes:
+              internal-net:
+                type: switch
+              kali:
+                type: vm
+                services:
+                  - {name: ssh, port: 22, protocol: tcp}
+            infrastructure:
+              internal-net:
+                properties: {cidr: 172.20.2.0/24, gateway: 172.20.2.1, internal: true}
+              kali:
+                links: [internal-net]
+            """
+        )
+    )
+    config = AptlConfig(
+        lab={"name": "t"},
+        containers={
+            "wazuh": False,
+            "victim": True,
+            "kali": True,
+            "reverse": False,
+            "enterprise": False,
+            "soc": False,
+            "mail": False,
+            "fileshare": False,
+            "dns": False,
+        },
+    )
+
+    details, check = check_provisioning_realization(
+        scenario=scenario, project_dir=tmp_path, config=config
+    )
+
+    assert details is not None
+    assert not check.passed
+    assert any("public lab start profiles" in d for d in check.diagnostics)
+
+
 def test_validate_scenario_composes_checks(monkeypatch, tmp_path):
     monkeypatch.setattr(gc, "check_parse", lambda p: ("scn", GateCheck("parse", True)))
     monkeypatch.setattr(gc, "check_import_lock", lambda p: GateCheck("import_lock", True))
@@ -576,3 +661,10 @@ def test_no_start_backend_refuses_everything():
         backend.stop()
     with pytest.raises(RuntimeError):
         backend.status()
+
+
+def _realized_aliases(details):
+    aliases = set()
+    for node in details.get("nodes", []):
+        aliases.update(node.get("aliases", []))
+    return aliases


### PR DESCRIPTION
## Summary
- add a pure ACES operational TechVault SDL that declares the steady-state public-start range without the deep asset inventory dump
- point the ACES public startup path and live gate defaults at the operational SDL while keeping the full TechVault SDL as inventory/parity evidence
- make the static gate fail when ACES-selected profiles do not match the normal public `aptl lab start` profiles, with tests for profile and service coverage

## Validation
- `.venv/bin/python -m pytest tests/test_aces_backend.py tests/test_techvault_static_gate.py tests/test_techvault_live_gate.py -m "not integration" -q`
- `.venv/bin/pre-commit run --all-files`
- `git diff --check`

Closes #370