### PR TITLE
feat: capture ACES-aligned run reproducibility record on lab start (REP-001)

### DIFF
--- a/changelog.d/423.added.md
+++ b/changelog.d/423.added.md
@@ -1,0 +1,1 @@
+ACES-aligned run reproducibility record written to the run archive on lab start (and `aptl runs list` now shows normal lab runs).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -65,3 +65,4 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [041](adr-041-kali-capture-sidecar-ownership-boundary.md) | Kali Capture Sidecar Ownership Boundary (PTY-typescript residual superseded by ADR-042) | accepted (amended) | 2026-06-20 |
 | [042](adr-042-sidecar-owned-pty-master.md) | Sidecar-Owned PTY Master for Kali Transcript Authenticity | accepted | 2026-06-20 |
 | [043](adr-043-suricata-runtime-config-ownership-boundary.md) | Suricata Runtime Config Ownership Boundary | accepted | 2026-06-20 |
+| [044](adr-044-aces-aligned-run-reproducibility-record.md) | ACES-Aligned Run Reproducibility Record | accepted | 2026-06-25 |

--- a/docs/adrs/adr-044-aces-aligned-run-reproducibility-record.md
+++ b/docs/adrs/adr-044-aces-aligned-run-reproducibility-record.md
@@ -1,0 +1,188 @@
+# ADR-044: ACES-Aligned Run Reproducibility Record
+
+## Status
+
+accepted
+
+## Date
+
+2026-06-25
+
+## Context
+
+REP-001 requires every run to preserve enough information to reproduce or audit
+the run after the TechVault cutover to ACES. The risk is not missing one field;
+the risk is building a second APTL experiment manifest that duplicates ACES task,
+run, apparatus, evidence, and provenance concepts under different names.
+
+APTL already has the pieces this record must compose:
+
+- ACES SDL parsing and semantic validation enter through `aces_sdl.parse_sdl_file`
+  and the ACES `RuntimeManager`.
+- APTL's backend capability claim is published by
+  `src/aptl/backends/aces_manifest.py:create_aptl_manifest()`. The current
+  code claims the `orchestration-evaluation` profile and passes the
+  corresponding conformance tests; do not copy older `orchestration-capable`
+  wording from stale planning text into new records.
+- ACES provisioning, orchestration, and evaluation state is adapted through
+  `AptlProvisioner`, `AptlOrchestrator`, `AptlEvaluator`,
+  `AptlRealization`, `ApplyResult`, `RuntimeSnapshot`, operation
+  receipt/status, workflow result/history, and evaluation result/history
+  contracts.
+- APTL backend realization evidence is already owned by `DeploymentBackend`,
+  `capture_snapshot()`, `RangeSnapshot.to_dict()`, `LocalRunStore`,
+  collectors, MCP run capture, and exporter packaging.
+- ADR-029 makes `LocalRunStore.write_json`, `write_jsonl`, and
+  `append_jsonl` the Python persistence serialization boundary for run
+  archives, with `write_file` and `copy_file` explicitly pass-through.
+
+## Decision
+
+The REP-001 reproducibility record is a composition record. It anchors run
+identity to ACES contracts where ACES has a contract, and it carries APTL-only
+data only as backend realization evidence or evidence references.
+
+When an ACES contract exists for a concept, the record stores that contract
+payload or a stable identity reference to it. APTL does not define local
+Pydantic/dataclass mirrors for ACES task, run, apparatus, evidence, provenance,
+backend manifest, operation receipt/status, runtime snapshot, workflow, or
+evaluation envelopes.
+
+The record may include APTL backend sections for realization evidence such as
+selected Docker Compose profiles, profile dependency closure, `AptlRealization`
+details, range snapshot identity, config and image digests, detector/rule
+content digests, tool versions, scenario parameters, seeds, and references to
+MCP-side, Kali-side, SOC, container-log, and inventory evidence. Those sections
+must be clearly backend-owned and must not become the canonical scenario or
+runtime schema.
+
+Runtime state has two distinct meanings and must stay separated:
+
+- ACES `RuntimeSnapshot` is the portable ACES state/provenance surface.
+- APTL `RangeSnapshot` is backend inventory evidence for the realized lab.
+
+Both may be referenced by one run record, but neither replaces the other.
+
+Structured run-record writes go through `LocalRunStore.write_json`,
+`write_jsonl`, or `append_jsonl`. Opaque binary evidence can remain in existing
+capture/export locations, but the structured reproducibility record should store
+references and digests rather than copying bytes into a new JSON object.
+Exporter code remains packaging-only and must not become the first redaction or
+normalization point.
+
+## Security Layers
+
+| Layer | Requirement |
+| --- | --- |
+| ACES parser and validator gate | Scenario inputs continue through `aces_sdl.parse_sdl_file`, ACES semantic validation, `RuntimeManager.plan()`, and planner diagnostics. Do not structurally revalidate ACES SDL with local models. |
+| Backend manifest and conformance gate | Backend identity comes from `create_aptl_manifest()` and its serialized ACES backend-manifest-v2 payload, including supported contract versions, compatible processors, realization support, concept bindings, provisioner, orchestrator, and evaluator capability declarations. |
+| Runtime contract gate | Operation receipt/status, ACES `RuntimeSnapshot`, workflow result/history, and evaluation result/history are the portable runtime surfaces. Backend exceptions are translated into redacted ACES diagnostics or `LabResult` errors at the adapter boundary. |
+| Deployment inventory gate | Docker, Compose, container, network, image, port, and host inventory flows through `DeploymentBackend` and existing snapshot helpers. Do not parse `docker-compose.yml` or call raw Docker from a record builder. |
+| Config and env binding | Durable non-secret settings come from strict `AptlConfig`; runtime secrets come from `.env` / `EnvVars`, placeholder checks, ADR-028 generated config, and ADR-034 SOC TLS material. The record may store digests and non-secret identities, not `.env` values, rendered config secrets, API tokens, cookies, private keys, or bearer material. |
+| Persistence and path containment | `LocalRunStore` owns run IDs, relative-path validation, run directory layout, and redacted JSON/JSONL writes. New record paths must use those methods and inherit their traversal checks. |
+| Snapshot serialization | APTL range inventory enters JSON through `RangeSnapshot.to_dict()`, preserving ADR-029 redaction for service credentials and other secret-shaped fields. |
+| Collector and SOC HTTP safety | Collectors stay fault-tolerant, log counts/status only, and use `curl_safe` where SOC API calls need token/body handling that avoids argv leakage. |
+| API and error envelope | If the record is later exposed through the web API, it must use the existing `verify_token` / `WebAuthSettings` boundary and existing Pydantic response projection style. Error text must be generic and redacted; auth tokens do not travel in URLs. |
+| OS/process exposure | Do not introduce subprocess calls that put tokens, hashes, cookies, passwords, private key material, or rendered secret config in process argv. File modes and ignored directories are defense in depth only. |
+| Export boundary | `exporter.py` packages already-safe run artifacts and computes checksums. It must not mutate records to hide leaks that were written earlier. |
+
+## Maintainability
+
+Canonical incumbents for REP-001 are:
+
+- `src/aptl/backends/aces_manifest.py` for backend identity and supported ACES
+  contract versions.
+- `src/aptl/backends/aces.py`,
+  `src/aptl/backends/aces_realization.py`,
+  `src/aptl/backends/aces_realization_model.py`,
+  `src/aptl/backends/aces_orchestrator.py`,
+  `src/aptl/backends/aces_evaluator.py`, and
+  `src/aptl/backends/aces_diagnostics.py` for the ACES adapter boundary.
+- `src/aptl/core/deployment/` for all Docker/Compose/container/host
+  interaction.
+- `src/aptl/core/snapshot.py` and `src/aptl/core/endpoints.py` for APTL range
+  inventory and endpoint annotation.
+- `src/aptl/core/runstore.py`, `src/aptl/core/collectors.py`, and
+  `src/aptl/core/exporter.py` for run archive persistence, collection, and
+  packaging.
+- `src/aptl/core/session.py` and `src/aptl/core/telemetry.py` for
+  cross-process trace/run correlation.
+- `src/aptl/core/config.py`, `src/aptl/core/env.py`,
+  `src/aptl/core/credentials.py`, and `src/aptl/utils/redaction.py` for
+  config, env, generated secret handling, and serialization redaction.
+- `mcp/aptl-mcp-common/src/runs.ts`,
+  `mcp/aptl-mcp-common/src/redaction.ts`, and `mcp/mcp-red/src/capture.ts`
+  for TypeScript-side run capture and redaction parity.
+
+Tests should extend the existing seams rather than introduce new harnesses:
+`tests/test_aces_backend.py`, `tests/test_snapshot.py`,
+`tests/test_runstore.py`, `tests/test_exporter.py`, `tests/test_collectors.py`,
+`tests/test_session.py`, and the MCP redaction/run-capture tests.
+
+## Extensibility
+
+The extensibility seam is the boundary between ACES contract identity and APTL
+backend evidence references.
+
+Future ACES contract additions for task/run/apparatus/evidence/provenance should
+replace APTL-specific placeholders at the ACES namespace, without changing the
+backend evidence namespace. Future APTL evidence sources should add a referenced
+evidence kind plus digest/path metadata under the backend evidence namespace,
+without editing ACES contract payloads or hardcoding TechVault-specific fields.
+
+The record must be parameterized by backend name, backend manifest version,
+supported contract versions, compatible processor identity, scenario identity,
+and run identity. It must not assume TechVault is the only scenario, Docker
+Compose is the only possible APTL backend forever, or that the current manifest
+profile string is static.
+
+## Non-Goals
+
+- Do not design a new APTL scenario schema, experiment manifest schema, or ACES
+  mirror schema.
+- Do not promote `RangeSnapshot` to the ACES `RuntimeSnapshot` role or flatten
+  ACES runtime state into APTL snapshot fields.
+- Do not redesign run archive layout, exporter packaging, OTel tracing,
+  MCP capture, web auth, deployment backends, or config/env binding as part of
+  REP-001.
+- Do not make the run archive a plaintext secret vault or full forensic image.
+- Do not add a new exception hierarchy, validation framework, redaction helper,
+  or logging taxonomy for reproducibility records.
+- Do not change APTL's backend profile claim as part of the record unless the
+  ACES manifest and conformance tests change in the same backend-focused work.
+
+## Anti-Patterns
+
+- Creating `ExperimentManifest`, `AcesRunManifest`, or similar local types that
+  restate ACES contract fields.
+- Storing backend-specific evidence at the top level so it looks portable.
+- Treating image tags as image identity when a digest is available.
+- Treating `.env` hashes or file permissions as permission to expose `.env`
+  values, rendered config secrets, tokens, or private keys.
+- Calling `docker`, `docker compose`, `curl`, or `ssh` directly from a record
+  builder instead of using the existing backend, collector, or safe-curl
+  boundary.
+- Copying raw evidence into JSON through `write_file` / `copy_file` and assuming
+  the runstore redacted it.
+- Letting API, CLI, or exporter code become a second normalizer for the same
+  record shape.
+- Hardcoding TechVault scenario names, compose profile names, or a stale backend
+  profile string in the canonical record.
+
+## References
+
+- [ADR-023](adr-023-container-interaction-in-deployment-backend.md): container
+  interaction belongs on the deployment backend.
+- [ADR-029](adr-029-control-plane-secret-handling.md): runstore and snapshot
+  redaction boundaries.
+- [ADR-033](adr-033-agent-reasoning-trace-boundary.md): per-run MCP/Kali capture
+  layout and trace correlation.
+- [ADR-035](adr-035-aces-sdl-adoption.md): ACES adoption and adapter guardrails.
+- [ADR-036](adr-036-snapshot-endpoint-registry.md): snapshot endpoint registry
+  boundary.
+- [ADR-039](adr-039-web-control-plane-authentication.md): web API auth and error
+  boundary.
+- [ADR-041](adr-041-kali-capture-sidecar-ownership-boundary.md) and
+  [ADR-042](adr-042-sidecar-owned-pty-master.md): Kali capture ownership and
+  transcript authenticity.
+- REP-001 / GitHub issue #423.

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -102,7 +102,7 @@ def start_aces_scenario(
     backend: "DeploymentBackend",
     scenario_path: Path | None = None,
     *,
-    run_store: "RunStorageBackend | None" = None,
+    run_store: RunStorageBackend | None = None,
     run_id: str | None = None,
 ) -> AcesStartOutcome:
     """Start an APTL lab by compiling and applying an ACES SDL scenario.
@@ -178,7 +178,7 @@ def _run_execution_plan(
     execution_plan: "ExecutionPlan",
     scenario_path: Path | None = None,
     *,
-    run_store: "RunStorageBackend | None" = None,
+    run_store: RunStorageBackend | None = None,
     run_id: str | None = None,
 ) -> AcesStartOutcome:
     """Apply a planned ACES scenario through the runtime control plane.
