### PR TITLE
changed: compute TechVault dependency closure

### DIFF
--- a/changelog.d/532.changed.md
+++ b/changelog.d/532.changed.md
@@ -1,0 +1,1 @@
+ACES-driven TechVault startup now computes transitive Compose dependency closure for selected subset nodes before starting the backend, adding required support profiles automatically and failing closed with ACES diagnostics when required dependencies are missing, ambiguous, or disabled.

--- a/docs/aces/parity-inventory.yaml
+++ b/docs/aces/parity-inventory.yaml
@@ -146,6 +146,17 @@ rows:
     blocking_followup: n/a
     notes: "SCN-010 issue #329 composition inventory; SDL encodes network topology, dependency/relationship graph, DNS, trust/account/content placement, observation chains, and defensive integration chains with No known remaining ACES expressivity blocker. The bundle cites per-asset inventories and records snapshot-only/non-destructive capture limits."
 
+  - id: scen.techvault-operational.startup-contract
+    surface: scenarios_yaml
+    legacy_source: scenarios/techvault-operational.sdl.yaml
+    legacy_field: operational startup nodes, profiles, public services, and health gate contract
+    category: validation_gate
+    aces_target: ACES operational subset startup validation gate for TechVault
+    runtime_owner: src/aptl/backends/aces.py::DEFAULT_ACES_SCENARIO
+    validation_evidence: "scenarios/techvault-operational.sdl.yaml + tests/test_techvault_static_gate.py::test_operational_scenario_matches_public_start_profiles_and_services + docs/aces/techvault-static-validation-gate.md"
+    blocking_followup: n/a
+    notes: Operational subset scenario used by the TechVault ACES backend gate; it constrains the public startup profile set and health-gated readiness surface rather than cataloguing a separate node inventory.
+
   - id: scen.techvault.webapp-inventory
     surface: scenarios_yaml
     legacy_source: scenarios/techvault.sdl.yaml

--- a/docs/aces/techvault-live-validation-gate.md
+++ b/docs/aces/techvault-live-validation-gate.md
@@ -45,9 +45,13 @@ layer that broke:
    The gate computes the realization matrix from `RuntimeManager.plan()` and
    `interpret_provisioning_plan()`, the same interpretation `AptlProvisioner`
    performs, so the expected node, service, network, and profile surface is
-   keyed by ACES resource addresses. It then runs `stop_lab(remove_volumes)`
-   cleanup and `orchestrate_lab_start()`, whose only container-start path is the
-   ACES handoff in `_step_start_containers()`. A realization with errors fails as
+   keyed by ACES resource addresses. Realization expands selected-node
+   dependencies through ACES provisioning edges and Compose `depends_on`
+   metadata before the backend starts; missing, ambiguous, or config-disabled
+   support services fail as `backend_interpretation` instead of booting an
+   incomplete range. It then runs `stop_lab(remove_volumes)` cleanup and
+   `orchestrate_lab_start()`, whose only container-start path is the ACES
+   handoff in `_step_start_containers()`. A realization with errors fails as
    `backend_interpretation`; a failed boot fails as `backend_instantiation`.
 4. **Defensive-stack readiness** (`defensive_stack_readiness`). Every
    ACES-realized node maps to a running, healthy container in the post-boot

--- a/docs/aces/techvault-static-validation-gate.md
+++ b/docs/aces/techvault-static-validation-gate.md
@@ -35,10 +35,14 @@ editing the gate. TechVault is the proving input, never a hardcoded branch.
    a downgraded warning and never a reason to accept an APTL-local manifest
    approximation.
 5. **Provisioning realization.** The interpreter realizes the provisioning plan
-   with no errors and produces nodes, services, and networks. The selected
-   Compose profiles must match the public lab-start profile set, so a scenario
-   that would instantiate a partial range fails the gate. The realization is
-   driven by declared content, not by the scenario identifier.
+   with no errors and produces nodes, services, and networks. It computes the
+   dependency closure for selected nodes from ACES provisioning dependencies
+   and Compose `depends_on` metadata before selecting backend profiles, so a
+   subset scenario pulls in required support profiles or fails with ACES
+   diagnostics for missing, ambiguous, or disabled support services. The
+   selected Compose profiles must match the public lab-start profile set, so a
+   scenario that would instantiate a partial range fails the gate. The
+   realization is driven by declared content, not by the scenario identifier.
 6. **Parity manifest.** Every required observable surface in
    `docs/aces/parity-inventory.yaml` under `required_surface_coverage` is either
    represented (proven by real compiled evidence) or deferred with a linked

