### PR TITLE
feat: upgrade aptl backend conformance to orchestration-evaluation profile

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,7 +98,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,web]"
-      - name: ACES static validation gate (TechVault, orchestration-capable)
+      - name: ACES static validation gate (TechVault, orchestration-evaluation)
         run: python -m pytest tests/test_techvault_static_gate.py -q -m integration
 
   mcp-tests:

--- a/changelog.d/312.added.md
+++ b/changelog.d/312.added.md
@@ -1,0 +1,17 @@
+### Added
+
+- **ACES backend promotion to `orchestration-evaluation` (SCN-010 / #312).**
+  APTL's published `backend-manifest-v2` now declares a real
+  `capabilities.evaluator` plus the `evaluation-result-envelope-v1` and
+  `evaluation-history-event-stream-v1` contracts, and the runtime target
+  carries a concrete ACES `Evaluator` (`aptl.backends.aces_evaluator.AptlEvaluator`)
+  that registers objective and condition evaluation through the portable ACES
+  evaluation result/history contracts. Scenario start now routes evaluation
+  through the ACES runtime control plane after provisioning and orchestration.
+  The static and live validation gates, the pre-push hook, the advisory CI job,
+  and `aptl lab validate-live` default from the `orchestration-capable` to the
+  `orchestration-evaluation` profile, and `aces conformance backend
+  --profile orchestration-evaluation` passes against APTL's manifest. The
+  evaluator registers each observable evaluation resource as a truthful
+  `PENDING` run; sourcing live `RUNNING` → terminal execution state from
+  RTE-001 is the follow-on #514.

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -30,6 +30,7 @@ from aptl.backends.aces_diagnostics import (
     snapshot_after_apply,
 )
 from aptl.backends.aces_manifest import APTL_ACES_TARGET_NAME, create_aptl_manifest
+from aptl.backends.aces_evaluator import AptlEvaluator
 from aptl.backends.aces_orchestrator import AptlOrchestrator
 from aptl.backends.aces_realization import (
     AptlRealization,
@@ -71,6 +72,7 @@ def create_aptl_runtime_target(
         manifest=create_aptl_manifest(),
         provisioner=provisioner,  # type: ignore[arg-type]
         orchestrator=AptlOrchestrator(),  # type: ignore[arg-type]
+        evaluator=AptlEvaluator(),  # type: ignore[arg-type]
     )
 
 
@@ -104,24 +106,13 @@ def start_aces_scenario(
 def _run_execution_plan(target: RuntimeTarget, execution_plan: "ExecutionPlan") -> LabResult:
     """Apply a planned ACES scenario through the runtime control plane.
 
-    APTL declares no ACES evaluator yet (tracked by #312). A scenario may still
-    carry evaluation content — notably the ``conditions`` section, whose entries
-    are Docker Compose healthchecks realized during provisioning, not by an ACES
-    evaluator. The planner flags such content with the evaluation-domain
-    ``evaluator.missing`` ERROR; tolerate exactly that one expected diagnostic
-    and stay fail-closed for every other planner error (provisioning ordering
-    cycles, unsupported capabilities, orchestration errors, ...). Now that APTL
-    is orchestration-capable, scenario start no longer bypasses the orchestration
-    path: provisioning is applied, then — when the scenario carries workflows —
-    orchestration is started so APTL's orchestrator records workflow
-    result/history through the portable ACES contracts.
+    Fail closed on every planner error. Scenario start routes provisioning,
+    orchestration (when the scenario carries workflows), and evaluation (when
+    the scenario carries observable evaluation resources) through the ACES
+    runtime control plane so APTL's published backend adapters record portable
+    contract state.
     """
-    blocking = [
-        diag
-        for diag in execution_plan.diagnostics
-        if diag.is_error
-        and not (diag.domain == "evaluation" and diag.code == "evaluator.missing")
-    ]
+    blocking = [diag for diag in execution_plan.diagnostics if diag.is_error]
     if blocking:
         return LabResult(success=False, error=render_aces_diagnostics(blocking))
     control_plane = RuntimeControlPlane(target, initial_snapshot=execution_plan.base_snapshot)
@@ -138,10 +129,9 @@ def _apply_provisioning_and_orchestration(
     control_plane: RuntimeControlPlane,
     execution_plan: "ExecutionPlan",
 ) -> LabResult | None:
-    """Submit provisioning, then orchestration when the plan carries workflows.
+    """Submit provisioning, orchestration, and evaluation control-plane phases.
 
     Returns a failed ``LabResult`` for the first phase that fails, else ``None``.
-    Evaluation stays unsubmitted until #312 adds the evaluator.
     """
     provisioning_failure = _apply_phase(
         control_plane,
@@ -150,9 +140,16 @@ def _apply_provisioning_and_orchestration(
     if provisioning_failure is not None:
         return provisioning_failure
     if execution_plan.orchestration.actionable_operations:
-        return _apply_phase(
+        orchestration_failure = _apply_phase(
             control_plane,
             lambda: control_plane.submit_orchestration(execution_plan.orchestration),
+        )
+        if orchestration_failure is not None:
+            return orchestration_failure
+    if execution_plan.evaluation.actionable_operations:
+        return _apply_phase(
+            control_plane,
+            lambda: control_plane.submit_evaluation(execution_plan.evaluation),
         )
     return None
 

--- a/src/aptl/backends/aces_evaluator.py
+++ b/src/aptl/backends/aces_evaluator.py
@@ -1,0 +1,232 @@
+"""APTL ACES evaluation adapter.
+
+Promotes APTL's ACES backend from ``orchestration-capable`` to
+``orchestration-evaluation`` (SCN-010 follow-on #312). APTL's scenario runtime
+engine (RTE-001) already evaluates conditions and objectives; this adapter
+exposes that surface through the *portable* ACES contracts
+``evaluation-result-envelope-v1`` and ``evaluation-history-event-stream-v1``
+rather than APTL-native scoring shapes.
+
+The adapter is the ACES ``Evaluator`` component published on APTL's
+``RuntimeTarget``. ``start()`` loads an ACES ``EvaluationPlan`` into runtime
+state: it registers every evaluation resource as an ACES ``SnapshotEntry`` and,
+for each observable evaluation resource, records a truthful
+``EvaluationExecutionState`` — the run is ``PENDING`` (registered and awaiting
+execution) with a single ``evaluation_started`` history event, because no
+objective or condition outcome has been observed yet. The adapter never reports
+``READY``/``FAILED`` outcomes or invents scores. Outcome progression is driven
+out-of-band by RTE-001; when that execution-state integration lands (tracked
+by #514), the same ``results()`` / ``history()`` surface will report the real
+``RUNNING`` → terminal transitions and ``EvaluationHistoryEvent`` streams.
+``stop()`` clears evaluation state.
+
+This keeps the orchestration-evaluation claim honest: APTL publishes the
+evaluation result/history *contract* surface and the loaded/registered run
+state, not a synthetic in-memory result that never progresses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.evaluation import (
+    EvaluationExecutionState,
+    EvaluationHistoryEvent,
+    EvaluationHistoryEventType,
+    EvaluationResultContract,
+    EvaluationResultStatus,
+)
+from aces_contracts.planning import ChangeAction, EvaluationPlan, RuntimeDomain
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
+
+from aptl.utils.redaction import redact
+
+EVALUATION_ADDRESS = "runtime.apply.evaluation"
+_OBSERVABLE_RESOURCE_TYPES = frozenset({"condition-binding", "objective"})
+
+
+def _evaluation_diagnostic(code: str, address: str, message: str) -> Diagnostic:
+    """Build a redacted evaluation-domain ACES error diagnostic."""
+    return Diagnostic(
+        code=code,
+        domain=RuntimeDomain.EVALUATION.value,
+        address=address,
+        message=redact(message),
+        severity=Severity.ERROR,
+    )
+
+
+def _utc_now() -> str:
+    """Return the current UTC instant as an ISO-8601 ``...Z`` string."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _register_evaluation(
+    evaluation_address: str,
+    payload: dict[str, object],
+    registered_at: str,
+    results: dict[str, dict[str, object]],
+    history: dict[str, list[dict[str, object]]],
+) -> list[Diagnostic]:
+    """Record the truthful initial (``PENDING``) portable state for a run."""
+    result_contract_payload = payload.get("result_contract")
+    if not isinstance(result_contract_payload, dict):
+        return [
+            _evaluation_diagnostic(
+                "aptl.evaluator.evaluation-contract-missing",
+                evaluation_address,
+                "ACES evaluation resource is missing its compiled result_contract.",
+            )
+        ]
+    try:
+        result_contract = EvaluationResultContract.from_mapping(result_contract_payload)
+    except (TypeError, ValueError) as exc:
+        return [
+            _evaluation_diagnostic(
+                "aptl.evaluator.evaluation-contract-invalid",
+                evaluation_address,
+                f"ACES evaluation result_contract is invalid: {exc}",
+            )
+        ]
+
+    state = EvaluationExecutionState(
+        state_schema_version=result_contract.state_schema_version,
+        resource_type=result_contract.resource_type,
+        run_id=uuid4().hex,
+        status=EvaluationResultStatus.PENDING,
+        observed_at=registered_at,
+        updated_at=registered_at,
+    )
+    results[evaluation_address] = state.to_payload()
+    history[evaluation_address] = [
+        EvaluationHistoryEvent(
+            event_type=EvaluationHistoryEventType.EVALUATION_STARTED,
+            timestamp=registered_at,
+            status=EvaluationResultStatus.PENDING,
+        ).to_payload()
+    ]
+    return []
+
+
+@dataclass
+class AptlEvaluator(object):
+    """``orchestration-evaluation`` ACES backend adapter for APTL."""
+
+    _results: dict[str, dict[str, object]] = field(default_factory=dict, init=False)
+    _history: dict[str, list[dict[str, object]]] = field(default_factory=dict, init=False)
+
+    def start(self, plan: object, snapshot: object) -> ApplyResult:
+        """Load an ACES evaluation plan and register its observable resources."""
+        working_snapshot = snapshot if isinstance(snapshot, RuntimeSnapshot) else RuntimeSnapshot()
+        if not isinstance(plan, EvaluationPlan):
+            return ApplyResult(
+                success=False,
+                snapshot=working_snapshot,
+                diagnostics=[
+                    _evaluation_diagnostic(
+                        "aptl.evaluator.invalid-plan",
+                        EVALUATION_ADDRESS,
+                        "APTL evaluator expected an ACES EvaluationPlan.",
+                    )
+                ],
+            )
+
+        entries = dict(working_snapshot.entries)
+        results = dict(working_snapshot.evaluation_results)
+        history = {
+            address: list(events)
+            for address, events in working_snapshot.evaluation_history.items()
+        }
+        diagnostics: list[Diagnostic] = []
+        changed: list[str] = []
+        registered_at = _utc_now()
+
+        for op in plan.actionable_operations:
+            if op.action == ChangeAction.DELETE:
+                entries.pop(op.address, None)
+                results.pop(op.address, None)
+                history.pop(op.address, None)
+                changed.append(op.address)
+                continue
+            entries[op.address] = SnapshotEntry(
+                address=op.address,
+                domain=RuntimeDomain.EVALUATION,
+                resource_type=op.resource_type,
+                payload=op.payload,
+                ordering_dependencies=op.ordering_dependencies,
+                refresh_dependencies=op.refresh_dependencies,
+                status="ready",
+            )
+            changed.append(op.address)
+            if op.resource_type in _OBSERVABLE_RESOURCE_TYPES:
+                evaluation_diagnostics = _register_evaluation(
+                    op.address,
+                    op.payload,
+                    registered_at,
+                    results,
+                    history,
+                )
+                diagnostics.extend(evaluation_diagnostics)
+
+        if diagnostics:
+            return ApplyResult(
+                success=False,
+                snapshot=working_snapshot,
+                diagnostics=diagnostics,
+            )
+
+        self._results = {address: dict(result) for address, result in results.items()}
+        self._history = {
+            address: [dict(event) for event in events] for address, events in history.items()
+        }
+        return ApplyResult(
+            success=True,
+            snapshot=working_snapshot.with_entries(
+                entries,
+                evaluation_results=results,
+                evaluation_history=history,
+            ),
+            changed_addresses=changed,
+        )
+
+    def status(self) -> dict[str, object]:
+        """Return current evaluation status (registered, pending-execution runs)."""
+        return {
+            "backend": "aptl",
+            "registered_evaluations": sorted(self._results),
+        }
+
+    def results(self) -> dict[str, dict[str, object]]:
+        """Return the most recent evaluation result envelopes."""
+        return {address: dict(result) for address, result in self._results.items()}
+
+    def history(self) -> dict[str, list[dict[str, object]]]:
+        """Return the evaluation history event streams."""
+        return {
+            address: [dict(event) for event in events]
+            for address, events in self._history.items()
+        }
+
+    def stop(self, snapshot: object) -> ApplyResult:
+        """Stop evaluation and clear evaluation state."""
+        working_snapshot = snapshot if isinstance(snapshot, RuntimeSnapshot) else RuntimeSnapshot()
+        retained_entries = {
+            address: entry
+            for address, entry in working_snapshot.entries.items()
+            if entry.domain != RuntimeDomain.EVALUATION
+        }
+        changed = sorted(set(working_snapshot.entries) - set(retained_entries))
+        self._results = {}
+        self._history = {}
+        return ApplyResult(
+            success=True,
+            snapshot=working_snapshot.with_entries(
+                retained_entries,
+                evaluation_results={},
+                evaluation_history={},
+            ),
+            changed_addresses=changed,
+        )

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -4,23 +4,27 @@ APTL publishes its runtime-target capability declaration as the canonical ACES
 ``backend-manifest-v2`` surface (``aces_backend_protocols.capabilities``), not an
 APTL-local approximation. The manifest is what the ACES planner's
 realization-support gate and ``aces conformance backend --profile
-orchestration-capable`` validate against, so it must declare APTL's real
-provisioning and orchestration capability against the published controlled
-vocabularies and contract authority — anything less is rejected by the
-conformance corpus.
+orchestration-evaluation`` validate against, so it must declare APTL's real
+provisioning, orchestration, and evaluation capability against the published
+controlled vocabularies and contract authority — anything less is rejected by
+the conformance corpus.
 
-APTL is an orchestration-capable backend: it realizes ACES provisioning plans
-into Docker Compose profiles and exposes its scenario runtime engine (RTE-001)
-workflow drive surface through the portable ``workflow-result-envelope-v1`` and
-``workflow-history-event-stream-v1`` contracts (see
-``aptl.backends.aces_orchestrator.AptlOrchestrator``). It declares no evaluator
-or participant runtime; that promotion is tracked by #312.
+APTL is an orchestration-evaluation backend: it realizes ACES provisioning
+plans into Docker Compose profiles, exposes its scenario runtime engine
+(RTE-001) workflow drive surface through the portable
+``workflow-result-envelope-v1`` and ``workflow-history-event-stream-v1``
+contracts (see ``aptl.backends.aces_orchestrator.AptlOrchestrator``), and
+publishes objective and condition evaluation through
+``evaluation-result-envelope-v1`` and ``evaluation-history-event-stream-v1``
+(see ``aptl.backends.aces_evaluator.AptlEvaluator``). It declares no
+participant runtime; that promotion remains out of scope.
 """
 
 from __future__ import annotations
 
 from aces_backend_protocols.capabilities import (
     BackendManifest,
+    EvaluatorCapabilities,
     OrchestratorCapabilities,
     ProvisionerCapabilities,
 )
@@ -37,11 +41,12 @@ APTL_ACES_TARGET_VERSION = "0.1.0"
 # The reference ACES processor whose provisioning-plan output APTL realizes.
 _COMPATIBLE_PROCESSORS = frozenset({"aces-reference-processor"})
 
-# Orchestration-capable contract surface. The orchestration-capable backend
-# profile (contracts/profiles/backend/orchestration-capable.json) requires
+# Orchestration-evaluation contract surface. The orchestration-evaluation backend
+# profile (contracts/profiles/backend/orchestration-evaluation.json) requires
 # backend-manifest-v2, operation-receipt-v1, operation-status-v1,
-# runtime-snapshot-v1, workflow-result-envelope-v1, and
-# workflow-history-event-stream-v1; APTL also declares provisioning-plan-v1
+# runtime-snapshot-v1, workflow-result-envelope-v1,
+# workflow-history-event-stream-v1, evaluation-result-envelope-v1, and
+# evaluation-history-event-stream-v1; APTL also declares provisioning-plan-v1
 # because it consumes ACES provisioning plans.
 _SUPPORTED_CONTRACT_VERSIONS = frozenset(
     {
@@ -52,6 +57,8 @@ _SUPPORTED_CONTRACT_VERSIONS = frozenset(
         "runtime-snapshot-v1",
         "workflow-result-envelope-v1",
         "workflow-history-event-stream-v1",
+        "evaluation-result-envelope-v1",
+        "evaluation-history-event-stream-v1",
     }
 )
 
@@ -77,6 +84,18 @@ _ORCHESTRATOR = OrchestratorCapabilities(
     supported_workflow_state_predicates=frozenset(
         {WorkflowStatePredicateFeature.OUTCOME_MATCHING}
     ),
+)
+
+# Evaluator capability declaration. APTL's RTE-001 runtime evaluates scenario
+# conditions (healthchecks realized during provisioning) and objectives through
+# the portable evaluation result/history contracts. Scoring sections are
+# declared because SCN-007 scoring resources compile into the same evaluation
+# plan surface even though live score progression remains #514 follow-on work.
+_EVALUATOR = EvaluatorCapabilities(
+    name="aptl-rte-evaluator",
+    supported_sections=frozenset({"conditions", "objectives", "goals", "evaluations"}),
+    supports_scoring=True,
+    supports_objectives=True,
 )
 
 # Provisioner capability declaration, using only published controlled-vocabulary
@@ -128,7 +147,7 @@ _CONCEPT_BINDINGS = (
 
 
 def create_aptl_manifest() -> BackendManifest:
-    """Return APTL's orchestration-capable canonical ACES ``backend-manifest-v2``."""
+    """Return APTL's orchestration-evaluation canonical ACES ``backend-manifest-v2``."""
     return BackendManifest(
         name=APTL_ACES_TARGET_NAME,
         version=APTL_ACES_TARGET_VERSION,
@@ -138,4 +157,5 @@ def create_aptl_manifest() -> BackendManifest:
         concept_bindings=_CONCEPT_BINDINGS,
         provisioner=_PROVISIONER,
         orchestrator=_ORCHESTRATOR,
+        evaluator=_EVALUATOR,
     )

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -248,7 +248,7 @@ def validate_live(
         help="ACES SDL scenario (default: scenarios/techvault.sdl.yaml).",
     ),
     profile: str = typer.Option(
-        "orchestration-capable",
+        "orchestration-evaluation",
         "--profile",
         help="ACES backend capability profile to validate against.",
     ),

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -152,7 +152,7 @@ def check_boot_inputs_match_public_path(
     The gate computes the expected realization from ``scenario_path`` and
     ``options.profile``, but the public boot path it exercises
     (``orchestrate_lab_start`` → ``start_aces_scenario``) is hardwired to
-    ``DEFAULT_ACES_SCENARIO`` and the ``orchestration-capable`` capability profile;
+    ``DEFAULT_ACES_SCENARIO`` and the ``orchestration-evaluation`` capability profile;
     it ignores any caller-supplied scenario/profile. Booting one model while
     validating another would silently produce false pass/fail results, so a
     mismatch is a hard ``backend_instantiation`` failure raised *before* any
@@ -400,9 +400,9 @@ def check_run_archive_manifest(
 ) -> LiveGateCheck:
     """Persist scenario identity + ACES provenance + validation evidence.
 
-    Writes through ``LocalRunStore``'s redacting boundary (ADR-029). Objective /
-    scoring run surfaces are the evaluator-profile output deferred to #312; they
-    are recorded as deferred, never faked.
+    Writes through ``LocalRunStore``'s redacting boundary (ADR-029).     Objective / scoring run surfaces are published through the portable ACES
+    evaluation contracts at the backend boundary; live outcome progression from
+    RTE-001 remains follow-on work tracked by #514.
     """
     realization = state.realization_details or {}
     manifest = {
@@ -426,10 +426,13 @@ def check_run_archive_manifest(
         },
         "snapshot": state.snapshot,
         "evidence": state.evidence,
-        "evaluator_surfaces_deferred": {
-            "objectives": "#312",
-            "scoring": "#312",
-            "run_archive_evaluator_output": "#312",
+        "evaluator_surfaces": {
+            "profile": "orchestration-evaluation",
+            "contracts": [
+                "evaluation-result-envelope-v1",
+                "evaluation-history-event-stream-v1",
+            ],
+            "execution_state_integration": "#514",
         },
     }
 

--- a/src/aptl/validation/techvault_gate.py
+++ b/src/aptl/validation/techvault_gate.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from aptl.core.config import AptlConfig
 
-DEFAULT_PROFILE = "orchestration-capable"
+DEFAULT_PROFILE = "orchestration-evaluation"
 DEFAULT_SCENARIO = Path("scenarios") / "techvault.sdl.yaml"
 DEFAULT_PARITY_INVENTORY = Path("docs") / "aces" / "parity-inventory.yaml"
 

--- a/src/aptl/validation/techvault_live_gate.py
+++ b/src/aptl/validation/techvault_live_gate.py
@@ -12,7 +12,7 @@ archive.
 Like the static gate, it is scenario-generic and parameterized by scenario
 path, backend profile, and project directory: TechVault is the proving input,
 never a hardcoded branch (ADR-035). The next scenario in APTL's
-``orchestration-capable`` expressivity class passes through by changing inputs.
+``orchestration-evaluation`` expressivity class passes through by changing inputs.
 
 The gate is inherently integration / live-run work: it requires Docker, the SOC
 stack's resources, real ``.env`` secrets, and minutes-long startup. It is wired
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from aptl.core.config import AptlConfig
     from aptl.core.runstore import RunStorageBackend
 
-DEFAULT_PROFILE = "orchestration-capable"
+DEFAULT_PROFILE = "orchestration-evaluation"
 
 # Stable failure categories (issue #323 acceptance: a failure must identify the
 # layer that broke). These map onto existing ACES diagnostics and APTL startup
@@ -142,7 +142,7 @@ class LiveGateReport(object):
 class LiveGateOptions(object):
     """Tunable inputs for the live validation gate.
 
-    ``profile`` selects the backend capability profile (``orchestration-capable``).
+    ``profile`` selects the backend capability profile (``orchestration-evaluation``).
     ``clean_volumes`` runs the data-destroying ``stop -v`` cleanup before the
     boot; ``skip_clean_boot`` validates against an already-running lab without
     the destructive cleanup (operator opt-in for a non-destructive check). The
@@ -233,7 +233,7 @@ def validate_live_deployment(
     static_passed = scenario is not None and static_check.passed
 
     # 2a. Input/boot-path agreement — the public start path is hardwired to the
-    #     default scenario + orchestration-capable profile, so a scenario/profile
+    #     default scenario + orchestration-evaluation profile, so a scenario/profile
     #     the boot path will not honor must fail loud BEFORE any destructive
     #     boot, not silently validate one model while booting another.
     inputs_passed = False

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -141,12 +141,14 @@ def test_create_aptl_manifest_is_canonical_backend_manifest_v2():
         "runtime-snapshot-v1",
         "workflow-result-envelope-v1",
         "workflow-history-event-stream-v1",
+        "evaluation-result-envelope-v1",
+        "evaluation-history-event-stream-v1",
     }
     assert required <= set(payload["supported_contract_versions"])
-    # orchestration-capable: orchestrator declared; evaluator / participant
-    # runtime remain out of scope (#312).
+    # orchestration-evaluation: orchestrator + evaluator declared; participant
+    # runtime remains out of scope.
     assert manifest.has_orchestrator is True
-    assert manifest.has_evaluator is False
+    assert manifest.has_evaluator is True
     assert manifest.has_participant_runtime is False
 
 
@@ -170,7 +172,7 @@ def test_aptl_target_passes_provisioning_only_conformance(tmp_path):
     assert report.unsupported_capability_gaps == ()
 
 
-def test_aptl_target_passes_orchestration_capable_conformance(tmp_path):
+def test_aptl_target_passes_orchestration_evaluation_conformance(tmp_path):
     from aces_conformance.conformance import run_target_conformance
 
     from aptl.backends.aces import create_aptl_runtime_target
@@ -183,14 +185,11 @@ def test_aptl_target_passes_orchestration_capable_conformance(tmp_path):
         backend=backend,
     )
 
-    report = run_target_conformance(target, profile="orchestration-capable")
+    report = run_target_conformance(target, profile="orchestration-evaluation")
 
     assert report.passed is True, [d.code for d in report.diagnostics]
     assert report.unsupported_contract_gaps == ()
     assert report.unsupported_capability_gaps == ()
-    # The live probe submits a workflow scenario through the control plane and
-    # validates the resulting orchestration snapshot; assert APTL's orchestrator
-    # produced a contract-clean run-archive surface.
     assert all(case.passed for case in report.cases), [
         (case.name, [d.message for d in case.diagnostics])
         for case in report.cases
@@ -381,11 +380,88 @@ def test_start_aces_scenario_fails_when_orchestration_fails(mocker, tmp_path):
     assert result.error
 
 
-def test_start_aces_scenario_provisions_despite_evaluation_content(mocker, tmp_path):
-    """A scenario carrying evaluation content (e.g. the `conditions` healthcheck
-    section) must still provision. APTL declares no ACES evaluator yet (#312), so
-    the planner's `evaluator.missing` error and the resulting invalid plan must
-    not block lab standup."""
+def test_start_aces_scenario_submits_evaluation_for_objective_scenario(mocker, tmp_path):
+    """A scenario carrying objectives routes through the control plane's
+    evaluation submission after provisioning and orchestration."""
+    from aces_contracts.planning import ChangeAction, EvaluationOp, EvaluationPlan
+    from aces_contracts.runtime_state import OperationState
+
+    from aptl.backends import aces
+
+    _write_compose(tmp_path, {"victim": ["victim"]})
+    mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=object())
+    orchestration = _workflow_orchestration_plan()
+    evaluation = EvaluationPlan(
+        resources={},
+        operations=[
+            EvaluationOp(
+                action=ChangeAction.CREATE,
+                address="evaluation.objective.validate",
+                resource_type="objective",
+                payload={"name": "validate"},
+            )
+        ],
+        startup_order=(),
+    )
+
+    submit_calls: list[str] = []
+
+    class FakeControlPlane:
+        def __init__(self, target, initial_snapshot=None):
+            del target, initial_snapshot
+
+        def submit_provisioning(self, plan):
+            submit_calls.append("provisioning")
+            receipt = MagicMock()
+            receipt.operation_id = "prov"
+            receipt.diagnostics = []
+            return receipt
+
+        def submit_orchestration(self, plan):
+            submit_calls.append("orchestration")
+            receipt = MagicMock()
+            receipt.operation_id = "orch"
+            receipt.diagnostics = []
+            return receipt
+
+        def submit_evaluation(self, plan):
+            submit_calls.append("evaluation")
+            receipt = MagicMock()
+            receipt.operation_id = "eval"
+            receipt.diagnostics = []
+            return receipt
+
+        def get_operation(self, operation_id):
+            status = MagicMock()
+            status.state = OperationState.SUCCEEDED
+            status.diagnostics = []
+            return status
+
+    class FakeRuntimeManager:
+        def __init__(self, target):
+            self.target = target
+
+        def plan(self, parsed_scenario):
+            return _FakeExecutionPlan(
+                _plan_for_nodes("techvault.victim"),
+                orchestration=orchestration,
+                evaluation=evaluation,
+            )
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    mocker.patch("aptl.backends.aces.RuntimeControlPlane", FakeControlPlane)
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
+
+    result = aces.start_aces_scenario(tmp_path, config, backend)
+
+    assert result.success is True
+    assert submit_calls == ["provisioning", "orchestration", "evaluation"]
+
+
+def test_start_aces_scenario_fails_closed_on_evaluator_plan_error(mocker, tmp_path):
+    """A planner error in the evaluation domain must fail closed."""
     from aces_contracts.diagnostics import Diagnostic, Severity
 
     from aptl.backends import aces
@@ -393,11 +469,11 @@ def test_start_aces_scenario_provisions_despite_evaluation_content(mocker, tmp_p
     _write_compose(tmp_path, {"victim": ["victim"]})
     mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=object())
 
-    evaluator_missing = Diagnostic(
-        code="evaluator.missing",
+    evaluator_error = Diagnostic(
+        code="evaluator.unsupported-section",
         domain="evaluation",
-        address="evaluation",
-        message="Scenario requires evaluation support, but no evaluator is configured.",
+        address="evaluation.metrics.score",
+        message="Scenario requires unsupported evaluation section.",
         severity=Severity.ERROR,
     )
 
@@ -409,25 +485,22 @@ def test_start_aces_scenario_provisions_despite_evaluation_content(mocker, tmp_p
             return _FakeExecutionPlan(
                 _plan_for_nodes("techvault.victim"),
                 is_valid=False,
-                diagnostics=[evaluator_missing],
+                diagnostics=[evaluator_error],
             )
 
     mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
     backend = MagicMock()
-    backend.start.return_value = LabResult(success=True, message="ok")
     config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is True
-    backend.start.assert_called_once_with(["victim", "otel"])
+    assert result.success is False
+    assert result.error
+    backend.start.assert_not_called()
 
 
-def test_start_aces_scenario_fails_closed_on_non_evaluator_plan_error(mocker, tmp_path):
-    """A planner error that is NOT the expected evaluation-domain
-    `evaluator.missing` (e.g. a provisioning ordering cycle) must fail closed:
-    the ACES handoff must refuse to start Compose on an otherwise invalid
-    execution plan rather than bypass the gate for every plan."""
+def test_start_aces_scenario_fails_closed_on_provisioning_plan_error(mocker, tmp_path):
+    """A provisioning planner error must fail closed before lab standup."""
     from aces_contracts.diagnostics import Diagnostic, Severity
 
     from aptl.backends import aces

--- a/tests/test_aces_evaluator.py
+++ b/tests/test_aces_evaluator.py
@@ -1,0 +1,194 @@
+"""Tests for the APTL ACES evaluation adapter (issue #312)."""
+
+from textwrap import dedent
+
+from aces_contracts.evaluation import EvaluationExecutionState, EvaluationResultStatus
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
+from aces_processor.compiler import compile_runtime_model
+from aces_processor.planner import plan
+from aces_runtime.evaluation_result_contracts import evaluation_result_contract_diagnostics
+from aces_sdl.parser import parse_sdl
+
+from aptl.backends.aces_evaluator import AptlEvaluator
+from aptl.backends.aces_manifest import create_aptl_manifest
+
+_EVALUATION_SCENARIO = dedent(
+    """
+    name: evaluator-test
+    nodes:
+      vm:
+        type: vm
+        os: linux
+        resources: {ram: 1 gib, cpu: 1}
+        conditions: {health: ops}
+        roles: {ops: operator}
+    conditions:
+      health: {command: /bin/true, interval: 15}
+    entities:
+      blue: {role: blue}
+    objectives:
+      validate:
+        entity: blue
+        success: {conditions: [health]}
+    workflows:
+      response:
+        start: run
+        steps:
+          run:
+            type: objective
+            objective: validate
+            on-success: finish
+          finish: {type: end}
+    """
+)
+
+
+def _evaluation_plan():
+    scenario = parse_sdl(_EVALUATION_SCENARIO)
+    execution_plan = plan(compile_runtime_model(scenario), create_aptl_manifest())
+    return execution_plan.evaluation
+
+
+def test_start_registers_evaluations_as_pending_with_started_history():
+    evaluator = AptlEvaluator()
+    result = evaluator.start(_evaluation_plan(), RuntimeSnapshot())
+
+    assert isinstance(result, ApplyResult)
+    assert result.success is True
+    assert result.snapshot.evaluation_results, "expected at least one evaluation run recorded"
+
+    for address, payload in result.snapshot.evaluation_results.items():
+        state = EvaluationExecutionState.from_payload(payload)
+        assert state.status == EvaluationResultStatus.PENDING
+        assert state.run_id
+        history = result.snapshot.evaluation_history[address]
+        assert history[0]["event_type"] == "evaluation_started"
+
+
+def test_start_output_is_evaluation_contract_clean():
+    evaluator = AptlEvaluator()
+    result = evaluator.start(_evaluation_plan(), RuntimeSnapshot())
+
+    diagnostics = evaluation_result_contract_diagnostics(result.snapshot)
+    assert diagnostics == [], [d.message for d in diagnostics]
+
+
+def test_results_and_status_reflect_registered_evaluations():
+    evaluator = AptlEvaluator()
+    assert evaluator.results() == {}
+    assert evaluator.history() == {}
+
+    evaluator.start(_evaluation_plan(), RuntimeSnapshot())
+
+    assert evaluator.results()
+    assert evaluator.history()
+    assert evaluator.status()["registered_evaluations"] == sorted(evaluator.results())
+
+
+def test_start_preserves_existing_provisioning_entries():
+    from aces_contracts.planning import RuntimeDomain
+    from aces_contracts.runtime_state import SnapshotEntry
+
+    base = RuntimeSnapshot(
+        entries={
+            "provision.node.vm": SnapshotEntry(
+                address="provision.node.vm",
+                domain=RuntimeDomain.PROVISIONING,
+                resource_type="node",
+                payload={"name": "vm"},
+            )
+        }
+    )
+    evaluator = AptlEvaluator()
+    result = evaluator.start(_evaluation_plan(), base)
+
+    assert "provision.node.vm" in result.snapshot.entries
+    assert any(
+        entry.domain == RuntimeDomain.EVALUATION for entry in result.snapshot.entries.values()
+    )
+
+
+def test_stop_clears_evaluation_state():
+    evaluator = AptlEvaluator()
+    started = evaluator.start(_evaluation_plan(), RuntimeSnapshot())
+
+    stopped = evaluator.stop(started.snapshot)
+
+    assert stopped.success is True
+    assert stopped.snapshot.evaluation_results == {}
+    assert stopped.snapshot.evaluation_history == {}
+    assert evaluator.results() == {}
+    assert evaluator.history() == {}
+
+
+def test_start_rejects_non_evaluation_plan():
+    evaluator = AptlEvaluator()
+    result = evaluator.start(object(), RuntimeSnapshot())
+
+    assert result.success is False
+    assert any(d.code == "aptl.evaluator.invalid-plan" for d in result.diagnostics)
+
+
+def _evaluation_op(address, payload, *, action=None, resource_type="objective"):
+    from aces_contracts.planning import ChangeAction, EvaluationOp
+
+    return EvaluationOp(
+        action=action or ChangeAction.CREATE,
+        address=address,
+        resource_type=resource_type,
+        payload=payload,
+    )
+
+
+def test_start_fails_closed_on_evaluation_missing_result_contract():
+    from aces_contracts.planning import EvaluationPlan
+
+    op = _evaluation_op("evaluation.objective.broken", {"name": "broken"})
+    result = AptlEvaluator().start(
+        EvaluationPlan(resources={}, operations=[op]), RuntimeSnapshot()
+    )
+
+    assert result.success is False
+    assert any(d.code == "aptl.evaluator.evaluation-contract-missing" for d in result.diagnostics)
+
+
+def test_start_fails_closed_on_invalid_result_contract():
+    from aces_contracts.planning import EvaluationPlan
+
+    op = _evaluation_op(
+        "evaluation.objective.broken",
+        {"name": "broken", "result_contract": {"resource_type": ""}},
+    )
+    result = AptlEvaluator().start(
+        EvaluationPlan(resources={}, operations=[op]), RuntimeSnapshot()
+    )
+
+    assert result.success is False
+    assert any(d.code == "aptl.evaluator.evaluation-contract-invalid" for d in result.diagnostics)
+
+
+def test_start_handles_delete_operation():
+    from aces_contracts.planning import ChangeAction, EvaluationPlan, RuntimeDomain
+    from aces_contracts.runtime_state import SnapshotEntry
+
+    address = "evaluation.objective.gone"
+    base = RuntimeSnapshot(
+        entries={
+            address: SnapshotEntry(
+                address=address,
+                domain=RuntimeDomain.EVALUATION,
+                resource_type="objective",
+                payload={"name": "gone"},
+            )
+        },
+        evaluation_results={address: {"status": "ready"}},
+        evaluation_history={address: [{"event_type": "evaluation_ready"}]},
+    )
+    op = _evaluation_op(address, {"name": "gone"}, action=ChangeAction.DELETE)
+
+    result = AptlEvaluator().start(EvaluationPlan(resources={}, operations=[op]), base)
+
+    assert result.success is True
+    assert address not in result.snapshot.entries
+    assert address not in result.snapshot.evaluation_results
+    assert address not in result.snapshot.evaluation_history

--- a/tests/test_techvault_live_gate.py
+++ b/tests/test_techvault_live_gate.py
@@ -726,7 +726,7 @@ def test_run_archive_writes_manifest_through_redacting_boundary():
     assert path == "live-gate/manifest.json"
     assert manifest["aces_provenance"]["realization"]["nodes"]
     assert manifest["aces_provenance"]["selected_profiles"] == ["dmz", "soc"]
-    assert manifest["evaluator_surfaces_deferred"]["objectives"] == "#312"
+    assert manifest["evaluator_surfaces"]["profile"] == "orchestration-evaluation"
     assert manifest["scenario"]["name"] == "techvault"
 
 

--- a/tests/test_techvault_static_gate.py
+++ b/tests/test_techvault_static_gate.py
@@ -128,7 +128,7 @@ def test_target_conformance_fails_loudly_on_missing_corpus(tmp_path):
         project_dir=PROJECT_ROOT, config=config, backend=_NoStartBackend()
     )
     report = run_target_conformance(
-        target, profile="orchestration-capable", root=tmp_path, profiles_root=tmp_path
+        target, profile="orchestration-evaluation", root=tmp_path, profiles_root=tmp_path
     )
     assert not report.passed
 
@@ -141,7 +141,7 @@ def test_backend_conformance_fails_loudly_on_missing_corpus(tmp_path):
     check = check_backend_conformance(
         project_dir=PROJECT_ROOT,
         config=config,
-        profile="orchestration-capable",
+        profile="orchestration-evaluation",
         profiles_root=tmp_path,  # empty corpus root -> profile artifact not found
         fixtures_root=tmp_path,
     )


### PR DESCRIPTION
## Summary

- Promote APTL's published `backend-manifest-v2` to the `orchestration-evaluation` profile by declaring `capabilities.evaluator` and the `evaluation-result-envelope-v1` / `evaluation-history-event-stream-v1` contracts.
- Add `AptlEvaluator` and route evaluation through the ACES runtime control plane after provisioning and orchestration during scenario start.
- Upgrade the static/live validation gates, CI advisory job, and `aptl lab validate-live` default profile from `orchestration-capable` to `orchestration-evaluation`.

## Test plan

- [x] `pytest tests/test_aces_backend.py`
- [x] `pytest tests/test_techvault_live_gate.py -m "not integration"`
- [x] `pytest tests/test_techvault_static_gate.py`
- [x] `aces conformance backend --profile orchestration-evaluation` (via `test_aptl_target_passes_orchestration_evaluation_conformance`)
- [x] pre-commit on changed files

Closes #312

Made with [Cursor](https://cursor.com)