### PR TITLE
chore: enforce CI strictness on protected branches

### DIFF
--- a/.github/branch-protection-baseline.json
+++ b/.github/branch-protection-baseline.json
@@ -1,0 +1,35 @@
+{
+  "source": "APTL required merge checks (issue #502); advisory scanners per ADR-026 stay optional",
+  "branches": {
+    "main": {
+      "admin_bypass_allowed": true,
+      "changes_land_via_pull_request": true,
+      "required_status_checks": {
+        "strict": true,
+        "contexts": [
+          "Pre-commit hooks",
+          "Docs (Vale prose lint + mkdocs strict build)",
+          "Python tests + coverage",
+          "MCP TypeScript tests + coverage",
+          "Web frontend tests + coverage",
+          "SonarCloud quality gate"
+        ]
+      }
+    },
+    "dev": {
+      "admin_bypass_allowed": true,
+      "changes_land_via_pull_request": true,
+      "required_status_checks": {
+        "strict": true,
+        "contexts": [
+          "Pre-commit hooks",
+          "Docs (Vale prose lint + mkdocs strict build)",
+          "Python tests + coverage",
+          "MCP TypeScript tests + coverage",
+          "Web frontend tests + coverage",
+          "SonarCloud quality gate"
+        ]
+      }
+    }
+  }
+}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -444,18 +444,9 @@ jobs:
           retention-days: 7
 
   sonarcloud:
-    name: SonarCloud quality gate (advisory)
+    name: SonarCloud quality gate
     needs: [python-tests, mcp-tests, web-tests]
     runs-on: ubuntu-latest
-    # Advisory — the scan still uploads results to SonarCloud and the
-    # dashboard reflects current state; removing -Dsonar.qualitygate.wait
-    # means the action does not fail the workflow when the gate is RED.
-    # The lab is research code; coverage targets that make sense for
-    # production apps would block infra-only commits (Dockerfiles, compose,
-    # workflows, scripts). Re-enable strict gating by adding the wait flag
-    # back and re-listing this job as a required status check on the
-    # branch protection rule once the project's coverage debt is sized.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
         with:
@@ -487,3 +478,11 @@ jobs:
       - uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.qualitygate.wait=true
+      - name: Fail on new SonarCloud issues
+        if: github.ref_type != 'tag'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: python3 tools/sonar/assert_no_new_issues.py --project-key Brad-Edwards_aptl

--- a/changelog.d/502.changed.md
+++ b/changelog.d/502.changed.md
@@ -1,0 +1,1 @@
+Enforce CI strictness on protected branches: SonarCloud waits for the quality gate and fails on new issues, branch-protection baseline records strict required checks for `main` and `dev`, and the Docs job joins the required merge gate.

--- a/docs/adrs/adr-010-sonarcloud-quality.md
+++ b/docs/adrs/adr-010-sonarcloud-quality.md
@@ -55,17 +55,32 @@ Integrate SonarCloud via GitHub Actions for continuous code quality analysis acr
 - SonarCloud free tier limits may be reached as the codebase grows (currently well within limits for open-source projects)
 - Coverage thresholds are not yet enforced as quality gates—currently informational only
 
-## Update (2026-05-10): SonarCloud gate stays advisory; a hard in-repo complexity gate is added
+## Update (2026-06-21): SonarCloud gate is required again (issue #502)
 
-The SonarCloud analysis now lives in `.github/workflows/checks.yml` (the
-former `sonarcloud.yml` was folded in), and the quality-gate job is run
+The SonarCloud job in `.github/workflows/checks.yml` is a **required** merge
+gate again: it runs with `-Dsonar.qualitygate.wait=true` and invokes
+`tools/sonar/assert_no_new_issues.py` so any open issue in the new-code leak
+period fails CI. Advisory vulnerability scanners (Trivy, OSV-scanner,
+dependency-audit) stay non-blocking per ADR-026.
+
+Branch protection on `main` and `dev` uses strict required status checks
+(documented in `.github/branch-protection-baseline.json`): pre-commit, docs,
+Python/MCP/web test jobs, and SonarCloud. Admin bypass is retained
+(`enforce_admins: false`).
+
+The hard in-repo per-function complexity gates (`ruff` `C901`, ESLint
+`complexity`) remain unchanged and continue to gate through the required
+Pre-commit hooks job.
+
+## Update (2026-05-10): SonarCloud gate stayed advisory; hard complexity gate added
+
+The SonarCloud analysis lived in `.github/workflows/checks.yml` (the
+former `sonarcloud.yml` was folded in), and the quality-gate job was run
 **advisory** (`continue-on-error`, no `-Dsonar.qualitygate.wait`): the
 "Sonar way" gate's *Coverage on New Code ≥ 80%* condition would otherwise
 block infra-only commits (Dockerfiles, compose, workflows, scripts) that add