--- a/scenarios/aces.lock.json
+++ b/scenarios/aces.lock.json
@@ -49,8 +49,8 @@
       "source": "local:techvault/nodes/security-net.sdl.yaml"
     },
     {
-      "content_digest": "sha256:ea82d1a1e82d8b3d5495ee9d9d756310ab3a61f6c6632ce87860840a120781e5",
-      "export_hash": "6530e1e2f4c6a562e0cd20b6c68e0004a9bca5a960cb0a4dbfb316a5e81ea8dc",
+      "content_digest": "sha256:6ca1748a867c5224b7bdc357f77808988a67a3864aa4c9f7ed822e2e373ba56e",
+      "export_hash": "aaa7b39bc42420f747a2c2f153d2a28f3cb5e20ed2d26758c969d359aae0ad9c",
       "manifest_digest": "",
       "module_id": "techvault/nodes/db.sdl.yaml",
       "module_version": "*",
@@ -109,8 +109,8 @@
       "source": "local:techvault/nodes/shuffle-orborus.sdl.yaml"
     },
     {
-      "content_digest": "sha256:86cd7b0499f02073312384b793d612839e8847d466421cbe65455a80414ed355",
-      "export_hash": "a44ac6efa4c891896de45992d649d496358ac45755c0a30362545b859534211b",
+      "content_digest": "sha256:d42f69711e1f65792faf0b70fc6536b8538319bcf14abc75edc08709c17f0351",
+      "export_hash": "4f6ef35603cef43ce62d7574bcd6ac4b528b25a157992f254b67f8ac8388ce3b",
       "manifest_digest": "",
       "module_id": "techvault/nodes/wazuh-manager.sdl.yaml",
       "module_version": "*",
@@ -217,8 +217,8 @@
       "source": "local:techvault/nodes/fileshare.sdl.yaml"
     },
     {
-      "content_digest": "sha256:add14265e5e1f26fd6a37256febbd35d8f886a1b5f82e55d17e761f8518bcca3",
-      "export_hash": "0b9d25e7a2768428ec938743fa46217ee3df60628d03208bf7e64528a676df47",
+      "content_digest": "sha256:202cc0faccce37838a1f3921d65d575a763a966c4560576f71dbb26e16c092f9",
+      "export_hash": "75479a91dd9e05c295723edb26a0180c87647c163dc3b815ff388e108b00044d",
       "manifest_digest": "",
       "module_id": "techvault/nodes/kali.sdl.yaml",
       "module_version": "*",

--- a/scenarios/techvault/nodes/db.sdl.yaml
+++ b/scenarios/techvault/nodes/db.sdl.yaml
@@ -1,4 +1,11 @@
 name: techvault-node-db
+conditions:
+  db-postgres-ready:
+    command: "pg_isready -U techvault -d techvault"
+    interval: 10
+    timeout: 5
+    retries: 5
+    start_period: 15
 nodes:
   db:
     type: vm
@@ -351,7 +358,8 @@ nodes:
     os_version: Alpine Linux v3.23
     features:
       techvault.techvault-postgres-service: db-postgres
-    conditions: {}
+    conditions:
+      db-postgres-ready: db-postgres
     injects: {}
     vulnerabilities: []
     roles:

--- a/scenarios/techvault/nodes/kali.sdl.yaml
+++ b/scenarios/techvault/nodes/kali.sdl.yaml
@@ -1,4 +1,11 @@
 name: techvault-node-kali
+conditions:
+  kali-healthcheck:
+    command: "/usr/local/bin/aptl-healthcheck.sh"
+    interval: 15
+    timeout: 5
+    retries: 5
+    start_period: 30
 nodes:
   kali:
     type: vm
@@ -422,7 +429,8 @@ nodes:
     os: linux
     os_version: Kali GNU/Linux Rolling 2026.1
     features: {}
-    conditions: {}
+    conditions:
+      kali-healthcheck: kali-root
     injects: {}
     vulnerabilities: []
     roles:

--- a/src/aptl/backends/aces_dependency_closure.py
+++ b/src/aptl/backends/aces_dependency_closure.py
@@ -168,27 +168,27 @@ def _resolve_dependency_service(
 ) -> str | None:
     """Resolve one ACES dependency reference to one Compose service."""
 
-    if _is_network_dependency(dependency, network_aliases):
-        return None
-    matches = profile_index.service_names_for_aliases(
-        _dependency_reference_aliases(dependency)
-    )
-    if not matches:
-        _append_dependency_unresolved_diagnostic(
-            resource_address,
-            dependency,
-            diagnostics,
+    service_name = None
+    if not _is_network_dependency(dependency, network_aliases):
+        matches = profile_index.service_names_for_aliases(
+            _dependency_reference_aliases(dependency)
         )
-        return None
-    if len(matches) > 1:
-        _append_dependency_ambiguous_diagnostic(
-            resource_address,
-            dependency,
-            matches,
-            diagnostics,
-        )
-        return None
-    return next(iter(matches))
+        if not matches:
+            _append_dependency_unresolved_diagnostic(
+                resource_address,
+                dependency,
+                diagnostics,
+            )
+        elif len(matches) > 1:
+            _append_dependency_ambiguous_diagnostic(
+                resource_address,
+                dependency,
+                matches,
+                diagnostics,
+            )
+        else:
+            service_name = next(iter(matches))
+    return service_name
 
 
 def _append_dependency_unresolved_diagnostic(

--- a/src/aptl/backends/aces_dependency_closure.py
+++ b/src/aptl/backends/aces_dependency_closure.py
@@ -118,15 +118,21 @@ def _aces_dependency_services(
         for dependency in _node_dependency_values(resource, payload):
             if _has_seen_dependency(resource.address, dependency, seen):
                 continue
-            service_name = _resolve_dependency_service(
-                resource.address,
+            is_network, matches = _dependency_service_matches(
                 dependency,
                 network_aliases,
                 profile_index,
+            )
+            if is_network:
+                continue
+            _append_dependency_resolution_diagnostics(
+                resource.address,
+                dependency,
+                matches,
                 diagnostics,
             )
-            if service_name:
-                dependency_services.add(service_name)
+            if len(matches) == 1:
+                dependency_services.add(next(iter(matches)))
     return dependency_services
 
 
@@ -159,36 +165,43 @@ def _has_seen_dependency(
     return False
 
 
-def _resolve_dependency_service(
-    resource_address: str,
+def _dependency_service_matches(
     dependency: str,
     network_aliases: set[str],
     profile_index: ComposeProfileIndex,
-    diagnostics: list[Diagnostic],
-) -> str | None:
-    """Resolve one ACES dependency reference to one Compose service."""
+) -> tuple[bool, set[str]]:
+    """Return whether a dependency is a network and its Compose service matches."""
 
-    service_name = None
-    if not _is_network_dependency(dependency, network_aliases):
+    is_network = _is_network_dependency(dependency, network_aliases)
+    matches: set[str] = set()
+    if not is_network:
         matches = profile_index.service_names_for_aliases(
             _dependency_reference_aliases(dependency)
         )
-        if not matches:
-            _append_dependency_unresolved_diagnostic(
-                resource_address,
-                dependency,
-                diagnostics,
-            )
-        elif len(matches) > 1:
-            _append_dependency_ambiguous_diagnostic(
-                resource_address,
-                dependency,
-                matches,
-                diagnostics,
-            )
-        else:
-            service_name = next(iter(matches))
-    return service_name
+    return is_network, matches
+
+
+def _append_dependency_resolution_diagnostics(
+    resource_address: str,
+    dependency: str,
+    matches: set[str],
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record diagnostics for non-network dependency resolution failures."""
+
+    if not matches:
+        _append_dependency_unresolved_diagnostic(
+            resource_address,
+            dependency,
+            diagnostics,
+        )
+    elif len(matches) > 1:
+        _append_dependency_ambiguous_diagnostic(
+            resource_address,
+            dependency,
+            matches,
+            diagnostics,
+        )
 
 
 def _append_dependency_unresolved_diagnostic(

--- a/src/aptl/backends/aces_dependency_closure.py
+++ b/src/aptl/backends/aces_dependency_closure.py
@@ -1,0 +1,321 @@
+"""Dependency closure support for ACES-backed APTL realization."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import PlannedResource
+
+from aptl.backends.aces_diagnostics import PROVISIONING_ADDRESS, diagnostic
+from aptl.backends.aces_profiles import (
+    ComposeProfileIndex,
+    normalized_identifier_aliases,
+    public_start_profiles,
+)
+from aptl.backends.aces_realization_model import NetworkRealization, NodeRealization
+from aptl.backends.aces_realization_values import (
+    dependency_names as _dependency_names,
+    mapping as _mapping,
+)
+from aptl.core.config import AptlConfig
+
+
+def append_dependency_closure(
+    payload_resources: list[PlannedResource],
+    nodes: list[NodeRealization],
+    networks: list[NetworkRealization],
+    profile_index: ComposeProfileIndex,
+    config: AptlConfig,
+    profiles: set[str],
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Expand profiles required by selected ACES and Compose dependencies."""
+
+    selected_profiles = set(public_start_profiles(config))
+    service_by_address = _service_by_node_address(nodes, profile_index, diagnostics)
+    selected_node_addresses = {
+        node.address
+        for node in nodes
+        if set(node.profiles) & selected_profiles
+    }
+    seed_services = {
+        service_name
+        for address, service_name in service_by_address.items()
+        if address in selected_node_addresses
+    }
+    seed_services.update(
+        _aces_dependency_services(
+            payload_resources,
+            selected_node_addresses,
+            networks,
+            profile_index,
+            diagnostics,
+        )
+    )
+    if not seed_services:
+        return
+
+    closure_services, missing_dependencies = profile_index.dependency_closure_for_services(
+        seed_services
+    )
+    _append_missing_compose_dependency_diagnostics(missing_dependencies, diagnostics)
+    _append_disabled_dependency_diagnostics(
+        closure_services,
+        selected_profiles,
+        profile_index,
+        diagnostics,
+    )
+    profiles.update(profile_index.profiles_for_services(set(closure_services)))
+
+
+def _service_by_node_address(
+    nodes: list[NodeRealization],
+    profile_index: ComposeProfileIndex,
+    diagnostics: list[Diagnostic],
+) -> dict[str, str]:
+    """Return unambiguous Compose service matches for realized nodes."""
+
+    service_by_address: dict[str, str] = {}
+    for node in nodes:
+        matches = profile_index.service_names_for_aliases(set(node.aliases))
+        if len(matches) > 1:
+            diagnostics.append(
+                diagnostic(
+                    "aptl.provisioner.node-compose-service-ambiguous",
+                    node.address,
+                    (
+                        "ACES node aliases match multiple APTL Compose "
+                        f"services: {', '.join(sorted(matches))}."
+                    ),
+                )
+            )
+            continue
+        if matches:
+            service_by_address[node.address] = next(iter(matches))
+    return service_by_address
+
+
+def _aces_dependency_services(
+    payload_resources: list[PlannedResource],
+    selected_node_addresses: set[str],
+    networks: list[NetworkRealization],
+    profile_index: ComposeProfileIndex,
+    diagnostics: list[Diagnostic],
+) -> set[str]:
+    """Resolve selected ACES node dependencies to Compose service names."""
+
+    dependency_services: set[str] = set()
+    network_aliases = _network_reference_aliases(networks) | set(
+        profile_index.network_aliases()
+    )
+    seen: set[tuple[str, str]] = set()
+    for resource, payload in _selected_node_payloads(
+        payload_resources,
+        selected_node_addresses,
+    ):
+        for dependency in _node_dependency_values(resource, payload):
+            if _has_seen_dependency(resource.address, dependency, seen):
+                continue
+            service_name = _resolve_dependency_service(
+                resource.address,
+                dependency,
+                network_aliases,
+                profile_index,
+                diagnostics,
+            )
+            if service_name:
+                dependency_services.add(service_name)
+    return dependency_services
+
+
+def _selected_node_payloads(
+    payload_resources: list[PlannedResource],
+    selected_node_addresses: set[str],
+) -> Iterator[tuple[PlannedResource, Mapping[str, Any]]]:
+    """Yield selected ACES node resources with mapping payloads."""
+
+    for resource in payload_resources:
+        if resource.resource_type != "node":
+            continue
+        if resource.address not in selected_node_addresses:
+            continue
+        if isinstance(resource.payload, Mapping):
+            yield resource, resource.payload
+
+
+def _has_seen_dependency(
+    resource_address: str,
+    dependency: str,
+    seen: set[tuple[str, str]],
+) -> bool:
+    """Return whether a node dependency was already processed."""
+
+    key = (resource_address, dependency)
+    if key in seen:
+        return True
+    seen.add(key)
+    return False
+
+
+def _resolve_dependency_service(
+    resource_address: str,
+    dependency: str,
+    network_aliases: set[str],
+    profile_index: ComposeProfileIndex,
+    diagnostics: list[Diagnostic],
+) -> str | None:
+    """Resolve one ACES dependency reference to one Compose service."""
+
+    if _is_network_dependency(dependency, network_aliases):
+        return None
+    matches = profile_index.service_names_for_aliases(
+        _dependency_reference_aliases(dependency)
+    )
+    if not matches:
+        _append_dependency_unresolved_diagnostic(
+            resource_address,
+            dependency,
+            diagnostics,
+        )
+        return None
+    if len(matches) > 1:
+        _append_dependency_ambiguous_diagnostic(
+            resource_address,
+            dependency,
+            matches,
+            diagnostics,
+        )
+        return None
+    return next(iter(matches))
+
+
+def _append_dependency_unresolved_diagnostic(
+    resource_address: str,
+    dependency: str,
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record a dependency reference that does not match Compose."""
+
+    diagnostics.append(
+        diagnostic(
+            "aptl.provisioner.dependency-unresolved",
+            resource_address,
+            (
+                "ACES node dependency does not map to an APTL "
+                f"Compose service: {dependency}."
+            ),
+        )
+    )
+
+
+def _append_dependency_ambiguous_diagnostic(
+    resource_address: str,
+    dependency: str,
+    matches: set[str],
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record a dependency reference that matches multiple Compose services."""
+
+    diagnostics.append(
+        diagnostic(
+            "aptl.provisioner.dependency-ambiguous",
+            resource_address,
+            (
+                "ACES node dependency maps to multiple APTL "
+                "Compose services: "
+                f"{dependency} -> {', '.join(sorted(matches))}."
+            ),
+        )
+    )
+
+
+def _node_dependency_values(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+) -> set[str]:
+    """Return dependency references declared by one planned ACES node."""
+
+    values = {
+        str(value)
+        for value in (*resource.ordering_dependencies, *resource.refresh_dependencies)
+        if str(value).strip()
+    }
+    spec = _mapping(payload.get("spec"))
+    infra_spec = _mapping(spec.get("infrastructure")) if spec else None
+    values.update(_dependency_names(infra_spec))
+    return values
+
+
+def _network_reference_aliases(networks: list[NetworkRealization]) -> set[str]:
+    """Return normalized ACES network aliases that are not service dependencies."""
+
+    aliases: set[str] = set()
+    for network in networks:
+        aliases.update(_dependency_reference_aliases(network.address))
+        aliases.update(_dependency_reference_aliases(network.name))
+    return aliases
+
+
+def _is_network_dependency(dependency: str, network_aliases: set[str]) -> bool:
+    """Return whether a dependency reference names an ACES network resource."""
+
+    return ".network." in dependency or bool(
+        _dependency_reference_aliases(dependency) & network_aliases
+    )
+
+
+def _dependency_reference_aliases(reference: str) -> set[str]:
+    """Return normalized aliases for an ACES dependency reference."""
+
+    aliases = normalized_identifier_aliases(reference)
+    if "." in reference:
+        aliases.update(normalized_identifier_aliases(reference.rsplit(".", 1)[-1]))
+    return aliases
+
+
+def _append_missing_compose_dependency_diagnostics(
+    missing_dependencies: dict[str, tuple[str, ...]],
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record diagnostics for Compose ``depends_on`` edges without services."""
+
+    for service_name, dependencies in sorted(missing_dependencies.items()):
+        diagnostics.append(
+            diagnostic(
+                "aptl.provisioner.compose-dependency-unresolved",
+                PROVISIONING_ADDRESS,
+                (
+                    "APTL Compose service dependency is not declared as a "
+                    f"service: {service_name} -> {', '.join(dependencies)}."
+                ),
+            )
+        )
+
+
+def _append_disabled_dependency_diagnostics(
+    closure_services: frozenset[str],
+    selected_profiles: set[str],
+    profile_index: ComposeProfileIndex,
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record diagnostics for required services outside enabled profiles."""
+
+    for service_name in sorted(closure_services):
+        service = profile_index.services.get(service_name)
+        if service is None or not service.profiles:
+            continue
+        if service.profiles.isdisjoint(selected_profiles):
+            diagnostics.append(
+                diagnostic(
+                    "aptl.provisioner.dependency-profile-disabled",
+                    PROVISIONING_ADDRESS,
+                    (
+                        "Required APTL Compose dependency is disabled by "
+                        "configuration: "
+                        f"{service_name} requires profile(s) "
+                        f"{', '.join(sorted(service.profiles))}."
+                    ),
+                )
+            )

--- a/src/aptl/backends/aces_profiles.py
+++ b/src/aptl/backends/aces_profiles.py
@@ -17,10 +17,23 @@ IDENTIFIER_SEPARATORS = re.compile(r"[^a-z0-9]+")
 
 
 @dataclass(frozen=True)
+class ComposeServiceInfo(object):
+    """APTL-relevant metadata for one Compose service."""
+
+    name: str
+    aliases: frozenset[str]
+    profiles: frozenset[str]
+    dependencies: frozenset[str]
+    networks: frozenset[str]
+
+
+@dataclass(frozen=True)
 class ComposeProfileIndex(object):
-    """Compose service aliases indexed to profile names."""
+    """Compose service aliases indexed to profile names and dependencies."""
 
     alias_to_profiles: dict[str, frozenset[str]]
+    alias_to_services: dict[str, frozenset[str]]
+    services: dict[str, ComposeServiceInfo]
 
     def profiles_for_aliases(self, aliases: set[str]) -> frozenset[str]:
         """Return all profiles associated with any normalized alias."""
@@ -29,18 +42,82 @@ class ComposeProfileIndex(object):
             profiles.update(self.alias_to_profiles.get(alias, frozenset()))
         return frozenset(profiles)
 
+    def service_names_for_aliases(self, aliases: set[str]) -> frozenset[str]:
+        """Return Compose service names associated with normalized aliases."""
+        services: set[str] = set()
+        for alias in aliases:
+            services.update(self.alias_to_services.get(alias, frozenset()))
+        return frozenset(services)
+
+    def profiles_for_services(self, service_names: set[str]) -> frozenset[str]:
+        """Return all profiles for the named Compose services."""
+        profiles: set[str] = set()
+        for service_name in service_names:
+            service = self.services.get(service_name)
+            if service is not None:
+                profiles.update(service.profiles)
+        return frozenset(profiles)
+
+    def network_aliases(self) -> frozenset[str]:
+        """Return normalized Compose network aliases used by indexed services."""
+        aliases: set[str] = set()
+        for service in self.services.values():
+            for network_name in service.networks:
+                aliases.update(normalized_identifier_aliases(network_name))
+        return frozenset(aliases)
+
+    def dependency_closure_for_services(
+        self, service_names: set[str]
+    ) -> tuple[frozenset[str], dict[str, tuple[str, ...]]]:
+        """Return transitive Compose ``depends_on`` closure and missing edges."""
+        closure = set(service_names)
+        pending = list(service_names)
+        missing: dict[str, set[str]] = {}
+        while pending:
+            service_name = pending.pop()
+            service = self.services.get(service_name)
+            if service is None:
+                continue
+            for dependency in service.dependencies:
+                if dependency not in self.services:
+                    missing.setdefault(service_name, set()).add(dependency)
+                    continue
+                if dependency not in closure:
+                    closure.add(dependency)
+                    pending.append(dependency)
+        return (
+            frozenset(closure),
+            {
+                service_name: tuple(sorted(dependencies))
+                for service_name, dependencies in missing.items()
+            },
+        )
+
 
 def load_compose_profile_index(project_dir: Path) -> ComposeProfileIndex:
     """Load Compose service/profile aliases from ``docker-compose.yml``."""
     services = _load_compose_services(project_dir)
     alias_to_profiles: dict[str, set[str]] = {}
+    alias_to_services: dict[str, set[str]] = {}
+    service_infos: dict[str, ComposeServiceInfo] = {}
     for service_name, service_def in services.items():
-        _register_service_profiles(alias_to_profiles, str(service_name), service_def)
+        info = _service_info(str(service_name), service_def)
+        if info is None:
+            continue
+        service_infos[info.name] = info
+        for alias in info.aliases:
+            alias_to_services.setdefault(alias, set()).add(info.name)
+            alias_to_profiles.setdefault(alias, set()).update(info.profiles)
     return ComposeProfileIndex(
-        {
+        alias_to_profiles={
             alias: frozenset(profiles)
             for alias, profiles in alias_to_profiles.items()
-        }
+        },
+        alias_to_services={
+            alias: frozenset(service_names)
+            for alias, service_names in alias_to_services.items()
+        },
+        services=service_infos,
     )
 
 
@@ -142,20 +219,20 @@ def _load_compose_services(project_dir: Path) -> Mapping[str, object]:
     return services
 
 
-def _register_service_profiles(
-    alias_to_profiles: dict[str, set[str]],
+def _service_info(
     service_name: str,
     service_def: object,
-) -> None:
-    """Add one Compose service's aliases to the profile index."""
+) -> ComposeServiceInfo | None:
+    """Return indexed metadata for one Compose service."""
     if not isinstance(service_def, Mapping):
-        return
-    profiles = _service_profiles(service_def)
-    if not profiles:
-        return
-    for alias in _service_aliases(service_name, service_def):
-        for normalized in normalized_identifier_aliases(alias):
-            alias_to_profiles.setdefault(normalized, set()).update(profiles)
+        return None
+    return ComposeServiceInfo(
+        name=service_name,
+        aliases=frozenset(_normalized_service_aliases(service_name, service_def)),
+        profiles=frozenset(_service_profiles(service_def)),
+        dependencies=frozenset(_service_dependencies(service_def)),
+        networks=frozenset(_service_networks(service_def)),
+    )
 
 
 def _service_profiles(service_def: Mapping[str, object]) -> set[str]:
@@ -165,6 +242,26 @@ def _service_profiles(service_def: Mapping[str, object]) -> set[str]:
         for profile in (service_def.get("profiles") or [])
         if str(profile).strip()
     }
+
+
+def _service_dependencies(service_def: Mapping[str, object]) -> set[str]:
+    """Return service names from a Compose ``depends_on`` declaration."""
+    depends_on = service_def.get("depends_on")
+    if isinstance(depends_on, Mapping):
+        return {str(service_name) for service_name in depends_on if str(service_name)}
+    if isinstance(depends_on, list | tuple | set | frozenset):
+        return {str(service_name) for service_name in depends_on if str(service_name)}
+    return set()
+
+
+def _service_networks(service_def: Mapping[str, object]) -> set[str]:
+    """Return network names selected by a Compose service."""
+    networks = service_def.get("networks")
+    if isinstance(networks, Mapping):
+        return {str(network_name) for network_name in networks if str(network_name)}
+    if isinstance(networks, list | tuple | set | frozenset):
+        return {str(network_name) for network_name in networks if str(network_name)}
+    return set()
 
 
 def _service_selected(service_def: object, selected_profiles: set[str]) -> bool:

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -17,12 +17,12 @@ from aptl.backends.aces_diagnostics import (
     diagnostic,
     unsupported_resource_diagnostics,
 )
+from aptl.backends.aces_dependency_closure import append_dependency_closure
 from aptl.backends.aces_profiles import (
     ComposeProfileIndex,
     explicit_compose_profile_hints,
     load_compose_profile_index,
     node_aliases,
-    normalized_identifier_aliases,
     normalize_identifier,
     public_start_profiles,
 )
@@ -33,7 +33,6 @@ from aptl.backends.aces_realization_model import (
     PlacementRealization,
 )
 from aptl.backends.aces_realization_values import (
-    dependency_names as _dependency_names,
     first_nonempty_string as _first_nonempty_string,
     mapping as _mapping,
     network_names as _network_names,
@@ -75,7 +74,7 @@ def interpret_provisioning_plan(
         profile_index,
         diagnostics,
     )
-    _append_dependency_closure(
+    append_dependency_closure(
         payload_resources,
         nodes,
         networks,
@@ -167,231 +166,6 @@ def _append_node_profile_diagnostic(
             ),
         )
     )
-
-
-def _append_dependency_closure(
-    payload_resources: list[PlannedResource],
-    nodes: list[NodeRealization],
-    networks: list[NetworkRealization],
-    profile_index: ComposeProfileIndex,
-    config: AptlConfig,
-    profiles: set[str],
-    diagnostics: list[Diagnostic],
-) -> None:
-    """Expand profiles required by selected ACES and Compose dependencies."""
-
-    selected_profiles = set(public_start_profiles(config))
-    service_by_address = _service_by_node_address(nodes, profile_index, diagnostics)
-    selected_node_addresses = {
-        node.address
-        for node in nodes
-        if set(node.profiles) & selected_profiles
-    }
-    seed_services = {
-        service_name
-        for address, service_name in service_by_address.items()
-        if address in selected_node_addresses
-    }
-    seed_services.update(
-        _aces_dependency_services(
-            payload_resources,
-            selected_node_addresses,
-            networks,
-            profile_index,
-            diagnostics,
-        )
-    )
-    if not seed_services:
-        return
-
-    closure_services, missing_dependencies = profile_index.dependency_closure_for_services(
-        seed_services
-    )
-    _append_missing_compose_dependency_diagnostics(missing_dependencies, diagnostics)
-    _append_disabled_dependency_diagnostics(
-        closure_services,
-        selected_profiles,
-        profile_index,
-        diagnostics,
-    )
-    profiles.update(profile_index.profiles_for_services(set(closure_services)))
-
-
-def _service_by_node_address(
-    nodes: list[NodeRealization],
-    profile_index: ComposeProfileIndex,
-    diagnostics: list[Diagnostic],
-) -> dict[str, str]:
-    """Return unambiguous Compose service matches for realized nodes."""
-
-    service_by_address: dict[str, str] = {}
-    for node in nodes:
-        matches = profile_index.service_names_for_aliases(set(node.aliases))
-        if len(matches) > 1:
-            diagnostics.append(
-                diagnostic(
-                    "aptl.provisioner.node-compose-service-ambiguous",
-                    node.address,
-                    (
-                        "ACES node aliases match multiple APTL Compose "
-                        f"services: {', '.join(sorted(matches))}."
-                    ),
-                )
-            )
-            continue
-        if matches:
-            service_by_address[node.address] = next(iter(matches))
-    return service_by_address
-
-
-def _aces_dependency_services(
-    payload_resources: list[PlannedResource],
-    selected_node_addresses: set[str],
-    networks: list[NetworkRealization],
-    profile_index: ComposeProfileIndex,
-    diagnostics: list[Diagnostic],
-) -> set[str]:
-    """Resolve selected ACES node dependencies to Compose service names."""
-
-    dependency_services: set[str] = set()
-    network_aliases = _network_reference_aliases(networks) | set(
-        profile_index.network_aliases()
-    )
-    seen: set[tuple[str, str]] = set()
-    for resource in payload_resources:
-        if (
-            resource.resource_type != "node"
-            or resource.address not in selected_node_addresses
-            or not isinstance(resource.payload, Mapping)
-        ):
-            continue
-        for dependency in _node_dependency_values(resource, resource.payload):
-            key = (resource.address, dependency)
-            if key in seen:
-                continue
-            seen.add(key)
-            if _is_network_dependency(dependency, network_aliases):
-                continue
-            matches = profile_index.service_names_for_aliases(
-                _dependency_reference_aliases(dependency)
-            )
-            if not matches:
-                diagnostics.append(
-                    diagnostic(
-                        "aptl.provisioner.dependency-unresolved",
-                        resource.address,
-                        (
-                            "ACES node dependency does not map to an APTL "
-                            f"Compose service: {dependency}."
-                        ),
-                    )
-                )
-                continue
-            if len(matches) > 1:
-                diagnostics.append(
-                    diagnostic(
-                        "aptl.provisioner.dependency-ambiguous",
-                        resource.address,
-                        (
-                            "ACES node dependency maps to multiple APTL "
-                            "Compose services: "
-                            f"{dependency} -> {', '.join(sorted(matches))}."
-                        ),
-                    )
-                )
-                continue
-            dependency_services.add(next(iter(matches)))
-    return dependency_services
-
-
-def _node_dependency_values(
-    resource: PlannedResource,
-    payload: Mapping[str, Any],
-) -> set[str]:
-    """Return dependency references declared by one planned ACES node."""
-
-    values = {
-        str(value)
-        for value in (*resource.ordering_dependencies, *resource.refresh_dependencies)
-        if str(value).strip()
-    }
-    spec = _mapping(payload.get("spec"))
-    infra_spec = _mapping(spec.get("infrastructure")) if spec else None
-    values.update(_dependency_names(infra_spec))
-    return values
-
-
-def _network_reference_aliases(networks: list[NetworkRealization]) -> set[str]:
-    """Return normalized ACES network aliases that are not service dependencies."""
-
-    aliases: set[str] = set()
-    for network in networks:
-        aliases.update(_dependency_reference_aliases(network.address))
-        aliases.update(_dependency_reference_aliases(network.name))
-    return aliases
-
-
-def _is_network_dependency(dependency: str, network_aliases: set[str]) -> bool:
-    """Return whether a dependency reference names an ACES network resource."""
-
-    return ".network." in dependency or bool(
-        _dependency_reference_aliases(dependency) & network_aliases
-    )
-
-
-def _dependency_reference_aliases(reference: str) -> set[str]:
-    """Return normalized aliases for an ACES dependency reference."""
-
-    aliases = normalized_identifier_aliases(reference)
-    if "." in reference:
-        aliases.update(normalized_identifier_aliases(reference.rsplit(".", 1)[-1]))
-    return aliases
-
-
-def _append_missing_compose_dependency_diagnostics(
-    missing_dependencies: dict[str, tuple[str, ...]],
-    diagnostics: list[Diagnostic],
-) -> None:
-    """Record diagnostics for Compose ``depends_on`` edges without services."""
-
-    for service_name, dependencies in sorted(missing_dependencies.items()):
-        diagnostics.append(
-            diagnostic(
-                "aptl.provisioner.compose-dependency-unresolved",
-                PROVISIONING_ADDRESS,
-                (
-                    "APTL Compose service dependency is not declared as a "
-                    f"service: {service_name} -> {', '.join(dependencies)}."
-                ),
-            )
-        )
-
-
-def _append_disabled_dependency_diagnostics(
-    closure_services: frozenset[str],
-    selected_profiles: set[str],
-    profile_index: ComposeProfileIndex,
-    diagnostics: list[Diagnostic],
-) -> None:
-    """Record diagnostics for required services outside enabled profiles."""
-
-    for service_name in sorted(closure_services):
-        service = profile_index.services.get(service_name)
-        if service is None or not service.profiles:
-            continue
-        if service.profiles.isdisjoint(selected_profiles):
-            diagnostics.append(
-                diagnostic(
-                    "aptl.provisioner.dependency-profile-disabled",
-                    PROVISIONING_ADDRESS,
-                    (
-                        "Required APTL Compose dependency is disabled by "
-                        "configuration: "
-                        f"{service_name} requires profile(s) "
-                        f"{', '.join(sorted(service.profiles))}."
-                    ),
-                )
-            )
 
 
 def _realize_placements(

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -22,6 +22,7 @@ from aptl.backends.aces_profiles import (
     explicit_compose_profile_hints,
     load_compose_profile_index,
     node_aliases,
+    normalized_identifier_aliases,
     normalize_identifier,
     public_start_profiles,
 )
@@ -32,6 +33,7 @@ from aptl.backends.aces_realization_model import (
     PlacementRealization,
 )
 from aptl.backends.aces_realization_values import (
+    dependency_names as _dependency_names,
     first_nonempty_string as _first_nonempty_string,
     mapping as _mapping,
     network_names as _network_names,
@@ -71,6 +73,15 @@ def interpret_provisioning_plan(
     nodes, networks, profiles = _realize_nodes_and_networks(
         payload_resources,
         profile_index,
+        diagnostics,
+    )
+    _append_dependency_closure(
+        payload_resources,
+        nodes,
+        networks,
+        profile_index,
+        config,
+        profiles,
         diagnostics,
     )
     placements = _realize_placements(payload_resources, _node_lookup(nodes), diagnostics)
@@ -156,6 +167,231 @@ def _append_node_profile_diagnostic(
             ),
         )
     )
+
+
+def _append_dependency_closure(
+    payload_resources: list[PlannedResource],
+    nodes: list[NodeRealization],
+    networks: list[NetworkRealization],
+    profile_index: ComposeProfileIndex,
+    config: AptlConfig,
+    profiles: set[str],
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Expand profiles required by selected ACES and Compose dependencies."""
+
+    selected_profiles = set(public_start_profiles(config))
+    service_by_address = _service_by_node_address(nodes, profile_index, diagnostics)
+    selected_node_addresses = {
+        node.address
+        for node in nodes
+        if set(node.profiles) & selected_profiles
+    }
+    seed_services = {
+        service_name
+        for address, service_name in service_by_address.items()
+        if address in selected_node_addresses
+    }
+    seed_services.update(
+        _aces_dependency_services(
+            payload_resources,
+            selected_node_addresses,
+            networks,
+            profile_index,
+            diagnostics,
+        )
+    )
+    if not seed_services:
+        return
+
+    closure_services, missing_dependencies = profile_index.dependency_closure_for_services(
+        seed_services
+    )
+    _append_missing_compose_dependency_diagnostics(missing_dependencies, diagnostics)
+    _append_disabled_dependency_diagnostics(
+        closure_services,
+        selected_profiles,
+        profile_index,
+        diagnostics,
+    )
+    profiles.update(profile_index.profiles_for_services(set(closure_services)))
+
+
+def _service_by_node_address(
+    nodes: list[NodeRealization],
+    profile_index: ComposeProfileIndex,
+    diagnostics: list[Diagnostic],
+) -> dict[str, str]:
+    """Return unambiguous Compose service matches for realized nodes."""
+
+    service_by_address: dict[str, str] = {}
+    for node in nodes:
+        matches = profile_index.service_names_for_aliases(set(node.aliases))
+        if len(matches) > 1:
+            diagnostics.append(
+                diagnostic(
+                    "aptl.provisioner.node-compose-service-ambiguous",
+                    node.address,
+                    (
+                        "ACES node aliases match multiple APTL Compose "
+                        f"services: {', '.join(sorted(matches))}."
+                    ),
+                )
+            )
+            continue
+        if matches:
+            service_by_address[node.address] = next(iter(matches))
+    return service_by_address
+
+
+def _aces_dependency_services(
+    payload_resources: list[PlannedResource],
+    selected_node_addresses: set[str],
+    networks: list[NetworkRealization],
+    profile_index: ComposeProfileIndex,
+    diagnostics: list[Diagnostic],
+) -> set[str]:
+    """Resolve selected ACES node dependencies to Compose service names."""
+
+    dependency_services: set[str] = set()
+    network_aliases = _network_reference_aliases(networks) | set(
+        profile_index.network_aliases()
+    )
+    seen: set[tuple[str, str]] = set()
+    for resource in payload_resources:
+        if (
+            resource.resource_type != "node"
+            or resource.address not in selected_node_addresses
+            or not isinstance(resource.payload, Mapping)
+        ):
+            continue
+        for dependency in _node_dependency_values(resource, resource.payload):
+            key = (resource.address, dependency)
+            if key in seen:
+                continue
+            seen.add(key)
+            if _is_network_dependency(dependency, network_aliases):
+                continue
+            matches = profile_index.service_names_for_aliases(
+                _dependency_reference_aliases(dependency)
+            )
+            if not matches:
+                diagnostics.append(
+                    diagnostic(
+                        "aptl.provisioner.dependency-unresolved",
+                        resource.address,
+                        (
+                            "ACES node dependency does not map to an APTL "
+                            f"Compose service: {dependency}."
+                        ),
+                    )
+                )
+                continue
+            if len(matches) > 1:
+                diagnostics.append(
+                    diagnostic(
+                        "aptl.provisioner.dependency-ambiguous",
+                        resource.address,
+                        (
+                            "ACES node dependency maps to multiple APTL "
+                            "Compose services: "
+                            f"{dependency} -> {', '.join(sorted(matches))}."
+                        ),
+                    )
+                )
+                continue
+            dependency_services.add(next(iter(matches)))
+    return dependency_services
+
+
+def _node_dependency_values(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+) -> set[str]:
+    """Return dependency references declared by one planned ACES node."""
+
+    values = {
+        str(value)
+        for value in (*resource.ordering_dependencies, *resource.refresh_dependencies)
+        if str(value).strip()
+    }
+    spec = _mapping(payload.get("spec"))
+    infra_spec = _mapping(spec.get("infrastructure")) if spec else None
+    values.update(_dependency_names(infra_spec))
+    return values
+
+
+def _network_reference_aliases(networks: list[NetworkRealization]) -> set[str]:
+    """Return normalized ACES network aliases that are not service dependencies."""
+
+    aliases: set[str] = set()
+    for network in networks:
+        aliases.update(_dependency_reference_aliases(network.address))
+        aliases.update(_dependency_reference_aliases(network.name))
+    return aliases
+
+
+def _is_network_dependency(dependency: str, network_aliases: set[str]) -> bool:
+    """Return whether a dependency reference names an ACES network resource."""
+
+    return ".network." in dependency or bool(
+        _dependency_reference_aliases(dependency) & network_aliases
+    )
+
+
+def _dependency_reference_aliases(reference: str) -> set[str]:
+    """Return normalized aliases for an ACES dependency reference."""
+
+    aliases = normalized_identifier_aliases(reference)
+    if "." in reference:
+        aliases.update(normalized_identifier_aliases(reference.rsplit(".", 1)[-1]))
+    return aliases
+
+
+def _append_missing_compose_dependency_diagnostics(
+    missing_dependencies: dict[str, tuple[str, ...]],
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record diagnostics for Compose ``depends_on`` edges without services."""
+
+    for service_name, dependencies in sorted(missing_dependencies.items()):
+        diagnostics.append(
+            diagnostic(
+                "aptl.provisioner.compose-dependency-unresolved",
+                PROVISIONING_ADDRESS,
+                (
+                    "APTL Compose service dependency is not declared as a "
+                    f"service: {service_name} -> {', '.join(dependencies)}."
+                ),
+            )
+        )
+
+
+def _append_disabled_dependency_diagnostics(
+    closure_services: frozenset[str],
+    selected_profiles: set[str],
+    profile_index: ComposeProfileIndex,
+    diagnostics: list[Diagnostic],
+) -> None:
+    """Record diagnostics for required services outside enabled profiles."""
+
+    for service_name in sorted(closure_services):
+        service = profile_index.services.get(service_name)
+        if service is None or not service.profiles:
+            continue
+        if service.profiles.isdisjoint(selected_profiles):
+            diagnostics.append(
+                diagnostic(
+                    "aptl.provisioner.dependency-profile-disabled",
+                    PROVISIONING_ADDRESS,
+                    (
+                        "Required APTL Compose dependency is disabled by "
+                        "configuration: "
+                        f"{service_name} requires profile(s) "
+                        f"{', '.join(sorted(service.profiles))}."
+                    ),
+                )
+            )
 
 
 def _realize_placements(

--- a/src/aptl/backends/aces_realization_values.py
+++ b/src/aptl/backends/aces_realization_values.py
@@ -88,6 +88,14 @@ def network_names(infra_spec: Mapping[str, Any] | None) -> set[str]:
     return string_values(infra_spec.get("links"))
 
 
+def dependency_names(infra_spec: Mapping[str, Any] | None) -> set[str]:
+    """Extract declared node dependency names from infrastructure details."""
+
+    if infra_spec is None:
+        return set()
+    return string_values(infra_spec.get("dependencies"))
+
+
 def static_addresses(infra_spec: Mapping[str, Any] | None) -> set[str]:
     """Extract static host addresses from infrastructure details."""
 

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -32,6 +32,33 @@ def _write_compose(project_dir: Path, services: dict[str, list[str]]) -> None:
     (project_dir / "docker-compose.yml").write_text("\n".join(lines))
 
 
+def _write_compose_graph(
+    project_dir: Path,
+    services: dict[str, tuple[list[str], list[str]]],
+    networks: dict[str, list[str]] | None = None,
+) -> None:
+    lines = ["services:"]
+    for service_name, (profiles, dependencies) in services.items():
+        rendered = ", ".join(f'"{profile}"' for profile in profiles)
+        lines.extend(
+            [
+                f"  {service_name}:",
+                f"    profiles: [{rendered}]",
+                "    image: example:latest",
+            ]
+        )
+        if dependencies:
+            lines.append("    depends_on:")
+            for dependency in dependencies:
+                lines.extend([f"      {dependency}:", "        condition: service_started"])
+        service_networks = (networks or {}).get(service_name, [])
+        if service_networks:
+            lines.append("    networks:")
+            for network in service_networks:
+                lines.append(f"      - {network}")
+    (project_dir / "docker-compose.yml").write_text("\n".join(lines))
+
+
 def _node_resource(node_name: str) -> PlannedResource:
     address = f"provision.node.{node_name}"
     payload = {
@@ -47,6 +74,15 @@ def _node_resource(node_name: str) -> PlannedResource:
         resource_type="node",
         payload=payload,
     )
+
+
+def _node_resource_with_dependencies(
+    node_name: str,
+    *dependencies: str,
+) -> PlannedResource:
+    resource = _node_resource(node_name)
+    resource.payload["spec"]["infrastructure"]["dependencies"] = list(dependencies)
+    return resource
 
 
 def _plan_for_resources(*resources: PlannedResource) -> ProvisioningPlan:
@@ -626,6 +662,212 @@ def test_provisioner_profiles_are_derived_from_plan_content(tmp_path):
     assert second.success is True
     assert backend.start.call_args_list[0].args == (["kali", "otel"],)
     assert backend.start.call_args_list[1].args == (["victim", "otel"],)
+
+
+def test_provisioner_closes_subset_dependency_profiles_before_start(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose_graph(
+        tmp_path,
+        {
+            "webapp": (["enterprise"], []),
+            "db": (["soc"], ["wazuh.manager"]),
+            "wazuh.manager": (["wazuh"], []),
+            "aptl-otel-collector": (["otel"], []),
+        },
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(
+        lab={"name": "test"},
+        containers={"enterprise": True, "soc": True, "wazuh": True},
+    )
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+
+    result = provisioner.apply(
+        _plan_for_resources(_node_resource_with_dependencies("techvault.webapp", "db")),
+        RuntimeSnapshot(),
+    )
+
+    assert result.success is True
+    backend.start.assert_called_once_with(["wazuh", "enterprise", "soc", "otel"])
+    assert result.details["realization"]["profiles"] == ["enterprise", "soc", "wazuh"]
+
+
+def test_provisioner_treats_compose_network_dependency_as_network_support(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose_graph(
+        tmp_path,
+        {
+            "webapp": (["enterprise"], []),
+            "aptl-otel-collector": (["otel"], []),
+        },
+        networks={"webapp": ["internal-net"]},
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"}, containers={"enterprise": True})
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+
+    result = provisioner.apply(
+        _plan_for_resources(
+            _node_resource_with_dependencies("techvault.webapp", "internal-net")
+        ),
+        RuntimeSnapshot(),
+    )
+
+    assert result.success is True
+    assert all(
+        diagnostic.code != "aptl.provisioner.dependency-unresolved"
+        for diagnostic in result.diagnostics
+    )
+    backend.start.assert_called_once_with(["enterprise", "otel"])
+
+
+def test_provisioner_rejects_disabled_dependency_profile(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose_graph(
+        tmp_path,
+        {
+            "webapp": (["enterprise"], ["db"]),
+            "db": (["wazuh"], []),
+            "aptl-otel-collector": (["otel"], []),
+        },
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(
+        lab={"name": "test"},
+        containers={"enterprise": True, "wazuh": False},
+    )
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+
+    result = provisioner.apply(
+        _plan_for_resources(_node_resource_with_dependencies("techvault.webapp", "db")),
+        RuntimeSnapshot(),
+    )
+
+    assert result.success is False
+    assert any(
+        diagnostic.code == "aptl.provisioner.dependency-profile-disabled"
+        for diagnostic in result.diagnostics
+    )
+    backend.start.assert_not_called()
+
+
+def test_provisioner_rejects_missing_declared_dependency(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose_graph(
+        tmp_path,
+        {
+            "webapp": (["enterprise"], []),
+            "aptl-otel-collector": (["otel"], []),
+        },
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"}, containers={"enterprise": True})
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+
+    result = provisioner.apply(
+        _plan_for_resources(_node_resource_with_dependencies("techvault.webapp", "db")),
+        RuntimeSnapshot(),
+    )
+
+    assert result.success is False
+    assert any(
+        diagnostic.code == "aptl.provisioner.dependency-unresolved"
+        for diagnostic in result.diagnostics
+    )
+    backend.start.assert_not_called()
+
+
+def test_provisioner_rejects_missing_compose_dependency(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose_graph(
+        tmp_path,
+        {
+            "webapp": (["enterprise"], ["missing-db"]),
+            "aptl-otel-collector": (["otel"], []),
+        },
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"}, containers={"enterprise": True})
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+
+    result = provisioner.apply(
+        _plan_for_resources(_node_resource("techvault.webapp")),
+        RuntimeSnapshot(),
+    )
+
+    assert result.success is False
+    assert any(
+        diagnostic.code == "aptl.provisioner.compose-dependency-unresolved"
+        for diagnostic in result.diagnostics
+    )
+    backend.start.assert_not_called()
+
+
+def test_provisioner_rejects_ambiguous_declared_dependency(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose_graph(
+        tmp_path,
+        {
+            "webapp": (["enterprise"], []),
+            "db": (["soc"], []),
+            "aptl-db": (["wazuh"], []),
+            "aptl-otel-collector": (["otel"], []),
+        },
+    )
+    backend = MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(
+        lab={"name": "test"},
+        containers={"enterprise": True, "soc": True, "wazuh": True},
+    )
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+
+    result = provisioner.apply(
+        _plan_for_resources(_node_resource_with_dependencies("techvault.webapp", "db")),
+        RuntimeSnapshot(),
+    )
+
+    assert result.success is False
+    assert any(
+        diagnostic.code == "aptl.provisioner.dependency-ambiguous"
+        for diagnostic in result.diagnostics
+    )
+    backend.start.assert_not_called()
 
 
 def test_provisioner_realization_details_follow_distinct_plan_content(tmp_path):


### PR DESCRIPTION
## Summary

Computes the ACES-to-APTL TechVault dependency closure before backend profile selection so subset scenarios pull required Compose support profiles or fail with structured diagnostics.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #532

## ADR Impact

- ADR-021
- ADR-035

## Changes

- Indexed Compose services as a graph of aliases, profiles, networks, and depends_on edges.
- Expanded ACES realization to seed selected nodes, resolve declared dependencies, classify network references, compute transitive Compose closure, and fail on missing, ambiguous, or disabled dependencies.
- Extracted dependency-closure support into a focused backend module after SonarCloud flagged the original helper shape.
- Added focused backend tests for dependency closure, network support, missing Compose edges, ambiguous aliases, and disabled profiles.
- Updated TechVault gate docs, parity inventory coverage, SDL health condition bindings, and the ACES import lock.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification: `uv run pytest`; `pre-commit run --all-files`; focused `uv run pytest tests/test_aces_backend.py -q`; commit hooks for SonarCloud fix cycles. CI run 27971052015 passed. Pre-push Codex review was clean. Test-quality review reported one coverage gap; added focused diagnostic-branch tests and reran local gates. User authorized no additional over-cap review cycle.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #532 ← src/aptl/backends/aces_realization.py, Issue #532 ← src/aptl/backends/aces_dependency_closure.py, Issue #532 ← src/aptl/backends/aces_profiles.py, Issue #532 ← src/aptl/backends/aces_realization_values.py, Issue #532 ← docs/aces/techvault-static-validation-gate.md, Issue #532 ← docs/aces/techvault-live-validation-gate.md
- TESTS: Issue #532 ← tests/test_aces_backend.py, Issue #532 ← tests/test_techvault_static_gate.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/532.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