@@ -229,7 +229,7 @@ def _apply_provisioning_and_orchestration(
     execution_plan: "ExecutionPlan",
     target: RuntimeTarget,
     *,
-    run_store: "RunStorageBackend | None" = None,
+    run_store: RunStorageBackend | None = None,
     run_id: str | None = None,
 ) -> tuple[LabResult | None, dict[str, Any], list[str]]:
     """Submit provisioning, orchestration, and evaluation control-plane phases.

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -10,9 +10,9 @@ start.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.planning import ChangeAction, ProvisioningPlan
@@ -49,10 +49,28 @@ if TYPE_CHECKING:
     from aces_processor.models import ExecutionPlan
 
     from aptl.core.deployment.backend import DeploymentBackend
+    from aptl.core.runstore import RunStorageBackend
 
 log = get_logger("aces-backend")
 
 DEFAULT_ACES_SCENARIO = Path("scenarios") / "techvault-operational.sdl.yaml"
+
+
+@dataclass
+class AcesStartOutcome:
+    """Reference-holder for start_aces_scenario outputs (REP-001 / ADR-044).
+
+    Carries the lab result alongside ACES runtime facts captured during
+    _run_execution_plan so downstream steps can build a reproducibility
+    record without re-running ACES planning or calling Docker.
+    """
+
+    lab_result: LabResult
+    final_snapshot: RuntimeSnapshot
+    realization_details: dict[str, Any]
+    selected_profiles: list[str]
+    scenario_path: Path | None
+    manifest_payload: dict[str, Any] = field(default_factory=dict)
 
 
 def create_aptl_runtime_target(
@@ -83,8 +101,17 @@ def start_aces_scenario(
     config: AptlConfig,
     backend: "DeploymentBackend",
     scenario_path: Path | None = None,
-) -> LabResult:
-    """Start an APTL lab by compiling and applying an ACES SDL scenario."""
+    *,
+    run_store: "RunStorageBackend | None" = None,
+    run_id: str | None = None,
+) -> AcesStartOutcome:
+    """Start an APTL lab by compiling and applying an ACES SDL scenario.
+
+    ``run_store`` and ``run_id`` (resolved once for the whole lab-start run,
+    REP-001 / GAP 4) are threaded into orchestration so workflow result and
+    history artifacts persist under the same run directory the reproducibility
+    record is written to.
+    """
 
     resolved_scenario = scenario_path or DEFAULT_ACES_SCENARIO
     if not resolved_scenario.is_absolute():
@@ -97,11 +124,23 @@ def start_aces_scenario(
             backend=backend,
         )
         execution_plan = RuntimeManager(target).plan(scenario)
-        return _run_execution_plan(target, execution_plan)
+        return _run_execution_plan(
+            target,
+            execution_plan,
+            resolved_scenario,
+            run_store=run_store,
+            run_id=run_id,
+        )
     except (FileNotFoundError, SDLError, TypeError, ValueError) as exc:
-        return LabResult(
-            success=False,
-            error=redact(f"ACES runtime handoff failed: {exc}"),
+        return AcesStartOutcome(
+            lab_result=LabResult(
+                success=False,
+                error=redact(f"ACES runtime handoff failed: {exc}"),
+            ),
+            final_snapshot=RuntimeSnapshot(),
+            realization_details={},
+            selected_profiles=[],
+            scenario_path=resolved_scenario,
         )
 
 
@@ -134,7 +173,14 @@ def selected_profiles_for_scenario(
     return select_backend_profiles(config, realization.profiles)
 
 
-def _run_execution_plan(target: RuntimeTarget, execution_plan: "ExecutionPlan") -> LabResult:
+def _run_execution_plan(
+    target: RuntimeTarget,
+    execution_plan: "ExecutionPlan",
+    scenario_path: Path | None = None,
+    *,
+    run_store: "RunStorageBackend | None" = None,
+    run_id: str | None = None,
+) -> AcesStartOutcome:
     """Apply a planned ACES scenario through the runtime control plane.
 
     Fail closed on every planner error. Scenario start routes provisioning,
@@ -145,14 +191,36 @@ def _run_execution_plan(target: RuntimeTarget, execution_plan: "ExecutionPlan") 
     """
     blocking = [diag for diag in execution_plan.diagnostics if diag.is_error]
     if blocking:
-        return LabResult(success=False, error=render_aces_diagnostics(blocking))
+        return AcesStartOutcome(
+            lab_result=LabResult(
+                success=False, error=render_aces_diagnostics(blocking)
+            ),
+            final_snapshot=RuntimeSnapshot(),
+            realization_details={},
+            selected_profiles=[],
+            scenario_path=scenario_path,
+        )
     control_plane = RuntimeControlPlane(target, initial_snapshot=execution_plan.base_snapshot)
-    failure = _apply_provisioning_and_orchestration(control_plane, execution_plan, target)
+    failure, realization_details, selected_profiles = _apply_provisioning_and_orchestration(
+        control_plane, execution_plan, target, run_store=run_store, run_id=run_id
+    )
     if failure is not None:
-        return failure
-    return LabResult(
-        success=True,
-        message=f"Lab started through ACES runtime target '{APTL_ACES_TARGET_NAME}'",
+        return AcesStartOutcome(
+            lab_result=failure,
+            final_snapshot=control_plane.get_snapshot(),
+            realization_details=realization_details,
+            selected_profiles=selected_profiles,
+            scenario_path=scenario_path,
+        )
+    return AcesStartOutcome(
+        lab_result=LabResult(
+            success=True,
+            message=f"Lab started through ACES runtime target '{APTL_ACES_TARGET_NAME}'",
+        ),
+        final_snapshot=control_plane.get_snapshot(),
+        realization_details=realization_details,
+        selected_profiles=selected_profiles,
+        scenario_path=scenario_path,
     )
 
 
@@ -160,12 +228,22 @@ def _apply_provisioning_and_orchestration(
     control_plane: RuntimeControlPlane,
     execution_plan: "ExecutionPlan",
     target: RuntimeTarget,
-) -> LabResult | None:
+    *,
+    run_store: "RunStorageBackend | None" = None,
+    run_id: str | None = None,
+) -> tuple[LabResult | None, dict[str, Any], list[str]]:
     """Submit provisioning, orchestration, and evaluation control-plane phases.
 
-    Returns a failed ``LabResult`` for the first phase that fails, else ``None``.
+    Returns a triple of (failure | None, realization_details, selected_profiles).
+    Failure is a failed LabResult for the first phase that fails, else None.
+
+    ``realization_details`` and ``selected_profiles`` are populated (REP-001 /
+    GAP 1) by interpreting the provisioning plan through the same public path
+    the provisioner uses, so the reproducibility record carries real
+    realization evidence rather than empty placeholders.
     """
-    phases = [
+    realization_details, selected_profiles = _interpret_realization(target, execution_plan)
+    phases: list[Callable[[], object]] = [
         lambda: control_plane.submit_provisioning(execution_plan.provisioning),
     ]
     if execution_plan.orchestration.actionable_operations:
@@ -179,7 +257,7 @@ def _apply_provisioning_and_orchestration(
     for submit in phases:
         failure = _apply_phase(control_plane, submit)
         if failure is not None:
-            return failure
+            return failure, realization_details, selected_profiles
     evaluation_results: dict[str, dict[str, object]] = {}
     if execution_plan.evaluation.actionable_operations and target.evaluator is not None:
         evaluation_results = target.evaluator.results()
@@ -187,13 +265,42 @@ def _apply_provisioning_and_orchestration(
     if isinstance(orchestrator, AptlOrchestrator) and orchestrator.results():
         drive_diagnostics = orchestrator.drive_workflows(
             evaluation_results=evaluation_results,
+            run_store=run_store,
+            run_id=run_id,
         )
         if drive_diagnostics:
-            return LabResult(
-                success=False,
-                error=render_aces_diagnostics(drive_diagnostics),
+            return (
+                LabResult(
+                    success=False,
+                    error=render_aces_diagnostics(drive_diagnostics),
+                ),
+                realization_details,
+                selected_profiles,
             )
-    return None
+    return None, realization_details, selected_profiles
+
+
+def _interpret_realization(
+    target: RuntimeTarget,
+    execution_plan: "ExecutionPlan",
+) -> tuple[dict[str, Any], list[str]]:
+    """Interpret the provisioning plan into realization details + profiles.
+
+    Reuses the ``AptlProvisioner``'s ``project_dir``/``config`` (REP-001 /
+    GAP 1) so the realization is computed exactly once with the real backend
+    context. Returns empty placeholders when the provisioner is unavailable.
+    """
+    provisioner = target.provisioner
+    if not isinstance(provisioner, AptlProvisioner):
+        return {}, []
+    realization = interpret_provisioning_plan(
+        plan=execution_plan.provisioning,
+        project_dir=provisioner.project_dir,
+        config=provisioner.config,
+    )
+    return realization.details(), select_backend_profiles(
+        provisioner.config, realization.profiles
+    )
 
 
 def _apply_phase(

--- a/src/aptl/backends/aces_repro.py
+++ b/src/aptl/backends/aces_repro.py
@@ -1,0 +1,100 @@
+"""ACES-aligned run reproducibility record builder (REP-001 / ADR-044).
+
+Pure composition module: anchors run identity to ACES contracts where they
+exist; carries APTL-only data only as backend-owned realization evidence.
+No Docker/curl/ssh calls. All inputs are already-captured objects/dicts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from aces_backend_protocols.manifest import backend_manifest_payload
+from aces_runtime.control_plane_store import _snapshot_payload
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+
+if TYPE_CHECKING:
+    from aces_contracts.runtime_state import RuntimeSnapshot
+
+SCHEMA_VERSION = "aptl.run-record/v1"
+
+_SEEDS_ABSENT_NOTE = (
+    "ACES ExecutionPlan does not currently expose a scenario-level "
+    "seed or parameter surface; seeds absent is the honest state."
+)
+
+
+def build_reproducibility_record(
+    *,
+    run_id: str,
+    backend_name: str,
+    started_at: str,
+    finished_at: str,
+    outcome: str,
+    final_snapshot: "RuntimeSnapshot",
+    realization_details: dict[str, Any],
+    selected_profiles: list[str],
+    scenario_path: Path | None,
+    scenario_display_name: str,
+    range_snapshot_dict: dict[str, Any],
+    config_digests: dict[str, str],
+    container_image_digests: dict[str, str],
+    detection_content_digest: str,
+    tool_versions: dict[str, str],
+    evidence_references: list[dict[str, str]],
+) -> dict[str, Any]:
+    """Build a REP-001 run reproducibility record dict.
+
+    Anchors ACES-contract identity at record["aces"] and carries
+    APTL backend realization evidence at record["backend_evidence"].
+    """
+    manifest = create_aptl_manifest()
+    manifest_payload = backend_manifest_payload(manifest)
+    runtime_snapshot_payload = _snapshot_payload(final_snapshot)
+    aces_lock_digest = _aces_lock_digest(scenario_path)
+
+    scenario_section: dict[str, Any] = {
+        "sdl_path": str(scenario_path) if scenario_path else None,
+        "display_name": scenario_display_name,
+        "aces_lock_digest": aces_lock_digest,
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "backend_name": backend_name,
+        "backend_manifest_version": manifest_payload.get("schema_version", ""),
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "outcome": outcome,
+        "aces": {
+            "backend_manifest": manifest_payload,
+            "runtime_snapshot": runtime_snapshot_payload,
+            "scenario": scenario_section,
+            "scenario_parameters": None,
+            "scenario_parameters_note": _SEEDS_ABSENT_NOTE,
+            "realization": realization_details,
+        },
+        "backend_evidence": {
+            "selected_profiles": selected_profiles,
+            "range_snapshot": range_snapshot_dict,
+            "config_digests": config_digests,
+            "container_image_digests": container_image_digests,
+            "detection_content_digest": detection_content_digest,
+            "tool_versions": tool_versions,
+            "evidence_references": evidence_references,
+        },
+    }
+
+
+def _aces_lock_digest(scenario_path: Path | None) -> str | None:
+    """Compute the sha256 of aces.lock.json adjacent to scenario_path, or None."""
+    if scenario_path is None:
+        return None
+    lock_path = scenario_path.parent / "aces.lock.json"
+    if not lock_path.exists():
+        return None
+    return hashlib.sha256(lock_path.read_bytes()).hexdigest()

