### PR TITLE
added: ephemeral clean-boot lab lifecycle mode (RNG-001)

### DIFF
--- a/changelog.d/424.added.md
+++ b/changelog.d/424.added.md
@@ -1,0 +1,16 @@
+### Added
+
+**Ephemeral environments with clean-state guarantees (RNG-001).** A new
+`aptl lab start --clean` mode tears down the project-scoped deployment,
+removes the Compose-managed volumes, and boots the lab again through the
+standard start path, guaranteeing a fresh environment free of state
+contamination (service databases, indexes, logs, generated in-container
+credentials) from a prior run. This makes reliable batch execution and
+benchmarking possible. Add `--yes` to skip the destructive-action
+confirmation in scripted runs. A clean boot removes only Docker Compose
+state for the configured project — never `.env`, `keys/`, `.mcp.json`,
+checked-in config, or archived run directories — and a failed cleanup is
+fatal (the lab does not start, so a contaminated environment is never
+reused as clean). The capability is exposed as a reusable
+`clean_boot_lab` lifecycle function that the `aptl lab validate-live`
+gate now consumes for its pre-snapshot clean boot.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -153,3 +153,7 @@ The victim and kali containers publish no host ports; use
 - Victim: Rocky Linux, SSH, Wazuh agent, Falco eBPF monitoring
 - Kali: Attack tools, MCP integration
 - Reverse Engineering: Binary analysis tools, MCP integration
+
+## Preflights
+
+- [RNG-001 Ephemeral Environments](rng-001-ephemeral-environments-preflight.md)