-no covered code. The scan still runs on every PR/push and the dashboard
-reflects current state; SonarCloud's PR analysis is also new-code-scoped, so
-it only surfaces issues on the lines a PR changes—pre-existing complexity
-debt in a lightly touched file is invisible to it.
+no covered code. Issue #502 reverts that posture now that the repo also
+carries the new-code issue gate script.
 
 To keep god-methods / non-modular code out of the tree without the coverage
 trap and without the new-code-only blind spot, a dedicated, **hard**,

--- a/tests/test_sonar_assert_no_new_issues.py
+++ b/tests/test_sonar_assert_no_new_issues.py
@@ -1,0 +1,59 @@
+"""Tests for tools.sonar.assert_no_new_issues."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "assert_no_new_issues",
+    _REPO_ROOT / "tools/sonar/assert_no_new_issues.py",
+)
+assert _SPEC and _SPEC.loader
+gate = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = gate
+_SPEC.loader.exec_module(gate)
+
+
+def test_resolve_scope_from_pull_request_arg() -> None:
+    scope = gate.resolve_scope(gate.parse_args(["--project-key", "proj", "--pull-request", "42"]))
+    assert scope.query_key == "pullRequest"
+    assert scope.query_value == "42"
+    assert scope.label == "PR 42"
+
+
+def test_resolve_scope_from_branch_arg() -> None:
+    scope = gate.resolve_scope(gate.parse_args(["--project-key", "proj", "--branch", "dev"]))
+    assert scope.query_key == "branch"
+    assert scope.query_value == "dev"
+
+
+def test_resolve_scope_from_github_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": {"number": 99}}), encoding="utf-8")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    scope = gate.resolve_scope(gate.parse_args(["--project-key", "proj"]))
+    assert scope.query_key == "pullRequest"
+    assert scope.query_value == "99"
+
+
+def test_render_issue_includes_rule_and_location() -> None:
+    rendered = gate.render_issue(
+        {
+            "severity": "MAJOR",
+            "type": "CODE_SMELL",
+            "rule": "python:S1234",
+            "component": "src/aptl/core/lab.py",
+            "line": 10,
+            "message": "example",
+        }
+    )
+    assert "MAJOR" in rendered
+    assert "python:S1234" in rendered
+    assert "src/aptl/core/lab.py:10" in rendered
+    assert "example" in rendered

--- a/tools/sonar/README.md
+++ b/tools/sonar/README.md
@@ -1,0 +1,19 @@
+# Sonar configuration artifacts
+
+SonarCloud tooling for APTL. The scanner config (`sonar-project.properties`)
+stays at the repository root because the Sonar scanner reads it from there.
+
+## Layout
+
+- `assert_no_new_issues.py`: CI guard that queries SonarCloud after scanner
+  completion and fails the job when the current pull request or branch has
+  any open issue in the new-code leak period.
+
+## New-issue gate
+
+The CI `SonarCloud quality gate` job runs the scanner with
+`-Dsonar.qualitygate.wait=true`, then runs `tools/sonar/assert_no_new_issues.py`.
+The script uses `SONAR_TOKEN` only for SonarCloud API authentication, derives
+the pull request number from the GitHub event payload, and prints only issue
+metadata when it fails. This keeps the repo-side merge gate stricter than a
+SonarCloud project gate that may still allow non-blocking code smells.

--- a/tools/sonar/assert_no_new_issues.py
+++ b/tools/sonar/assert_no_new_issues.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Fail CI when SonarCloud reports open issues on new code."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SONARCLOUD_API = "https://sonarcloud.io/api/issues/search"
+OPEN_ISSUE_STATUSES = "OPEN,CONFIRMED"
+
+
+@dataclass(frozen=True)
+class AnalysisScope:
+    query_key: str
+    query_value: str
+
+    @property
+    def label(self) -> str:
+        if self.query_key == "pullRequest":
+            return f"PR {self.query_value}"
+        return f"branch {self.query_value}"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-key", required=True, help="SonarCloud project key.")
+    parser.add_argument("--pull-request", help="Pull request number to inspect.")
+    parser.add_argument("--branch", help="Branch name to inspect when this is not a PR run.")
+    parser.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=60,
+        help="How long to retry transient SonarCloud API failures.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=10,
+        help="Seconds between transient-failure retries.",
+    )
+    return parser.parse_args(argv)
+
+
+def resolve_scope(args: argparse.Namespace) -> AnalysisScope:
+    if args.pull_request:
+        return AnalysisScope("pullRequest", args.pull_request)
+    if args.branch:
+        return AnalysisScope("branch", args.branch)
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path:
+        event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        pull_request = event.get("pull_request")
+        if isinstance(pull_request, dict) and pull_request.get("number"):
+            return AnalysisScope("pullRequest", str(pull_request["number"]))
+
+    ref_name = os.environ.get("GITHUB_REF_NAME")
+    if ref_name:
+        return AnalysisScope("branch", ref_name)
+
+    raise SystemExit("Unable to determine SonarCloud PR or branch scope.")
+
+
+def build_request_url(project_key: str, scope: AnalysisScope, page: int) -> str:
+    query = {
+        "componentKeys": project_key,
+        scope.query_key: scope.query_value,
+        "issueStatuses": OPEN_ISSUE_STATUSES,
+        "sinceLeakPeriod": "true",
+        "p": str(page),
+        "ps": "500",
+    }
+    return f"{SONARCLOUD_API}?{urllib.parse.urlencode(query)}"
+
+
+def fetch_json(url: str, token: str) -> dict[str, Any]:
+    encoded = base64.b64encode(f"{token}:".encode("utf-8")).decode("ascii")
+    request = urllib.request.Request(url, headers={"Authorization": f"Basic {encoded}"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def fetch_issues(project_key: str, scope: AnalysisScope, token: str) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    page = 1
+    total = 0
+    while page == 1 or len(issues) < total:
+        payload = fetch_json(build_request_url(project_key, scope, page), token)
+        total = int(payload.get("total", 0))
+        issues.extend(payload.get("issues", []))
+        if not payload.get("issues"):
+            break
+        page += 1
+    return issues
+
+
+def fetch_issues_with_retry(
+    project_key: str,
+    scope: AnalysisScope,
+    token: str,
+    wait_seconds: int,
+    poll_interval: int,
+) -> list[dict[str, Any]]:
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        try:
+            return fetch_issues(project_key, scope, token)
+        except Exception as exc:  # noqa: BLE001 - CI gate should retry any transient API failure.
+            if time.monotonic() >= deadline:
+                raise SystemExit(f"SonarCloud issue lookup failed: {exc}") from exc
+            print(f"SonarCloud issue lookup failed, retrying: {exc}", file=sys.stderr)
+            time.sleep(poll_interval)
+
+
+def render_issue(issue: dict[str, Any]) -> str:
+    component = issue.get("component", "")
+    line = issue.get("line")
+    location = f"{component}:{line}" if line else component
+    return (
+        f"- {issue.get('severity', 'UNKNOWN')} {issue.get('type', 'ISSUE')} "
+        f"{issue.get('rule', 'unknown-rule')} at {location}: {issue.get('message', '')}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    token = os.environ.get("SONAR_TOKEN")
+    if not token:
+        print("SONAR_TOKEN is required for the SonarCloud new-issue gate.", file=sys.stderr)
+        return 2
+
+    scope = resolve_scope(args)
+    issues = fetch_issues_with_retry(
+        args.project_key,
+        scope,
+        token,
+        args.wait_seconds,
+        args.poll_interval,
+    )
+    if not issues:
+        print(f"SonarCloud new-issue gate passed for {scope.label}.")
+        return 0
+
+    print(f"SonarCloud new-issue gate failed for {scope.label}: {len(issues)} issue(s).", file=sys.stderr)
+    for issue in issues:
+        print(render_issue(issue), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Make the SonarCloud CI job a required merge gate: `-Dsonar.qualitygate.wait=true` plus `tools/sonar/assert_no_new_issues.py` to fail on any new open issue in the leak period.
- Add `.github/branch-protection-baseline.json` documenting strict required checks for `main` and `dev` (pre-commit, docs, Python/MCP/web tests, SonarCloud); advisory scanners stay optional per ADR-026.
- Update ADR-010 to record the strict Sonar posture restored by issue #502.

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest tests/test_sonar_assert_no_new_issues.py`
- [ ] CI Checks workflow green on this PR
- [ ] Apply branch protection on `main` and `dev` from the baseline (strict + expanded contexts)

Closes #502

Made with [Cursor](https://cursor.com)