--- a/src/aptl/backends/aces_repro.py
+++ b/src/aptl/backends/aces_repro.py
@@ -8,6 +8,7 @@ No Docker/curl/ssh calls. All inputs are already-captured objects/dicts.
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -27,25 +28,35 @@ _SEEDS_ABSENT_NOTE = (
 )
 
 
-def build_reproducibility_record(
-    *,
-    run_id: str,
-    backend_name: str,
-    started_at: str,
-    finished_at: str,
-    outcome: str,
-    final_snapshot: "RuntimeSnapshot",
-    realization_details: dict[str, Any],
-    selected_profiles: list[str],
-    scenario_path: Path | None,
-    scenario_display_name: str,
-    range_snapshot_dict: dict[str, Any],
-    config_digests: dict[str, str],
-    container_image_digests: dict[str, str],
-    detection_content_digest: str,
-    tool_versions: dict[str, str],
-    evidence_references: list[dict[str, str]],
-) -> dict[str, Any]:
+@dataclass(frozen=True)
+class RunRecordInputs:
+    """Builder-input holder for build_reproducibility_record (REP-001 / ADR-044).
+
+    Carries already-prepared primitives and ACES objects through to the record
+    builder.  This is NOT a local mirror of any ACES task/run/apparatus/
+    evidence/provenance/manifest/snapshot contract — it is a value-transport
+    struct whose fields are resolved by the caller before construction.
+    """
+
+    run_id: str
+    backend_name: str
+    started_at: str
+    finished_at: str
+    outcome: str
+    final_snapshot: RuntimeSnapshot
+    realization_details: dict[str, Any]
+    selected_profiles: list[str]
+    scenario_path: Path | None
+    scenario_display_name: str
+    range_snapshot_dict: dict[str, Any]
+    config_digests: dict[str, str]
+    container_image_digests: dict[str, str]
+    detection_content_digest: str
+    tool_versions: dict[str, str]
+    evidence_references: list[dict[str, str]]
+
+
+def build_reproducibility_record(inputs: RunRecordInputs) -> dict[str, Any]:
     """Build a REP-001 run reproducibility record dict.
 
     Anchors ACES-contract identity at record["aces"] and carries
@@ -53,39 +64,39 @@ def build_reproducibility_record(
     """
     manifest = create_aptl_manifest()
     manifest_payload = backend_manifest_payload(manifest)
-    runtime_snapshot_payload = _snapshot_payload(final_snapshot)
-    aces_lock_digest = _aces_lock_digest(scenario_path)
+    runtime_snapshot_payload = _snapshot_payload(inputs.final_snapshot)
+    aces_lock_digest = _aces_lock_digest(inputs.scenario_path)
 
     scenario_section: dict[str, Any] = {
-        "sdl_path": str(scenario_path) if scenario_path else None,
-        "display_name": scenario_display_name,
+        "sdl_path": str(inputs.scenario_path) if inputs.scenario_path else None,
+        "display_name": inputs.scenario_display_name,
         "aces_lock_digest": aces_lock_digest,
     }
 
     return {
         "schema_version": SCHEMA_VERSION,
-        "run_id": run_id,
-        "backend_name": backend_name,
+        "run_id": inputs.run_id,
+        "backend_name": inputs.backend_name,
         "backend_manifest_version": manifest_payload.get("schema_version", ""),
-        "started_at": started_at,
-        "finished_at": finished_at,
-        "outcome": outcome,
+        "started_at": inputs.started_at,
+        "finished_at": inputs.finished_at,
+        "outcome": inputs.outcome,
         "aces": {
             "backend_manifest": manifest_payload,
             "runtime_snapshot": runtime_snapshot_payload,
             "scenario": scenario_section,
             "scenario_parameters": None,
             "scenario_parameters_note": _SEEDS_ABSENT_NOTE,
-            "realization": realization_details,
+            "realization": inputs.realization_details,
         },
         "backend_evidence": {
-            "selected_profiles": selected_profiles,
-            "range_snapshot": range_snapshot_dict,
-            "config_digests": config_digests,
-            "container_image_digests": container_image_digests,
-            "detection_content_digest": detection_content_digest,
-            "tool_versions": tool_versions,
-            "evidence_references": evidence_references,
+            "selected_profiles": inputs.selected_profiles,
+            "range_snapshot": inputs.range_snapshot_dict,
+            "config_digests": inputs.config_digests,
+            "container_image_digests": inputs.container_image_digests,
+            "detection_content_digest": inputs.detection_content_digest,
+            "tool_versions": inputs.tool_versions,
+            "evidence_references": inputs.evidence_references,
         },
     }
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -74,6 +74,7 @@ from aptl.utils.redaction import redact
 if TYPE_CHECKING:
     from docker.client import DockerClient
 
+    from aptl.backends.aces import AcesStartOutcome
     from aptl.core.deployment.backend import DeploymentBackend
 
 log = get_logger("lab")