--- a/docs/architecture/rng-001-ephemeral-environments-preflight.md
+++ b/docs/architecture/rng-001-ephemeral-environments-preflight.md
@@ -1,0 +1,153 @@
+# RNG-001 Ephemeral Environments Preflight
+
+This note is the architecture preflight for RNG-001 / issue #424. It is
+guidance, not an implementation plan. Existing ADRs remain binding: ADR-013
+and ADR-023 own deployment backends, ADR-025 owns first-party config shape,
+ADR-028 owns runtime-rendered config, ADR-029 owns secret handling, ADR-030
+owns lab-result envelopes, ADR-031 owns orchestration contract guards, and
+ADR-037 owns Docker Compose backend cohesion.
+
+## Architecture Decisions
+
+- Treat "ephemeral environment" as a destructive lab lifecycle mode:
+  stop the selected lab deployment with volume removal, then boot through the
+  public start path. The behavior under test is the same core lifecycle used by
+  `aptl lab start`, `aptl lab stop -v`, and the ACES live gate, not a new
+  Docker script.
+- Clean state means removing runtime contamination from containers, processes,
+  Compose-managed volumes, service databases, service logs, and generated
+  in-container credentials. It does not mean deleting source inputs, `.env`,
+  run archives, ACES inventory evidence, local SSH keys, or checked-in config
+  unless a future requirement explicitly adds a separate purge surface.
+- Keep clean boot project-scoped. Cleanup must target the configured
+  `deployment.project_name` and selected profiles through `DeploymentBackend`;
+  it must not enumerate or remove unrelated Docker containers, networks, or
+  volumes on a shared daemon.
+- Reuse the existing startup pipeline after cleanup:
+  `orchestrate_lab_start()`, `_LAB_START_STEPS`, the ACES handoff in
+  `_step_start_containers()`, generated config renderers, Suricata volume
+  seeding, bind-mount checks, SOC seeding, MCP config sync, and snapshot
+  capture.
+- Do not make the live validation gate the only clean-state implementation.
+  `aptl lab validate-live` already proves the destructive sequence, but
+  RNG-001 should expose a reusable lifecycle capability that validation can
+  continue to consume.
+
+## Cross-Cutting Concerns To Reuse
+
+- Lab lifecycle: `orchestrate_lab_start()`, `stop_lab(remove_volumes=True)`,
+  `_LabStartContext`, `_LAB_START_STEPS`, `LabResult`, `StartupOutcome`, and
+  `StartupDiagnostic`.
+- Deployment boundary: `DeploymentBackend`, `DockerComposeBackend`,
+  `SSHComposeBackend`, project-name scoping, compose-project labels, backend
+  timeouts, `BackendTimeoutError`, and `BackendSeedError`.
+- Config and environment: `AptlConfig`, `DeploymentConfig`,
+  `ContainerSettings.enabled_profiles()`, `load_config()`, `load_dotenv()`,
+  `EnvVars`, `env_vars_from_dict()`, and `find_placeholder_env_values()`.
+- Generated artifacts: `sync_dashboard_config()`, `sync_manager_config()`,
+  `build_suricata_volume_seeds()`, `ensure_ssl_certs()`, `ensure_soc_certs()`,
+  `_check_bind_mounts()`, and `scripts/seed-prime.sh`.
+- API and web surfaces: `LabActionResponse`, `StartupDiagnosticModel`,
+  `StartupOutcomeLiteral`, `web/src/lib/types.ts`, and the existing API auth
+  dependency chain in `aptl.api.deps`.
+- Observability and persistence: `get_logger()`, `redact()`,
+  `RangeSnapshot.to_dict()`, `LocalRunStore.write_json()` /
+  `write_jsonl()` / `append_jsonl()`, and existing run archive docs.
+- Existing destructive proof point: `_live_gate_probes._boot_lab()` and
+  `LiveGateOptions.clean_volumes` / `skip_clean_boot`.
+
+## Security And Validation Layers
+
+- **Auth surface:** any API or web trigger for clean boot must remain behind
+  ADR-039 bearer-token auth. Do not pass destructive-mode intent, API tokens,
+  or control-plane secrets in query strings, WebSocket subprotocols, logs, or
+  EventSource URLs.
+- **Environment binding:** `.env` continues to flow through `load_dotenv()`,
+  `env_vars_from_dict()`, `EnvVars`, and placeholder rejection before generated
+  config or service probes consume it. Clean boot must not parse `.env` again in
+  a second helper.
+- **Config shape:** durable knobs belong in strict `AptlConfig` /
+  `DeploymentConfig` with `extra="forbid"`. Transient CLI/API options may exist
+  at the public boundary, but do not add unchecked dictionaries, duplicate
+  profile lists, or a second clean-state schema.
+- **Deployment boundary:** cleanup and boot go through `DeploymentBackend`.
+  Docker Compose implementations must preserve `-p <project_name>`,
+  compose-project label filters, SSH transport semantics, timeout translation,
+  and argv-list subprocess construction.
+- **Generated-artifact boundary:** clean boot must re-run the existing render
+  and seed steps. Do not reuse stale `.aptl/config/...`, Suricata named-volume
+  contents, SOC certs, or SOC API key wiring as proof of clean state. Existing
+  SSH-remote generated-artifact refusals remain valid until backend-owned
+  remote materialization exists.
+- **OS/process exposure:** no bearer tokens, passwords, API keys, private keys,
+  raw `.env` values, or command lines with credentials may appear in argv,
+  shell strings, diagnostics, or logs. Preserve argv-list subprocess calls and
+  avoid `shell=True`.
+- **Error envelopes:** return existing `LabResult` / `LabActionResponse`
+  shapes. A failed cleanup is a fatal lifecycle failure, not a new exception
+  hierarchy or a partial-readiness category. Redact raw Docker stderr before it
+  crosses CLI, API, web, telemetry, or persistence.
+- **Persistence boundary:** clean boot may write new snapshots, diagnostics,
+  or run evidence through existing redacting runstore methods. It must not
+  delete run archives or inventory bundles as part of the clean-state guarantee
+  unless a separate purge feature explicitly owns that risk.
+
+## Extensibility Seam
+
+The seam belongs at the public lab lifecycle boundary as one destructive clean
+boot mode carrying the existing inputs: project directory, scenario selection,
+seed behavior, and a cleanup policy whose first implementation is volume
+removal. Future variations, such as preserving run archives, selecting a
+scenario catalog entry, or implementing non-Docker cleanup semantics, should
+extend that single lifecycle mode or the backend's typed cleanup behavior
+rather than re-editing validation, CLI, API, and test code independently.
+
+## Whole-Repo Surface
+
+- `aptl.json`, `.env`, `.env.example`, and `DeploymentConfig.project_name`.
+- `docker-compose.yml`, top-level volumes, profiles, generated bind mounts,
+  and Compose project labels.
+- `.aptl/config/...`, `config/soc_certs/...`, `config/suricata/...`, `keys/`,
+  and `.mcp.json`.
+- `src/aptl/core/lab.py`, `src/aptl/core/deployment/`,
+  `src/aptl/validation/_live_gate_probes.py`, `src/aptl/cli/lab.py`,
+  `src/aptl/api/routers/lab.py`, `src/aptl/api/schemas.py`, and
+  `web/src/lib/types.ts`.
+- `src/aptl/core/runstore.py`, `src/aptl/core/snapshot.py`, collectors,
+  `docs/reference/experiment-runs.md`, and live-gate evidence reports.
+- Host Docker daemon state: containers, networks, named volumes, image cache,
+  subprocess argv, and logs.
+- Repo workflow gates: `.gc/plan-rules.md`, `pytest`, and
+  `pre-commit run --all-files`.
+
+## Gotchas And Anti-Patterns
+
+- Calling `docker compose down -v`, `docker volume rm`, `docker ps`, or
+  `docker network rm` directly from CLI, API, web, validation, or tests when a
+  backend method already owns Docker access.
+- Treating clean state as only "container restart" while preserving service
+  volumes, SOC databases, generated rule volumes, or stale API-key sync state.
+- Deleting broad host paths, run archives, `.env`, `.mcp.json`, `keys/`, or
+  checked-in config as part of the default guarantee.
+- Adding a `clean_state` section to `aptl.json` for behavior that is really an
+  invocation-time choice.
+- Inferring destructive behavior from scenario names, folders, issue IDs,
+  config `lab.name`, or ACES metadata.
+- Adding a new readiness taxonomy, exception hierarchy, Docker row DTO, or web
+  response model when existing lifecycle and API envelopes already cover it.
+- Logging raw Docker stderr, raw exception payloads, rendered config, or `.env`
+  values to explain cleanup failures.
+- Weakening remote deployment safety by pretending local generated artifacts
+  are visible to an SSH remote Docker daemon.
+
+## Non-Goals
+
+- Do not implement RNG-001 in this preflight.
+- Do not redesign Docker Compose, deployment backends, ACES realization,
+  run archive layout, SOC seeding, Suricata rule semantics, or web
+  authentication.
+- Do not add Kubernetes, Podman, Nomad, or cloud cleanup semantics here.
+- Do not guarantee byte-identical regenerated credentials, logs, timestamps,
+  Docker object IDs, network IDs, endpoint IDs, or image cache contents across
+  runs.
+- Do not make destructive clean boot part of default fast CI or pre-commit.

