### PR TITLE
security: reject cross-origin mutating requests in SvelteKit API proxy

### DIFF
--- a/changelog.d/521.security.md
+++ b/changelog.d/521.security.md
@@ -1,0 +1,6 @@
+### Security
+
+The SvelteKit `/api/*` auth proxy now rejects cross-origin mutating requests
+(`POST`, `PUT`, `PATCH`, `DELETE`) when `Origin` does not match the UI origin
+or `Sec-Fetch-Site` is `cross-site`, preventing blind lab lifecycle changes
+via CSRF through the operator's browser.

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,12 +1,35 @@
 import type { Handle } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function isCrossOriginMutatingRequest(request: Request, expectedOrigin: string): boolean {
+	if (!MUTATING_METHODS.has(request.method)) {
+		return false;
+	}
+
+	const secFetchSite = request.headers.get('sec-fetch-site');
+	if (secFetchSite === 'cross-site') {
+		return true;
+	}
+
+	const origin = request.headers.get('origin');
+	if (origin !== null && origin !== expectedOrigin) {
+		return true;
+	}
+
+	return false;
+}
+
 /**
  * Server-side proxy for all /api/* requests (ADR-039).
  *
  * The SvelteKit server injects the bearer token so the browser never needs to
  * carry it in request headers or URLs. Streaming responses (SSE) are forwarded
  * unchanged, preserving the EventSource protocol.
+ *
+ * Mutating requests must be same-origin (Origin / Sec-Fetch-Site gate) so a
+ * malicious page cannot trigger blind lab lifecycle changes through the proxy.
  */
 export const handle: Handle = async ({ event, resolve }) => {
 	if (event.url.pathname.startsWith('/api/')) {
@@ -16,6 +39,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 		if (!token) {
 			return new Response(JSON.stringify({ detail: 'API token not configured on server' }), {
 				status: 503,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+
+		if (isCrossOriginMutatingRequest(event.request, event.url.origin)) {
+			return new Response(JSON.stringify({ detail: 'Cross-origin API request rejected' }), {
+				status: 403,
 				headers: { 'Content-Type': 'application/json' }
 			});
 		}

--- a/web/tests/server/hooks.test.ts
+++ b/web/tests/server/hooks.test.ts
@@ -21,10 +21,15 @@ vi.mock('$env/dynamic/private', () => ({ env: mockEnv }));
 // Import AFTER vi.mock so vitest's hoisting applies the mock first.
 import { handle } from '../../src/hooks.server';
 
-function makeEvent(pathname: string, method = 'GET') {
+function makeEvent(
+	pathname: string,
+	method = 'GET',
+	headers: Record<string, string> = {}
+) {
+	const url = `http://localhost${pathname}`;
 	return {
-		url: new URL(`http://localhost${pathname}`),
-		request: new Request(`http://localhost${pathname}`, { method })
+		url: new URL(url),
+		request: new Request(url, { method, headers })
 	};
 }
 
@@ -96,5 +101,58 @@ describe('handle', () => {
 
 		expect(resolve).toHaveBeenCalledWith(event);
 		expect(response.status).toBe(200);
+	});
+
+	it.each([
+		['/api/lab/start'],
+		['/api/lab/stop'],
+		['/api/lab/kill?containers=true']
+	])('rejects cross-origin POST %s without upstream fetch', async (pathname) => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		const event = makeEvent(pathname, 'POST', {
+			Origin: 'https://attacker.example'
+		});
+		const response = await handle({ event, resolve: vi.fn() } as Parameters<typeof handle>[0]);
+
+		expect(response.status).toBe(403);
+		expect(fetchMock).not.toHaveBeenCalled();
+		const body = await response.json();
+		expect(body.detail).toMatch(/cross-origin/i);
+	});
+
+	it('rejects mutating requests with Sec-Fetch-Site: cross-site', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		const event = makeEvent('/api/lab/start', 'POST', {
+			'Sec-Fetch-Site': 'cross-site'
+		});
+		const response = await handle({ event, resolve: vi.fn() } as Parameters<typeof handle>[0]);
+
+		expect(response.status).toBe(403);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('allows same-origin POST with matching Origin', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response('{"status":"ok"}', {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const event = makeEvent('/api/lab/start', 'POST', {
+			Origin: 'http://localhost',
+			'Sec-Fetch-Site': 'same-origin'
+		});
+		const response = await handle({ event, resolve: vi.fn() } as Parameters<typeof handle>[0]);
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect((opts.headers as Headers).get('authorization')).toBe('Bearer test-hook-token');
 	});
 });


### PR DESCRIPTION
## Summary

Adds an explicit same-origin gate to the SvelteKit `/api/*` auth proxy (`hooks.server.ts`) so cross-origin mutating requests are rejected with HTTP 403 before the bearer token is injected or upstream `fetch` runs. This closes a CSRF vector where a malicious page could trigger blind lab lifecycle changes through the operator's browser.

## Requirement UIDs

- (none — bug/security maintenance run; see Traceability section below)

## ADR References

- ADR-039 (Web Control Plane Authentication and Loopback Exposure)
- ADR-021 (Gated Agentic Development Loop)

## Changes

- `web/src/hooks.server.ts` — reject `POST`/`PUT`/`PATCH`/`DELETE` when `Sec-Fetch-Site: cross-site` or `Origin` does not match `event.url.origin`
- `web/tests/server/hooks.test.ts` — cross-origin rejection tests for `/api/lab/start`, `/api/lab/stop`, `/api/lab/kill`; same-origin POST still proxies with bearer token
- `changelog.d/521.security.md` — security fragment

## Traceability

**IMPLEMENTS**
- issue #521 ← `web/src/hooks.server.ts`

**TESTS**
- issue #521 ← `web/tests/server/hooks.test.ts`

## Test Plan

- [x] `cd web && npx vitest run tests/server/hooks.test.ts` — 10/10 pass
- [x] `cd web && npx vitest run` — 82/82 pass
- [x] pre-commit `vitest-web` hook passes on staged files

## Related Issues

Closes #521

Made with [Cursor](https://cursor.com)