@@ -95,7 +96,7 @@ def start_aces_scenario(
     artifacts under the same run directory the run record is written to.
     """
     try:
-        from aptl.backends.aces import AcesStartOutcome, start_aces_scenario as _start_aces_scenario
+        from aptl.backends.aces import start_aces_scenario as _start_aces_scenario
     except ImportError as exc:
         error = f"ACES runtime handoff unavailable: {redact(str(exc))}"
         log.error(error)
@@ -1302,11 +1303,61 @@ def _resolve_run_target(ctx: _LabStartContext) -> tuple[object, str]:
     return LocalRunStore(state_dir / "runs"), run_id
 
 
+def _resolve_aces_snapshot(outcome: object) -> object:
+    """Return a valid RuntimeSnapshot from the ACES outcome, or a blank default."""
+    from aces_contracts.runtime_state import RuntimeSnapshot as _RuntimeSnapshot
+
+    final_snapshot = getattr(outcome, "final_snapshot", None)
+    if final_snapshot is None or not isinstance(final_snapshot, _RuntimeSnapshot):
+        return _RuntimeSnapshot()
+    return final_snapshot
+
+
+def _assemble_container_image_digests(snapshot: object) -> dict[str, str]:
+    """Build the container-name → image-digest mapping from a RangeSnapshot."""
+    return {
+        c.name: c.image_digest
+        for c in snapshot.containers  # type: ignore[attr-defined]
+        if c.image_digest
+    }
+
+
+def _assemble_tool_versions(snapshot: object) -> dict[str, str]:
+    """Build the tool-name → version mapping from a RangeSnapshot.software."""
+    sw = snapshot.software  # type: ignore[attr-defined]
+    return {
+        k: v
+        for k, v in (
+            ("python", sw.python_version),
+            ("docker", sw.docker_version),
+            ("compose", sw.compose_version),
+            ("aptl", sw.aptl_version),
+            ("aces_sdl", sw.aces_sdl_version),
+        )
+        if v
+    }
+
+
+def _safe_dict(value: object) -> dict[str, Any]:
+    """Return value if it is a dict, else an empty dict."""
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: object) -> list[str]:
+    """Return list(value) if value is truthy, else an empty list."""
+    return list(value) if value else []  # type: ignore[arg-type]
+
+
+def _scenario_display_name(scenario_path: Path | None) -> str:
+    """Return the scenario file name, or 'unknown' when path is absent."""
+    return str(scenario_path.name) if scenario_path else "unknown"
+
+
 def _write_run_record(ctx: _LabStartContext) -> None:
     """Internal helper: build and persist the reproducibility record."""
     from datetime import datetime, timezone
 
-    from aptl.backends.aces_repro import build_reproducibility_record
+    from aptl.backends.aces_repro import RunRecordInputs, build_reproducibility_record
     from aptl.core.snapshot import RangeSnapshot, detection_content_digest
 
     outcome = ctx.aces_outcome
@@ -1326,51 +1377,28 @@ def _write_run_record(ctx: _LabStartContext) -> None:
 
     store.create_run(run_id)
 
-    final_snapshot = getattr(outcome, "final_snapshot", None)
-    realization_details = getattr(outcome, "realization_details", {})
-    selected_profiles = getattr(outcome, "selected_profiles", [])
-    scenario_path = getattr(outcome, "scenario_path", None)
-
-    from aces_contracts.runtime_state import RuntimeSnapshot as _RuntimeSnapshot
-    if final_snapshot is None or not isinstance(final_snapshot, _RuntimeSnapshot):
-        final_snapshot = _RuntimeSnapshot()
-
+    final_snapshot = _resolve_aces_snapshot(outcome)
     now_str = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    container_image_digests = {
-        c.name: c.image_digest
-        for c in snapshot.containers
-        if c.image_digest
-    }
-    tool_versions = {
-        k: v
-        for k, v in (
-            ("python", snapshot.software.python_version),
-            ("docker", snapshot.software.docker_version),
-            ("compose", snapshot.software.compose_version),
-            ("aptl", snapshot.software.aptl_version),
-            ("aces_sdl", snapshot.software.aces_sdl_version),
-        )
-        if v
-    }
 
-    record = build_reproducibility_record(
+    inputs = RunRecordInputs(
         run_id=run_id,
         backend_name="aptl",
         started_at=snapshot.timestamp,
         finished_at=now_str,
         outcome="success",
         final_snapshot=final_snapshot,
-        realization_details=realization_details if isinstance(realization_details, dict) else {},
-        selected_profiles=list(selected_profiles) if selected_profiles else [],
-        scenario_path=scenario_path,
-        scenario_display_name=str(scenario_path.name) if scenario_path else "unknown",
+        realization_details=_safe_dict(getattr(outcome, "realization_details", {})),
+        selected_profiles=_safe_list(getattr(outcome, "selected_profiles", [])),
+        scenario_path=getattr(outcome, "scenario_path", None),
+        scenario_display_name=_scenario_display_name(getattr(outcome, "scenario_path", None)),
         range_snapshot_dict=snapshot.to_dict(),
         config_digests=snapshot.config_hashes,
-        container_image_digests=container_image_digests,
+        container_image_digests=_assemble_container_image_digests(snapshot),
         detection_content_digest=detection_content_digest(ctx.project_dir),
-        tool_versions=tool_versions,
+        tool_versions=_assemble_tool_versions(snapshot),
         evidence_references=_collect_evidence_references(store, run_id),
     )
+    record = build_reproducibility_record(inputs)
     store.write_json(run_id, "manifest.json", record)
     log.info("REP-001: Run record written to run archive (run_id=%s)", run_id)
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -6,6 +6,8 @@ Compose as the default backend.  Includes the full orchestration of lab
 startup.
 """
 
+from __future__ import annotations
+
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -88,7 +90,7 @@ def start_aces_scenario(
     *,
     run_store: object = None,
     run_id: str | None = None,
-) -> "AcesStartOutcome | LabResult":
+) -> AcesStartOutcome | LabResult:
     """Lazy ACES handoff import for the public lab-start path.
 
     ``run_store``/``run_id`` (resolved once per lab-start run, REP-001 / GAP 4)

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -84,10 +84,18 @@ def start_aces_scenario(
     config: AptlConfig,
     backend: "DeploymentBackend",
     scenario_path: Path | None = None,
-) -> LabResult:
-    """Lazy ACES handoff import for the public lab-start path."""
+    *,
+    run_store: object = None,
+    run_id: str | None = None,
+) -> "AcesStartOutcome | LabResult":
+    """Lazy ACES handoff import for the public lab-start path.
+
+    ``run_store``/``run_id`` (resolved once per lab-start run, REP-001 / GAP 4)
+    are threaded into the ACES handoff so orchestration persists workflow
+    artifacts under the same run directory the run record is written to.
+    """
     try:
-        from aptl.backends.aces import start_aces_scenario as _start_aces_scenario
+        from aptl.backends.aces import AcesStartOutcome, start_aces_scenario as _start_aces_scenario
     except ImportError as exc:
         error = f"ACES runtime handoff unavailable: {redact(str(exc))}"
         log.error(error)
@@ -98,6 +106,8 @@ def start_aces_scenario(
         config,
         backend,
         scenario_path=scenario_path,
+        run_store=run_store,
+        run_id=run_id,
     )
 
 
@@ -484,6 +494,15 @@ class _LabStartContext(object):
     ssh_key_path: Path | None = None
     selected_profiles: set[str] = field(default_factory=set)
     diagnostics: list[StartupDiagnostic] = field(default_factory=list)
+    # REP-001: ACES start outcome and range snapshot for run record writing.
+    # Use object to avoid circular imports; typed at use sites.
+    aces_outcome: object = None
+    snapshot: object = None
+    # REP-001 / GAP 4: one run store + run_id resolved once per lab-start run,
+    # threaded through orchestration and reused by the run-record step so
+    # workflow artifacts and the record share a single run directory.
+    run_store: object = None
+    run_id: str | None = None
 
 
 # Log format string for structured diagnostics. Kept module-level so
@@ -982,26 +1001,38 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
     log.info("Step 8: Starting containers...")
     # Runtime guards above.
     assert ctx.config is not None and ctx.backend is not None
-    start_result = start_aces_scenario(
+    # GAP 4: resolve the single run target ONCE, before the ACES handoff, so
+    # orchestration persists workflow artifacts and the later run-record step
+    # write to the same run directory / run_id.
+    ctx.run_store, ctx.run_id = _resolve_run_target(ctx)
+    outcome = start_aces_scenario(
         ctx.project_dir,
         ctx.config,
         ctx.backend,
         scenario_path=ctx.scenario_path,
+        run_store=ctx.run_store,
+        run_id=ctx.run_id,
     )
-    if not start_result.success and ctx.config.containers.soc:
+    lab_result = outcome.lab_result if hasattr(outcome, "lab_result") else outcome
+    if not lab_result.success and ctx.config.containers.soc:
         log.warning(
             "Initial compose up failed (SOC dependencies may still be "
             "initializing). Waiting 60s and retrying..."
         )
         import time
         time.sleep(60)
-        start_result = start_aces_scenario(
+        outcome = start_aces_scenario(
             ctx.project_dir,
             ctx.config,
             ctx.backend,
             scenario_path=ctx.scenario_path,
+            run_store=ctx.run_store,
+            run_id=ctx.run_id,
         )
-    if start_result.success:
+        lab_result = outcome.lab_result if hasattr(outcome, "lab_result") else outcome
+    if lab_result.success:
+        # Store the ACES start outcome for the run record step (REP-001).
+        ctx.aces_outcome = outcome
         # Scope the post-start readiness checks to the profiles this scenario
         # actually started, not the global config flags. A curated bounded
         # scenario starts a subset, so a config-flag gate would wait on (and
@@ -1013,10 +1044,10 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
             scenario_path=ctx.scenario_path,
         )
         return None
-    log.error("Lab start failed: %s", start_result.error)
+    log.error("Lab start failed: %s", lab_result.error)
     return LabResult(
         success=False,
-        error=f"Lab start failed: {start_result.error}",
+        error=f"Lab start failed: {lab_result.error}",
     )
 
 
@@ -1208,6 +1239,8 @@ def _step_capture_snapshot(ctx: _LabStartContext) -> LabResult | None:
             ),
         )
         return None
+    # Store snapshot for run record step (REP-001).
+    ctx.snapshot = snapshot
     log.info(
         "Range: %d containers, %d networks, %d services, %d SSH endpoints",
         len(snapshot.containers),
@@ -1216,6 +1249,163 @@ def _step_capture_snapshot(ctx: _LabStartContext) -> LabResult | None:
         len(snapshot.ssh),
     )
     return None
+
+
+def _step_write_run_record(ctx: _LabStartContext) -> LabResult | None:
+    """Write an ACES-aligned reproducibility record into the run archive (REP-001).
+
+    Non-fatal: a failure to write the record emits a WARNING diagnostic but
+    does not abort the lab start. The lab is already running at this point.
+    """
+    log.info("Step 11c: Writing run reproducibility record...")
+    if ctx.aces_outcome is None or ctx.snapshot is None:
+        log.warning(
+            "REP-001: Skipping run record — ACES outcome or range snapshot unavailable"
+        )
+        return None
+    try:
+        _write_run_record(ctx)
+    except Exception:
+        log.exception("REP-001: Run record write failed (non-fatal)")
+        _emit_diagnostic(
+            ctx,
+            step="write_run_record",
+            impact=DiagnosticImpact.TELEMETRY,
+            severity=DiagnosticSeverity.WARNING,
+            message="Run reproducibility record could not be written; run archive will lack REP-001 record",
+            operator_action=(
+                "Inspect lab logs; the lab is running but the run archive "
+                "will be missing its reproducibility record"
+            ),
+        )
+    return None
+
+
+def _resolve_run_target(ctx: _LabStartContext) -> tuple[object, str]:
+    """Resolve the single (run_store, run_id) for this lab-start run (GAP 4).
+
+    Prefers the active scenario's trace-scoped run dir (``resolve_active_run_dir``)
+    so MCP-side and lab-side artifacts share one directory; otherwise mints a
+    filesystem-safe ``run_<UTC timestamp>`` id under the default run store base
+    dir. The minted id is shaped to pass ``runstore._validate_id``. Resolved
+    once and cached on ctx so orchestration and the run record agree.
+    """
+    from datetime import datetime, timezone
+
+    from aptl.core.runstore import LocalRunStore, resolve_active_run_dir
+
+    state_dir = ctx.project_dir / ".aptl"
+    active_run_dir = resolve_active_run_dir(state_dir)
+    if active_run_dir is not None:
+        return LocalRunStore(active_run_dir.parent), active_run_dir.name
+    run_id = datetime.now(timezone.utc).strftime("run_%Y%m%dT%H%M%SZ")
+    return LocalRunStore(state_dir / "runs"), run_id
+
+
+def _write_run_record(ctx: _LabStartContext) -> None:
+    """Internal helper: build and persist the reproducibility record."""
+    from datetime import datetime, timezone
+
+    from aptl.backends.aces_repro import build_reproducibility_record
+    from aptl.core.snapshot import RangeSnapshot, detection_content_digest
+
+    outcome = ctx.aces_outcome
+    snapshot = ctx.snapshot
+    if not isinstance(snapshot, RangeSnapshot):
+        log.warning("REP-001: ctx.snapshot is not a RangeSnapshot; skipping")
+        return
+
+    # GAP 4: reuse the run target resolved in _step_start_containers so the
+    # record and orchestration artifacts share one run_id; fall back to a
+    # fresh resolution only if the start step did not run (defensive).
+    if ctx.run_store is not None and ctx.run_id:
+        store: object = ctx.run_store
+        run_id = ctx.run_id
+    else:
+        store, run_id = _resolve_run_target(ctx)
+
+    store.create_run(run_id)
+
+    final_snapshot = getattr(outcome, "final_snapshot", None)
+    realization_details = getattr(outcome, "realization_details", {})
+    selected_profiles = getattr(outcome, "selected_profiles", [])
+    scenario_path = getattr(outcome, "scenario_path", None)
+
+    from aces_contracts.runtime_state import RuntimeSnapshot as _RuntimeSnapshot
+    if final_snapshot is None or not isinstance(final_snapshot, _RuntimeSnapshot):
+        final_snapshot = _RuntimeSnapshot()
+
+    now_str = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    container_image_digests = {
+        c.name: c.image_digest
+        for c in snapshot.containers
+        if c.image_digest
+    }
+    tool_versions = {
+        k: v
+        for k, v in (
+            ("python", snapshot.software.python_version),
+            ("docker", snapshot.software.docker_version),
+            ("compose", snapshot.software.compose_version),
+            ("aptl", snapshot.software.aptl_version),
+            ("aces_sdl", snapshot.software.aces_sdl_version),
+        )
+        if v
+    }
+
+    record = build_reproducibility_record(
+        run_id=run_id,
+        backend_name="aptl",
+        started_at=snapshot.timestamp,
+        finished_at=now_str,
+        outcome="success",
+        final_snapshot=final_snapshot,
+        realization_details=realization_details if isinstance(realization_details, dict) else {},
+        selected_profiles=list(selected_profiles) if selected_profiles else [],
+        scenario_path=scenario_path,
+        scenario_display_name=str(scenario_path.name) if scenario_path else "unknown",
+        range_snapshot_dict=snapshot.to_dict(),
+        config_digests=snapshot.config_hashes,
+        container_image_digests=container_image_digests,
+        detection_content_digest=detection_content_digest(ctx.project_dir),
+        tool_versions=tool_versions,
+        evidence_references=_collect_evidence_references(store, run_id),
+    )
+    store.write_json(run_id, "manifest.json", record)
+    log.info("REP-001: Run record written to run archive (run_id=%s)", run_id)
+
+
+# Evidence artifact subtrees scanned for the REP-001 record (GAP 3). Each
+# existing file under these directories is referenced by its relative path;
+# bytes are never inlined into the record.
+_EVIDENCE_KINDS = ("orchestration", "mcp-side", "kali-side")
+
+
+def _collect_evidence_references(store: object, run_id: str) -> list[dict[str, str]]:
+    """Enumerate evidence artifacts that EXIST under the run dir (GAP 3).
+
+    References are RELATIVE to the run directory (never absolute) and the
+    manifest never inlines file bytes. On a bare lab start this may be just
+    orchestration artifacts (or empty), which is fine.
+    """
+    try:
+        run_dir = store.get_run_path(run_id)
+    except Exception:
+        return []
+    references: list[dict[str, str]] = []
+    for kind in _EVIDENCE_KINDS:
+        subtree = run_dir / kind
+        if not subtree.is_dir():
+            continue
+        for path in sorted(subtree.rglob("*")):
+            if path.is_file():
+                references.append(
+                    {
+                        "path": path.relative_to(run_dir).as_posix(),
+                        "kind": kind,
+                    }
+                )
+    return references
 
 
 def _step_pin_terminal_host_keys(ctx: _LabStartContext) -> LabResult | None:
@@ -1490,6 +1680,7 @@ _LAB_START_STEPS = (
     _step_wait_for_services,
     _step_test_ssh,
     _step_capture_snapshot,
+    _step_write_run_record,
     _step_pin_terminal_host_keys,
     _step_build_mcps,
     _step_seed_soc,

--- a/src/aptl/core/snapshot.py
+++ b/src/aptl/core/snapshot.py
@@ -38,6 +38,7 @@ class SoftwareVersions(object):
     wazuh_manager_version: str = ""
     wazuh_indexer_version: str = ""
     aptl_version: str = ""
+    aces_sdl_version: str = ""
 
 
 @dataclass
@@ -52,6 +53,7 @@ class ContainerSnapshot(object):
     labels: dict[str, str] = field(default_factory=dict)
     networks: dict[str, str] = field(default_factory=dict)
     ports: list[str] = field(default_factory=list)
+    image_digest: str = ""
 
 
 @dataclass
@@ -183,6 +185,14 @@ def _get_software_versions(backend: "DeploymentBackend") -> SoftwareVersions:
         versions.aptl_version = version("aptl")
     except PackageNotFoundError:
         versions.aptl_version = "dev"
+
+    # ACES SDL version from package metadata
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        versions.aces_sdl_version = version("aces-sdl")
+    except PackageNotFoundError:
+        versions.aces_sdl_version = ""
 
     return versions
 
@@ -371,6 +381,30 @@ def _hash_config_files(config_dir: Path | None = None) -> dict[str, str]:
                 hashes[f.name] = digest
 
     return hashes
+
+
+def detection_content_digest(project_dir: Path) -> str:
+    """Compute a combined sha256 digest of detection content under project_dir.
+
+    Hashes Suricata custom rules and Wazuh custom rules found under the
+    project directory. Returns an empty string when no detection files are
+    found (empty-safe). Reuses the same file-glob/hash pattern as
+    :func:`_hash_config_files`.
+    """
+    patterns = [
+        "config/suricata/rules/*.rules",
+        "config/suricata/rules/*.conf",
+        "config/wazuh/etc/rules/*.xml",
+        "config/wazuh/etc/decoders/*.xml",
+    ]
+    combined = hashlib.sha256()
+    found_any = False
+    for pattern in patterns:
+        for f in sorted(project_dir.glob(pattern)):
+            if f.is_file():
+                combined.update(f.read_bytes())
+                found_any = True
+    return combined.hexdigest() if found_any else ""
 
 
 def capture_snapshot(

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -428,7 +428,7 @@ def check_run_archive_manifest(
             "execution_state_integration": "#514",
         },
         "orchestrator_surfaces": {
-            "profile": "orchestration-capable",
+            "profile": "orchestration-evaluation",
             "contracts": [
                 "workflow-result-envelope-v1",
                 "workflow-history-event-stream-v1",

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -195,70 +195,6 @@ def test_realization_accepts_core_otel_as_public_start_profile(tmp_path):
     assert [diag.code for diag in realization.diagnostics] == []
 
 
-def _otel_only_config() -> AptlConfig:
-    return AptlConfig(
-        lab={"name": "test"},
-        containers={
-            "wazuh": False,
-            "victim": False,
-            "kali": False,
-            "reverse": False,
-            "enterprise": False,
-            "soc": False,
-            "mail": False,
-            "fileshare": False,
-            "dns": False,
-        },
-    )
-
-
-def _node_resource_with_health(node_name: str, status: str) -> PlannedResource:
-    # ACES carries the SDL ``runtime.health`` declaration into the compiled node
-    # payload at ``spec.node.runtime.health`` (verified against a real compile).
-    resource = _node_resource(node_name)
-    resource.payload["spec"]["node"]["runtime"] = {
-        "health": {
-            "status": status,
-            "description": "Compose healthcheck must pass before startup is ready.",
-        }
-    }
-    return resource
-
-
-def test_realization_extracts_declared_node_health(tmp_path):
-    from aptl.backends.aces_realization import interpret_provisioning_plan
-
-    _write_compose(tmp_path, {"aptl-otel-collector": ["otel"]})
-
-    realization = interpret_provisioning_plan(
-        plan=_plan_for_resources(
-            _node_resource_with_health("aptl-otel-collector", "healthy")
-        ),
-        project_dir=tmp_path,
-        config=_otel_only_config(),
-    )
-
-    node = realization.nodes[0]
-    assert node.declared_health == "healthy"
-    assert node.details()["declared_health"] == "healthy"
-
-
-def test_realization_declared_health_absent_when_undeclared(tmp_path):
-    from aptl.backends.aces_realization import interpret_provisioning_plan
-
-    _write_compose(tmp_path, {"aptl-otel-collector": ["otel"]})
-
-    realization = interpret_provisioning_plan(
-        plan=_plan_for_nodes("aptl-otel-collector"),
-        project_dir=tmp_path,
-        config=_otel_only_config(),
-    )
-
-    node = realization.nodes[0]
-    assert node.declared_health is None
-    assert node.details()["declared_health"] is None
-
-
 class _FakeExecutionPlan:
     """Minimal ExecutionPlan stand-in exposing the fields the handoff reads."""
 
@@ -391,7 +327,7 @@ def test_start_aces_scenario_uses_parser_runtime_manager_and_backend(
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is True
+    assert result.lab_result.success is True
     parser.assert_called_once_with(
         tmp_path / "scenarios" / "techvault-operational.sdl.yaml"
     )
@@ -422,7 +358,7 @@ def test_start_aces_scenario_uses_selected_scenario_path(mocker, tmp_path):
 
     result = aces.start_aces_scenario(tmp_path, config, backend, scenario_path=selected)
 
-    assert result.success is True
+    assert result.lab_result.success is True
     parser.assert_called_once_with(selected)
 
 
@@ -505,6 +441,9 @@ def test_start_aces_scenario_submits_orchestration_for_workflow_scenario(mocker,
             status.diagnostics = []
             return status
 
+        def get_snapshot(self):
+            return RuntimeSnapshot()
+
     class FakeRuntimeManager:
         def __init__(self, target):
             self.target = target
@@ -522,7 +461,7 @@ def test_start_aces_scenario_submits_orchestration_for_workflow_scenario(mocker,
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is True
+    assert result.lab_result.success is True
     # The orchestration block actually ran: without it, submit_calls would omit
     # "orchestration" even though provisioning still succeeds. (Profile selection
     # for backend.start is covered by the provisioning-focused tests above; here
@@ -551,8 +490,8 @@ def test_start_aces_scenario_fails_when_provisioning_backend_fails(mocker, tmp_p
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is False
-    assert result.error
+    assert result.lab_result.success is False
+    assert result.lab_result.error
 
 
 def test_start_aces_scenario_fails_when_orchestration_fails(mocker, tmp_path):
@@ -594,8 +533,8 @@ def test_start_aces_scenario_fails_when_orchestration_fails(mocker, tmp_path):
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is False
-    assert result.error
+    assert result.lab_result.success is False
+    assert result.lab_result.error
 
 
 def test_start_aces_scenario_submits_evaluation_for_objective_scenario(mocker, tmp_path):
@@ -655,6 +594,9 @@ def test_start_aces_scenario_submits_evaluation_for_objective_scenario(mocker, t
             status.diagnostics = []
             return status
 
+        def get_snapshot(self):
+            return RuntimeSnapshot()
+
     class FakeRuntimeManager:
         def __init__(self, target):
             self.target = target
@@ -674,7 +616,7 @@ def test_start_aces_scenario_submits_evaluation_for_objective_scenario(mocker, t
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is True
+    assert result.lab_result.success is True
     assert submit_calls == ["provisioning", "orchestration", "evaluation"]
 
 
@@ -725,6 +667,9 @@ def test_start_aces_scenario_drives_workflows_after_registration(mocker, tmp_pat
             status.diagnostics = []
             return status
 
+        def get_snapshot(self):
+            return RuntimeSnapshot()
+
     class FakeRuntimeManager:
         def __init__(self, target):
             self.target = target
@@ -758,7 +703,7 @@ def test_start_aces_scenario_drives_workflows_after_registration(mocker, tmp_pat
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is True
+    assert result.lab_result.success is True
     assert drive_calls
     assert drive_calls[0]["evaluation_results"] == {}
 
@@ -797,8 +742,8 @@ def test_start_aces_scenario_fails_closed_on_evaluator_plan_error(mocker, tmp_pa
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is False
-    assert result.error
+    assert result.lab_result.success is False
+    assert result.lab_result.error
     backend.start.assert_not_called()
 
 
@@ -836,8 +781,8 @@ def test_start_aces_scenario_fails_closed_on_provisioning_plan_error(mocker, tmp
 
     result = aces.start_aces_scenario(tmp_path, config, backend)
 
-    assert result.success is False
-    assert result.error
+    assert result.lab_result.success is False
+    assert result.lab_result.error
     backend.start.assert_not_called()
 
 
@@ -1335,3 +1280,244 @@ def test_aces_backend_does_not_import_legacy_sdl_parser():
 
     assert "aptl.core.sdl" not in source
     assert "ScenarioDefinition" not in source
+
+
+def test_start_aces_scenario_returns_aces_start_outcome(tmp_path):
+    """start_aces_scenario returns AcesStartOutcome, not just LabResult."""
+    from unittest.mock import patch as _patch, MagicMock as _MagicMock
+
+    from aces_contracts.planning import (
+        EvaluationPlan,
+        OrchestrationPlan,
+    )
+    from aces_contracts.runtime_state import ApplyResult, OperationState, RuntimeSnapshot
+
+    from aptl.backends.aces import AcesStartOutcome, start_aces_scenario
+    from aptl.core.config import AptlConfig
+
+    _write_compose(tmp_path, {"aptl-victim": ["victim"]})
+    (tmp_path / "scenarios").mkdir()
+    sdl_path = tmp_path / "scenarios" / "test.sdl.yaml"
+    sdl_path.write_text(
+        "kind: ScenarioDefinition\napiVersion: v1\nmetadata:\n  name: test\nspec:\n  nodes: []\n"
+    )
+
+    backend = _MagicMock()
+    backend.start.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"})
+
+    op_status = _MagicMock()
+    op_status.state = OperationState.SUCCEEDED
+    op_status.diagnostics = []
+
+    apply_result = ApplyResult(
+        success=True,
+        snapshot=RuntimeSnapshot(),
+        diagnostics=[],
+    )
+
+    with (
+        _patch("aptl.backends.aces.parse_sdl_file") as mock_parse,
+        _patch("aptl.backends.aces.RuntimeManager") as mock_manager,
+        _patch("aptl.backends.aces.RuntimeControlPlane") as mock_cp,
+    ):
+        mock_scenario = _MagicMock()
+        mock_parse.return_value = mock_scenario
+
+        mock_plan = _MagicMock()
+        mock_plan.diagnostics = []
+        mock_plan.base_snapshot = RuntimeSnapshot()
+        mock_plan.orchestration.actionable_operations = []
+        mock_plan.evaluation.actionable_operations = []
+        mock_plan.provisioning = _MagicMock()
+        mock_manager.return_value.plan.return_value = mock_plan
+
+        mock_control = _MagicMock()
+        mock_cp.return_value = mock_control
+        receipt = _MagicMock()
+        receipt.operation_id = "op-1"
+        mock_control.submit_provisioning.return_value = receipt
+        mock_control.get_operation.return_value = op_status
+        mock_control.get_snapshot.return_value = RuntimeSnapshot()
+
+        result = start_aces_scenario(tmp_path, config, backend, scenario_path=sdl_path)
+
+    assert isinstance(result, AcesStartOutcome)
+    assert result.lab_result.success is True
+    assert isinstance(result.final_snapshot, RuntimeSnapshot)
+    assert isinstance(result.realization_details, dict)
+    assert isinstance(result.selected_profiles, list)
+
+
+def test_drive_workflows_receives_threaded_run_store_and_run_id(tmp_path):
+    """_apply_provisioning_and_orchestration threads its run_store/run_id args
+    into drive_workflows (GAP 2/4): a real run store + run_id, not None."""
+    from unittest.mock import MagicMock as _MagicMock
+
+    from aces_contracts.runtime_state import OperationState
+
+    from aptl.backends.aces import (
+        AptlOrchestrator,
+        _apply_provisioning_and_orchestration,
+    )
+    from aptl.core.runstore import LocalRunStore
+
+    store = LocalRunStore(tmp_path / "runs")
+    run_id = "run_20260101T000000Z"
+
+    mock_orchestrator = _MagicMock(spec=AptlOrchestrator)
+    mock_orchestrator.results.return_value = {"wf1": {"status": "PENDING"}}
+    mock_orchestrator.drive_workflows.return_value = []
+
+    mock_plan = _MagicMock()
+    mock_plan.orchestration.actionable_operations = []
+    mock_plan.evaluation.actionable_operations = []
+    mock_plan.provisioning = _MagicMock()
+
+    mock_target = _MagicMock()
+    mock_target.orchestrator = mock_orchestrator
+    mock_target.evaluator = None
+    mock_target.provisioner = None
+
+    receipt = _MagicMock()
+    receipt.operation_id = "op-prov"
+    op_status = _MagicMock()
+    op_status.state = OperationState.SUCCEEDED
+    op_status.diagnostics = []
+
+    mock_cp = _MagicMock()
+    mock_cp.submit_provisioning.return_value = receipt
+    mock_cp.get_operation.return_value = op_status
+
+    failure, _, _ = _apply_provisioning_and_orchestration(
+        mock_cp, mock_plan, mock_target, run_store=store, run_id=run_id
+    )
+
+    mock_orchestrator.drive_workflows.assert_called_once_with(
+        evaluation_results={},
+        run_store=store,
+        run_id=run_id,
+    )
+    assert failure is None
+
+
+def test_drive_workflows_persists_workflow_result_under_run_dir(tmp_path):
+    """A real AptlOrchestrator with a registered workflow persists its result
+    and history under the run dir when run_store + run_id are threaded."""
+    from aces_contracts.workflow import WorkflowExecutionState, WorkflowStatus
+
+    from aptl.backends.aces_orchestrator import AptlOrchestrator
+    from aptl.core.runstore import LocalRunStore
+    from aptl.core.runtime.workflow_engine import WorkflowRunRecord
+
+    store = LocalRunStore(tmp_path / "runs")
+    run_id = "run_20260101T000000Z"
+    store.create_run(run_id)
+
+    orchestrator = AptlOrchestrator()
+    address = "exercise.workflow.demo"
+    safe_address = address.replace("/", "_")
+
+    # Register a workflow payload and a PENDING engine record, then drive.
+    orchestrator._workflow_payloads = {address: {"steps": []}}
+
+    pending_payload = WorkflowExecutionState(
+        workflow_status=WorkflowStatus.PENDING,
+        run_id="wf-run-1",
+        started_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    ).to_payload()
+    done_payload = WorkflowExecutionState(
+        workflow_status=WorkflowStatus.SUCCEEDED,
+        run_id="wf-run-1",
+        started_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:01Z",
+        terminal_reason="completed",
+    ).to_payload()
+
+    record_pending = WorkflowRunRecord(
+        result=pending_payload,
+        history=[{"event": "registered"}],
+    )
+    record_done = WorkflowRunRecord(
+        result=done_payload,
+        history=[{"event": "registered"}, {"event": "completed"}],
+    )
+
+    class _FakeEngine:
+        def __init__(self):
+            self._calls = 0
+
+        def get(self, addr):
+            del addr
+            # First read returns PENDING (drive precondition); reads after
+            # drive() return the completed record persisted to the run store.
+            self._calls += 1
+            return record_pending if self._calls == 1 else record_done
+
+        def drive(self, addr, payload, *, objective_outcomes):
+            del addr, payload, objective_outcomes
+
+    orchestrator._engine = _FakeEngine()
+    orchestrator._sync_from_engine = lambda: None
+
+    diagnostics = orchestrator.drive_workflows(run_store=store, run_id=run_id)
+
+    assert diagnostics == []
+    run_dir = store.get_run_path(run_id)
+    result_path = run_dir / "orchestration" / safe_address / "result.json"
+    history_path = run_dir / "orchestration" / safe_address / "history.jsonl"
+    assert result_path.exists()
+    assert history_path.exists()
+
+
+def test_apply_provisioning_populates_realization_and_profiles(tmp_path):
+    """GAP 1: _apply_provisioning_and_orchestration returns NON-EMPTY
+    realization_details (with a 'nodes' key) and selected_profiles for a
+    scenario that realizes nodes, by interpreting the provisioning plan."""
+    from unittest.mock import MagicMock as _MagicMock
+
+    from aces_contracts.runtime_state import OperationState
+
+    from aptl.backends.aces import AptlProvisioner, _apply_provisioning_and_orchestration
+    from aptl.core.config import AptlConfig
+
+    _write_compose(tmp_path, {"victim": ["victim"]})
+    config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=_MagicMock(),
+    )
+
+    plan = _plan_for_resources(_node_resource("techvault.victim"))
+
+    mock_plan = _MagicMock()
+    mock_plan.orchestration.actionable_operations = []
+    mock_plan.evaluation.actionable_operations = []
+    mock_plan.provisioning = plan
+
+    mock_target = _MagicMock()
+    mock_target.orchestrator = None
+    mock_target.evaluator = None
+    mock_target.provisioner = provisioner
+
+    receipt = _MagicMock()
+    receipt.operation_id = "op-prov"
+    op_status = _MagicMock()
+    op_status.state = OperationState.SUCCEEDED
+    op_status.diagnostics = []
+
+    mock_cp = _MagicMock()
+    mock_cp.submit_provisioning.return_value = receipt
+    mock_cp.get_operation.return_value = op_status
+
+    failure, realization_details, selected_profiles = (
+        _apply_provisioning_and_orchestration(mock_cp, mock_plan, mock_target)
+    )
+
+    assert failure is None
+    assert isinstance(realization_details, dict)
+    assert "nodes" in realization_details
+    assert len(realization_details["nodes"]) >= 1
+    assert "victim" in selected_profiles

--- a/tests/test_aces_repro.py
+++ b/tests/test_aces_repro.py
@@ -7,31 +7,33 @@ import pytest
 
 from aces_contracts.runtime_state import RuntimeSnapshot
 
-from aptl.backends.aces_repro import build_reproducibility_record
+from aptl.backends.aces_repro import RunRecordInputs, build_reproducibility_record
+
+_DEFAULTS: dict = dict(
+    run_id="run_20260101T000000Z",
+    backend_name="aptl",
+    started_at="2026-01-01T00:00:00Z",
+    finished_at="2026-01-01T00:01:00Z",
+    outcome="success",
+    final_snapshot=None,  # replaced in _dummy_record to allow module-level dict
+    realization_details={"profiles": ["wazuh"]},
+    selected_profiles=["wazuh"],
+    scenario_path=None,
+    scenario_display_name="techvault-operational",
+    range_snapshot_dict={"timestamp": "2026-01-01T00:00:00Z", "containers": []},
+    config_digests={"aptl.json": "abc123"},
+    container_image_digests={},
+    detection_content_digest="",
+    tool_versions={"python": "3.11"},
+    evidence_references=[],
+)
 
 
 def _dummy_record(**overrides):
     """Build a minimal reproducibility record with monkeypatched ACES calls."""
-    defaults = dict(
-        run_id="run_20260101T000000Z",
-        backend_name="aptl",
-        started_at="2026-01-01T00:00:00Z",
-        finished_at="2026-01-01T00:01:00Z",
-        outcome="success",
-        final_snapshot=RuntimeSnapshot(),
-        realization_details={"profiles": ["wazuh"]},
-        selected_profiles=["wazuh"],
-        scenario_path=None,
-        scenario_display_name="techvault-operational",
-        range_snapshot_dict={"timestamp": "2026-01-01T00:00:00Z", "containers": []},
-        config_digests={"aptl.json": "abc123"},
-        container_image_digests={},
-        detection_content_digest="",
-        tool_versions={"python": "3.11"},
-        evidence_references=[],
-    )
-    defaults.update(overrides)
-    return build_reproducibility_record(**defaults)
+    fields = {**_DEFAULTS, "final_snapshot": RuntimeSnapshot()}
+    fields.update(overrides)
+    return build_reproducibility_record(RunRecordInputs(**fields))
 
 
 class TestReproRecord:

--- a/tests/test_aces_repro.py
+++ b/tests/test_aces_repro.py
@@ -1,0 +1,129 @@
+"""Tests for the REP-001 ACES-aligned run reproducibility record builder."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aces_contracts.runtime_state import RuntimeSnapshot
+
+from aptl.backends.aces_repro import build_reproducibility_record
+
+
+def _dummy_record(**overrides):
+    """Build a minimal reproducibility record with monkeypatched ACES calls."""
+    defaults = dict(
+        run_id="run_20260101T000000Z",
+        backend_name="aptl",
+        started_at="2026-01-01T00:00:00Z",
+        finished_at="2026-01-01T00:01:00Z",
+        outcome="success",
+        final_snapshot=RuntimeSnapshot(),
+        realization_details={"profiles": ["wazuh"]},
+        selected_profiles=["wazuh"],
+        scenario_path=None,
+        scenario_display_name="techvault-operational",
+        range_snapshot_dict={"timestamp": "2026-01-01T00:00:00Z", "containers": []},
+        config_digests={"aptl.json": "abc123"},
+        container_image_digests={},
+        detection_content_digest="",
+        tool_versions={"python": "3.11"},
+        evidence_references=[],
+    )
+    defaults.update(overrides)
+    return build_reproducibility_record(**defaults)
+
+
+class TestReproRecord:
+    """Tests for build_reproducibility_record."""
+
+    def test_backend_manifest_section_present_with_correct_profile(self):
+        record = _dummy_record()
+        assert record["aces"]["backend_manifest"]["schema_version"] == "backend-manifest/v2"
+        # Orchestrator name comes from create_aptl_manifest() — it is "aptl-rte-orchestrator"
+        orchestrator_name = (
+            record["aces"]["backend_manifest"]["capabilities"]["orchestrator"]["name"]
+        )
+        assert isinstance(orchestrator_name, str)
+        assert orchestrator_name  # non-empty
+
+    def test_aces_runtime_snapshot_separate_from_range_snapshot(self):
+        record = _dummy_record(
+            range_snapshot_dict={"timestamp": "2026-01-01T00:00:00Z", "containers": []}
+        )
+        assert "runtime_snapshot" in record["aces"]
+        assert record["aces"]["runtime_snapshot"]["schema_version"] == "runtime-snapshot/v1"
+        assert "range_snapshot" in record["backend_evidence"]
+        # They must be separate objects, not merged
+        assert record["aces"]["runtime_snapshot"] is not record["backend_evidence"]["range_snapshot"]
+
+    def test_secret_shaped_value_redacted_on_write(self, tmp_path):
+        """Inject a secret-shaped value and confirm write_json redacts it."""
+        from aptl.core.runstore import LocalRunStore
+
+        record = _dummy_record(
+            realization_details={"password": "s3cret"},
+        )
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run_20260101T000000Z"
+        store.create_run(run_id)
+        store.write_json(run_id, "manifest.json", record)
+        loaded = store.get_run_manifest(run_id)
+        # The redaction boundary in write_json should mask "s3cret"
+        import json
+        raw = json.dumps(loaded)
+        assert "s3cret" not in raw
+
+    def test_seeds_honest_absence(self):
+        record = _dummy_record()
+        assert record["aces"]["scenario_parameters"] is None
+        note = record["aces"]["scenario_parameters_note"]
+        assert isinstance(note, str) and len(note) > 0
+
+    def test_image_digest_captured_when_available(self):
+        record = _dummy_record(
+            container_image_digests={"aptl-victim": "sha256:abc123"},
+        )
+        assert record["backend_evidence"]["container_image_digests"]["aptl-victim"] == "sha256:abc123"
+
+    def test_image_digest_empty_safe(self):
+        record = _dummy_record(
+            container_image_digests={},
+        )
+        assert record["backend_evidence"]["container_image_digests"] == {}
+
+    def test_evidence_reference_paths_are_relative(self):
+        record = _dummy_record(
+            evidence_references=[
+                {"kind": "range-snapshot", "path": "snapshot.json"},
+                {"kind": "inventory", "path": "inventory/manifest.json"},
+            ],
+        )
+        for ref in record["backend_evidence"]["evidence_references"]:
+            path = ref.get("path", "")
+            assert not path.startswith("/"), f"Path should not be absolute: {path}"
+
+    def test_tool_versions_present(self):
+        record = _dummy_record(
+            tool_versions={"python": "3.11", "aptl": "0.2.0"},
+        )
+        assert record["backend_evidence"]["tool_versions"]["python"] == "3.11"
+        assert record["backend_evidence"]["tool_versions"]["aptl"] == "0.2.0"
+
+    def test_schema_version(self):
+        record = _dummy_record()
+        assert record["schema_version"] == "aptl.run-record/v1"
+
+    def test_aces_lock_digest_none_when_no_lock(self, tmp_path):
+        record = _dummy_record(scenario_path=tmp_path / "techvault.sdl.yaml")
+        assert record["aces"]["scenario"]["aces_lock_digest"] is None
+
+    def test_aces_lock_digest_computed_when_lock_present(self, tmp_path):
+        scenario = tmp_path / "scenarios" / "techvault.sdl.yaml"
+        scenario.parent.mkdir()
+        scenario.touch()
+        lock = scenario.parent / "aces.lock.json"
+        lock.write_text('{"version": 1}')
+        record = _dummy_record(scenario_path=scenario)
+        assert record["aces"]["scenario"]["aces_lock_digest"] is not None
+        assert len(record["aces"]["scenario"]["aces_lock_digest"]) == 64

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1518,7 +1518,8 @@ class TestStartupClassificationWiring:
         backend.pull_images.return_value = []
         ctx.backend = backend
 