--- a/docs/reference/experiment-runs.md
+++ b/docs/reference/experiment-runs.md
@@ -2,6 +2,24 @@
 
 The experiment run system captures data from each scenario execution for reproducibility and post-run analysis.
 
+## Clean State Between Runs
+
+Persistent containers accumulate state across runs: service databases, indexes, logs, generated in-container credentials, and files written during a prior exercise. That state contaminates the next run and undermines reliable batch execution and benchmarking.
+
+The clean-boot lifecycle mode guarantees a fresh environment. It tears down the project-scoped deployment, removes the Compose-managed volumes, and then boots the lab again through the standard start path, so certificates, seeds, and the SOC stack come up fresh:
+
+```bash
+# Ephemeral clean boot: destroy lab state, then start fresh.
+aptl lab start --clean
+
+# Skip the confirmation prompt (for scripted batch runs).
+aptl lab start --clean --yes
+```
+
+A clean boot removes only Docker Compose state for the configured project. It does not delete `.env`, the `keys/` directory, `.mcp.json`, checked-in configuration, or archived run directories. A failed cleanup is fatal: the lab does not start, because a contaminated environment must never be reused as clean.
+
+The same capability backs `aptl lab validate-live`, which clean-boots the lab before snapshotting it (pass `--skip-clean-boot` to validate the running lab without destroying it).
+
 ## Run Directory Structure
 
 Each run is stored under `<project_dir>/runs/<run_id>/` with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - Overview: architecture/index.md
     - Networking: architecture/networking.md
     - Enterprise Infrastructure: architecture/enterprise-infrastructure.md
+    - RNG-001 Ephemeral Environments Preflight: architecture/rng-001-ephemeral-environments-preflight.md
   - Deployment: deployment.md
   - Components:
     - Wazuh SIEM: components/wazuh-siem.md

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -9,6 +9,7 @@ import typer
 from aptl.cli.continuity import continuity_audit
 from aptl.core.lab import (
     LabResult,
+    clean_boot_lab,
     lab_status,
     orchestrate_lab_start,
     stop_lab,
@@ -47,6 +48,35 @@ _OUTCOME_HEADLINES: dict[StartupOutcome, str] = {
     ),
     StartupOutcome.FAILED: "Lab start failed.",
 }
+
+
+# Shared destructive-data warning. Both `stop --volumes` and
+# `start --clean` remove Compose-managed volumes, so the operator sees one
+# canonical statement of what gets destroyed.
+_DESTRUCTIVE_DATA_WARNING = (
+    "\n  WARNING: This will destroy all lab data including:\n"
+    "    - Wazuh SIEM indexes and configuration\n"
+    "    - MISP threat intelligence data\n"
+    "    - TheHive cases and analysis\n"
+    "    - Shuffle SOAR workflows\n"
+    "    - All container logs and state\n"
+)
+
+
+def _confirm_destructive(skip_prompt: bool) -> bool:
+    """Confirm a volume-destroying action; return False if the operator aborts.
+
+    Centralizes the destructive-action gate shared by ``stop --volumes`` and
+    ``start --clean``: print the canonical warning and require an explicit
+    ``y`` unless ``skip_prompt`` (``--yes``) was passed.
+    """
+    if skip_prompt:
+        return True
+    typer.echo(_DESTRUCTIVE_DATA_WARNING)
+    if not typer.confirm("  Continue?", default=False):
+        typer.echo("Aborted.")
+        return False
+    return True
 
 
 def _render_start_result(result: LabResult) -> None:
@@ -105,9 +135,25 @@ def start(
         "--scenario-path",
         help="Explicit ACES SDL scenario path under the project directory.",
     ),
+    clean: bool = typer.Option(
+        False,
+        "--clean",
+        "-c",
+        help=(
+            "Ephemeral clean boot (RNG-001): tear down the lab and remove "
+            "Compose volumes before starting, guaranteeing clean state "
+            "between runs. Destroys all lab data."
+        ),
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the confirmation prompt for --clean.",
+    ),
 ) -> None:
     """Start the APTL lab environment."""
-    log.info("Starting lab from %s", project_dir)
+    log.info("Starting lab from %s (clean=%s)", project_dir, clean)
 
     try:
         selected_scenario = resolve_scenario_selection(
@@ -119,11 +165,21 @@ def start(
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2)
 
-    result = orchestrate_lab_start(
-        project_dir,
-        skip_seed=skip_seed,
-        scenario_path=selected_scenario,
-    )
+    if clean:
+        if not _confirm_destructive(yes):
+            raise typer.Exit(code=0)
+        result = clean_boot_lab(
+            project_dir,
+            remove_volumes=True,
+            skip_seed=skip_seed,
+            scenario_path=selected_scenario,
+        )
+    else:
+        result = orchestrate_lab_start(
+            project_dir,
+            skip_seed=skip_seed,
+            scenario_path=selected_scenario,
+        )
 
     _render_start_result(result)
     if not result.success:
@@ -173,18 +229,8 @@ def stop(
     ),
 ) -> None:
     """Stop the APTL lab environment."""
