### PR TITLE
security: harden LocalRunStore run archive path containment

### DIFF
--- a/changelog.d/522.security.md
+++ b/changelog.d/522.security.md
@@ -1,0 +1,3 @@
+### Security
+
+- Harden `LocalRunStore` core archive methods against `run_id` and `relative_path` traversal so run evidence cannot be written outside the intended run archive tree; reject unsafe `--run-id` values at `aptl lab validate-live` ingress (issue #522).

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -277,12 +277,19 @@ def validate_live(
     fast CI: it needs Docker, the SOC stack's resources, and minutes of startup.
     """
     from aptl.cli._common import resolve_config_for_cli, resolve_run_store
+    from aptl.core.runstore import _validate_id
     from aptl.validation.techvault_live_gate import (
         LiveGateOptions,
         validate_live_deployment,
     )
 
     config, project_root = resolve_config_for_cli(project_dir)
+    if run_id is not None:
+        try:
+            _validate_id(run_id, "run_id")
+        except ValueError as exc:
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(code=2)
     if not skip_clean_boot and not yes:
         typer.echo(_LIVE_GATE_WARNING)
         if not typer.confirm("  Continue?", default=False):

--- a/src/aptl/core/runstore.py
+++ b/src/aptl/core/runstore.py
@@ -16,7 +16,7 @@ callers must not route control-plane secrets through them.
 import json
 import re
 import shutil
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, TypedDict
 
 from aptl.utils.logging import get_logger
@@ -52,6 +52,20 @@ def _validate_id(value: str, kind: str) -> str:
         # path-traversal segment. Reject defensively.
         raise ValueError(f"invalid {kind} (contains '..'): {value!r}")
     return value
+
+
+def _validate_relative_path(relative_path: str) -> str:
+    """Reject relative paths that could escape a run directory."""
+    if not isinstance(relative_path, str) or not relative_path:
+        raise ValueError(f"invalid relative_path: {relative_path!r}")
+    if Path(relative_path).is_absolute():
+        raise ValueError(f"invalid relative_path (absolute): {relative_path!r}")
+    parts = PurePosixPath(relative_path.replace("\\", "/")).parts
+    if ".." in parts:
+        raise ValueError(
+            f"invalid relative_path (contains '..'): {relative_path!r}"
+        )
+    return relative_path
 
 
 def _safe_default(obj: Any) -> str:
@@ -116,20 +130,36 @@ class LocalRunStore:
     """
 
     def __init__(self, base_dir: Path) -> None:
-        self._base_dir = base_dir
+        self._base_dir = base_dir.resolve()
 
     @property
     def base_dir(self) -> Path:
         return self._base_dir
 
+    def _run_dir(self, run_id: str) -> Path:
+        """Return the resolved run directory after validating ``run_id``."""
+        safe_run_id = _validate_id(run_id, "run_id")
+        return (self._base_dir / safe_run_id).resolve()
+
+    def _resolve_run_target(self, run_id: str, relative_path: str) -> Path:
+        """Resolve a write/read target under ``<base_dir>/<run_id>/``."""
+        run_dir = self._run_dir(run_id)
+        safe_rel = _validate_relative_path(relative_path)
+        target = (run_dir / safe_rel).resolve()
+        if not target.is_relative_to(run_dir):
+            raise ValueError(
+                f"invalid relative_path (escapes run dir): {relative_path!r}"
+            )
+        return target
+
     def create_run(self, run_id: str) -> Path:
-        run_dir = self._base_dir / run_id
+        run_dir = self._run_dir(run_id)
         run_dir.mkdir(parents=True, exist_ok=True)
         log.info("Created run directory: %s", run_dir)
         return run_dir
 
     def write_file(self, run_id: str, relative_path: str, data: bytes) -> None:
-        target = self._base_dir / run_id / relative_path
+        target = self._resolve_run_target(run_id, relative_path)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(data)
         log.debug("Wrote %d bytes to %s", len(data), target)
@@ -166,7 +196,7 @@ class LocalRunStore:
         """
         if not records:
             return
-        target = self._base_dir / run_id / relative_path
+        target = self._resolve_run_target(run_id, relative_path)
         target.parent.mkdir(parents=True, exist_ok=True)
         # Redact each record at the persistence boundary (ADR-029).
         lines = [
@@ -179,7 +209,7 @@ class LocalRunStore:
         log.debug("Appended %d JSONL records to %s", len(records), target)
 
     def copy_file(self, run_id: str, relative_path: str, source: Path) -> None:
-        target = self._base_dir / run_id / relative_path
+        target = self._resolve_run_target(run_id, relative_path)
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, target)
         log.debug("Copied %s -> %s", source, target)
@@ -194,13 +224,13 @@ class LocalRunStore:
         return runs
 
     def get_run_manifest(self, run_id: str) -> dict:
-        manifest_path = self._base_dir / run_id / "manifest.json"
+        manifest_path = self._resolve_run_target(run_id, "manifest.json")
         if not manifest_path.exists():
             raise FileNotFoundError(f"No manifest for run {run_id}")
         return json.loads(manifest_path.read_text(encoding="utf-8"))
 
     def get_run_path(self, run_id: str) -> Path:
-        return self._base_dir / run_id
+        return self._run_dir(run_id)
 
     # ------------------------------------------------------------------
     # OBS-003: per-session subdirectory contract.
@@ -215,12 +245,11 @@ class LocalRunStore:
     # ------------------------------------------------------------------
 
     def mcp_side_dir(self, run_id: str) -> Path:
-        return self._base_dir / _validate_id(run_id, "run_id") / "mcp-side"
+        return self._run_dir(run_id) / "mcp-side"
 
     def kali_side_session_dir(self, run_id: str, session_id: str) -> Path:
         return (
-            self._base_dir
-            / _validate_id(run_id, "run_id")
+            self._run_dir(run_id)
             / "kali-side"
             / _validate_id(session_id, "session_id")
         )

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -128,6 +128,19 @@ def check_static_prerequisite(
 # --------------------------------------------------------------------------- #
 
 
+def check_run_id_input(options: "LiveGateOptions") -> LiveGateCheck:
+    """Reject caller-supplied run ids that could escape the run archive tree."""
+    from aptl.core.runstore import _validate_id
+
+    if options.run_id is None:
+        return _check("run_id_input", CATEGORY_EVIDENCE_CAPTURE, [])
+    try:
+        _validate_id(options.run_id, "run_id")
+    except ValueError as exc:
+        return _check("run_id_input", CATEGORY_EVIDENCE_CAPTURE, [str(exc)])
+    return _check("run_id_input", CATEGORY_EVIDENCE_CAPTURE, [])
+
+
 def check_boot_inputs_match_public_path(
     scenario_path: Path,
     *,

--- a/src/aptl/validation/techvault_live_gate.py
+++ b/src/aptl/validation/techvault_live_gate.py
@@ -219,6 +219,11 @@ def validate_live_deployment(
     state = LiveGateState()
     results: list[LiveGateCheck] = []
 
+    run_id_check = checks.check_run_id_input(opts)
+    results.append(run_id_check)
+    if not run_id_check.passed:
+        return _report(scenario_path, run_id, opts, results)
+
     # 1. Static prerequisite — parse/compile/conformance/parity must pass; a
     #    static failure blocks the live boot rather than degrading to a warning.
     scenario, static_check = checks.check_static_prerequisite(

--- a/tests/test_runstore.py
+++ b/tests/test_runstore.py
@@ -271,6 +271,81 @@ class TestLocalRunStoreRedactionArgvShape:
         assert "alice" in text  # bare username preserved
 
 
+class TestLocalRunStorePathContainment:
+    """Core archive methods must stay inside ``<base_dir>/<run_id>/``.
+
+    OBS-003 helpers already validate ``run_id``; the write/read surface
+    (``create_run``, ``write_*``, ``copy_file``, ``get_run_path``) must
+    enforce the same contract (issue #522).
+    """
+
+    def test_create_run_rejects_traversal_run_id(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+
+        with pytest.raises(ValueError, match="run_id"):
+            store.create_run("../outside")
+
+    def test_write_json_rejects_traversal_run_id(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+
+        store.create_run("safe")
+        with pytest.raises(ValueError, match="run_id"):
+            store.write_json("../outside", "pwn.json", {"ok": True})
+
+    def test_write_json_rejects_traversal_relative_path(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+
+        store.create_run("safe")
+        with pytest.raises(ValueError, match="relative_path"):
+            store.write_json("safe", "../escape.json", {"ok": True})
+
+    def test_append_jsonl_rejects_traversal_relative_path(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+
+        store.create_run("safe")
+        with pytest.raises(ValueError, match="relative_path"):
+            store.append_jsonl("safe", "../../escape.jsonl", [{"a": 1}])
+
+    def test_copy_file_rejects_traversal_relative_path(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+
+        store.create_run("safe")
+        source = tmp_path / "source.txt"
+        source.write_text("data")
+        with pytest.raises(ValueError, match="relative_path"):
+            store.copy_file("safe", "../escape.txt", source)
+
+    def test_traversal_attempts_do_not_escape_base(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+
+        with pytest.raises(ValueError):
+            store.create_run("../outside")
+        with pytest.raises(ValueError):
+            store.write_json("safe", "../escape.json", {"ok": True})
+        assert not (tmp_path / "outside").exists()
+        assert not (tmp_path / "escape.json").exists()
+
+    def test_get_run_path_rejects_traversal_run_id(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+
+        with pytest.raises(ValueError, match="run_id"):
+            store.get_run_path("../outside")
+
+    def test_get_run_manifest_rejects_traversal_run_id(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        import pytest
+
+        with pytest.raises(ValueError, match="run_id"):
+            store.get_run_manifest("../outside")
+
+
 class TestSessionScopedHelpers:
     """OBS-003: per-session subdirectories under a run.
 

--- a/tests/test_techvault_live_gate.py
+++ b/tests/test_techvault_live_gate.py
@@ -222,6 +222,7 @@ def test_validate_live_deployment_composes_all_checks(monkeypatch):
     )
     assert report.passed
     assert {c.name for c in report.checks} == {
+        "run_id_input",
         "static_prerequisite",
         "boot_inputs_match_public_path",
         "aces_driven_boot",
@@ -248,7 +249,7 @@ def test_validate_live_deployment_short_circuits_on_static_failure(monkeypatch):
         SCENARIO, project_dir=PROJECT_ROOT, config=_config()
     )
     assert not report.passed
-    assert [c.name for c in report.checks] == ["static_prerequisite"]
+    assert [c.name for c in report.checks] == ["run_id_input", "static_prerequisite"]
 
 
 def test_validate_live_deployment_records_archive_on_boot_failure(monkeypatch):
@@ -274,6 +275,7 @@ def test_validate_live_deployment_records_archive_on_boot_failure(monkeypatch):
     )
     assert not report.passed
     assert [c.name for c in report.checks] == [
+        "run_id_input",
         "static_prerequisite",
         "boot_inputs_match_public_path",
         "aces_driven_boot",
@@ -432,6 +434,7 @@ def test_validate_live_deployment_short_circuits_on_input_mismatch(monkeypatch):
     )
     assert not report.passed
     assert [c.name for c in report.checks] == [
+        "run_id_input",
         "static_prerequisite",
         "boot_inputs_match_public_path",
     ]
@@ -918,6 +921,28 @@ def _patch_cli(mocker, *, passed=True):
         return_value=report,
     )
     return CliRunner(), run