-        _step_pull_images(ctx)
+        result = _step_pull_images(ctx)
+        assert result is None
 
         assert ctx.diagnostics == []
 
@@ -1534,7 +1535,8 @@ class TestStartupClassificationWiring:
         ]
         ctx.backend = backend
 
-        _step_pull_images(ctx)
+        result = _step_pull_images(ctx)
+        assert result is None
 
         assert len(ctx.diagnostics) == 1
         diag = ctx.diagnostics[0]
@@ -1566,7 +1568,8 @@ class TestStartupClassificationWiring:
             ],
         )
 
-        _step_wait_for_services(ctx)
+        result = _step_wait_for_services(ctx)
+        assert result is None
 
         indexer_diags = [d for d in ctx.diagnostics if d.component == "wazuh_indexer"]
         assert len(indexer_diags) == 1
@@ -1592,7 +1595,8 @@ class TestStartupClassificationWiring:
             ],
         )
 
-        _step_wait_for_services(ctx)
+        result = _step_wait_for_services(ctx)
+        assert result is None
 
         manager_diags = [d for d in ctx.diagnostics if d.component == "wazuh_manager"]
         assert len(manager_diags) == 1
@@ -1609,7 +1613,8 @@ class TestStartupClassificationWiring:
             return_value=ServiceResult(ready=True, elapsed_seconds=10.0),
         )
 