-    if volumes and not yes:
-        typer.echo(
-            "\n  WARNING: This will destroy all lab data including:\n"
-            "    - Wazuh SIEM indexes and configuration\n"
-            "    - MISP threat intelligence data\n"
-            "    - TheHive cases and analysis\n"
-            "    - Shuffle SOAR workflows\n"
-            "    - All container logs and state\n"
-        )
-        if not typer.confirm("  Continue?", default=False):
-            typer.echo("Aborted.")
-            raise typer.Exit(code=0)
+    if volumes and not _confirm_destructive(yes):
+        raise typer.Exit(code=0)
 
     log.info("Stopping lab (volumes=%s)", volumes)
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -321,6 +321,70 @@ def stop_lab(
     return backend.stop(profiles, remove_volumes=remove_volumes)
 
 
+def clean_boot_lab(
+    project_dir: Path,
+    *,
+    remove_volumes: bool = True,
+    skip_seed: bool = False,
+    scenario_path: Optional[Path] = None,
+    backend: Optional["DeploymentBackend"] = None,
+) -> LabResult:
+    """Boot the lab into a guaranteed clean state (RNG-001).
+
+    The single reusable destructive clean-state lifecycle mode: tear down
+    the project-scoped deployment removing Compose-managed volumes (the
+    first cleanup policy), then boot through the public start path so the
+    range comes up free of contamination (files, processes, service
+    databases/logs, generated in-container credentials) from a prior run.
+
+    Cleanup and boot reuse :func:`stop_lab` and
+    :func:`orchestrate_lab_start`; both are project-scoped through the
+    deployment backend (``-p <project_name>`` + compose-project labels),
+    so this never enumerates or removes unrelated Docker objects on a
+    shared daemon. It removes only Compose-managed state — never ``.env``,
+    ``keys/``, ``.mcp.json``, checked-in config, or run archives.
+
+    A failed cleanup is a fatal lifecycle failure, not a partial-readiness
+    state: a contaminated environment must never be reused as "clean", so
+    a stop failure short-circuits before the boot. Raw Docker stderr is
+    redacted before it crosses this boundary.
+
+    Args:
+        project_dir: Root directory of the APTL project.
+        remove_volumes: Cleanup policy. When ``True`` (default) the
+            teardown removes Compose-managed volumes; the knob lets future
+            cleanup variations extend this one mode.
+        skip_seed: Forwarded to the start path (skip SOC tool seeding).
+        scenario_path: Optional selected ACES SDL scenario path.
+        backend: Optional pre-created deployment backend, forwarded to the
+            teardown so callers that already resolved one avoid a re-create.
+
+    Returns:
+        LabResult — the boot outcome on success, or a fatal ``FAILED``
+        result carrying the redacted cleanup error when teardown fails.
+    """
+    stop_result = stop_lab(
+        remove_volumes=remove_volumes,
+        project_dir=project_dir,
+        backend=backend,
+    )
+    if not stop_result.success:
+        return LabResult(
+            success=False,
+            error=redact(
+                "clean-state cleanup failed; lab not booted: "
+                f"{stop_result.error}"
+            ),
+            outcome=StartupOutcome.FAILED,
+        )
+
+    return orchestrate_lab_start(
+        project_dir,
+        skip_seed=skip_seed,
+        scenario_path=scenario_path,
+    )
+
+
 def lab_status(
     project_dir: Optional[Path] = None,
     backend: Optional["DeploymentBackend"] = None,

--- a/src/aptl/validation/_live_gate_probes.py
+++ b/src/aptl/validation/_live_gate_probes.py
@@ -31,7 +31,7 @@ from aptl.backends.aces import create_aptl_runtime_target
 from aptl.backends.aces_realization import interpret_provisioning_plan
 from aptl.core.collectors import collect_suricata_eve, collect_wazuh_alerts
 from aptl.core.deployment import get_backend
-from aptl.core.lab import orchestrate_lab_start, stop_lab
+from aptl.core.lab import clean_boot_lab
 from aptl.core.lab_types import StartupOutcome
 from aptl.core.runstore import LocalRunStore
 from aptl.core.snapshot import capture_snapshot
@@ -134,23 +134,26 @@ def _boot_lab(
             diagnostics.append("snapshot capture returned no data for running lab")
         return diagnostics
 
-    stop_result = stop_lab(
-        remove_volumes=options.clean_volumes, project_dir=project_dir
+    # Reuse the RNG-001 clean-boot lifecycle capability rather than open-coding
+    # the destructive stop+start here: the gate is a proof point, not the only
+    # implementation home. A failed cleanup is fatal inside ``clean_boot_lab``
+    # (a contaminated environment must not be snapshotted as proof), so a
+    # ``FAILED`` outcome covers both cleanup and start failures.
+    boot_result = clean_boot_lab(
+        project_dir,
+        remove_volumes=options.clean_volumes,
+        scenario_path=scenario_path,
     )
-    if not stop_result.success:
-        diagnostics.append(redact(f"pre-boot cleanup failed: {stop_result.error}"))
-
-    start_result = orchestrate_lab_start(project_dir, scenario_path=scenario_path)
-    if start_result.outcome is StartupOutcome.FAILED:
+    if boot_result.outcome is StartupOutcome.FAILED:
         diagnostics.append(
-            redact(f"public lab start failed: {start_result.error or 'unknown'}")
+            redact(f"public lab start failed: {boot_result.error or 'unknown'}")
         )
-        diagnostics.extend(_startup_diag_lines(start_result))
+        diagnostics.extend(_startup_diag_lines(boot_result))
         return diagnostics
-    if start_result.outcome is not StartupOutcome.READY:
+    if boot_result.outcome is not StartupOutcome.READY:
         # Degraded-but-usable still boots the range; record the degradation but
         # let later readiness checks decide pass/fail on concrete components.
-        diagnostics_note = _startup_diag_lines(start_result)
+        diagnostics_note = _startup_diag_lines(boot_result)
         log.warning("lab booted degraded: %s", "; ".join(diagnostics_note) or "")
 
     state.snapshot = _capture(project_dir, config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,13 +341,22 @@ class TestLabStartCommand:
         mock_clean.assert_called_once()
 
     def test_start_clean_flag_listed_in_help(self, runner):
-        """The --clean flag is discoverable from start --help."""
+        """The --clean flag is discoverable from start --help.
+
+        Strip ANSI escapes first: when color is forced on (CI sets
+        ``FORCE_COLOR``), Rich styles the option name and injects escape
+        sequences inside the ``--clean`` token, so the raw stdout has no
+        literal ``--clean`` substring even though the flag is rendered.
+        """
+        import re
+
         from aptl.cli.main import app
 
         result = runner.invoke(app, ["lab", "start", "--help"])
 
         assert result.exit_code == 0
-        assert "--clean" in result.stdout
+        plain = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+        assert "--clean" in plain
 
     def test_lab_scenarios_lists_catalog_entries(self, runner, mocker, tmp_path):
         """The list command should read catalog rows dynamically."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -281,6 +281,74 @@ class TestLabStartCommand:
         assert result.exit_code == 2
         assert "mutually exclusive" in result.stderr
 
+    def test_start_clean_calls_clean_boot_lab(self, runner, mocker, tmp_path):
+        """--clean routes through clean_boot_lab, not the plain start path."""
+        from aptl.cli.main import app
+        from aptl.core.lab import LabResult
+
+        mock_clean = mocker.patch(
+            "aptl.cli.lab.clean_boot_lab",
+            return_value=LabResult(success=True, message="Lab started"),
+        )
+        mock_orchestrate = mocker.patch("aptl.cli.lab.orchestrate_lab_start")
+
+        result = runner.invoke(
+            app,
+            ["lab", "start", "--project-dir", str(tmp_path), "--clean", "--yes"],
+        )
+
+        assert result.exit_code == 0
+        mock_orchestrate.assert_not_called()
+        mock_clean.assert_called_once_with(
+            tmp_path,
+            remove_volumes=True,
+            skip_seed=False,
+            scenario_path=None,
+        )
+
+    def test_start_clean_aborts_without_confirmation(self, runner, mocker, tmp_path):
+        """--clean is destructive: declining the prompt aborts before any boot."""
+        from aptl.cli.main import app
+
+        mock_clean = mocker.patch("aptl.cli.lab.clean_boot_lab")
+
+        result = runner.invoke(
+            app,
+            ["lab", "start", "--project-dir", str(tmp_path), "--clean"],
+            input="n\n",
+        )
+
+        assert result.exit_code == 0
+        mock_clean.assert_not_called()
+        assert "Aborted" in result.stdout
+
+    def test_start_clean_yes_bypasses_prompt(self, runner, mocker, tmp_path):
+        """--yes skips the destructive confirmation prompt."""
+        from aptl.cli.main import app
+        from aptl.core.lab import LabResult
+
+        mock_clean = mocker.patch(
+            "aptl.cli.lab.clean_boot_lab",
+            return_value=LabResult(success=True, message="Lab started"),
+        )
+
+        result = runner.invoke(
+            app,
+            ["lab", "start", "--project-dir", str(tmp_path), "--clean", "--yes"],
+        )
+
+        assert result.exit_code == 0
+        mock_clean.assert_called_once()
+
+    def test_start_clean_flag_listed_in_help(self, runner):
+        """The --clean flag is discoverable from start --help."""
+        from aptl.cli.main import app
+
+        result = runner.invoke(app, ["lab", "start", "--help"])
+
+        assert result.exit_code == 0
+        assert "--clean" in result.stdout
+
     def test_lab_scenarios_lists_catalog_entries(self, runner, mocker, tmp_path):
         """The list command should read catalog rows dynamically."""
         from aptl.cli.main import app

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -259,6 +259,161 @@ class TestLabStop:
         assert "wazuh" in cmd_args
 
 
+class TestCleanBootLab:
+    """Tests for the RNG-001 clean-boot lifecycle mode.
+
+    ``clean_boot_lab`` is the single reusable destructive clean-state seam:
+    stop the project-scoped deployment with volume removal, then boot
+    through the public start path. A failed cleanup is fatal — a
+    contaminated environment must never be reused as ``clean``.
+    """
+
+    def test_clean_boot_stops_with_volumes_then_starts(self, monkeypatch, tmp_path):
+        """Clean boot tears down (volumes removed) before booting, in order."""
+        from aptl.core import lab
+        from aptl.core.lab import clean_boot_lab
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        order: list[str] = []
+
+        def fake_stop(**kwargs):
+            order.append("stop")
+            assert kwargs["remove_volumes"] is True
+            return LabResult(success=True, message="stopped")
+
+        def fake_start(project_dir, **kwargs):
+            order.append("start")
+            return LabResult(success=True, outcome=StartupOutcome.READY)
+
+        monkeypatch.setattr(lab, "stop_lab", fake_stop)
+        monkeypatch.setattr(lab, "orchestrate_lab_start", fake_start)
+
+        result = clean_boot_lab(tmp_path)
+
+        assert result.success is True
+        assert result.outcome is StartupOutcome.READY
+        assert order == ["stop", "start"]
+
+    def test_clean_boot_stop_failure_is_fatal_and_skips_start(
+        self, monkeypatch, tmp_path
+    ):
+        """A failed cleanup is fatal: do not start a contaminated lab."""
+        from aptl.core import lab
+        from aptl.core.lab import clean_boot_lab
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        started = []
+
+        monkeypatch.setattr(
+            lab,
+            "stop_lab",
+            lambda **k: LabResult(success=False, error="down failed"),
+        )
+        monkeypatch.setattr(
+            lab,
+            "orchestrate_lab_start",
+            lambda *a, **k: started.append(1)
+            or LabResult(success=True, outcome=StartupOutcome.READY),
+        )
+
+        result = clean_boot_lab(tmp_path)
+
+        assert result.success is False
+        assert result.outcome is StartupOutcome.FAILED
+        assert started == [], "start must not run after a failed cleanup"
+
+    def test_clean_boot_redacts_stop_error(self, monkeypatch, tmp_path):
+        """Raw Docker stderr from a failed cleanup is redacted in the envelope."""
+        from aptl.core import lab
+        from aptl.core.lab import clean_boot_lab
+        from aptl.core.lab_types import LabResult
+
+        monkeypatch.setattr(
+            lab,
+            "stop_lab",
+            lambda **k: LabResult(success=False, error="raw docker stderr"),
+        )
+        monkeypatch.setattr(lab, "redact", lambda s: f"REDACTED::{s}")
+        monkeypatch.setattr(
+            lab, "orchestrate_lab_start", lambda *a, **k: pytest.fail("unreachable")
+        )
+
+        result = clean_boot_lab(tmp_path)
+
+        assert "REDACTED::" in result.error
+
+    def test_clean_boot_threads_skip_seed_and_scenario_path(
+        self, monkeypatch, tmp_path
+    ):
+        """Seed behavior and scenario selection flow through to the start path."""
+        from aptl.core import lab
+        from aptl.core.lab import clean_boot_lab
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        captured = {}
+
+        monkeypatch.setattr(lab, "stop_lab", lambda **k: LabResult(success=True))
+
+        def fake_start(project_dir, *, skip_seed=False, scenario_path=None):
+            captured["skip_seed"] = skip_seed
+            captured["scenario_path"] = scenario_path
+            return LabResult(success=True, outcome=StartupOutcome.READY)
+
+        monkeypatch.setattr(lab, "orchestrate_lab_start", fake_start)
+
+        scenario = tmp_path / "scenario.yaml"
+        clean_boot_lab(tmp_path, skip_seed=True, scenario_path=scenario)
+
+        assert captured == {"skip_seed": True, "scenario_path": scenario}
+
+    def test_clean_boot_remove_volumes_false_honored(self, monkeypatch, tmp_path):
+        """The cleanup policy is a knob: remove_volumes=False is forwarded."""
+        from aptl.core import lab
+        from aptl.core.lab import clean_boot_lab
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        captured = {}
+
+        def fake_stop(**kwargs):
+            captured["remove_volumes"] = kwargs["remove_volumes"]
+            return LabResult(success=True)
+
+        monkeypatch.setattr(lab, "stop_lab", fake_stop)
+        monkeypatch.setattr(
+            lab,
+            "orchestrate_lab_start",
+            lambda *a, **k: LabResult(success=True, outcome=StartupOutcome.READY),
+        )
+
+        clean_boot_lab(tmp_path, remove_volumes=False)
+
+        assert captured["remove_volumes"] is False
+
+    def test_clean_boot_forwards_backend_to_stop(self, monkeypatch, tmp_path):
+        """An explicit backend is forwarded to the project-scoped stop."""
+        from aptl.core import lab
+        from aptl.core.lab import clean_boot_lab
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        sentinel_backend = MagicMock()
+        captured = {}
+
+        def fake_stop(**kwargs):
+            captured["backend"] = kwargs.get("backend")
+            return LabResult(success=True)
+
+        monkeypatch.setattr(lab, "stop_lab", fake_stop)
+        monkeypatch.setattr(
+            lab,
+            "orchestrate_lab_start",
+            lambda *a, **k: LabResult(success=True, outcome=StartupOutcome.READY),
+        )
+
+        clean_boot_lab(tmp_path, backend=sentinel_backend)
+
+        assert captured["backend"] is sentinel_backend
+
+
 class TestLabStatus:
     """Tests for lab status checking."""
 

--- a/tests/test_techvault_live_gate.py
+++ b/tests/test_techvault_live_gate.py
@@ -138,11 +138,12 @@ def _wire_boot(monkeypatch, *, outcome=StartupOutcome.READY, realization=None, s
     monkeypatch.setattr(
         lgc, "select_backend_profiles", lambda config, profiles: ["dmz", "soc"]
     )
-    monkeypatch.setattr(lgp, "stop_lab", lambda **k: LabResult(success=True))
     monkeypatch.setattr(
         lgp,
-        "orchestrate_lab_start",
-        lambda p, scenario_path=None: LabResult(success=True, outcome=outcome),
+        "clean_boot_lab",
+        lambda p, *, remove_volumes=True, scenario_path=None: LabResult(
+            success=True, outcome=outcome
+        ),
     )
     monkeypatch.setattr(
         lgp, "capture_snapshot", lambda config_dir, backend: _Snapshot(snapshot)
@@ -369,13 +370,12 @@ def test_check_aces_driven_boot_fails_on_boot_failed(monkeypatch):
 
 
 def test_check_aces_driven_boot_skips_cleanup_and_reboot_when_requested(monkeypatch):
-    stops, boots = [], []
+    boots = []
     _wire_boot(monkeypatch)
-    monkeypatch.setattr(lgp, "stop_lab", lambda **k: stops.append(1) or LabResult(success=True))
     monkeypatch.setattr(
         lgp,
-        "orchestrate_lab_start",
-        lambda p, scenario_path=None: boots.append(1)
+        "clean_boot_lab",
+        lambda *a, **k: boots.append(1)
         or LabResult(success=True, outcome=StartupOutcome.READY),
     )
     state = LiveGateState()
@@ -386,10 +386,34 @@ def test_check_aces_driven_boot_skips_cleanup_and_reboot_when_requested(monkeypa
         options=LiveGateOptions(skip_clean_boot=True),
         state=state,
     )
-    # Non-destructive: neither cleanup nor reboot, but the running lab is still
-    # snapshotted and the realization matrix is still computed.
-    assert stops == [] and boots == []
+    # Non-destructive: no clean boot (cleanup+reboot), but the running lab is
+    # still snapshotted and the realization matrix is still computed.
+    assert boots == []
     assert check.passed and state.snapshot["containers"]
+
+
+def test_check_aces_driven_boot_fails_when_clean_boot_fails(monkeypatch):
+    """A failed clean boot (e.g. fatal cleanup) fails the gate, no snapshot."""
+    _wire_boot(monkeypatch)
+    monkeypatch.setattr(
+        lgp,
+        "clean_boot_lab",
+        lambda *a, **k: LabResult(
+            success=False,
+            error="clean-state cleanup failed; lab not booted",
+            outcome=StartupOutcome.FAILED,
+        ),
+    )
+    state = LiveGateState()
+    check = lgc.check_aces_driven_boot(
+        object(),
+        project_dir=PROJECT_ROOT,
+        config=_config(),
+        options=LiveGateOptions(),
+        state=state,
+    )
+    assert not check.passed and check.category == CATEGORY_BACKEND_INSTANTIATION
+    assert any("public lab start failed" in d for d in check.diagnostics)
 
 
 def test_check_aces_driven_boot_passes_selected_scenario_to_public_start(monkeypatch):
@@ -397,8 +421,10 @@ def test_check_aces_driven_boot_passes_selected_scenario_to_public_start(monkeyp
     boots = []
     monkeypatch.setattr(
         lgp,
-        "orchestrate_lab_start",
-        lambda p, scenario_path=None: boots.append((p, scenario_path))
+        "clean_boot_lab",
+        lambda p, *, remove_volumes=True, scenario_path=None: boots.append(
+            (p, scenario_path)
+        )
         or LabResult(success=True, outcome=StartupOutcome.READY),
     )
     state = LiveGateState()


### PR DESCRIPTION
## Summary

Adds a first-class ephemeral clean-state lifecycle mode so the platform guarantees clean state between runs (RNG-001). Previously the destructive teardown+reboot sequence existed only inline inside the live-validation gate and as two separate manual operator steps. A new clean_boot_lab() seam tears down the project-scoped deployment removing Compose-managed volumes, then boots through the existing public start path so each run comes up free of contamination (service databases, indexes, logs, generated in-container credentials) from a prior exercise — the prerequisite for reliable batch execution and benchmarking. A failed cleanup is fatal (a contaminated environment is never reused as clean) and raw Docker stderr is redacted at the boundary.

## Requirement UIDs

- `RNG-001`

## Related Issues

Closes #424

## ADR Impact

- No ADR required

## Changes

- Add clean_boot_lab() in src/aptl/core/lab.py: project-scoped stop with volume removal, then orchestrate_lab_start(); fatal-on-cleanup-failure; redacted error envelope; remove_volumes/skip_seed/scenario_path/backend knobs
- Add 'aptl lab start --clean' (and '--yes' to skip the destructive confirmation) in src/aptl/cli/lab.py; extract a shared _confirm_destructive() helper reused by 'stop --volumes'
- Refactor _live_gate_probes._boot_lab to consume clean_boot_lab instead of open-coding stop+start, unifying the destructive sequence on one implementation
- Document the clean-state guarantee and removed-vs-preserved scope in docs/reference/experiment-runs.md
- Add changelog fragment changelog.d/424.added.md

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

All subprocess/docker calls are mocked; no live lab required. New: TestCleanBootLab (stop→start ordering, fatal-on-cleanup-failure, redaction, knob/backend passthrough), CLI start --clean tests (routing, confirmation, --yes bypass, help), and updated live-gate boot tests consuming clean_boot_lab. Completion gate green: 2059 passed + integration static gate (4 passed).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: RNG-001 ← src/aptl/core/lab.py, RNG-001 ← src/aptl/cli/lab.py, RNG-001 ← src/aptl/validation/_live_gate_probes.py
- TESTS: RNG-001 ← tests/test_lab.py, RNG-001 ← tests/test_cli.py, RNG-001 ← tests/test_techvault_live_gate.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/424.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