+
+
+def test_validate_live_deployment_rejects_unsafe_run_id():
+    report = validate_live_deployment(
+        project_dir=PROJECT_ROOT,
+        config=_config(),
+        options=LiveGateOptions(run_id="../escape"),
+    )
+    assert not report.passed
+    assert any("run_id" in d for check in report.checks for d in check.diagnostics)
+
+
+def test_cli_validate_live_rejects_traversal_run_id(mocker):
+    from aptl.cli.main import app
+
+    runner, run = _patch_cli(mocker, passed=True)
+    result = runner.invoke(
+        app,
+        ["lab", "validate-live", "--skip-clean-boot", "--run-id", "../escape"],
+    )
+    assert result.exit_code != 0
+    run.assert_not_called()
 
 
 def test_cli_validate_live_help():


### PR DESCRIPTION
## Summary

- Route all core `LocalRunStore` archive methods through `_validate_id()` for `run_id` and a new `_resolve_run_target()` helper that rejects absolute paths, `..` segments, and resolved targets outside `<base_dir>/<run_id>/`.
- Reject unsafe `--run-id` values at `aptl lab validate-live` CLI ingress and in `validate_live_deployment` via `check_run_id_input` before any destructive boot.

## Related Issues

Closes #522

## Requirement UIDs

- (none — bug/security hardening run; see ADR-029)

## ADR refs

- ADR-029 (control-plane secret handling / run archive persistence boundary)
- ADR-021 (gated agentic development loop)

## Traceability

**IMPLEMENTS**
- (none — requirement-free security fix)

**TESTS**
- `tests/test_runstore.py` — `TestLocalRunStorePathContainment`
- `tests/test_techvault_live_gate.py` — unsafe run_id rejection (orchestrator + CLI)

## Changelog

- `changelog.d/522.security.md`

## Test plan

- [x] `pytest tests/test_runstore.py::TestLocalRunStorePathContainment`
- [x] `pytest tests/test_techvault_live_gate.py` (including new run_id rejection tests)
- [x] pre-commit on changed files

Made with [Cursor](https://cursor.com)