-        _step_wait_for_services(ctx)
+        result = _step_wait_for_services(ctx)
+        assert result is None
 
         assert ctx.diagnostics == []
 
@@ -1623,7 +1628,8 @@ class TestStartupClassificationWiring:
             return_value=ServiceResult(ready=False, elapsed_seconds=300.0, error="timed out"),
         )
 
-        _step_wait_for_services(ctx)
+        result = _step_wait_for_services(ctx)
+        assert result is None
 
         # Wazuh probes never ran -> no diagnostics.
         assert ctx.diagnostics == []
@@ -1645,7 +1651,8 @@ class TestStartupClassificationWiring:
         )
         wait_mock = mocker.patch("aptl.core.lab.wait_for_service")
 
-        _step_wait_for_services(ctx)
+        result = _step_wait_for_services(ctx)
+        assert result is None
 
         wait_mock.assert_not_called()
         assert ctx.diagnostics == []
@@ -1676,7 +1683,8 @@ class TestStartupClassificationWiring:
             ],
         )
 
-        _step_test_ssh(ctx)
+        result = _step_test_ssh(ctx)
+        assert result is None
 
         readiness_diags = [
             d for d in ctx.diagnostics if d.impact is DiagnosticImpact.READINESS
@@ -1704,7 +1712,8 @@ class TestStartupClassificationWiring:
             return_value=ServiceResult(ready=True, elapsed_seconds=1.0),
         )
 
-        _step_test_ssh(ctx)
+        result = _step_test_ssh(ctx)
+        assert result is None
 
         # Inspect the partial passed to wait_for_service for the SSH probe.
         for call in wait.call_args_list:
@@ -1725,7 +1734,8 @@ class TestStartupClassificationWiring:
         mocker.patch("aptl.core.lab.container_networks", return_value={})
         wait = mocker.patch("aptl.core.lab.wait_for_service")
 
-        _step_test_ssh(ctx)
+        result = _step_test_ssh(ctx)
+        assert result is None
 
         readiness_diags = [
             d for d in ctx.diagnostics if d.impact is DiagnosticImpact.READINESS
@@ -1749,7 +1759,8 @@ class TestStartupClassificationWiring:
             return_value=ServiceResult(ready=True, elapsed_seconds=2.0),
         )
 
-        _step_test_ssh(ctx)
+        result = _step_test_ssh(ctx)
+        assert result is None
 
         assert ctx.diagnostics == []
 
@@ -1767,7 +1778,8 @@ class TestStartupClassificationWiring:
         networks = mocker.patch("aptl.core.lab.container_networks")
         wait_mock = mocker.patch("aptl.core.lab.wait_for_service")
 
-        _step_test_ssh(ctx)
+        result = _step_test_ssh(ctx)
+        assert result is None
 
         networks.assert_not_called()
         wait_mock.assert_not_called()
@@ -1781,7 +1793,8 @@ class TestStartupClassificationWiring:
 
         ctx = self._ctx(tmp_path)
         # No mcp/build-all-mcps.sh script in tmp_path
-        _step_build_mcps(ctx)
+        result = _step_build_mcps(ctx)
+        assert result is None
 
         assert len(ctx.diagnostics) == 1
         diag = ctx.diagnostics[0]
@@ -1812,7 +1825,8 @@ class TestStartupClassificationWiring:
             ),
         )
 
-        _step_build_mcps(ctx)
+        result = _step_build_mcps(ctx)
+        assert result is None
 
         assert len(ctx.diagnostics) == 1
         diag = ctx.diagnostics[0]
@@ -1837,7 +1851,8 @@ class TestStartupClassificationWiring:
             return_value=MagicMock(returncode=0, stdout="", stderr=""),
         )
 
-        _step_build_mcps(ctx)
+        result = _step_build_mcps(ctx)
+        assert result is None
 
         assert ctx.diagnostics == []
 
@@ -1853,7 +1868,8 @@ class TestStartupClassificationWiring:
             "aptl.core.lab.capture_snapshot", return_value=RangeSnapshot()
         )
 
-        _step_capture_snapshot(ctx)
+        result = _step_capture_snapshot(ctx)
+        assert result is None
 
         assert ctx.diagnostics == []
 
@@ -1874,7 +1890,8 @@ class TestStartupClassificationWiring:
         )
 
         # Must not raise — degradation, not failure.
-        _step_capture_snapshot(ctx)
+        result = _step_capture_snapshot(ctx)
+        assert result is None
 
         assert len(ctx.diagnostics) == 1
         diag = ctx.diagnostics[0]
@@ -1884,6 +1901,113 @@ class TestStartupClassificationWiring:
         # Exception text must not leak into the structured message
         # (ADR-029 / ADR-030).
         assert "docker daemon unreachable" not in diag.message
+
+    # -- write_run_record (REP-001) ------------------------------------
+
+    def _run_record_ctx(self, tmp_path):
+        """A ctx carrying a real run target + aces_outcome + snapshot so
+        _step_write_run_record writes a real manifest under the run dir."""
+        from aptl.backends.aces import AcesStartOutcome
+        from aptl.core.lab import _LabStartContext
+        from aptl.core.lab_types import LabResult
+        from aptl.core.runstore import LocalRunStore
+        from aptl.core.snapshot import RangeSnapshot
+
+        from aces_contracts.runtime_state import RuntimeSnapshot
+
+        run_store = LocalRunStore(tmp_path / ".aptl" / "runs")
+        run_id = "run_20260101T000000Z"
+        outcome = AcesStartOutcome(
+            lab_result=LabResult(success=True, message="ok"),
+            final_snapshot=RuntimeSnapshot(),
+            realization_details={"nodes": [{"name": "techvault.victim"}]},
+            selected_profiles=["victim", "otel"],
+            scenario_path=tmp_path / "scenarios" / "demo.sdl.yaml",
+        )
+        ctx = _LabStartContext(
+            project_dir=tmp_path,
+            skip_seed=False,
+            config=self._make_config(),
+            backend=MagicMock(),
+        )
+        ctx.aces_outcome = outcome
+        ctx.snapshot = RangeSnapshot()
+        ctx.run_store = run_store
+        ctx.run_id = run_id
+        return ctx, run_store, run_id
+
+    def test_write_run_record_references_existing_orchestration_evidence(
+        self, tmp_path
+    ):
+        """GAP 3: evidence_references lists an existing orchestration artifact
+        by RELATIVE path and does NOT inline its bytes into the manifest."""
+        from aptl.core.lab import _step_write_run_record
+
+        ctx, run_store, run_id = self._run_record_ctx(tmp_path)
+        # Stage an orchestration artifact under the run dir before writing.
+        run_store.write_json(
+            run_id,
+            "orchestration/exercise.workflow.demo/result.json",
+            {"workflow_status": "COMPLETED", "secret_value": "should-not-inline"},
+        )
+
+        result = _step_write_run_record(ctx)
+        assert result is None
+
+        manifest = run_store.get_run_manifest(run_id)
+        refs = manifest["backend_evidence"]["evidence_references"]
+        paths = {ref["path"] for ref in refs}
+        rel = "orchestration/exercise.workflow.demo/result.json"
+        assert rel in paths
+        # Relative, never absolute.
+        for ref in refs:
+            assert not ref["path"].startswith("/")
+            assert ref["kind"] == "orchestration"
+        # Bytes are referenced, not inlined: the artifact's payload value must
+        # not appear anywhere in the serialized manifest.
+        import json as _json
+
+        assert "should-not-inline" not in _json.dumps(manifest)
+
+    def test_write_run_record_shares_run_id_with_orchestration(self, tmp_path):
+        """GAP 4: the run record and orchestration artifacts share one run_id —
+        the manifest run_id equals the run dir holding the orchestration data."""
+        from aptl.core.lab import _step_write_run_record
+
+        ctx, run_store, run_id = self._run_record_ctx(tmp_path)
+        run_store.write_json(
+            run_id,
+            "orchestration/wf/result.json",
+            {"workflow_status": "PENDING"},
+        )
+
+        result = _step_write_run_record(ctx)
+        assert result is None
+
+        manifest = run_store.get_run_manifest(run_id)
+        assert manifest["run_id"] == run_id
+        # The realization populated by GAP 1 is carried into the record.
+        assert manifest["aces"]["realization"]["nodes"]
+        assert manifest["backend_evidence"]["selected_profiles"] == [
+            "victim",
+            "otel",
+        ]
+        assert run_id in run_store.list_runs()
+
+    def test_resolve_run_target_mints_validatable_run_id(self, tmp_path):
+        """_resolve_run_target mints a run_id that passes runstore._validate_id
+        when no active trace context exists (GAP 4 fallback)."""
+        from aptl.core.lab import _LabStartContext, _resolve_run_target
+        from aptl.core.runstore import _validate_id
+
+        ctx = _LabStartContext(project_dir=tmp_path, skip_seed=False)
+        store, run_id = _resolve_run_target(ctx)
+        # Must not raise.
+        assert _validate_id(run_id, "run_id") == run_id
+        # create_run + manifest must round-trip under the minted id.
+        store.create_run(run_id)
+        store.write_json(run_id, "manifest.json", {"run_id": run_id})
+        assert run_id in store.list_runs()
 
     # -- seed_soc (capability) -----------------------------------------
 
@@ -1924,7 +2048,8 @@ class TestStartupClassificationWiring:
             ),
         )
 
-        _step_seed_soc(ctx)
+        result = _step_seed_soc(ctx)
+        assert result is None
 
         assert len(ctx.diagnostics) == 1
         diag = ctx.diagnostics[0]
@@ -1965,7 +2090,8 @@ class TestStartupClassificationWiring:
             side_effect=subprocess.TimeoutExpired(cmd=str(seed_script), timeout=1),
         )
 
-        _step_seed_soc(ctx)
+        result = _step_seed_soc(ctx)
+        assert result is None
 
         assert len(ctx.diagnostics) == 1
         diag = ctx.diagnostics[0]
@@ -1981,7 +2107,8 @@ class TestStartupClassificationWiring:
         ctx = self._ctx(tmp_path)
         ctx.skip_seed = True
 
-        _step_seed_soc(ctx)
+        result = _step_seed_soc(ctx)
+        assert result is None
 
         assert ctx.diagnostics == []
 
@@ -2009,7 +2136,8 @@ class TestStartupClassificationWiring:
             ),
         )
         # No scripts/seed-prime.sh in tmp_path
-        _step_seed_soc(ctx)
+        result = _step_seed_soc(ctx)
+        assert result is None
 
         assert len(ctx.diagnostics) == 1
         diag = ctx.diagnostics[0]
@@ -2025,7 +2153,8 @@ class TestStartupClassificationWiring:
 
         ctx = self._ctx(tmp_path, config=self._make_config())  # soc not set -> False
         # No scripts/seed-prime.sh in tmp_path
-        _step_seed_soc(ctx)
+        result = _step_seed_soc(ctx)
+        assert result is None
 
         assert ctx.diagnostics == []
 
@@ -2043,7 +2172,8 @@ class TestStartupClassificationWiring:
             side_effect=RuntimeError("THEHIVE_API_KEY mismatch"),
         )
 
-        _step_sync_mcp_config(ctx)
+        result = _step_sync_mcp_config(ctx)
+        assert result is None
 
         assert len(ctx.diagnostics) == 1
         diag = ctx.diagnostics[0]
@@ -2060,7 +2190,8 @@ class TestStartupClassificationWiring:
         ctx = self._ctx(tmp_path)
         mocker.patch("aptl.core.lab._sync_mcp_config_keys", return_value=None)
 
-        _step_sync_mcp_config(ctx)
+        result = _step_sync_mcp_config(ctx)
+        assert result is None
 
         assert ctx.diagnostics == []
 
@@ -2280,12 +2411,18 @@ class TestLabOrchestrationContracts:
         result = _step_start_containers(ctx)
 
         assert result is None
+        # GAP 4: the handoff is invoked with the single run target resolved
+        # once on ctx, so orchestration and the run record share a run_id.
         start_aces.assert_called_once_with(
             tmp_path,
             ctx.config,
             ctx.backend,
             scenario_path=None,
+            run_store=ctx.run_store,
+            run_id=ctx.run_id,
         )
+        assert ctx.run_store is not None
+        assert ctx.run_id
 
     def test_start_containers_preserves_scenario_path_on_soc_retry(self, mocker, tmp_path):
         from aptl.core.lab import LabResult, _step_start_containers

--- a/tests/test_runstore.py
+++ b/tests/test_runstore.py
@@ -455,3 +455,14 @@ class TestResolveActiveRunDir:
         # Invariant: trace_id from a malformed/hostile source must not
         # let an attacker write outside the runs/ dir. Reject defensively.
         assert resolve_active_run_dir(state) is None
+
+    def test_list_runs_returns_run_after_manifest_write(self, tmp_path):
+        """list_runs() includes a run_id once manifest.json exists."""
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run_20260101T000000Z"
+        store.create_run(run_id)
+        # Before writing manifest, list_runs should not include the run
+        assert run_id not in store.list_runs()
+        # After writing manifest.json, list_runs should include it
+        store.write_json(run_id, "manifest.json", {"schema_version": "aptl.run-record/v1"})
+        assert run_id in store.list_runs()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -533,3 +533,60 @@ class TestCaptureSnapshot:
         assert loaded["containers"] == []
         assert loaded["services"] == []
         assert loaded["ssh"] == []
+
+    def test_container_snapshot_has_image_digest_field(self):
+        cs = ContainerSnapshot()
+        assert hasattr(cs, "image_digest")
+        assert cs.image_digest == ""
+
+    def test_container_snapshot_image_digest_set(self):
+        cs = ContainerSnapshot(image_digest="sha256:abc123")
+        assert cs.image_digest == "sha256:abc123"
+
+    def test_software_versions_has_aces_sdl_version(self):
+        sv = SoftwareVersions()
+        assert hasattr(sv, "aces_sdl_version")
+        assert sv.aces_sdl_version == ""
+
+    def test_get_software_versions_populates_aces_sdl_version(self):
+        backend = MagicMock()
+        backend.host_versions.return_value = {}
+        backend.container_inspect.return_value = {}
+        backend.container_exec.return_value = MagicMock(returncode=1, stdout="", stderr="")
+        versions = _get_software_versions(backend)
+        # aces-sdl is installed in the test environment
+        assert isinstance(versions.aces_sdl_version, str)
+        assert len(versions.aces_sdl_version) > 0
+
+
+class TestDetectionContentDigest:
+    """Tests for detection_content_digest helper."""
+
+    def test_detection_content_digest_helper_exists(self, tmp_path):
+        from aptl.core.snapshot import detection_content_digest
+        result = detection_content_digest(tmp_path)
+        assert isinstance(result, str)
+
+    def test_detection_content_digest_empty_when_no_files(self, tmp_path):
+        from aptl.core.snapshot import detection_content_digest
+        result = detection_content_digest(tmp_path)
+        assert result == ""
+
+    def test_detection_content_digest_non_empty_when_rules_present(self, tmp_path):
+        from aptl.core.snapshot import detection_content_digest
+        rules_dir = tmp_path / "config" / "suricata" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "custom.rules").write_text('alert tcp any any -> any any (msg:"test"; sid:1;)')
+        result = detection_content_digest(tmp_path)
+        assert len(result) == 64  # sha256 hex
+
+    def test_detection_content_digest_changes_with_content(self, tmp_path):
+        from aptl.core.snapshot import detection_content_digest
+        rules_dir = tmp_path / "config" / "suricata" / "rules"
+        rules_dir.mkdir(parents=True)
+        rule_file = rules_dir / "custom.rules"
+        rule_file.write_text('alert tcp any any -> any any (msg:"v1"; sid:1;)')
+        digest1 = detection_content_digest(tmp_path)
+        rule_file.write_text('alert tcp any any -> any any (msg:"v2"; sid:1;)')
+        digest2 = detection_content_digest(tmp_path)
+        assert digest1 != digest2


### PR DESCRIPTION
## Summary

Implements REP-001: every `aptl lab start` now writes an ACES-aligned run reproducibility record (`manifest.json`) to the run archive. Per ADR-044 the record is a composition record — it anchors run identity to ACES contracts where they exist (backend manifest payload, ACES RuntimeSnapshot, realization details, scenario identity) under an `aces` section, and carries APTL-only data only as clearly backend-owned realization evidence (range snapshot, config/image digests, detection-content digest, tool versions, evidence references) under a `backend_evidence` section. No local mirror types of ACES contracts are introduced; structured writes go through `LocalRunStore.write_json` (ADR-029 redaction). This also fixes a latent bug: because nothing wrote `manifest.json` on a normal lab start, `aptl runs list` previously returned empty for every normal run.

## Requirement UIDs

- `REP-001`

## Related Issues

Closes #423

## ADR Impact

- ADR-044

## Changes

- New src/aptl/backends/aces_repro.py: pure composition builder for the REP-001 record (ACES-anchored section + backend-evidence section), no Docker/curl/ssh.
- src/aptl/backends/aces.py: AcesStartOutcome holder surfaces the post-apply ACES RuntimeSnapshot (via control_plane.get_snapshot()), realization details, and selected profiles; drive_workflows now receives the threaded run_store/run_id so workflow result/history persist.
- src/aptl/core/lab.py: new non-fatal _step_write_run_record after snapshot capture; _resolve_run_target resolves ONE run_id for the whole lab-start run (active trace dir else minted run_<UTC>Z); _collect_evidence_references enumerates orchestration/mcp-side/kali-side artifacts as relative paths.
- src/aptl/core/snapshot.py: ContainerSnapshot.image_digest (full sha256 via backend inspect), aces_sdl version in SoftwareVersions, detection_content_digest() for Suricata/Wazuh rule content.
- Adjacent fix: live-gate manifest orchestrator profile corrected from stale 'orchestration-capable' to 'orchestration-evaluation' (ADR-044).
- docs/adrs/adr-044: status proposed -> accepted; changelog.d/423.added.md.

## Test Plan

- [x] Unit tests pass
- [x] Integration static gate passes
- [x] No coverage regression

Unit tests drive a monkeypatched backend / run store (no live lab), per the repo's fast-suite convention. Full gate green: 2073 unit tests + 4 integration static-gate tests pass; pre-commit clean. Live-lab verification is covered by the integration gate; the running lab was not cycled from this worktree.

## Ground Control Checks

- [x] `make policy` passes
- [x] quality gates pass or unchanged by this repo-only change
- [x] codex + test-quality reviews clean / findings fixed

## Traceability

- IMPLEMENTS: REP-001 ← src/aptl/backends/aces_repro.py, REP-001 ← src/aptl/core/lab.py, REP-001 ← src/aptl/backends/aces.py, REP-001 ← src/aptl/core/snapshot.py
- TESTS: REP-001 ← tests/test_aces_repro.py, REP-001 ← tests/test_lab.py, REP-001 ← tests/test_aces_backend.py, REP-001 ← tests/test_snapshot.py

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/423.added.md`
- [x] ADR-044 added and accepted