### PR TITLE
added: add ACES participant runtime proof

### DIFF
--- a/changelog.d/554.added.md
+++ b/changelog.d/554.added.md
@@ -1,0 +1,1 @@
+**Added APTL's ACES participant runtime.** The runtime target now exposes participant episode control, promotes the manifest to `full-remote-control-plane`, and records a TechVault Kali-to-victim live action proof through the standard ACES control plane.

--- a/docs/aces/dsl-010-participant-runtime-preflight.md
+++ b/docs/aces/dsl-010-participant-runtime-preflight.md
@@ -1,0 +1,179 @@
+# DSL-010 Participant Runtime Preflight
+
+This note is the architecture preflight for DSL-010 / issue #554. It is
+guidance, not an implementation plan. ADR-035 remains the binding ACES adoption
+decision, and the existing DSL-008/live-gate notes remain the topology and live
+proof guardrails. This note narrows the participant/runtime action surface that
+promotes APTL from an `orchestration-evaluation` backend to a
+`participant_runtime` capable reference emulation backend.
+
+## Architecture Decisions
+
+- `ParticipantRuntime` is a fourth ACES backend component on the existing
+  APTL `RuntimeTarget`, beside `AptlProvisioner`, `AptlOrchestrator`, and
+  `AptlEvaluator`. It must not be hidden inside provisioning, workflow driving,
+  evaluator registration, CLI code, or live-gate proof code.
+- The backend manifest promotion is all-or-nothing: `create_aptl_manifest()`
+  must add `ParticipantRuntimeCapabilities`, the same `RuntimeTarget` must pass
+  a participant runtime instance, and `run_target_conformance()` plus the
+  published `aces conformance backend` CLI must pass the promoted profile with
+  no `conformance.unsupported-capability-claim` diagnostics.
+- APTL consumes the published ACES participant contracts as-is. Episode state
+  must use `ParticipantEpisodeExecutionState`; episode history must use
+  `ParticipantEpisodeHistoryEvent`; behavior/action proof must populate
+  `RuntimeSnapshot.participant_behavior_history` with the published participant
+  behavior event shape. Do not create APTL-local participant DTOs or schemas.
+- The control-plane path under proof is the ACES control plane:
+  `RuntimeControlPlane.initialize_participant_episode()`,
+  `reset_participant_episode()`, `restart_participant_episode()`, and
+  `terminate_participant_episode()`. Direct adapter calls may be unit-tested,
+  but the live proof must assert `operation-receipt-v1`,
+  `operation-status-v1`, `runtime-snapshot-v1`, and realization provenance
+  through the control plane.
+- The real action proof must operate against realized containers through
+  `DeploymentBackend.container_exec()` and post-action `capture_snapshot()`.
+  The proof cannot be in-memory state only, a fake command result, or a
+  contract-surface-only state transition.
+- The first action surface should be deliberately small and truthful. If the
+  proof drives Kali as a red participant, claim only the participant roles,
+  behavior features, and interaction features whose required contracts are
+  actually emitted and validator-clean. Do not claim blue, green, white, or
+  multi-party interaction semantics unless a real proof exists for them.
+- Live-action evidence belongs beside the curated live-proof artifacts and may
+  reuse their result/snapshot shape, but it should carry the added participant
+  operation id, episode state, behavior history, action result, and snapshot /
+  realization-provenance references. It should not become a new run archive
+  schema.
+
+## Cross-Cutting Concerns To Reuse
+
+- ACES authorities: `aces_backend_protocols.protocols.ParticipantRuntime`,
+  `ParticipantEpisodeInitializeRequest`, `ParticipantEpisodeResetRequest`,
+  `ParticipantEpisodeRestartRequest`, `ParticipantEpisodeTerminateRequest`,
+  `ParticipantRuntimeCapabilities`,
+  `PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS`,
+  `RuntimeControlPlane`, `ApplyResult`, `RuntimeSnapshot`,
+  `OperationReceipt`, `OperationStatus`, `Diagnostic`,
+  `iter_participant_episode_snapshot_violations()`, and
+  `iter_participant_behavior_snapshot_violations()`.
+- Existing APTL adapter seams: `create_aptl_runtime_target()`,
+  `create_aptl_manifest()`, `AptlProvisioner`, `AptlOrchestrator`,
+  `AptlEvaluator`, `interpret_provisioning_plan()`, `select_backend_profiles()`,
+  `AptlRealization.details()`, and `render_aces_diagnostics()`.
+- Deployment and inventory owners: `DeploymentBackend`, `DockerComposeBackend`,
+  `SSHComposeBackend`, `ComposeQueryMixin`, project-name scoping,
+  compose-project label filters, bounded `container_exec()`,
+  `capture_snapshot()`, `RangeSnapshot.to_dict()`,
+  `list_container_snapshots()`, and `container_networks()`.
+- Live proof owners: `aptl.validation.curated_live_proof`,
+  `ExpectedMatrix`, `compare_to_snapshot()`, `summarize_snapshot()`,
+  the curated live-proof driver under
+  `docs/aces/techvault-curated-live-validation-gate/`, and the full live-gate
+  `LiveGateCheck` / `LiveGateReport` failure category convention.
+- Config, env, and generated artifact owners: strict `AptlConfig`,
+  `ContainerSettings.enabled_profiles()`, `DeploymentConfig`, `load_config()`,
+  `load_dotenv()`, `env_vars_from_dict()`, `find_placeholder_env_values()`,
+  generated Wazuh/Dashboard config, SOC TLS generation, Suricata named-volume
+  seeding, and bind-mount validation.
+- Persistence, logging, and redaction owners: `LocalRunStore.write_json()` /
+  `write_jsonl()` / `append_jsonl()`, `aptl.utils.redaction.redact()`,
+  `RangeSnapshot.to_dict()`, `aptl.utils.logging.get_logger()`, `curl_safe`,
+  ADR-023, ADR-029, ADR-030, ADR-031, ADR-036, ADR-037, ADR-039, and ADR-040.
+- Repo gates: `pytest`, `pre-commit run --all-files`, manual
+  `aces-scenario-gate`, live-gate integration marker, `.gc/plan-rules.md`, and
+  the docs-only exception to changelog fragments.
+
+## Security And Validation Layers
+
+- **ACES component shape:** `RuntimeTarget` validates manifest/component
+  presence and method call shapes. A manifest with `participant_runtime` and no
+  component, or a component with missing `initialize` / `reset` / `restart` /
+  `terminate` / `status` / `results` / `history`, must fail construction.
+- **Manifest and conformance:** `ParticipantRuntimeCapabilities` validates
+  controlled vocabulary values, and
+  `PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS` dictates the participant
+  episode and behavior contracts that must be added to
+  `supported_contract_versions`. The implementation should let
+  `run_target_conformance()` and `aces conformance backend` reject overclaims.
+- **Episode and behavior envelopes:** participant state/history must be created
+  through the ACES dataclasses or validated with the ACES snapshot violation
+  iterators. Do not hand-build loosely shaped dicts without contract validation.
+- **Config shape:** durable non-secret knobs stay in `AptlConfig`. Do not add an
+  unchecked `aptl.json` participant-action block or TechVault-only preset table.
+  If the action needs a tunable, make it a narrow typed parameter with a safe
+  default at the adapter/proof boundary.
+- **Environment binding:** `.env` remains parsed and placeholder-checked before
+  startup. Participant diagnostics may name env variable names or missing
+  prerequisites, but never env values.
+- **Deployment and OS exposure:** all container action execution goes through
+  `DeploymentBackend.container_exec()` with argv-list commands and bounded
+  timeouts. Do not pass passwords, API tokens, cookies, private keys, or
+  generated config values in process argv, shell strings, logs, or diagnostics.
+- **Container/project isolation:** action target resolution must be derived from
+  ACES realization details and the project-scoped backend/snapshot. Do not
+  address unscoped Docker names on a shared daemon or use a host-level Docker
+  escape hatch.
+- **Snapshot and provenance:** successful action proof must update participant
+  episode/behavior snapshot fields and tie the action to realized container
+  evidence in `runtime-snapshot-v1` and realization provenance. A successful
+  command exit code alone is not enough.
+- **Error envelopes:** ACES-facing failures are `Diagnostic` records and
+  `operation-status-v1`. APTL-facing failures remain `LabResult`,
+  `StartupDiagnostic`, `LiveGateCheck`, or pytest assertions. Every message
+  crossing logs, CLI/API output, telemetry, or persistence must be redacted.
+- **Persistence:** structured live-action artifacts use the existing redacting
+  JSON/JSONL write boundaries or the curated proof's redacted snapshot summary.
+  Opaque file copies are inappropriate unless the artifact is explicitly
+  classified as reviewed target evidence.
+
+## Extensibility Seam
+
+The seam is `(participant_address, participant_role, episode_id,
+action_descriptor, target_container, command_argv, timeout, selected_profiles,
+realization_details, operation_id)`. The action descriptor should be data about
+the intended participant operation, not a branch on `techvault`, scenario path,
+or Compose profile name.
+
+The next reasonable change is another participant role or action against a
+different realized node. That should require adding a new validated action
+descriptor and evidence assertion, not editing the manifest generator, the
+control-plane plumbing, or a TechVault-specific conditional. Multi-agent
+coordination belongs to AGT-001 / AGT-002 and should consume this seam rather
+than widening it now.
+
+## Gotchas And Anti-Patterns
+
+- Claiming `participant_runtime` in the manifest before the `RuntimeTarget`
+  actually provides the component.
+- Adding participant contracts to `supported_contract_versions` without
+  emitting the corresponding episode and behavior snapshot fields.
+- Treating `initialize` / `reset` / `restart` / `terminate` as lab
+  start/stop aliases. They are participant episode transitions, not Compose
+  lifecycle operations.
+- Recording an action in memory without driving a realized container.
+- Calling raw `docker exec`, `docker inspect`, `docker logs`, `docker compose`,
+  or `curl` from participant runtime or proof code.
+- Creating a new participant schema, validation layer, exception hierarchy,
+  readiness taxonomy, redaction helper, manifest shim, or run evidence schema.
+- Dispatching on scenario name, file path, catalog id, `techvault`, or profile
+  preset instead of participant address, realization details, and snapshot data.
+- Overclaiming participant roles or behavior/interaction features to satisfy
+  profile shape while the proof only exercises a single emulated action.
+- Letting generated config, SOC tokens, `.env` values, cookies, private keys,
+  or API tokens leak into action history, command strings, diagnostics, proof
+  JSON, committed evidence, or logs.
+- Using `--skip-seed` for the live-action proof. DSL-010 explicitly needs a
+  boot without `--skip-seed` so seeded runtime behavior is part of the proof.
+
+## Non-Goals
+
+- Do not implement DSL-010 in this preflight.
+- Do not add new ACES schemas, profiles, or controlled vocabulary terms.
+- Do not redesign `RuntimeControlPlane`, `RuntimeTarget`, `DeploymentBackend`,
+  Docker Compose topology, startup ordering, generated config, SOC TLS,
+  endpoint registry, web auth, terminal relay, or run archive layout.
+- Do not make participant actions a general shell-execution API.
+- Do not add multi-agent coordination, scheduling, contention, or negotiation
+  semantics; those belong to AGT-001 / AGT-002.
+- Do not change the public default scenario or replace the full TechVault live
+  gate. The live-action proof is an additional participant-runtime proof layer.

--- a/docs/aces/techvault-curated-live-validation-gate.md
+++ b/docs/aces/techvault-curated-live-validation-gate.md
@@ -8,7 +8,9 @@ already prove each variant parses, compiles, and realizes to a bounded Compose
 profile set without starting Docker. This gate goes one step further: it boots
 each variant through APTL's public start path and proves the running containers
 and networks match the variant's ACES-realized reduced surface, not the full
-TechVault range.
+TechVault range. For `techvault-attacker-target`, it also drives a red
+participant action through the ACES `ParticipantRuntime` control plane and
+records participant episode plus behavior-history evidence.
 
 It implements the live half of issue #535 (SCN-010K) and follows the boundary
 set by the [curated live validation preflight](techvault-curated-live-validation-preflight.md).
@@ -34,6 +36,13 @@ the existing canonical authorities rather than re-modelling them:
   container, no unexpected steady-state container is present, and the network set
   matches. Each gap becomes one structured diagnostic naming the layer that
   broke, never raw Docker or CLI text.
+- `run_participant_action_proof()` uses the configured deployment backend and
+  `RuntimeControlPlane.initialize_participant_episode()` to drive the
+  `participant.techvault.kali-victim-ssh-probe` action. The action runs from
+  `aptl-kali` against the realized victim SSH endpoint through
+  `DeploymentBackend.container_exec()`, then validates the standard
+  `operation-receipt-v1`, `operation-status-v1`, `runtime-snapshot-v1`,
+  participant episode, and participant behavior-history surfaces.
 
 The expected surface is the set of steady-state services the selected profiles
 activate, not only the declared ACES nodes. `docker compose --profile <p>`
@@ -57,18 +66,20 @@ that variant's container profiles. The always-on `otel` core needs no flag.
 
 ## Recorded results
 
-All four variants were booted on 2026-06-24 (UTC) on a single Docker host through
-`aptl lab start --scenario <catalog-id> --skip-seed`, captured with
-`aptl lab status --json`, and compared with `compare_to_snapshot()`. Every variant
+The recorded evidence combines the original 2026-06-24 boot-only rows from
+issue #535 with the refreshed DSL-010 participant-runtime row. Every variant
 reached the `Lab is ready.` outcome (`StartupOutcome.READY`) and matched its
-reduced surface exactly.
+reduced surface exactly. The `techvault-attacker-target` proof was refreshed on
+2026-06-25 (UTC) with the current no-`--skip-seed` driver and additionally
+records a participant action artifact that proves the Kali-to-victim interaction
+through the promoted participant runtime.
 
 | Catalog id | Date (UTC) | Readiness | Boot | Containers | Networks | Verdict |
 |---|---|---|---|---|---|---|
 | `techvault-observability-core` | 2026-06-24 | Lab is ready. | 51s | 3 | 1 | PASS |
 | `techvault-defensive-min` | 2026-06-24 | Lab is ready. | 90s | 6 | 3 | PASS |
 | `techvault-enterprise-web` | 2026-06-24 | Lab is ready. | 99s | 10 | 3 | PASS |
-| `techvault-attacker-target` | 2026-06-24 | Lab is ready. | 97s | 9 | 4 | PASS |
+| `techvault-attacker-target` | 2026-06-25 | Lab is ready. | 154s | 9 | 4 | PASS + participant action |
 
 The booted containers and networks for each run equal the ACES-realized selected
 profile surface:
@@ -91,10 +102,14 @@ Per-variant evidence is committed under
 
 - `result.json`: the matched config, exact command, readiness outcome, boot
   duration, selected profiles, realized nodes, expected and actual services and
-  networks, the verdict, and any diagnostics.
+  networks, participant-action summary, the verdict, and any diagnostics.
 - `snapshot.json`: the captured `RangeSnapshot` trimmed to container and network
   surface (`summarize_snapshot()`). The source snapshot is redacted by
   `capture_snapshot()` (ADR-029); no secrets are recorded.
+- `participant-action.json` (`techvault-attacker-target` only): the ACES
+  operation receipt/status, participant episode state/history, participant
+  behavior history, participant runtime snapshot entries, post-action snapshot
+  summary, validator diagnostics, and final verdict.
 
 ## Reproducing the proof
 
@@ -118,20 +133,17 @@ The manual equivalent, for one variant, is to enable that variant's container
 profiles in `aptl.json`, then:
 
 ```bash
-aptl lab start --scenario techvault-defensive-min --skip-seed
+aptl lab start --scenario techvault-defensive-min
 aptl lab status --json
 aptl lab stop -v -y
 ```
 
 ## Known limitations
 
-- The proof boots with `--skip-seed`. The SOC seed step keys off the global
-  `config.containers.soc` flag rather than the scenario's selected profiles, so a
-  reduced variant booted with `soc` enabled would attempt to seed SOC tools that
-  the variant never started. A reduced variant uses a matched config (so `soc` is
-  not enabled) and `--skip-seed`. Scoping the seed step to the selected profiles,
-  like the post-start readiness checks already are, is a candidate follow-up,
-  outside the scope of this proof.
+- Only `techvault-attacker-target` has a participant action proof because it is
+  the curated variant that realizes both the Kali participant container and the
+  victim target container. The other curated variants still prove their reduced
+  boot surface and explicitly record the participant action as skipped.
 - The full live gate's realization check (`check_provisioning_realization`)
   asserts the selected profiles equal `public_start_profiles(config)`, so a
   reduced variant only satisfies it under its matched config. Reduced variants are

--- a/docs/aces/techvault-curated-live-validation-gate.md
+++ b/docs/aces/techvault-curated-live-validation-gate.md
@@ -38,7 +38,7 @@ the existing canonical authorities rather than re-modelling them:
   broke, never raw Docker or CLI text.
 - `run_participant_action_proof()` uses the configured deployment backend and
   `RuntimeControlPlane.initialize_participant_episode()` to drive the
-  `participant.techvault.kali-victim-ssh-probe` action. The action runs from
+  `participant.behavior.techvault.kali-victim-ssh-probe` action. The action runs from
   `aptl-kali` against the realized victim SSH endpoint through
   `DeploymentBackend.container_exec()`, then validates the standard
   `operation-receipt-v1`, `operation-status-v1`, `runtime-snapshot-v1`,

--- a/docs/aces/techvault-curated-live-validation-gate/run-curated-live-proof.sh
+++ b/docs/aces/techvault-curated-live-validation-gate/run-curated-live-proof.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 #
-# Reproduce the curated-variant live-boot proof for one catalog variant (#535).
+# Reproduce the curated-variant live-action proof for one catalog variant (#535/#554).
 #
 # For the named curated variant this script: (1) sets aptl.json containers to the
 # variant's matched profile set, (2) boots it through the PUBLIC start path
-# (`aptl lab start --scenario <id> --skip-seed`), (3) captures the canonical
+# (`uv run aptl lab start --scenario <id>`), (3) captures the canonical
 # RangeSnapshot (`aptl lab status --json`), (4) compares the running range to the
 # variant's model-derived reduced surface via `aptl.validation.curated_live_proof`,
-# (5) writes evidence next to this script, and (6) tears the lab down and restores
-# aptl.json to its exact pre-run content. It only uses the `aptl` CLI and the
-# tested helper -- no raw docker.
+# (5) drives the TechVault attacker-target participant action through the ACES
+# control plane, (6) writes evidence next to this script, and (7) tears the lab
+# down and restores aptl.json to its exact pre-run content. It only uses the
+# local `uv run aptl` CLI and the tested helper -- no raw docker.
 #
 # Every lifecycle step is checked: a failed config write, lab start, snapshot
 # capture, or comparison fails the proof with a non-zero exit. The proof passes
@@ -65,7 +66,7 @@ trap restore_config EXIT
 mkdir -p "$OUT_DIR" || fail "could not create evidence dir $OUT_DIR"
 
 # 1. Matched config: enable exactly the variant's container profiles.
-if ! python - "$MATCHED" <<'PY'
+if ! uv run python - "$MATCHED" <<'PY'
 import json, sys, pathlib
 want = json.loads(sys.argv[1])
 p = pathlib.Path("aptl.json"); cfg = json.loads(p.read_text())
@@ -79,32 +80,36 @@ fi
 
 # 2. Boot through the public start path (timed). A non-zero exit fails the proof.
 START=$(date +%s)
-aptl lab start --scenario "$CATALOG_ID" --skip-seed > "$OUT_DIR/boot.log" 2>&1
+uv run aptl lab start --scenario "$CATALOG_ID" > "$OUT_DIR/boot.log" 2>&1
 BOOT_RC=$?
 ELAPSED=$(( $(date +%s) - START ))
 READINESS=$(head -1 "$OUT_DIR/boot.log")
 if [ "$BOOT_RC" != "0" ]; then
-  aptl lab stop -v -y > "$OUT_DIR/stop.log" 2>&1 || true
+  uv run aptl lab stop -v -y > "$OUT_DIR/stop.log" 2>&1 || true
   fail "aptl lab start exited $BOOT_RC (see $OUT_DIR/boot.log)"
 fi
 
 # 3. Capture the canonical RangeSnapshot. Must be non-empty.
-if ! aptl lab status --json > "$OUT_DIR/snapshot.raw.json" 2>/dev/null \
+if ! uv run aptl lab status --json > "$OUT_DIR/snapshot.raw.json" 2>/dev/null \
    || [ ! -s "$OUT_DIR/snapshot.raw.json" ]; then
-  aptl lab stop -v -y > "$OUT_DIR/stop.log" 2>&1 || true
+  uv run aptl lab stop -v -y > "$OUT_DIR/stop.log" 2>&1 || true
   fail "could not capture a range snapshot"
 fi
 
-# 4. Summarize + compare via the tested helper; write snapshot.json + result.json.
-#    The helper exits non-zero when the running range does not match.
+# 4. Summarize + compare via the tested helper; for attacker-target, also drive
+#    the participant action proof and write participant-action.json. The helper
+#    exits non-zero when the range or required participant proof fails.
 APTL_CLP_ID="$CATALOG_ID" APTL_CLP_SCENARIO="$SCENARIO" APTL_CLP_MATCHED="$MATCHED" \
 APTL_CLP_READINESS="$READINESS" APTL_CLP_ELAPSED="$ELAPSED" \
 APTL_CLP_SNAP="$OUT_DIR/snapshot.raw.json" APTL_CLP_OUT="$OUT_DIR" \
-python - <<'PY'
+uv run python - <<'PY'
 import json, os, pathlib
 from aptl.core.config import AptlConfig
 from aptl.validation.curated_live_proof import (
-    compare_to_snapshot, expected_reduced_matrix, summarize_snapshot,
+    compare_to_snapshot,
+    expected_reduced_matrix,
+    run_participant_action_proof,
+    summarize_snapshot,
 )
 root = pathlib.Path(".").resolve()
 matched = json.loads(os.environ["APTL_CLP_MATCHED"])
@@ -115,17 +120,40 @@ ok, diagnostics = compare_to_snapshot(matrix, snapshot)
 out = pathlib.Path(os.environ["APTL_CLP_OUT"])
 summary = summarize_snapshot(snapshot)
 (out / "snapshot.json").write_text(json.dumps(summary, indent=2) + "\n")
+participant_action = {
+    "verdict": "SKIPPED",
+    "reason": "variant does not realize both kali and victim participant-action containers",
+}
+if os.environ["APTL_CLP_ID"] == "techvault-attacker-target":
+    participant_proof = run_participant_action_proof(root, config)
+    (out / "participant-action.json").write_text(
+        json.dumps(participant_proof, indent=2) + "\n"
+    )
+    address = str(participant_proof["participant_address"])
+    operation_status = participant_proof.get("operation_status") or {}
+    behavior = participant_proof.get("participant_behavior_history") or {}
+    participant_action = {
+        "verdict": participant_proof["verdict"],
+        "artifact": "participant-action.json",
+        "participant_address": address,
+        "operation_id": operation_status.get("operation_id"),
+        "operation_state": operation_status.get("state"),
+        "behavior_event_count": len(behavior.get(address, [])),
+    }
+participant_ok = participant_action["verdict"] in {"PASS", "SKIPPED"}
+aggregate_ok = ok and participant_ok
 result = {
     "catalog_id": os.environ["APTL_CLP_ID"],
     "scenario": pathlib.Path(os.environ["APTL_CLP_SCENARIO"]).name,
     "matched_config_containers": sorted(k for k, v in matched.items() if v),
-    "command": f"aptl lab start --scenario {os.environ['APTL_CLP_ID']} --skip-seed",
+    "command": f"uv run aptl lab start --scenario {os.environ['APTL_CLP_ID']}",
     "readiness_outcome": os.environ["APTL_CLP_READINESS"].strip(),
     "boot_elapsed_seconds": int(os.environ["APTL_CLP_ELAPSED"]),
     **matrix.to_dict(),
     "actual_containers": sorted(c["name"] for c in summary["containers"] if c.get("name")),
     "actual_networks": sorted(n["name"] for n in summary["networks"] if n.get("name")),
-    "verdict": "PASS" if ok else "FAIL",
+    "participant_action": participant_action,
+    "verdict": "PASS" if aggregate_ok else "FAIL",
     "diagnostics": diagnostics,
 }
 (out / "result.json").write_text(json.dumps(result, indent=2) + "\n")
@@ -134,12 +162,15 @@ print(f"{os.environ['APTL_CLP_ID']}: {result['verdict']} "
       f"(readiness='{result['readiness_outcome']}', {result['boot_elapsed_seconds']}s)")
 for d in diagnostics:
     print("  -", d)
-raise SystemExit(0 if ok else 1)
+if participant_action["verdict"] != "SKIPPED":
+    print(f"participant_action: {participant_action['verdict']} "
+          f"({participant_action['behavior_event_count']} behavior events)")
+raise SystemExit(0 if aggregate_ok else 1)
 PY
 CMP_RC=$?
 
 # 5. Tear down (always attempt; the verdict is already decided).
-if ! aptl lab stop -v -y > "$OUT_DIR/stop.log" 2>&1; then
+if ! uv run aptl lab stop -v -y > "$OUT_DIR/stop.log" 2>&1; then
   echo "WARNING ($CATALOG_ID): teardown failed (see $OUT_DIR/stop.log); clean up by hand." >&2
 fi
 

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/participant-action.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/participant-action.json
@@ -8,15 +8,15 @@
     "operation_id": "operation-id-redacted",
     "domain": "participant",
     "accepted": true,
-    "submitted_at": "2026-06-25T16:35:18.161985Z",
+    "submitted_at": "2026-06-25T17:01:58.677436Z",
     "diagnostics": []
   },
   "operation_status": {
     "operation_id": "operation-id-redacted",
     "domain": "participant",
     "state": "succeeded",
-    "submitted_at": "2026-06-25T16:35:18.161985Z",
-    "updated_at": "2026-06-25T16:35:18.351833Z",
+    "submitted_at": "2026-06-25T17:01:58.677436Z",
+    "updated_at": "2026-06-25T17:01:58.891076Z",
     "diagnostics": [],
     "changed_addresses": [
       "runtime.snapshot.participant-episode-results.participant.behavior.techvault.kali-victim-ssh-probe",
@@ -45,8 +45,8 @@
       "sequence_number": 0,
       "status": "running",
       "terminal_reason": null,
-      "initialized_at": "2026-06-25T16:35:18.162077Z",
-      "updated_at": "2026-06-25T16:35:18.162077Z",
+      "initialized_at": "2026-06-25T17:01:58.677519Z",
+      "updated_at": "2026-06-25T17:01:58.677519Z",
       "terminated_at": null,
       "last_control_action": "initialize",
       "previous_episode_id": null
@@ -56,7 +56,7 @@
     "participant.behavior.techvault.kali-victim-ssh-probe": [
       {
         "event_type": "episode_initialized",
-        "timestamp": "2026-06-25T16:35:18.162077Z",
+        "timestamp": "2026-06-25T17:01:58.677519Z",
         "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
         "episode_id": "episode-id-redacted",
         "sequence_number": 0,
@@ -66,7 +66,7 @@
       },
       {
         "event_type": "episode_running",
-        "timestamp": "2026-06-25T16:35:18.162077Z",
+        "timestamp": "2026-06-25T17:01:58.677519Z",
         "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
         "episode_id": "episode-id-redacted",
         "sequence_number": 0,
@@ -80,7 +80,7 @@
     "participant.behavior.techvault.kali-victim-ssh-probe": [
       {
         "event_type": "action_attempted",
-        "timestamp": "2026-06-25T16:35:18.162178Z",
+        "timestamp": "2026-06-25T17:01:58.677598Z",
         "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
         "episode_id": "episode-id-redacted",
         "action_instance_id": "participant.behavior.techvault.kali-victim-ssh-probe.action-instance-redacted",
@@ -125,7 +125,7 @@
       },
       {
         "event_type": "observation_emitted",
-        "timestamp": "2026-06-25T16:35:18.351105Z",
+        "timestamp": "2026-06-25T17:01:58.890527Z",
         "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
         "episode_id": "episode-id-redacted",
         "action_instance_id": "participant.behavior.techvault.kali-victim-ssh-probe.action-instance-redacted",
@@ -152,7 +152,7 @@
         "details": {
           "returncode": 0,
           "success": true,
-          "stdout_excerpt": "# Nmap 7.99 scan initiated Thu Jun 25 16:35:18 2026 as: /usr/lib/nmap/nmap -p 22 -Pn --open -oG - 172.20.2.20\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tStatus: Up\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tPorts: 22/open/tcp//ssh///\n# Nmap done at Thu Jun 25 16:35:18 2026 -- 1 IP address (1 host up) scanned in 0.11 seconds\n",
+          "stdout_excerpt": "# Nmap 7.99 scan initiated Thu Jun 25 17:01:58 2026 as: /usr/lib/nmap/nmap -p 22 -Pn --open -oG - 172.20.2.20\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tStatus: Up\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tPorts: 22/open/tcp//ssh///\n# Nmap done at Thu Jun 25 17:01:58 2026 -- 1 IP address (1 host up) scanned in 0.11 seconds\n",
           "stderr_excerpt": "",
           "success_markers": [
             "22/open"
@@ -266,12 +266,12 @@
     }
   },
   "post_action_range_snapshot": {
-    "timestamp": "2026-06-25T16:35:18.617454+00:00",
+    "timestamp": "2026-06-25T17:01:59.183577+00:00",
     "containers": [
       {
         "name": "aptl-victim",
         "image": "aptl-victim",
-        "status": "Up 52 seconds (healthy)",
+        "status": "Up 54 seconds (healthy)",
         "health": "healthy",
         "networks": {
           "aptl_aptl-internal": "172.20.2.20"
@@ -284,7 +284,7 @@
       {
         "name": "aptl-wazuh-dashboard",
         "image": "wazuh/wazuh-dashboard:4.12.0",
-        "status": "Up 52 seconds (healthy)",
+        "status": "Up 54 seconds (healthy)",
         "health": "healthy",
         "networks": {
           "aptl_aptl-security": "172.20.0.11"
@@ -334,18 +334,6 @@
         ]
       },
       {
-        "name": "aptl-grafana-otel",
-        "image": "grafana/grafana:11.6.0",
-        "status": "Up About a minute",
-        "health": "",
-        "networks": {
-          "aptl_aptl-security": "172.20.0.52"
-        },
-        "ports": [
-          "127.0.0.1:3100->3000/tcp"
-        ]
-      },
-      {
         "name": "aptl-otel-collector",
         "image": "otel/opentelemetry-collector-contrib:0.123.0",
         "status": "Up About a minute (healthy)",
@@ -356,6 +344,18 @@
         "ports": [
           "127.0.0.1:4317-4318->4317-4318/tcp",
           "55678-55679/tcp"
+        ]
+      },
+      {
+        "name": "aptl-grafana-otel",
+        "image": "grafana/grafana:11.6.0",
+        "status": "Up About a minute",
+        "health": "",
+        "networks": {
+          "aptl_aptl-security": "172.20.0.52"
+        },
+        "ports": [
+          "127.0.0.1:3100->3000/tcp"
         ]
       },
       {

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/participant-action.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/participant-action.json
@@ -1,6 +1,6 @@
 {
   "schema": "aptl.participant-action-proof/v1",
-  "participant_address": "participant.techvault.kali-victim-ssh-probe",
+  "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
   "operation_receipt_contract": "operation-receipt-v1",
   "operation_status_contract": "operation-status-v1",
   "runtime_snapshot_contract": "runtime-snapshot-v1",
@@ -8,55 +8,56 @@
     "operation_id": "operation-id-redacted",
     "domain": "participant",
     "accepted": true,
-    "submitted_at": "2026-06-25T05:50:49.904415Z",
+    "submitted_at": "2026-06-25T16:35:18.161985Z",
     "diagnostics": []
   },
   "operation_status": {
     "operation_id": "operation-id-redacted",
     "domain": "participant",
     "state": "succeeded",
-    "submitted_at": "2026-06-25T05:50:49.904415Z",
-    "updated_at": "2026-06-25T05:50:50.170200Z",
+    "submitted_at": "2026-06-25T16:35:18.161985Z",
+    "updated_at": "2026-06-25T16:35:18.351833Z",
     "diagnostics": [],
     "changed_addresses": [
-      "runtime.snapshot.participant-episode-results.participant.techvault.kali-victim-ssh-probe",
-      "runtime.snapshot.participant-episode-history.participant.techvault.kali-victim-ssh-probe",
-      "runtime.snapshot.participant-behavior-history.participant.techvault.kali-victim-ssh-probe",
+      "runtime.snapshot.participant-episode-results.participant.behavior.techvault.kali-victim-ssh-probe",
+      "runtime.snapshot.participant-episode-history.participant.behavior.techvault.kali-victim-ssh-probe",
+      "runtime.snapshot.participant-behavior-history.participant.behavior.techvault.kali-victim-ssh-probe",
+      "participant.behavior.techvault.kali-victim-ssh-probe",
       "participant.action-contract.aptl.kali-victim-ssh-probe",
       "participant.observation-boundary.aptl.kali-victim-ssh-probe",
-      "participant.techvault.kali-victim-ssh-probe.action-instance-redacted"
+      "participant.behavior.techvault.kali-victim-ssh-probe.action-instance-redacted"
     ]
   },
   "participant_runtime_status": {
     "backend": "aptl",
     "participants": [
-      "participant.techvault.kali-victim-ssh-probe"
+      "participant.behavior.techvault.kali-victim-ssh-probe"
     ],
     "action_participants": [
-      "participant.techvault.kali-victim-ssh-probe"
+      "participant.behavior.techvault.kali-victim-ssh-probe"
     ]
   },
   "participant_episode_results": {
-    "participant.techvault.kali-victim-ssh-probe": {
+    "participant.behavior.techvault.kali-victim-ssh-probe": {
       "state_schema_version": "participant-episode-state/v1",
-      "participant_address": "participant.techvault.kali-victim-ssh-probe",
+      "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
       "episode_id": "episode-id-redacted",
       "sequence_number": 0,
       "status": "running",
       "terminal_reason": null,
-      "initialized_at": "2026-06-25T05:50:49.904555Z",
-      "updated_at": "2026-06-25T05:50:49.904555Z",
+      "initialized_at": "2026-06-25T16:35:18.162077Z",
+      "updated_at": "2026-06-25T16:35:18.162077Z",
       "terminated_at": null,
       "last_control_action": "initialize",
       "previous_episode_id": null
     }
   },
   "participant_episode_history": {
-    "participant.techvault.kali-victim-ssh-probe": [
+    "participant.behavior.techvault.kali-victim-ssh-probe": [
       {
         "event_type": "episode_initialized",
-        "timestamp": "2026-06-25T05:50:49.904555Z",
-        "participant_address": "participant.techvault.kali-victim-ssh-probe",
+        "timestamp": "2026-06-25T16:35:18.162077Z",
+        "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
         "episode_id": "episode-id-redacted",
         "sequence_number": 0,
         "terminal_reason": null,
@@ -65,8 +66,8 @@
       },
       {
         "event_type": "episode_running",
-        "timestamp": "2026-06-25T05:50:49.904555Z",
-        "participant_address": "participant.techvault.kali-victim-ssh-probe",
+        "timestamp": "2026-06-25T16:35:18.162077Z",
+        "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
         "episode_id": "episode-id-redacted",
         "sequence_number": 0,
         "terminal_reason": null,
@@ -76,13 +77,13 @@
     ]
   },
   "participant_behavior_history": {
-    "participant.techvault.kali-victim-ssh-probe": [
+    "participant.behavior.techvault.kali-victim-ssh-probe": [
       {
         "event_type": "action_attempted",
-        "timestamp": "2026-06-25T05:50:49.904698Z",
-        "participant_address": "participant.techvault.kali-victim-ssh-probe",
+        "timestamp": "2026-06-25T16:35:18.162178Z",
+        "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
         "episode_id": "episode-id-redacted",
-        "action_instance_id": "participant.techvault.kali-victim-ssh-probe.action-instance-redacted",
+        "action_instance_id": "participant.behavior.techvault.kali-victim-ssh-probe.action-instance-redacted",
         "action_contract_address": "participant.action-contract.aptl.kali-victim-ssh-probe",
         "observation_boundary_address": null,
         "observation_status": null,
@@ -97,6 +98,7 @@
         "joint_action_set_id": null,
         "realized_order": null,
         "interaction_ref": null,
+        "interaction_class": "shared_state_change",
         "shared_state_refs": [
           "container:aptl-kali",
           "container:aptl-victim",
@@ -123,10 +125,10 @@
       },
       {
         "event_type": "observation_emitted",
-        "timestamp": "2026-06-25T05:50:50.169643Z",
-        "participant_address": "participant.techvault.kali-victim-ssh-probe",
+        "timestamp": "2026-06-25T16:35:18.351105Z",
+        "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
         "episode_id": "episode-id-redacted",
-        "action_instance_id": "participant.techvault.kali-victim-ssh-probe.action-instance-redacted",
+        "action_instance_id": "participant.behavior.techvault.kali-victim-ssh-probe.action-instance-redacted",
         "action_contract_address": "participant.action-contract.aptl.kali-victim-ssh-probe",
         "observation_boundary_address": "participant.observation-boundary.aptl.kali-victim-ssh-probe",
         "observation_status": "terminal",
@@ -141,6 +143,7 @@
         "joint_action_set_id": null,
         "realized_order": null,
         "interaction_ref": null,
+        "interaction_class": "shared_state_change",
         "shared_state_refs": [
           "container:aptl-kali",
           "container:aptl-victim",
@@ -149,7 +152,7 @@
         "details": {
           "returncode": 0,
           "success": true,
-          "stdout_excerpt": "# Nmap 7.99 scan initiated Thu Jun 25 05:50:50 2026 as: /usr/lib/nmap/nmap -p 22 -Pn --open -oG - 172.20.2.20\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tStatus: Up\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tPorts: 22/open/tcp//ssh///\n# Nmap done at Thu Jun 25 05:50:50 2026 -- 1 IP address (1 host up) scanned in 0.14 seconds\n",
+          "stdout_excerpt": "# Nmap 7.99 scan initiated Thu Jun 25 16:35:18 2026 as: /usr/lib/nmap/nmap -p 22 -Pn --open -oG - 172.20.2.20\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tStatus: Up\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tPorts: 22/open/tcp//ssh///\n# Nmap done at Thu Jun 25 16:35:18 2026 -- 1 IP address (1 host up) scanned in 0.11 seconds\n",
           "stderr_excerpt": "",
           "success_markers": [
             "22/open"
@@ -158,12 +161,47 @@
       }
     ]
   },
+  "participant_shared_state_records": {},
+  "participant_shared_state_history": {},
+  "participant_joint_action_records": {},
+  "participant_time_management_contexts": {},
   "participant_snapshot_entries": {
+    "participant.behavior.techvault.kali-victim-ssh-probe": {
+      "domain": "participant",
+      "resource_type": "participant-behavior",
+      "status": "ready",
+      "payload": {
+        "action_contract_addresses": [
+          "participant.action-contract.aptl.kali-victim-ssh-probe"
+        ],
+        "observation_boundary_addresses": [
+          "participant.observation-boundary.aptl.kali-victim-ssh-probe"
+        ],
+        "shared_state_refs": [
+          "container:aptl-kali",
+          "container:aptl-victim",
+          "tcp:172.20.2.20:22"
+        ]
+      }
+    },
     "participant.action-contract.aptl.kali-victim-ssh-probe": {
       "domain": "participant",
       "resource_type": "participant-action-contract",
       "status": "ready",
       "payload": {
+        "name": "APTL Kali victim SSH probe",
+        "action_name": "kali-victim-ssh-probe",
+        "semantic_version": "1.0.0",
+        "lifecycle_state": "active",
+        "behavioral_granularity": "single-command",
+        "interaction_classes": [
+          "shared_state_change"
+        ],
+        "shared_state_refs": [
+          "container:aptl-kali",
+          "container:aptl-victim",
+          "tcp:172.20.2.20:22"
+        ],
         "source_container": "aptl-kali",
         "command": [
           "nmap",
@@ -190,6 +228,23 @@
       "resource_type": "participant-observation-boundary",
       "status": "ready",
       "payload": {
+        "name": "APTL Kali victim SSH observation boundary",
+        "boundary_name": "kali-victim-ssh-probe-output",
+        "projection_basis": "nmap grepable output excerpt",
+        "observable_refs": [
+          "container:aptl-kali",
+          "container:aptl-victim",
+          "tcp:172.20.2.20:22"
+        ],
+        "evidence_refs": [
+          "participant.behavior.techvault.kali-victim-ssh-probe.action-instance-redacted"
+        ],
+        "disclosed_refs": [
+          "container:aptl-kali",
+          "container:aptl-victim",
+          "tcp:172.20.2.20:22"
+        ],
+        "realized_view_disclosure": "terminal-observation",
         "source_container": "aptl-kali",
         "target_refs": [
           "container:aptl-kali",
@@ -198,7 +253,7 @@
         ]
       }
     },
-    "participant.techvault.kali-victim-ssh-probe.action-instance-redacted": {
+    "participant.behavior.techvault.kali-victim-ssh-probe.action-instance-redacted": {
       "domain": "participant",
       "resource_type": "participant-action-instance",
       "status": "ready",
@@ -211,12 +266,12 @@
     }
   },
   "post_action_range_snapshot": {
-    "timestamp": "2026-06-25T05:50:50.603143+00:00",
+    "timestamp": "2026-06-25T16:35:18.617454+00:00",
     "containers": [
       {
         "name": "aptl-victim",
         "image": "aptl-victim",
-        "status": "Up About a minute (healthy)",
+        "status": "Up 52 seconds (healthy)",
         "health": "healthy",
         "networks": {
           "aptl_aptl-internal": "172.20.2.20"
@@ -229,7 +284,7 @@
       {
         "name": "aptl-wazuh-dashboard",
         "image": "wazuh/wazuh-dashboard:4.12.0",
-        "status": "Up About a minute (healthy)",
+        "status": "Up 52 seconds (healthy)",
         "health": "healthy",
         "networks": {
           "aptl_aptl-security": "172.20.0.11"
@@ -242,7 +297,7 @@
       {
         "name": "aptl-kali-capture",
         "image": "aptl-kali-capture",
-        "status": "Up 2 minutes",
+        "status": "Up About a minute",
         "health": "",
         "networks": {},
         "ports": []
@@ -267,7 +322,7 @@
       {
         "name": "aptl-kali",
         "image": "aptl-kali",
-        "status": "Up 2 minutes (healthy)",
+        "status": "Up About a minute (healthy)",
         "health": "healthy",
         "networks": {
           "aptl_aptl-dmz": "172.20.1.30",
@@ -279,9 +334,21 @@
         ]
       },
       {
+        "name": "aptl-grafana-otel",
+        "image": "grafana/grafana:11.6.0",
+        "status": "Up About a minute",
+        "health": "",
+        "networks": {
+          "aptl_aptl-security": "172.20.0.52"
+        },
+        "ports": [
+          "127.0.0.1:3100->3000/tcp"
+        ]
+      },
+      {
         "name": "aptl-otel-collector",
         "image": "otel/opentelemetry-collector-contrib:0.123.0",
-        "status": "Up 2 minutes (healthy)",
+        "status": "Up About a minute (healthy)",
         "health": "healthy",
         "networks": {
           "aptl_aptl-security": "172.20.0.53"
@@ -292,21 +359,9 @@
         ]
       },
       {
-        "name": "aptl-grafana-otel",
-        "image": "grafana/grafana:11.6.0",
-        "status": "Up 2 minutes",
-        "health": "",
-        "networks": {
-          "aptl_aptl-security": "172.20.0.52"
-        },
-        "ports": [
-          "127.0.0.1:3100->3000/tcp"
-        ]
-      },
-      {
         "name": "aptl-tempo",
         "image": "grafana/tempo:2.7.2",
-        "status": "Up 2 minutes",
+        "status": "Up About a minute",
         "health": "",
         "networks": {
           "aptl_aptl-security": "172.20.0.51"
@@ -318,7 +373,7 @@
       {
         "name": "aptl-wazuh-indexer",
         "image": "wazuh/wazuh-indexer:4.12.0",
-        "status": "Up 2 minutes (healthy)",
+        "status": "Up About a minute (healthy)",
         "health": "healthy",
         "networks": {
           "aptl_aptl-security": "172.20.0.12"
@@ -374,6 +429,8 @@
   "validation": {
     "episode_violations": [],
     "behavior_violations": [],
+    "shared_state_violations": [],
+    "concurrency_violations": [],
     "capture_diagnostics": []
   },
   "verdict": "PASS"

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/participant-action.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/participant-action.json
@@ -1,0 +1,380 @@
+{
+  "schema": "aptl.participant-action-proof/v1",
+  "participant_address": "participant.techvault.kali-victim-ssh-probe",
+  "operation_receipt_contract": "operation-receipt-v1",
+  "operation_status_contract": "operation-status-v1",
+  "runtime_snapshot_contract": "runtime-snapshot-v1",
+  "operation_receipt": {
+    "operation_id": "operation-id-redacted",
+    "domain": "participant",
+    "accepted": true,
+    "submitted_at": "2026-06-25T05:50:49.904415Z",
+    "diagnostics": []
+  },
+  "operation_status": {
+    "operation_id": "operation-id-redacted",
+    "domain": "participant",
+    "state": "succeeded",
+    "submitted_at": "2026-06-25T05:50:49.904415Z",
+    "updated_at": "2026-06-25T05:50:50.170200Z",
+    "diagnostics": [],
+    "changed_addresses": [
+      "runtime.snapshot.participant-episode-results.participant.techvault.kali-victim-ssh-probe",
+      "runtime.snapshot.participant-episode-history.participant.techvault.kali-victim-ssh-probe",
+      "runtime.snapshot.participant-behavior-history.participant.techvault.kali-victim-ssh-probe",
+      "participant.action-contract.aptl.kali-victim-ssh-probe",
+      "participant.observation-boundary.aptl.kali-victim-ssh-probe",
+      "participant.techvault.kali-victim-ssh-probe.action-instance-redacted"
+    ]
+  },
+  "participant_runtime_status": {
+    "backend": "aptl",
+    "participants": [
+      "participant.techvault.kali-victim-ssh-probe"
+    ],
+    "action_participants": [
+      "participant.techvault.kali-victim-ssh-probe"
+    ]
+  },
+  "participant_episode_results": {
+    "participant.techvault.kali-victim-ssh-probe": {
+      "state_schema_version": "participant-episode-state/v1",
+      "participant_address": "participant.techvault.kali-victim-ssh-probe",
+      "episode_id": "episode-id-redacted",
+      "sequence_number": 0,
+      "status": "running",
+      "terminal_reason": null,
+      "initialized_at": "2026-06-25T05:50:49.904555Z",
+      "updated_at": "2026-06-25T05:50:49.904555Z",
+      "terminated_at": null,
+      "last_control_action": "initialize",
+      "previous_episode_id": null
+    }
+  },
+  "participant_episode_history": {
+    "participant.techvault.kali-victim-ssh-probe": [
+      {
+        "event_type": "episode_initialized",
+        "timestamp": "2026-06-25T05:50:49.904555Z",
+        "participant_address": "participant.techvault.kali-victim-ssh-probe",
+        "episode_id": "episode-id-redacted",
+        "sequence_number": 0,
+        "terminal_reason": null,
+        "control_action": "initialize",
+        "details": {}
+      },
+      {
+        "event_type": "episode_running",
+        "timestamp": "2026-06-25T05:50:49.904555Z",
+        "participant_address": "participant.techvault.kali-victim-ssh-probe",
+        "episode_id": "episode-id-redacted",
+        "sequence_number": 0,
+        "terminal_reason": null,
+        "control_action": null,
+        "details": {}
+      }
+    ]
+  },
+  "participant_behavior_history": {
+    "participant.techvault.kali-victim-ssh-probe": [
+      {
+        "event_type": "action_attempted",
+        "timestamp": "2026-06-25T05:50:49.904698Z",
+        "participant_address": "participant.techvault.kali-victim-ssh-probe",
+        "episode_id": "episode-id-redacted",
+        "action_instance_id": "participant.techvault.kali-victim-ssh-probe.action-instance-redacted",
+        "action_contract_address": "participant.action-contract.aptl.kali-victim-ssh-probe",
+        "observation_boundary_address": null,
+        "observation_status": null,
+        "actor_provenance": "codex-cli",
+        "lifecycle_phase": "execution_attempt",
+        "phase_realization": "runtime_mediated",
+        "admission_disposition": null,
+        "operation_ref": "container_exec:aptl-kali",
+        "operation_state": "running",
+        "state_transition_kind": null,
+        "post_state_digest": null,
+        "joint_action_set_id": null,
+        "realized_order": null,
+        "interaction_ref": null,
+        "shared_state_refs": [
+          "container:aptl-kali",
+          "container:aptl-victim",
+          "tcp:172.20.2.20:22"
+        ],
+        "details": {
+          "source_container": "aptl-kali",
+          "command": [
+            "nmap",
+            "-p",
+            "22",
+            "-Pn",
+            "--open",
+            "172.20.2.20",
+            "-oG",
+            "-"
+          ],
+          "target_refs": [
+            "container:aptl-kali",
+            "container:aptl-victim",
+            "tcp:172.20.2.20:22"
+          ]
+        }
+      },
+      {
+        "event_type": "observation_emitted",
+        "timestamp": "2026-06-25T05:50:50.169643Z",
+        "participant_address": "participant.techvault.kali-victim-ssh-probe",
+        "episode_id": "episode-id-redacted",
+        "action_instance_id": "participant.techvault.kali-victim-ssh-probe.action-instance-redacted",
+        "action_contract_address": "participant.action-contract.aptl.kali-victim-ssh-probe",
+        "observation_boundary_address": "participant.observation-boundary.aptl.kali-victim-ssh-probe",
+        "observation_status": "terminal",
+        "actor_provenance": "codex-cli",
+        "lifecycle_phase": "observation_emission",
+        "phase_realization": "observed",
+        "admission_disposition": null,
+        "operation_ref": null,
+        "operation_state": null,
+        "state_transition_kind": null,
+        "post_state_digest": "sha256:redacted-proof-digest",
+        "joint_action_set_id": null,
+        "realized_order": null,
+        "interaction_ref": null,
+        "shared_state_refs": [
+          "container:aptl-kali",
+          "container:aptl-victim",
+          "tcp:172.20.2.20:22"
+        ],
+        "details": {
+          "returncode": 0,
+          "success": true,
+          "stdout_excerpt": "# Nmap 7.99 scan initiated Thu Jun 25 05:50:50 2026 as: /usr/lib/nmap/nmap -p 22 -Pn --open -oG - 172.20.2.20\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tStatus: Up\nHost: 172.20.2.20 (aptl-victim.aptl_aptl-internal)\tPorts: 22/open/tcp//ssh///\n# Nmap done at Thu Jun 25 05:50:50 2026 -- 1 IP address (1 host up) scanned in 0.14 seconds\n",
+          "stderr_excerpt": "",
+          "success_markers": [
+            "22/open"
+          ]
+        }
+      }
+    ]
+  },
+  "participant_snapshot_entries": {
+    "participant.action-contract.aptl.kali-victim-ssh-probe": {
+      "domain": "participant",
+      "resource_type": "participant-action-contract",
+      "status": "ready",
+      "payload": {
+        "source_container": "aptl-kali",
+        "command": [
+          "nmap",
+          "-p",
+          "22",
+          "-Pn",
+          "--open",
+          "172.20.2.20",
+          "-oG",
+          "-"
+        ],
+        "success_markers": [
+          "22/open"
+        ],
+        "target_refs": [
+          "container:aptl-kali",
+          "container:aptl-victim",
+          "tcp:172.20.2.20:22"
+        ]
+      }
+    },
+    "participant.observation-boundary.aptl.kali-victim-ssh-probe": {
+      "domain": "participant",
+      "resource_type": "participant-observation-boundary",
+      "status": "ready",
+      "payload": {
+        "source_container": "aptl-kali",
+        "target_refs": [
+          "container:aptl-kali",
+          "container:aptl-victim",
+          "tcp:172.20.2.20:22"
+        ]
+      }
+    },
+    "participant.techvault.kali-victim-ssh-probe.action-instance-redacted": {
+      "domain": "participant",
+      "resource_type": "participant-action-instance",
+      "status": "ready",
+      "payload": {
+        "action_contract_address": "participant.action-contract.aptl.kali-victim-ssh-probe",
+        "observation_boundary_address": "participant.observation-boundary.aptl.kali-victim-ssh-probe",
+        "actor_provenance": "codex-cli",
+        "success": true
+      }
+    }
+  },
+  "post_action_range_snapshot": {
+    "timestamp": "2026-06-25T05:50:50.603143+00:00",
+    "containers": [
+      {
+        "name": "aptl-victim",
+        "image": "aptl-victim",
+        "status": "Up About a minute (healthy)",
+        "health": "healthy",
+        "networks": {
+          "aptl_aptl-internal": "172.20.2.20"
+        },
+        "ports": [
+          "22/tcp",
+          "514/tcp"
+        ]
+      },
+      {
+        "name": "aptl-wazuh-dashboard",
+        "image": "wazuh/wazuh-dashboard:4.12.0",
+        "status": "Up About a minute (healthy)",
+        "health": "healthy",
+        "networks": {
+          "aptl_aptl-security": "172.20.0.11"
+        },
+        "ports": [
+          "443/tcp",
+          "127.0.0.1:443->5601/tcp"
+        ]
+      },
+      {
+        "name": "aptl-kali-capture",
+        "image": "aptl-kali-capture",
+        "status": "Up 2 minutes",
+        "health": "",
+        "networks": {},
+        "ports": []
+      },
+      {
+        "name": "aptl-wazuh-manager",
+        "image": "wazuh/wazuh-manager:4.12.0",
+        "status": "Up About a minute (healthy)",
+        "health": "healthy",
+        "networks": {
+          "aptl_aptl-dmz": "172.20.1.10",
+          "aptl_aptl-internal": "172.20.2.30",
+          "aptl_aptl-security": "172.20.0.10"
+        },
+        "ports": [
+          "127.0.0.1:1514-1515->1514-1515/tcp",
+          "127.0.0.1:514->514/udp",
+          "127.0.0.1:55000->55000/tcp",
+          "1516/tcp"
+        ]
+      },
+      {
+        "name": "aptl-kali",
+        "image": "aptl-kali",
+        "status": "Up 2 minutes (healthy)",
+        "health": "healthy",
+        "networks": {
+          "aptl_aptl-dmz": "172.20.1.30",
+          "aptl_aptl-internal": "172.20.2.35",
+          "aptl_aptl-redteam": "172.20.4.30"
+        },
+        "ports": [
+          "22/tcp"
+        ]
+      },
+      {
+        "name": "aptl-otel-collector",
+        "image": "otel/opentelemetry-collector-contrib:0.123.0",
+        "status": "Up 2 minutes (healthy)",
+        "health": "healthy",
+        "networks": {
+          "aptl_aptl-security": "172.20.0.53"
+        },
+        "ports": [
+          "127.0.0.1:4317-4318->4317-4318/tcp",
+          "55678-55679/tcp"
+        ]
+      },
+      {
+        "name": "aptl-grafana-otel",
+        "image": "grafana/grafana:11.6.0",
+        "status": "Up 2 minutes",
+        "health": "",
+        "networks": {
+          "aptl_aptl-security": "172.20.0.52"
+        },
+        "ports": [
+          "127.0.0.1:3100->3000/tcp"
+        ]
+      },
+      {
+        "name": "aptl-tempo",
+        "image": "grafana/tempo:2.7.2",
+        "status": "Up 2 minutes",
+        "health": "",
+        "networks": {
+          "aptl_aptl-security": "172.20.0.51"
+        },
+        "ports": [
+          "127.0.0.1:3200->3200/tcp"
+        ]
+      },
+      {
+        "name": "aptl-wazuh-indexer",
+        "image": "wazuh/wazuh-indexer:4.12.0",
+        "status": "Up 2 minutes (healthy)",
+        "health": "healthy",
+        "networks": {
+          "aptl_aptl-security": "172.20.0.12"
+        },
+        "ports": [
+          "127.0.0.1:9200->9200/tcp"
+        ]
+      }
+    ],
+    "networks": [
+      {
+        "name": "aptl_aptl-dmz",
+        "subnet": "172.20.1.0/24",
+        "gateway": "172.20.1.1",
+        "containers": [
+          "aptl-kali",
+          "aptl-wazuh-manager"
+        ]
+      },
+      {
+        "name": "aptl_aptl-internal",
+        "subnet": "172.20.2.0/24",
+        "gateway": "172.20.2.1",
+        "containers": [
+          "aptl-kali",
+          "aptl-victim",
+          "aptl-wazuh-manager"
+        ]
+      },
+      {
+        "name": "aptl_aptl-redteam",
+        "subnet": "172.20.4.0/24",
+        "gateway": "172.20.4.1",
+        "containers": [
+          "aptl-kali"
+        ]
+      },
+      {
+        "name": "aptl_aptl-security",
+        "subnet": "172.20.0.0/24",
+        "gateway": "172.20.0.1",
+        "containers": [
+          "aptl-grafana-otel",
+          "aptl-otel-collector",
+          "aptl-tempo",
+          "aptl-wazuh-dashboard",
+          "aptl-wazuh-indexer",
+          "aptl-wazuh-manager"
+        ]
+      }
+    ]
+  },
+  "validation": {
+    "episode_violations": [],
+    "behavior_violations": [],
+    "capture_diagnostics": []
+  },
+  "verdict": "PASS"
+}

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/result.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/result.json
@@ -8,7 +8,7 @@
   ],
   "command": "uv run aptl lab start --scenario techvault-attacker-target",
   "readiness_outcome": "Lab is ready.",
-  "boot_elapsed_seconds": 103,
+  "boot_elapsed_seconds": 120,
   "selected_profiles": [
     "wazuh",
     "victim",

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/result.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/result.json
@@ -8,7 +8,7 @@
   ],
   "command": "uv run aptl lab start --scenario techvault-attacker-target",
   "readiness_outcome": "Lab is ready.",
-  "boot_elapsed_seconds": 154,
+  "boot_elapsed_seconds": 103,
   "selected_profiles": [
     "wazuh",
     "victim",
@@ -62,7 +62,7 @@
   "participant_action": {
     "verdict": "PASS",
     "artifact": "participant-action.json",
-    "participant_address": "participant.techvault.kali-victim-ssh-probe",
+    "participant_address": "participant.behavior.techvault.kali-victim-ssh-probe",
     "operation_id": "operation-id-redacted",
     "operation_state": "succeeded",
     "behavior_event_count": 2

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/result.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/result.json
@@ -6,9 +6,9 @@
     "victim",
     "wazuh"
   ],
-  "command": "aptl lab start --scenario techvault-attacker-target --skip-seed",
+  "command": "uv run aptl lab start --scenario techvault-attacker-target",
   "readiness_outcome": "Lab is ready.",
-  "boot_elapsed_seconds": 97,
+  "boot_elapsed_seconds": 154,
   "selected_profiles": [
     "wazuh",
     "victim",
@@ -59,6 +59,14 @@
     "aptl_aptl-redteam",
     "aptl_aptl-security"
   ],
+  "participant_action": {
+    "verdict": "PASS",
+    "artifact": "participant-action.json",
+    "participant_address": "participant.techvault.kali-victim-ssh-probe",
+    "operation_id": "operation-id-redacted",
+    "operation_state": "succeeded",
+    "behavior_event_count": 2
+  },
   "verdict": "PASS",
   "diagnostics": []
 }

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/snapshot.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/snapshot.json
@@ -1,10 +1,10 @@
 {
-  "timestamp": "2026-06-25T05:50:46.585579+00:00",
+  "timestamp": "2026-06-25T16:35:16.007443+00:00",
   "containers": [
     {
       "name": "aptl-victim",
       "image": "aptl-victim",
-      "status": "Up About a minute (healthy)",
+      "status": "Up 50 seconds (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-internal": "172.20.2.20"
@@ -17,7 +17,7 @@
     {
       "name": "aptl-wazuh-dashboard",
       "image": "wazuh/wazuh-dashboard:4.12.0",
-      "status": "Up About a minute (healthy)",
+      "status": "Up 50 seconds (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-security": "172.20.0.11"
@@ -30,7 +30,7 @@
     {
       "name": "aptl-kali-capture",
       "image": "aptl-kali-capture",
-      "status": "Up 2 minutes",
+      "status": "Up About a minute",
       "health": "",
       "networks": {},
       "ports": []
@@ -55,7 +55,7 @@
     {
       "name": "aptl-kali",
       "image": "aptl-kali",
-      "status": "Up 2 minutes (healthy)",
+      "status": "Up About a minute (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-dmz": "172.20.1.30",
@@ -67,9 +67,21 @@
       ]
     },
     {
+      "name": "aptl-grafana-otel",
+      "image": "grafana/grafana:11.6.0",
+      "status": "Up About a minute",
+      "health": "",
+      "networks": {
+        "aptl_aptl-security": "172.20.0.52"
+      },
+      "ports": [
+        "127.0.0.1:3100->3000/tcp"
+      ]
+    },
+    {
       "name": "aptl-otel-collector",
       "image": "otel/opentelemetry-collector-contrib:0.123.0",
-      "status": "Up 2 minutes (healthy)",
+      "status": "Up About a minute (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-security": "172.20.0.53"
@@ -80,21 +92,9 @@
       ]
     },
     {
-      "name": "aptl-grafana-otel",
-      "image": "grafana/grafana:11.6.0",
-      "status": "Up 2 minutes",
-      "health": "",
-      "networks": {
-        "aptl_aptl-security": "172.20.0.52"
-      },
-      "ports": [
-        "127.0.0.1:3100->3000/tcp"
-      ]
-    },
-    {
       "name": "aptl-tempo",
       "image": "grafana/tempo:2.7.2",
-      "status": "Up 2 minutes",
+      "status": "Up About a minute",
       "health": "",
       "networks": {
         "aptl_aptl-security": "172.20.0.51"
@@ -106,7 +106,7 @@
     {
       "name": "aptl-wazuh-indexer",
       "image": "wazuh/wazuh-indexer:4.12.0",
-      "status": "Up 2 minutes (healthy)",
+      "status": "Up About a minute (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-security": "172.20.0.12"

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/snapshot.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/snapshot.json
@@ -1,10 +1,10 @@
 {
-  "timestamp": "2026-06-24T05:04:24.004920+00:00",
+  "timestamp": "2026-06-25T05:50:46.585579+00:00",
   "containers": [
     {
       "name": "aptl-victim",
       "image": "aptl-victim",
-      "status": "Up 47 seconds (healthy)",
+      "status": "Up About a minute (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-internal": "172.20.2.20"
@@ -17,7 +17,7 @@
     {
       "name": "aptl-wazuh-dashboard",
       "image": "wazuh/wazuh-dashboard:4.12.0",
-      "status": "Up 47 seconds (healthy)",
+      "status": "Up About a minute (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-security": "172.20.0.11"
@@ -30,7 +30,7 @@
     {
       "name": "aptl-kali-capture",
       "image": "aptl-kali-capture",
-      "status": "Up About a minute",
+      "status": "Up 2 minutes",
       "health": "",
       "networks": {},
       "ports": []
@@ -55,7 +55,7 @@
     {
       "name": "aptl-kali",
       "image": "aptl-kali",
-      "status": "Up About a minute (healthy)",
+      "status": "Up 2 minutes (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-dmz": "172.20.1.30",
@@ -67,33 +67,9 @@
       ]
     },
     {
-      "name": "aptl-grafana-otel",
-      "image": "grafana/grafana:11.6.0",
-      "status": "Up About a minute",
-      "health": "",
-      "networks": {
-        "aptl_aptl-security": "172.20.0.52"
-      },
-      "ports": [
-        "127.0.0.1:3100->3000/tcp"
-      ]
-    },
-    {
-      "name": "aptl-wazuh-indexer",
-      "image": "wazuh/wazuh-indexer:4.12.0",
-      "status": "Up About a minute (healthy)",
-      "health": "healthy",
-      "networks": {
-        "aptl_aptl-security": "172.20.0.12"
-      },
-      "ports": [
-        "127.0.0.1:9200->9200/tcp"
-      ]
-    },
-    {
       "name": "aptl-otel-collector",
       "image": "otel/opentelemetry-collector-contrib:0.123.0",
-      "status": "Up About a minute (healthy)",
+      "status": "Up 2 minutes (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-security": "172.20.0.53"
@@ -104,15 +80,39 @@
       ]
     },
     {
+      "name": "aptl-grafana-otel",
+      "image": "grafana/grafana:11.6.0",
+      "status": "Up 2 minutes",
+      "health": "",
+      "networks": {
+        "aptl_aptl-security": "172.20.0.52"
+      },
+      "ports": [
+        "127.0.0.1:3100->3000/tcp"
+      ]
+    },
+    {
       "name": "aptl-tempo",
       "image": "grafana/tempo:2.7.2",
-      "status": "Up About a minute",
+      "status": "Up 2 minutes",
       "health": "",
       "networks": {
         "aptl_aptl-security": "172.20.0.51"
       },
       "ports": [
         "127.0.0.1:3200->3200/tcp"
+      ]
+    },
+    {
+      "name": "aptl-wazuh-indexer",
+      "image": "wazuh/wazuh-indexer:4.12.0",
+      "status": "Up 2 minutes (healthy)",
+      "health": "healthy",
+      "networks": {
+        "aptl_aptl-security": "172.20.0.12"
+      },
+      "ports": [
+        "127.0.0.1:9200->9200/tcp"
       ]
     }
   ],

--- a/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/snapshot.json
+++ b/docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/snapshot.json
@@ -1,10 +1,10 @@
 {
-  "timestamp": "2026-06-25T16:35:16.007443+00:00",
+  "timestamp": "2026-06-25T17:01:56.384722+00:00",
   "containers": [
     {
       "name": "aptl-victim",
       "image": "aptl-victim",
-      "status": "Up 50 seconds (healthy)",
+      "status": "Up 51 seconds (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-internal": "172.20.2.20"
@@ -17,7 +17,7 @@
     {
       "name": "aptl-wazuh-dashboard",
       "image": "wazuh/wazuh-dashboard:4.12.0",
-      "status": "Up 50 seconds (healthy)",
+      "status": "Up 51 seconds (healthy)",
       "health": "healthy",
       "networks": {
         "aptl_aptl-security": "172.20.0.11"
@@ -67,18 +67,6 @@
       ]
     },
     {
-      "name": "aptl-grafana-otel",
-      "image": "grafana/grafana:11.6.0",
-      "status": "Up About a minute",
-      "health": "",
-      "networks": {
-        "aptl_aptl-security": "172.20.0.52"
-      },
-      "ports": [
-        "127.0.0.1:3100->3000/tcp"
-      ]
-    },
-    {
       "name": "aptl-otel-collector",
       "image": "otel/opentelemetry-collector-contrib:0.123.0",
       "status": "Up About a minute (healthy)",
@@ -89,6 +77,18 @@
       "ports": [
         "127.0.0.1:4317-4318->4317-4318/tcp",
         "55678-55679/tcp"
+      ]
+    },
+    {
+      "name": "aptl-grafana-otel",
+      "image": "grafana/grafana:11.6.0",
+      "status": "Up About a minute",
+      "health": "",
+      "networks": {
+        "aptl_aptl-security": "172.20.0.52"
+      },
+      "ports": [
+        "127.0.0.1:3100->3000/tcp"
       ]
     },
     {

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -32,6 +32,7 @@ from aptl.backends.aces_diagnostics import (
 from aptl.backends.aces_manifest import APTL_ACES_TARGET_NAME, create_aptl_manifest
 from aptl.backends.aces_evaluator import AptlEvaluator
 from aptl.backends.aces_orchestrator import AptlOrchestrator
+from aptl.backends.aces_participant_runtime import AptlParticipantRuntime
 from aptl.backends.aces_realization import (
     AptlRealization,
     interpret_provisioning_plan,
@@ -87,12 +88,14 @@ def create_aptl_runtime_target(
         deployment_backend=backend,
     )
     orchestrator = AptlOrchestrator()
+    participant_runtime = AptlParticipantRuntime(deployment_backend=backend)
     return RuntimeTarget(
         name=APTL_ACES_TARGET_NAME,
         manifest=create_aptl_manifest(),
         provisioner=provisioner,  # type: ignore[arg-type]
         orchestrator=orchestrator,  # type: ignore[arg-type]
         evaluator=AptlEvaluator(),  # type: ignore[arg-type]
+        participant_runtime=participant_runtime,  # type: ignore[arg-type]
     )
 
 
@@ -200,9 +203,19 @@ def _run_execution_plan(
             selected_profiles=[],
             scenario_path=scenario_path,
         )
-    control_plane = RuntimeControlPlane(target, initial_snapshot=execution_plan.base_snapshot)
-    failure, realization_details, selected_profiles = _apply_provisioning_and_orchestration(
-        control_plane, execution_plan, target, run_store=run_store, run_id=run_id
+    control_plane = RuntimeControlPlane(
+        target, initial_snapshot=execution_plan.base_snapshot
+    )
+    (
+        failure,
+        realization_details,
+        selected_profiles,
+    ) = _apply_provisioning_and_orchestration(
+        control_plane,
+        execution_plan,
+        target,
+        run_store=run_store,
+        run_id=run_id,
     )
     if failure is not None:
         return AcesStartOutcome(
@@ -316,7 +329,9 @@ def _apply_phase(
     status = control_plane.get_operation(receipt.operation_id)
     if status is not None and status.state == OperationState.SUCCEEDED:
         return None
-    diagnostics = list(status.diagnostics) if status is not None else list(receipt.diagnostics)
+    diagnostics = (
+        list(status.diagnostics) if status is not None else list(receipt.diagnostics)
+    )
     return LabResult(success=False, error=render_aces_diagnostics(diagnostics))
 
 

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -206,11 +206,7 @@ def _run_execution_plan(
     control_plane = RuntimeControlPlane(
         target, initial_snapshot=execution_plan.base_snapshot
     )
-    (
-        failure,
-        realization_details,
-        selected_profiles,
-    ) = _apply_provisioning_and_orchestration(
+    failure, realization_details, selected_profiles = _apply_provisioning_and_orchestration(
         control_plane,
         execution_plan,
         target,

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -37,6 +37,11 @@ from aces_contracts.apparatus import (
 )
 from aces_contracts.vocabulary import WorkflowFeature, WorkflowStatePredicateFeature
 
+try:
+    from aces_contracts.manifest_authority import BACKEND_SUPPORTED_CONTRACT_IDS
+except ImportError:  # pragma: no cover - older ACES packages still expose validation.
+    BACKEND_SUPPORTED_CONTRACT_IDS = ()
+
 from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS
 
 APTL_ACES_TARGET_NAME = "aptl"
@@ -49,7 +54,7 @@ _COMPATIBLE_PROCESSORS = frozenset({"aces-reference-processor"})
 # operation/status, runtime-snapshot, workflow, evaluation, and participant
 # episode/behavior contracts. APTL consumes the plan contracts and emits the
 # result/history contracts through its adapters.
-_SUPPORTED_CONTRACT_VERSIONS = frozenset(
+_BASE_SUPPORTED_CONTRACT_VERSIONS = frozenset(
     {
         "backend-manifest-v2",
         "provisioning-plan-v1",
@@ -66,6 +71,21 @@ _SUPPORTED_CONTRACT_VERSIONS = frozenset(
         "participant-episode-history-event-stream-v1",
         "participant-behavior-history-event-stream-v1",
     }
+)
+
+_CURRENT_PARTICIPANT_CONTRACT_VERSIONS = frozenset(
+    {
+        "participant-lifecycle-event-v1",
+        "participant-observation-envelope-v1",
+        "participant-shared-state-record-v1",
+        "participant-joint-action-record-v1",
+        "participant-time-management-context-v1",
+    }
+)
+
+_SUPPORTED_CONTRACT_VERSIONS = _BASE_SUPPORTED_CONTRACT_VERSIONS | (
+    _CURRENT_PARTICIPANT_CONTRACT_VERSIONS
+    & frozenset(BACKEND_SUPPORTED_CONTRACT_IDS)
 )
 
 # Orchestrator capability declaration. APTL's RTE-001 runtime engine drives

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -39,7 +39,8 @@ from aces_contracts.vocabulary import WorkflowFeature, WorkflowStatePredicateFea
 
 try:
     from aces_contracts.manifest_authority import BACKEND_SUPPORTED_CONTRACT_IDS
-except ImportError:  # pragma: no cover - older ACES packages still expose validation.
+except ImportError:
+    # Older ACES packages still expose validation without manifest authority.
     BACKEND_SUPPORTED_CONTRACT_IDS = ()
 
 from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -4,20 +4,21 @@ APTL publishes its runtime-target capability declaration as the canonical ACES
 ``backend-manifest-v2`` surface (``aces_backend_protocols.capabilities``), not an
 APTL-local approximation. The manifest is what the ACES planner's
 realization-support gate and ``aces conformance backend --profile
-orchestration-evaluation`` validate against, so it must declare APTL's real
-provisioning, orchestration, and evaluation capability against the published
-controlled vocabularies and contract authority — anything less is rejected by
-the conformance corpus.
+full-remote-control-plane`` validate against, so it must declare APTL's real
+provisioning, orchestration, evaluation, and participant-runtime capability
+against the published controlled vocabularies and contract authority — anything
+less is rejected by the conformance corpus.
 
-APTL is an orchestration-evaluation backend: it realizes ACES provisioning
-plans into Docker Compose profiles, exposes its scenario runtime engine
-(RTE-001) workflow drive surface through the portable
-``workflow-result-envelope-v1`` and ``workflow-history-event-stream-v1``
-contracts (see ``aptl.backends.aces_orchestrator.AptlOrchestrator``), and
-publishes objective and condition evaluation through
-``evaluation-result-envelope-v1`` and ``evaluation-history-event-stream-v1``
-(see ``aptl.backends.aces_evaluator.AptlEvaluator``). It declares no
-participant runtime; that promotion remains out of scope.
+APTL is a full remote-control-plane backend: it realizes ACES provisioning plans
+into Docker Compose profiles, exposes its scenario runtime engine (RTE-001)
+workflow drive surface through the portable ``workflow-result-envelope-v1`` and
+``workflow-history-event-stream-v1`` contracts (see
+``aptl.backends.aces_orchestrator.AptlOrchestrator``), publishes objective and
+condition evaluation through ``evaluation-result-envelope-v1`` and
+``evaluation-history-event-stream-v1`` (see
+``aptl.backends.aces_evaluator.AptlEvaluator``), and exposes a narrow red
+participant runtime through the participant episode and behavior-history
+contracts.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ from aces_backend_protocols.capabilities import (
     BackendManifest,
     EvaluatorCapabilities,
     OrchestratorCapabilities,
+    ParticipantRuntimeCapabilities,
     ProvisionerCapabilities,
 )
 from aces_contracts.apparatus import (
@@ -35,23 +37,24 @@ from aces_contracts.apparatus import (
 )
 from aces_contracts.vocabulary import WorkflowFeature, WorkflowStatePredicateFeature
 
+from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS
+
 APTL_ACES_TARGET_NAME = "aptl"
 APTL_ACES_TARGET_VERSION = "0.1.0"
 
 # The reference ACES processor whose provisioning-plan output APTL realizes.
 _COMPATIBLE_PROCESSORS = frozenset({"aces-reference-processor"})
 
-# Orchestration-evaluation contract surface. The orchestration-evaluation backend
-# profile (contracts/profiles/backend/orchestration-evaluation.json) requires
-# backend-manifest-v2, operation-receipt-v1, operation-status-v1,
-# runtime-snapshot-v1, workflow-result-envelope-v1,
-# workflow-history-event-stream-v1, evaluation-result-envelope-v1, and
-# evaluation-history-event-stream-v1; APTL also declares provisioning-plan-v1
-# because it consumes ACES provisioning plans.
+# Full remote-control-plane contract surface. The profile requires the planning,
+# operation/status, runtime-snapshot, workflow, evaluation, and participant
+# episode/behavior contracts. APTL consumes the plan contracts and emits the
+# result/history contracts through its adapters.
 _SUPPORTED_CONTRACT_VERSIONS = frozenset(
     {
         "backend-manifest-v2",
         "provisioning-plan-v1",
+        "orchestration-plan-v1",
+        "evaluation-plan-v1",
         "operation-receipt-v1",
         "operation-status-v1",
         "runtime-snapshot-v1",
@@ -59,6 +62,9 @@ _SUPPORTED_CONTRACT_VERSIONS = frozenset(
         "workflow-history-event-stream-v1",
         "evaluation-result-envelope-v1",
         "evaluation-history-event-stream-v1",
+        "participant-episode-state-envelope-v1",
+        "participant-episode-history-event-stream-v1",
+        "participant-behavior-history-event-stream-v1",
     }
 )
 
@@ -98,6 +104,21 @@ _EVALUATOR = EvaluatorCapabilities(
     supports_objectives=True,
 )
 
+# Participant runtime capability declaration. The current proof drives a single
+# red participant action from Kali against a realized victim container and emits
+# participant episode plus behavior-history snapshot surfaces. It does not claim
+# blue/green/white roles or multi-party coordination semantics.
+_PARTICIPANT_RUNTIME = ParticipantRuntimeCapabilities(
+    name="aptl-participant-runtime",
+    supported_participant_roles=frozenset({"red"}),
+    supported_behavior_features=frozenset({"behavior_history"}),
+    supported_interaction_features=frozenset({"shared_state_change"}),
+    constraints={
+        "default_participant_action_address": PARTICIPANT_ACTION_ADDRESS,
+        "backend_boundary": "DeploymentBackend.container_exec",
+    },
+)
+
 # Provisioner capability declaration, using only published controlled-vocabulary
 # terms (validated against contracts/concept-authority/controlled-vocabularies-v1).
 _PROVISIONER = ProvisionerCapabilities(
@@ -133,8 +154,12 @@ _REALIZATION_SUPPORT = (
 # Concept-authority bindings: which controlled-vocabulary family each
 # provisioner capability scope draws its terms from.
 _CONCEPT_BINDINGS = (
-    ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
-    ConceptBinding(scope="capabilities.provisioner.supported_os_families", family="assets"),
+    ConceptBinding(
+        scope="capabilities.provisioner.supported_node_types", family="assets"
+    ),
+    ConceptBinding(
+        scope="capabilities.provisioner.supported_os_families", family="assets"
+    ),
     ConceptBinding(
         scope="capabilities.provisioner.supported_content_types",
         family="tools-and-artifacts",
@@ -147,7 +172,7 @@ _CONCEPT_BINDINGS = (
 
 
 def create_aptl_manifest() -> BackendManifest:
-    """Return APTL's orchestration-evaluation canonical ACES ``backend-manifest-v2``."""
+    """Return APTL's canonical full remote-control-plane backend manifest."""
     return BackendManifest(
         name=APTL_ACES_TARGET_NAME,
         version=APTL_ACES_TARGET_VERSION,
@@ -158,4 +183,5 @@ def create_aptl_manifest() -> BackendManifest:
         provisioner=_PROVISIONER,
         orchestrator=_ORCHESTRATOR,
         evaluator=_EVALUATOR,
+        participant_runtime=_PARTICIPANT_RUNTIME,
     )

--- a/src/aptl/backends/aces_participant_actions.py
+++ b/src/aptl/backends/aces_participant_actions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -117,7 +117,7 @@ def drive_participant_action(
     participant_address: str,
     state: ParticipantEpisodeExecutionState,
     *,
-    timestamp_factory,
+    timestamp_factory: Callable[[], str],
 ) -> ParticipantActionExecution | None:
     """Drive the configured participant action and emit ACES evidence surfaces."""
 

--- a/src/aptl/backends/aces_participant_actions.py
+++ b/src/aptl/backends/aces_participant_actions.py
@@ -1,0 +1,386 @@
+"""Participant action helpers for the APTL ACES runtime."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.participant_behavior import (
+    ParticipantBehaviorHistoryEventType,
+    ParticipantLifecycleOperationState,
+    ParticipantObservationStatus,
+    ParticipantPhaseRealization,
+    ParticipantRuntimeLifecyclePhase,
+)
+from aces_contracts.participant_episode import ParticipantEpisodeExecutionState
+from aces_contracts.planning import RuntimeDomain
+from aces_contracts.runtime_state import SnapshotEntry
+
+from aptl.utils.redaction import redact
+
+if TYPE_CHECKING:
+    from aptl.core.deployment.backend import DeploymentBackend
+
+PARTICIPANT_ACTION_ADDRESS = "participant.behavior.techvault.kali-victim-ssh-probe"
+PARTICIPANT_ACTION_CONTRACT_ADDRESS = (
+    "participant.action-contract.aptl.kali-victim-ssh-probe"
+)
+PARTICIPANT_OBSERVATION_BOUNDARY_ADDRESS = (
+    "participant.observation-boundary.aptl.kali-victim-ssh-probe"
+)
+PARTICIPANT_BEHAVIOR_ADDRESS = PARTICIPANT_ACTION_ADDRESS
+TECHVAULT_VICTIM_SSH_ADDRESS = ".".join(("172", "20", "2", "20"))
+TECHVAULT_VICTIM_SSH_REF = f"tcp:{TECHVAULT_VICTIM_SSH_ADDRESS}:22"
+
+
+@dataclass(frozen=True)
+class ParticipantActionSpec:
+    """A bounded participant action that can be driven through the backend."""
+
+    source_container: str
+    command: tuple[str, ...]
+    success_markers: tuple[str, ...]
+    action_contract_address: str
+    observation_boundary_address: str
+    actor_provenance: str = "codex-cli"
+    target_refs: tuple[str, ...] = ()
+    timeout_seconds: int = 120
+
+
+@dataclass(frozen=True)
+class ParticipantCommandObservation:
+    """Captured terminal observation from a participant action command."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    success: bool
+
+
+@dataclass(frozen=True)
+class ParticipantActionExecution:
+    """Participant action result projected into ACES snapshot surfaces."""
+
+    success: bool
+    behavior_events: list[dict[str, object]]
+    diagnostics: list[Diagnostic]
+    snapshot_entries: dict[str, SnapshotEntry]
+    shared_state_records: dict[str, dict[str, object]]
+
+
+DEFAULT_PARTICIPANT_ACTIONS = {
+    PARTICIPANT_ACTION_ADDRESS: ParticipantActionSpec(
+        source_container="aptl-kali",
+        command=(
+            "nmap",
+            "-p",
+            "22",
+            "-Pn",
+            "--open",
+            TECHVAULT_VICTIM_SSH_ADDRESS,
+            "-oG",
+            "-",
+        ),
+        success_markers=("22/open",),
+        action_contract_address=PARTICIPANT_ACTION_CONTRACT_ADDRESS,
+        observation_boundary_address=PARTICIPANT_OBSERVATION_BOUNDARY_ADDRESS,
+        target_refs=(
+            "container:aptl-kali",
+            "container:aptl-victim",
+            TECHVAULT_VICTIM_SSH_REF,
+        ),
+    )
+}
+
+
+def participant_action_diagnostic(
+    code: str, address: str, message: str
+) -> Diagnostic:
+    """Build a redacted participant-runtime error diagnostic."""
+
+    return Diagnostic(
+        code=code,
+        domain=RuntimeDomain.PARTICIPANT.value,
+        address=address,
+        message=redact(message),
+        severity=Severity.ERROR,
+    )
+
+
+def drive_participant_action(
+    deployment_backend: "DeploymentBackend",
+    action_specs: Mapping[str, ParticipantActionSpec],
+    participant_address: str,
+    state: ParticipantEpisodeExecutionState,
+    *,
+    timestamp_factory,
+) -> ParticipantActionExecution | None:
+    """Drive the configured participant action and emit ACES evidence surfaces."""
+
+    spec = action_specs.get(participant_address)
+    if spec is None:
+        return None
+    action_instance_id = f"{participant_address}.{uuid4().hex}"
+    started_at = timestamp_factory()
+    attempted = _action_attempted_event(spec, state, action_instance_id, started_at)
+    observation, diagnostics = _run_action_command(
+        deployment_backend, spec, participant_address
+    )
+    finished_at = timestamp_factory()
+    observed = _observation_event(
+        spec, state, action_instance_id, finished_at, observation
+    )
+    if not observation.success:
+        diagnostics.append(
+            participant_action_diagnostic(
+                "aptl.participant-runtime.action-failed",
+                participant_address,
+                (
+                    "Participant action did not observe the expected lab result "
+                    f"(returncode={observation.returncode}, "
+                    f"markers={spec.success_markers})."
+                ),
+            )
+        )
+    return ParticipantActionExecution(
+        success=observation.success,
+        behavior_events=[attempted, observed],
+        diagnostics=diagnostics,
+        snapshot_entries=_action_snapshot_entries(
+            spec, action_instance_id, observation.success
+        ),
+        shared_state_records=_shared_state_records(
+            spec, action_instance_id, observation.success
+        ),
+    )
+
+
+def _run_action_command(
+    deployment_backend: "DeploymentBackend",
+    spec: ParticipantActionSpec,
+    participant_address: str,
+) -> tuple[ParticipantCommandObservation, list[Diagnostic]]:
+    """Execute the participant command and classify the captured output."""
+
+    diagnostics: list[Diagnostic] = []
+    stdout = ""
+    stderr = ""
+    returncode = 1
+    try:
+        result = deployment_backend.container_exec(
+            spec.source_container,
+            list(spec.command),
+            timeout=spec.timeout_seconds,
+        )
+        stdout = redact(str(getattr(result, "stdout", "")))
+        stderr = redact(str(getattr(result, "stderr", "")))
+        returncode = int(getattr(result, "returncode", 1))
+    except Exception as exc:
+        stderr = redact(f"{type(exc).__name__}: {exc}")
+        diagnostics.append(
+            participant_action_diagnostic(
+                "aptl.participant-runtime.action-backend-failed",
+                participant_address,
+                "Participant action backend call failed: " + stderr,
+            )
+        )
+    combined = f"{stdout}\n{stderr}"
+    marker_ok = all(marker in combined for marker in spec.success_markers)
+    observation = ParticipantCommandObservation(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        success=returncode == 0 and marker_ok,
+    )
+    return observation, diagnostics
+
+
+def _action_attempted_event(
+    spec: ParticipantActionSpec,
+    state: ParticipantEpisodeExecutionState,
+    action_instance_id: str,
+    timestamp: str,
+) -> dict[str, object]:
+    """Build the behavior-history event for an attempted participant action."""
+
+    return {
+        "event_type": ParticipantBehaviorHistoryEventType.ACTION_ATTEMPTED.value,
+        "timestamp": timestamp,
+        "participant_address": state.participant_address,
+        "episode_id": state.episode_id,
+        "action_instance_id": action_instance_id,
+        "action_contract_address": spec.action_contract_address,
+        "observation_boundary_address": None,
+        "observation_status": None,
+        "actor_provenance": spec.actor_provenance,
+        "lifecycle_phase": ParticipantRuntimeLifecyclePhase.EXECUTION_ATTEMPT.value,
+        "phase_realization": ParticipantPhaseRealization.RUNTIME_MEDIATED.value,
+        "admission_disposition": None,
+        "operation_ref": f"container_exec:{spec.source_container}",
+        "operation_state": ParticipantLifecycleOperationState.RUNNING.value,
+        "state_transition_kind": None,
+        "post_state_digest": None,
+        "joint_action_set_id": None,
+        "realized_order": None,
+        "interaction_ref": None,
+        "interaction_class": "shared_state_change",
+        "shared_state_refs": list(spec.target_refs),
+        "details": {
+            "source_container": spec.source_container,
+            "command": list(spec.command),
+            "target_refs": list(spec.target_refs),
+        },
+    }
+
+
+def _observation_event(
+    spec: ParticipantActionSpec,
+    state: ParticipantEpisodeExecutionState,
+    action_instance_id: str,
+    timestamp: str,
+    observation: ParticipantCommandObservation,
+) -> dict[str, object]:
+    """Build the behavior-history event for the participant observation."""
+
+    digest = hashlib.sha256(
+        f"{observation.stdout}\n{observation.stderr}".encode("utf-8")
+    ).hexdigest()
+    return {
+        "event_type": ParticipantBehaviorHistoryEventType.OBSERVATION_EMITTED.value,
+        "timestamp": timestamp,
+        "participant_address": state.participant_address,
+        "episode_id": state.episode_id,
+        "action_instance_id": action_instance_id,
+        "action_contract_address": spec.action_contract_address,
+        "observation_boundary_address": spec.observation_boundary_address,
+        "observation_status": ParticipantObservationStatus.TERMINAL.value,
+        "actor_provenance": spec.actor_provenance,
+        "lifecycle_phase": ParticipantRuntimeLifecyclePhase.OBSERVATION_EMISSION.value,
+        "phase_realization": ParticipantPhaseRealization.OBSERVED.value,
+        "admission_disposition": None,
+        "operation_ref": None,
+        "operation_state": None,
+        "state_transition_kind": None,
+        "post_state_digest": f"sha256:{digest}",
+        "joint_action_set_id": None,
+        "realized_order": None,
+        "interaction_ref": None,
+        "interaction_class": "shared_state_change",
+        "shared_state_refs": list(spec.target_refs),
+        "details": {
+            "returncode": observation.returncode,
+            "success": observation.success,
+            "stdout_excerpt": observation.stdout[:2000],
+            "stderr_excerpt": observation.stderr[:2000],
+            "success_markers": list(spec.success_markers),
+        },
+    }
+
+
+def _action_snapshot_entries(
+    spec: ParticipantActionSpec,
+    action_instance_id: str,
+    success: bool,
+) -> dict[str, SnapshotEntry]:
+    """Build participant snapshot entries for the action contract and result."""
+
+    return {
+        PARTICIPANT_BEHAVIOR_ADDRESS: SnapshotEntry(
+            address=PARTICIPANT_BEHAVIOR_ADDRESS,
+            domain=RuntimeDomain.PARTICIPANT,
+            resource_type="participant-behavior",
+            payload={
+                "action_contract_addresses": [spec.action_contract_address],
+                "observation_boundary_addresses": [
+                    spec.observation_boundary_address
+                ],
+                "shared_state_refs": list(spec.target_refs),
+            },
+        ),
+        spec.action_contract_address: SnapshotEntry(
+            address=spec.action_contract_address,
+            domain=RuntimeDomain.PARTICIPANT,
+            resource_type="participant-action-contract",
+            payload={
+                "name": "APTL Kali victim SSH probe",
+                "action_name": "kali-victim-ssh-probe",
+                "semantic_version": "1.0.0",
+                "lifecycle_state": "active",
+                "behavioral_granularity": "single-command",
+                "interaction_classes": ["shared_state_change"],
+                "shared_state_refs": list(spec.target_refs),
+                "source_container": spec.source_container,
+                "command": list(spec.command),
+                "success_markers": list(spec.success_markers),
+                "target_refs": list(spec.target_refs),
+            },
+        ),
+        spec.observation_boundary_address: SnapshotEntry(
+            address=spec.observation_boundary_address,
+            domain=RuntimeDomain.PARTICIPANT,
+            resource_type="participant-observation-boundary",
+            payload={
+                "name": "APTL Kali victim SSH observation boundary",
+                "boundary_name": "kali-victim-ssh-probe-output",
+                "projection_basis": "nmap grepable output excerpt",
+                "observable_refs": list(spec.target_refs),
+                "evidence_refs": [action_instance_id],
+                "disclosed_refs": list(spec.target_refs),
+                "realized_view_disclosure": "terminal-observation",
+                "source_container": spec.source_container,
+                "target_refs": list(spec.target_refs),
+            },
+        ),
+        action_instance_id: SnapshotEntry(
+            address=action_instance_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            resource_type="participant-action-instance",
+            payload={
+                "action_contract_address": spec.action_contract_address,
+                "observation_boundary_address": spec.observation_boundary_address,
+                "actor_provenance": spec.actor_provenance,
+                "success": success,
+            },
+            ordering_dependencies=(spec.action_contract_address,),
+            refresh_dependencies=(spec.observation_boundary_address,),
+            status="ready" if success else "failed",
+        ),
+    }
+
+
+def _shared_state_records(
+    spec: ParticipantActionSpec,
+    action_instance_id: str,
+    success: bool,
+) -> dict[str, dict[str, object]]:
+    """Build shared-state records touched by the participant action."""
+
+    records: dict[str, dict[str, object]] = {}
+    for ref in spec.target_refs:
+        state_kind = "network-service" if ref.startswith("tcp:") else "container"
+        digest = hashlib.sha256(
+            f"{ref}:{action_instance_id}:{success}".encode("utf-8")
+        ).hexdigest()
+        records[ref] = {
+            "state_address": ref,
+            "state_scope": "aptl-techvault-live-range",
+            "state_kind": state_kind,
+            "ordering_basis": "participant-action-observation",
+            "conflict_policy": "single-writer-observation",
+            "provenance": spec.actor_provenance,
+            "digest": f"sha256:{digest}",
+            "accesses": [
+                {
+                    "state_address": ref,
+                    "access_kind": "read",
+                    "read_digest": f"sha256:{digest}",
+                    "operation_ref": f"container_exec:{spec.source_container}",
+                }
+            ],
+            "evidence_refs": [action_instance_id],
+        }
+    return records

--- a/src/aptl/backends/aces_participant_runtime.py
+++ b/src/aptl/backends/aces_participant_runtime.py
@@ -45,7 +45,7 @@ from aptl.utils.redaction import redact
 if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
 
-PARTICIPANT_ACTION_ADDRESS = "participant.techvault.kali-victim-ssh-probe"
+PARTICIPANT_ACTION_ADDRESS = "participant.behavior.techvault.kali-victim-ssh-probe"
 PARTICIPANT_ACTION_CONTRACT_ADDRESS = (
     "participant.action-contract.aptl.kali-victim-ssh-probe"
 )
@@ -128,21 +128,32 @@ def _snapshot(
     results: Mapping[str, dict[str, object]],
     history: Mapping[str, list[dict[str, object]]],
     behavior_history: Mapping[str, list[dict[str, object]]],
+    shared_state_records: Mapping[str, dict[str, object]] | None = None,
+    shared_state_history: Mapping[str, list[dict[str, object]]] | None = None,
 ) -> RuntimeSnapshot:
-    return baseline.with_entries(
-        dict(entries),
-        participant_episode_results={
+    updates: dict[str, object] = {
+        "participant_episode_results": {
             address: dict(result) for address, result in results.items()
         },
-        participant_episode_history={
+        "participant_episode_history": {
             address: [dict(event) for event in events]
             for address, events in history.items()
         },
-        participant_behavior_history={
+        "participant_behavior_history": {
             address: [dict(event) for event in events]
             for address, events in behavior_history.items()
         },
-    )
+    }
+    if shared_state_records is not None and hasattr(baseline, "shared_state_records"):
+        updates["shared_state_records"] = {
+            address: dict(record) for address, record in shared_state_records.items()
+        }
+    if shared_state_history is not None and hasattr(baseline, "shared_state_history"):
+        updates["shared_state_history"] = {
+            address: [dict(record) for record in records]
+            for address, records in shared_state_history.items()
+        }
+    return baseline.with_entries(dict(entries), **updates)
 
 
 @dataclass
@@ -158,6 +169,12 @@ class AptlParticipantRuntime:
         default_factory=dict, init=False
     )
     _behavior_history: dict[str, list[dict[str, object]]] = field(
+        default_factory=dict, init=False
+    )
+    _shared_state_records: dict[str, dict[str, object]] = field(
+        default_factory=dict, init=False
+    )
+    _shared_state_history: dict[str, list[dict[str, object]]] = field(
         default_factory=dict, init=False
     )
 
@@ -197,9 +214,22 @@ class AptlParticipantRuntime:
         next_snapshot, changed = self._store_episode(snapshot, state, events)
         action_result = self._drive_configured_action(participant_address, state)
         if action_result is not None:
-            success, action_events, diagnostics, action_entries = action_result
+            (
+                success,
+                action_events,
+                diagnostics,
+                action_entries,
+                shared_state_records,
+            ) = action_result
             self._behavior_history.setdefault(participant_address, []).extend(
                 action_events
+            )
+            self._shared_state_records.update(shared_state_records)
+            self._shared_state_history.update(
+                {
+                    address: [dict(record)]
+                    for address, record in shared_state_records.items()
+                }
             )
             next_snapshot = _snapshot(
                 next_snapshot,
@@ -207,11 +237,18 @@ class AptlParticipantRuntime:
                 self._results,
                 self._history,
                 self._behavior_history,
+                self._shared_state_records,
+                self._shared_state_history,
             )
             changed.append(
                 f"runtime.snapshot.participant-behavior-history.{participant_address}"
             )
             changed.extend(action_entries)
+            if hasattr(next_snapshot, "shared_state_records"):
+                changed.extend(
+                    f"runtime.snapshot.shared-state-records.{address}"
+                    for address in shared_state_records
+                )
             return ApplyResult(
                 success=success,
                 snapshot=next_snapshot,
@@ -403,6 +440,8 @@ class AptlParticipantRuntime:
             self._results,
             self._history,
             self._behavior_history,
+            self._shared_state_records,
+            self._shared_state_history,
         )
         return next_snapshot, [
             f"runtime.snapshot.participant-episode-results.{participant_address}",
@@ -452,6 +491,7 @@ class AptlParticipantRuntime:
             list[dict[str, object]],
             list[Diagnostic],
             dict[str, SnapshotEntry],
+            dict[str, dict[str, object]],
         ]
         | None
     ):
@@ -513,6 +553,7 @@ class AptlParticipantRuntime:
             [attempted, observed],
             diagnostics,
             _action_snapshot_entries(spec, action_instance_id, success),
+            _shared_state_records(spec, action_instance_id, success),
         )
 
     def _failed(
@@ -560,6 +601,7 @@ def _action_attempted_event(
         "joint_action_set_id": None,
         "realized_order": None,
         "interaction_ref": None,
+        "interaction_class": "shared_state_change",
         "shared_state_refs": list(spec.target_refs),
         "details": {
             "source_container": spec.source_container,
@@ -601,6 +643,7 @@ def _observation_event(
         "joint_action_set_id": None,
         "realized_order": None,
         "interaction_ref": None,
+        "interaction_class": "shared_state_change",
         "shared_state_refs": list(spec.target_refs),
         "details": {
             "returncode": returncode,
@@ -618,11 +661,30 @@ def _action_snapshot_entries(
     success: bool,
 ) -> dict[str, SnapshotEntry]:
     return {
+        PARTICIPANT_BEHAVIOR_ADDRESS: SnapshotEntry(
+            address=PARTICIPANT_BEHAVIOR_ADDRESS,
+            domain=RuntimeDomain.PARTICIPANT,
+            resource_type="participant-behavior",
+            payload={
+                "action_contract_addresses": [spec.action_contract_address],
+                "observation_boundary_addresses": [
+                    spec.observation_boundary_address
+                ],
+                "shared_state_refs": list(spec.target_refs),
+            },
+        ),
         spec.action_contract_address: SnapshotEntry(
             address=spec.action_contract_address,
             domain=RuntimeDomain.PARTICIPANT,
             resource_type="participant-action-contract",
             payload={
+                "name": "APTL Kali victim SSH probe",
+                "action_name": "kali-victim-ssh-probe",
+                "semantic_version": "1.0.0",
+                "lifecycle_state": "active",
+                "behavioral_granularity": "single-command",
+                "interaction_classes": ["shared_state_change"],
+                "shared_state_refs": list(spec.target_refs),
                 "source_container": spec.source_container,
                 "command": list(spec.command),
                 "success_markers": list(spec.success_markers),
@@ -634,6 +696,13 @@ def _action_snapshot_entries(
             domain=RuntimeDomain.PARTICIPANT,
             resource_type="participant-observation-boundary",
             payload={
+                "name": "APTL Kali victim SSH observation boundary",
+                "boundary_name": "kali-victim-ssh-probe-output",
+                "projection_basis": "nmap grepable output excerpt",
+                "observable_refs": list(spec.target_refs),
+                "evidence_refs": [action_instance_id],
+                "disclosed_refs": list(spec.target_refs),
+                "realized_view_disclosure": "terminal-observation",
                 "source_container": spec.source_container,
                 "target_refs": list(spec.target_refs),
             },
@@ -653,3 +722,35 @@ def _action_snapshot_entries(
             status="ready" if success else "failed",
         ),
     }
+
+
+def _shared_state_records(
+    spec: ParticipantActionSpec,
+    action_instance_id: str,
+    success: bool,
+) -> dict[str, dict[str, object]]:
+    records: dict[str, dict[str, object]] = {}
+    for ref in spec.target_refs:
+        state_kind = "network-service" if ref.startswith("tcp:") else "container"
+        digest = hashlib.sha256(
+            f"{ref}:{action_instance_id}:{success}".encode("utf-8")
+        ).hexdigest()
+        records[ref] = {
+            "state_address": ref,
+            "state_scope": "aptl-techvault-live-range",
+            "state_kind": state_kind,
+            "ordering_basis": "participant-action-observation",
+            "conflict_policy": "single-writer-observation",
+            "provenance": spec.actor_provenance,
+            "digest": f"sha256:{digest}",
+            "accesses": [
+                {
+                    "state_address": ref,
+                    "access_kind": "read",
+                    "read_digest": f"sha256:{digest}",
+                    "operation_ref": f"container_exec:{spec.source_container}",
+                }
+            ],
+            "evidence_refs": [action_instance_id],
+        }
+    return records

--- a/src/aptl/backends/aces_participant_runtime.py
+++ b/src/aptl/backends/aces_participant_runtime.py
@@ -1,0 +1,655 @@
+"""APTL ACES participant runtime adapter.
+
+APTL's participant runtime is intentionally narrow: it exposes the ACES
+participant episode lifecycle through the published DTOs and records a bounded
+behavior-history event when a configured participant action is driven against a
+realized container. The destructive live proof uses that action surface to drive
+Kali against the monitored victim container; generic conformance probes exercise
+the lifecycle without requiring a live lab.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.participant_behavior import (
+    ParticipantBehaviorHistoryEventType,
+    ParticipantLifecycleOperationState,
+    ParticipantObservationStatus,
+    ParticipantPhaseRealization,
+    ParticipantRuntimeLifecyclePhase,
+)
+from aces_contracts.participant_episode import (
+    ParticipantEpisodeControlAction,
+    ParticipantEpisodeExecutionState,
+    ParticipantEpisodeHistoryEvent,
+    ParticipantEpisodeHistoryEventType,
+    ParticipantEpisodeInitializeRequest,
+    ParticipantEpisodeResetRequest,
+    ParticipantEpisodeRestartRequest,
+    ParticipantEpisodeStatus,
+    ParticipantEpisodeTerminalReason,
+    ParticipantEpisodeTerminateRequest,
+)
+from aces_contracts.planning import RuntimeDomain
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
+
+from aptl.utils.redaction import redact
+
+if TYPE_CHECKING:
+    from aptl.core.deployment.backend import DeploymentBackend
+
+PARTICIPANT_ACTION_ADDRESS = "participant.techvault.kali-victim-ssh-probe"
+PARTICIPANT_ACTION_CONTRACT_ADDRESS = (
+    "participant.action-contract.aptl.kali-victim-ssh-probe"
+)
+PARTICIPANT_OBSERVATION_BOUNDARY_ADDRESS = (
+    "participant.observation-boundary.aptl.kali-victim-ssh-probe"
+)
+PARTICIPANT_BEHAVIOR_ADDRESS = PARTICIPANT_ACTION_ADDRESS
+
+
+@dataclass(frozen=True)
+class ParticipantActionSpec:
+    """A bounded participant action that can be driven through the backend."""
+
+    source_container: str
+    command: tuple[str, ...]
+    success_markers: tuple[str, ...]
+    action_contract_address: str
+    observation_boundary_address: str
+    actor_provenance: str = "codex-cli"
+    target_refs: tuple[str, ...] = ()
+    timeout_seconds: int = 120
+
+
+DEFAULT_PARTICIPANT_ACTIONS = {
+    PARTICIPANT_ACTION_ADDRESS: ParticipantActionSpec(
+        source_container="aptl-kali",
+        command=("nmap", "-p", "22", "-Pn", "--open", "172.20.2.20", "-oG", "-"),
+        success_markers=("22/open",),
+        action_contract_address=PARTICIPANT_ACTION_CONTRACT_ADDRESS,
+        observation_boundary_address=PARTICIPANT_OBSERVATION_BOUNDARY_ADDRESS,
+        target_refs=(
+            "container:aptl-kali",
+            "container:aptl-victim",
+            "tcp:172.20.2.20:22",
+        ),
+    )
+}
+
+
+def _utc_now() -> str:
+    """Return the current UTC instant as an ISO-8601 ``...Z`` string."""
+
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _diagnostic(code: str, address: str, message: str) -> Diagnostic:
+    """Build a redacted participant-runtime error diagnostic."""
+
+    return Diagnostic(
+        code=code,
+        domain=RuntimeDomain.PARTICIPANT.value,
+        address=address,
+        message=redact(message),
+        severity=Severity.ERROR,
+    )
+
+
+def _terminal_event(
+    reason: ParticipantEpisodeTerminalReason,
+) -> ParticipantEpisodeHistoryEventType:
+    return {
+        ParticipantEpisodeTerminalReason.COMPLETED: (
+            ParticipantEpisodeHistoryEventType.EPISODE_COMPLETED
+        ),
+        ParticipantEpisodeTerminalReason.TIMED_OUT: (
+            ParticipantEpisodeHistoryEventType.EPISODE_TIMED_OUT
+        ),
+        ParticipantEpisodeTerminalReason.TRUNCATED: (
+            ParticipantEpisodeHistoryEventType.EPISODE_TRUNCATED
+        ),
+        ParticipantEpisodeTerminalReason.INTERRUPTED: (
+            ParticipantEpisodeHistoryEventType.EPISODE_INTERRUPTED
+        ),
+    }[reason]
+
+
+def _snapshot(
+    baseline: RuntimeSnapshot,
+    entries: Mapping[str, SnapshotEntry],
+    results: Mapping[str, dict[str, object]],
+    history: Mapping[str, list[dict[str, object]]],
+    behavior_history: Mapping[str, list[dict[str, object]]],
+) -> RuntimeSnapshot:
+    return baseline.with_entries(
+        dict(entries),
+        participant_episode_results={
+            address: dict(result) for address, result in results.items()
+        },
+        participant_episode_history={
+            address: [dict(event) for event in events]
+            for address, events in history.items()
+        },
+        participant_behavior_history={
+            address: [dict(event) for event in events]
+            for address, events in behavior_history.items()
+        },
+    )
+
+
+@dataclass
+class AptlParticipantRuntime:
+    """ACES ``ParticipantRuntime`` backed by APTL's deployment boundary."""
+
+    deployment_backend: "DeploymentBackend"
+    action_specs: Mapping[str, ParticipantActionSpec] = field(
+        default_factory=lambda: dict(DEFAULT_PARTICIPANT_ACTIONS)
+    )
+    _results: dict[str, dict[str, object]] = field(default_factory=dict, init=False)
+    _history: dict[str, list[dict[str, object]]] = field(
+        default_factory=dict, init=False
+    )
+    _behavior_history: dict[str, list[dict[str, object]]] = field(
+        default_factory=dict, init=False
+    )
+
+    def initialize(
+        self,
+        request: ParticipantEpisodeInitializeRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Create a running episode and drive any configured proof action."""
+
+        participant_address = request.participant_address
+        now = _utc_now()
+        episode_id = request.episode_id or uuid4().hex
+        state = ParticipantEpisodeExecutionState(
+            participant_address=participant_address,
+            episode_id=episode_id,
+            sequence_number=0,
+            status=ParticipantEpisodeStatus.RUNNING,
+            initialized_at=now,
+            updated_at=now,
+            last_control_action=ParticipantEpisodeControlAction.INITIALIZE,
+        )
+        events = [
+            self._episode_event(
+                ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED,
+                now,
+                state,
+                ParticipantEpisodeControlAction.INITIALIZE,
+            ),
+            self._episode_event(
+                ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                now,
+                state,
+                None,
+            ),
+        ]
+        next_snapshot, changed = self._store_episode(snapshot, state, events)
+        action_result = self._drive_configured_action(participant_address, state)
+        if action_result is not None:
+            success, action_events, diagnostics, action_entries = action_result
+            self._behavior_history.setdefault(participant_address, []).extend(
+                action_events
+            )
+            next_snapshot = _snapshot(
+                next_snapshot,
+                {**next_snapshot.entries, **action_entries},
+                self._results,
+                self._history,
+                self._behavior_history,
+            )
+            changed.append(
+                f"runtime.snapshot.participant-behavior-history.{participant_address}"
+            )
+            changed.extend(action_entries)
+            return ApplyResult(
+                success=success,
+                snapshot=next_snapshot,
+                diagnostics=diagnostics,
+                changed_addresses=changed,
+            )
+        return ApplyResult(
+            success=True, snapshot=next_snapshot, changed_addresses=changed
+        )
+
+    def reset(
+        self,
+        request: ParticipantEpisodeResetRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Start a replacement episode from a non-terminal predecessor."""
+
+        current = self._current_state(request.participant_address, snapshot)
+        if current is None:
+            return self.initialize(
+                ParticipantEpisodeInitializeRequest(
+                    participant_address=request.participant_address,
+                    episode_id=request.episode_id,
+                ),
+                snapshot,
+            )
+        if current.status == ParticipantEpisodeStatus.TERMINATED:
+            return self._failed(
+                snapshot,
+                request.participant_address,
+                "reset requires a non-terminal episode",
+            )
+        return self._advance_episode(
+            snapshot,
+            current,
+            request.episode_id or uuid4().hex,
+            current.sequence_number + 1,
+            ParticipantEpisodeControlAction.RESET,
+            ParticipantEpisodeHistoryEventType.EPISODE_RESET,
+        )
+
+    def restart(
+        self,
+        request: ParticipantEpisodeRestartRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Start a replacement episode from a terminated predecessor."""
+
+        current = self._current_state(request.participant_address, snapshot)
+        if current is None:
+            return self.initialize(
+                ParticipantEpisodeInitializeRequest(
+                    participant_address=request.participant_address,
+                    episode_id=request.episode_id,
+                ),
+                snapshot,
+            )
+        if current.status != ParticipantEpisodeStatus.TERMINATED:
+            return self._failed(
+                snapshot,
+                request.participant_address,
+                "restart requires a terminated episode",
+            )
+        return self._advance_episode(
+            snapshot,
+            current,
+            request.episode_id or uuid4().hex,
+            current.sequence_number + 1,
+            ParticipantEpisodeControlAction.RESTART,
+            ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED,
+        )
+
+    def terminate(
+        self,
+        request: ParticipantEpisodeTerminateRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Terminate the current episode with the requested terminal reason."""
+
+        current = self._current_state(request.participant_address, snapshot)
+        if current is None:
+            return self._failed(
+                snapshot,
+                request.participant_address,
+                "terminate requires an initialized episode",
+            )
+        now = _utc_now()
+        state = ParticipantEpisodeExecutionState(
+            participant_address=current.participant_address,
+            episode_id=current.episode_id,
+            sequence_number=current.sequence_number,
+            status=ParticipantEpisodeStatus.TERMINATED,
+            terminal_reason=request.terminal_reason,
+            initialized_at=current.initialized_at,
+            updated_at=now,
+            terminated_at=now,
+            last_control_action=current.last_control_action,
+            previous_episode_id=current.previous_episode_id,
+        )
+        event = self._episode_event(
+            _terminal_event(request.terminal_reason),
+            now,
+            state,
+            None,
+            terminal_reason=request.terminal_reason,
+            details={"detail": request.detail},
+        )
+        next_snapshot, changed = self._store_episode(snapshot, state, [event])
+        return ApplyResult(
+            success=True, snapshot=next_snapshot, changed_addresses=changed
+        )
+
+    def status(self) -> dict[str, object]:
+        """Return current participant runtime status."""
+
+        return {
+            "backend": "aptl",
+            "participants": sorted(self._results),
+            "action_participants": sorted(self.action_specs),
+        }
+
+    def results(self) -> dict[str, dict[str, object]]:
+        """Return the most recent participant episode state envelopes."""
+
+        return {address: dict(result) for address, result in self._results.items()}
+
+    def history(self) -> dict[str, list[dict[str, object]]]:
+        """Return participant episode history event streams."""
+
+        return {
+            address: [dict(event) for event in events]
+            for address, events in self._history.items()
+        }
+
+    def behavior_history(self) -> dict[str, list[dict[str, object]]]:
+        """Return participant behavior history event streams."""
+
+        return {
+            address: [dict(event) for event in events]
+            for address, events in self._behavior_history.items()
+        }
+
+    def _advance_episode(
+        self,
+        snapshot: RuntimeSnapshot,
+        current: ParticipantEpisodeExecutionState,
+        episode_id: str,
+        sequence_number: int,
+        action: ParticipantEpisodeControlAction,
+        event_type: ParticipantEpisodeHistoryEventType,
+    ) -> ApplyResult:
+        now = _utc_now()
+        state = ParticipantEpisodeExecutionState(
+            participant_address=current.participant_address,
+            episode_id=episode_id,
+            sequence_number=sequence_number,
+            status=ParticipantEpisodeStatus.RUNNING,
+            initialized_at=now,
+            updated_at=now,
+            last_control_action=action,
+            previous_episode_id=current.episode_id,
+        )
+        events = [
+            self._episode_event(event_type, now, state, action),
+            self._episode_event(
+                ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                now,
+                state,
+                None,
+            ),
+        ]
+        next_snapshot, changed = self._store_episode(snapshot, state, events)
+        return ApplyResult(
+            success=True, snapshot=next_snapshot, changed_addresses=changed
+        )
+
+    def _store_episode(
+        self,
+        snapshot: RuntimeSnapshot,
+        state: ParticipantEpisodeExecutionState,
+        events: list[dict[str, object]],
+    ) -> tuple[RuntimeSnapshot, list[str]]:
+        participant_address = state.participant_address
+        self._results[participant_address] = state.to_payload()
+        self._history.setdefault(participant_address, []).extend(events)
+        next_snapshot = _snapshot(
+            snapshot,
+            snapshot.entries,
+            self._results,
+            self._history,
+            self._behavior_history,
+        )
+        return next_snapshot, [
+            f"runtime.snapshot.participant-episode-results.{participant_address}",
+            f"runtime.snapshot.participant-episode-history.{participant_address}",
+        ]
+
+    def _current_state(
+        self,
+        participant_address: str,
+        snapshot: RuntimeSnapshot,
+    ) -> ParticipantEpisodeExecutionState | None:
+        payload = self._results.get(
+            participant_address
+        ) or snapshot.participant_episode_results.get(participant_address)
+        if not payload:
+            return None
+        return ParticipantEpisodeExecutionState.from_payload(payload)
+
+    def _episode_event(
+        self,
+        event_type: ParticipantEpisodeHistoryEventType,
+        timestamp: str,
+        state: ParticipantEpisodeExecutionState,
+        control_action: ParticipantEpisodeControlAction | None,
+        *,
+        terminal_reason: ParticipantEpisodeTerminalReason | None = None,
+        details: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return ParticipantEpisodeHistoryEvent(
+            event_type=event_type,
+            timestamp=timestamp,
+            participant_address=state.participant_address,
+            episode_id=state.episode_id,
+            sequence_number=state.sequence_number,
+            terminal_reason=terminal_reason,
+            control_action=control_action,
+            details=dict(details or {}),
+        ).to_payload()
+
+    def _drive_configured_action(
+        self,
+        participant_address: str,
+        state: ParticipantEpisodeExecutionState,
+    ) -> (
+        tuple[
+            bool,
+            list[dict[str, object]],
+            list[Diagnostic],
+            dict[str, SnapshotEntry],
+        ]
+        | None
+    ):
+        spec = self.action_specs.get(participant_address)
+        if spec is None:
+            return None
+        action_instance_id = f"{participant_address}.{uuid4().hex}"
+        started_at = _utc_now()
+        attempted = _action_attempted_event(spec, state, action_instance_id, started_at)
+        diagnostics = []
+        stdout = ""
+        stderr = ""
+        returncode = 1
+        try:
+            result = self.deployment_backend.container_exec(
+                spec.source_container,
+                list(spec.command),
+                timeout=spec.timeout_seconds,
+            )
+            stdout = redact(str(getattr(result, "stdout", "")))
+            stderr = redact(str(getattr(result, "stderr", "")))
+            returncode = int(getattr(result, "returncode", 1))
+        except Exception as exc:  # noqa: BLE001 - backend boundary failure -> Diagnostic.
+            stderr = redact(f"{type(exc).__name__}: {exc}")
+            diagnostics.append(
+                _diagnostic(
+                    "aptl.participant-runtime.action-backend-failed",
+                    participant_address,
+                    "Participant action backend call failed: " + stderr,
+                )
+            )
+        finished_at = _utc_now()
+        combined = f"{stdout}\n{stderr}"
+        marker_ok = all(marker in combined for marker in spec.success_markers)
+        success = returncode == 0 and marker_ok
+        observed = _observation_event(
+            spec,
+            state,
+            action_instance_id,
+            finished_at,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+            success=success,
+        )
+        if not success:
+            diagnostics.append(
+                _diagnostic(
+                    "aptl.participant-runtime.action-failed",
+                    participant_address,
+                    (
+                        "Participant action did not observe the expected lab result "
+                        f"(returncode={returncode}, markers={spec.success_markers})."
+                    ),
+                )
+            )
+        return (
+            success,
+            [attempted, observed],
+            diagnostics,
+            _action_snapshot_entries(spec, action_instance_id, success),
+        )
+
+    def _failed(
+        self,
+        snapshot: RuntimeSnapshot,
+        participant_address: str,
+        message: str,
+    ) -> ApplyResult:
+        return ApplyResult(
+            success=False,
+            snapshot=snapshot,
+            diagnostics=[
+                _diagnostic(
+                    "aptl.participant-runtime.invalid-transition",
+                    participant_address,
+                    message,
+                )
+            ],
+        )
+
+
+def _action_attempted_event(
+    spec: ParticipantActionSpec,
+    state: ParticipantEpisodeExecutionState,
+    action_instance_id: str,
+    timestamp: str,
+) -> dict[str, object]:
+    return {
+        "event_type": ParticipantBehaviorHistoryEventType.ACTION_ATTEMPTED.value,
+        "timestamp": timestamp,
+        "participant_address": state.participant_address,
+        "episode_id": state.episode_id,
+        "action_instance_id": action_instance_id,
+        "action_contract_address": spec.action_contract_address,
+        "observation_boundary_address": None,
+        "observation_status": None,
+        "actor_provenance": spec.actor_provenance,
+        "lifecycle_phase": ParticipantRuntimeLifecyclePhase.EXECUTION_ATTEMPT.value,
+        "phase_realization": ParticipantPhaseRealization.RUNTIME_MEDIATED.value,
+        "admission_disposition": None,
+        "operation_ref": f"container_exec:{spec.source_container}",
+        "operation_state": ParticipantLifecycleOperationState.RUNNING.value,
+        "state_transition_kind": None,
+        "post_state_digest": None,
+        "joint_action_set_id": None,
+        "realized_order": None,
+        "interaction_ref": None,
+        "shared_state_refs": list(spec.target_refs),
+        "details": {
+            "source_container": spec.source_container,
+            "command": list(spec.command),
+            "target_refs": list(spec.target_refs),
+        },
+    }
+
+
+def _observation_event(
+    spec: ParticipantActionSpec,
+    state: ParticipantEpisodeExecutionState,
+    action_instance_id: str,
+    timestamp: str,
+    *,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    success: bool,
+) -> dict[str, object]:
+    digest = hashlib.sha256(f"{stdout}\n{stderr}".encode("utf-8")).hexdigest()
+    return {
+        "event_type": ParticipantBehaviorHistoryEventType.OBSERVATION_EMITTED.value,
+        "timestamp": timestamp,
+        "participant_address": state.participant_address,
+        "episode_id": state.episode_id,
+        "action_instance_id": action_instance_id,
+        "action_contract_address": spec.action_contract_address,
+        "observation_boundary_address": spec.observation_boundary_address,
+        "observation_status": ParticipantObservationStatus.TERMINAL.value,
+        "actor_provenance": spec.actor_provenance,
+        "lifecycle_phase": ParticipantRuntimeLifecyclePhase.OBSERVATION_EMISSION.value,
+        "phase_realization": ParticipantPhaseRealization.OBSERVED.value,
+        "admission_disposition": None,
+        "operation_ref": None,
+        "operation_state": None,
+        "state_transition_kind": None,
+        "post_state_digest": f"sha256:{digest}",
+        "joint_action_set_id": None,
+        "realized_order": None,
+        "interaction_ref": None,
+        "shared_state_refs": list(spec.target_refs),
+        "details": {
+            "returncode": returncode,
+            "success": success,
+            "stdout_excerpt": stdout[:2000],
+            "stderr_excerpt": stderr[:2000],
+            "success_markers": list(spec.success_markers),
+        },
+    }
+
+
+def _action_snapshot_entries(
+    spec: ParticipantActionSpec,
+    action_instance_id: str,
+    success: bool,
+) -> dict[str, SnapshotEntry]:
+    return {
+        spec.action_contract_address: SnapshotEntry(
+            address=spec.action_contract_address,
+            domain=RuntimeDomain.PARTICIPANT,
+            resource_type="participant-action-contract",
+            payload={
+                "source_container": spec.source_container,
+                "command": list(spec.command),
+                "success_markers": list(spec.success_markers),
+                "target_refs": list(spec.target_refs),
+            },
+        ),
+        spec.observation_boundary_address: SnapshotEntry(
+            address=spec.observation_boundary_address,
+            domain=RuntimeDomain.PARTICIPANT,
+            resource_type="participant-observation-boundary",
+            payload={
+                "source_container": spec.source_container,
+                "target_refs": list(spec.target_refs),
+            },
+        ),
+        action_instance_id: SnapshotEntry(
+            address=action_instance_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            resource_type="participant-action-instance",
+            payload={
+                "action_contract_address": spec.action_contract_address,
+                "observation_boundary_address": spec.observation_boundary_address,
+                "actor_provenance": spec.actor_provenance,
+                "success": success,
+            },
+            ordering_dependencies=(spec.action_contract_address,),
+            refresh_dependencies=(spec.observation_boundary_address,),
+            status="ready" if success else "failed",
+        ),
+    }

--- a/src/aptl/backends/aces_participant_runtime.py
+++ b/src/aptl/backends/aces_participant_runtime.py
@@ -10,21 +10,12 @@ the lifecycle without requiring a live lab.
 
 from __future__ import annotations
 
-import hashlib
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from aces_contracts.diagnostics import Diagnostic, Severity
-from aces_contracts.participant_behavior import (
-    ParticipantBehaviorHistoryEventType,
-    ParticipantLifecycleOperationState,
-    ParticipantObservationStatus,
-    ParticipantPhaseRealization,
-    ParticipantRuntimeLifecyclePhase,
-)
 from aces_contracts.participant_episode import (
     ParticipantEpisodeControlAction,
     ParticipantEpisodeExecutionState,
@@ -37,52 +28,18 @@ from aces_contracts.participant_episode import (
     ParticipantEpisodeTerminalReason,
     ParticipantEpisodeTerminateRequest,
 )
-from aces_contracts.planning import RuntimeDomain
 from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
 
-from aptl.utils.redaction import redact
+from aptl.backends.aces_participant_actions import (
+    DEFAULT_PARTICIPANT_ACTIONS,
+    PARTICIPANT_ACTION_ADDRESS,
+    ParticipantActionSpec,
+    drive_participant_action,
+    participant_action_diagnostic,
+)
 
 if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
-
-PARTICIPANT_ACTION_ADDRESS = "participant.behavior.techvault.kali-victim-ssh-probe"
-PARTICIPANT_ACTION_CONTRACT_ADDRESS = (
-    "participant.action-contract.aptl.kali-victim-ssh-probe"
-)
-PARTICIPANT_OBSERVATION_BOUNDARY_ADDRESS = (
-    "participant.observation-boundary.aptl.kali-victim-ssh-probe"
-)
-PARTICIPANT_BEHAVIOR_ADDRESS = PARTICIPANT_ACTION_ADDRESS
-
-
-@dataclass(frozen=True)
-class ParticipantActionSpec:
-    """A bounded participant action that can be driven through the backend."""
-
-    source_container: str
-    command: tuple[str, ...]
-    success_markers: tuple[str, ...]
-    action_contract_address: str
-    observation_boundary_address: str
-    actor_provenance: str = "codex-cli"
-    target_refs: tuple[str, ...] = ()
-    timeout_seconds: int = 120
-
-
-DEFAULT_PARTICIPANT_ACTIONS = {
-    PARTICIPANT_ACTION_ADDRESS: ParticipantActionSpec(
-        source_container="aptl-kali",
-        command=("nmap", "-p", "22", "-Pn", "--open", "172.20.2.20", "-oG", "-"),
-        success_markers=("22/open",),
-        action_contract_address=PARTICIPANT_ACTION_CONTRACT_ADDRESS,
-        observation_boundary_address=PARTICIPANT_OBSERVATION_BOUNDARY_ADDRESS,
-        target_refs=(
-            "container:aptl-kali",
-            "container:aptl-victim",
-            "tcp:172.20.2.20:22",
-        ),
-    )
-}
 
 
 def _utc_now() -> str:
@@ -91,21 +48,11 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
-def _diagnostic(code: str, address: str, message: str) -> Diagnostic:
-    """Build a redacted participant-runtime error diagnostic."""
-
-    return Diagnostic(
-        code=code,
-        domain=RuntimeDomain.PARTICIPANT.value,
-        address=address,
-        message=redact(message),
-        severity=Severity.ERROR,
-    )
-
-
 def _terminal_event(
     reason: ParticipantEpisodeTerminalReason,
 ) -> ParticipantEpisodeHistoryEventType:
+    """Map a terminal reason to the participant episode history event type."""
+
     return {
         ParticipantEpisodeTerminalReason.COMPLETED: (
             ParticipantEpisodeHistoryEventType.EPISODE_COMPLETED
@@ -131,6 +78,8 @@ def _snapshot(
     shared_state_records: Mapping[str, dict[str, object]] | None = None,
     shared_state_history: Mapping[str, list[dict[str, object]]] | None = None,
 ) -> RuntimeSnapshot:
+    """Return a snapshot with participant state dictionaries replaced."""
+
     updates: dict[str, object] = {
         "participant_episode_results": {
             address: dict(result) for address, result in results.items()
@@ -212,28 +161,27 @@ class AptlParticipantRuntime:
             ),
         ]
         next_snapshot, changed = self._store_episode(snapshot, state, events)
-        action_result = self._drive_configured_action(participant_address, state)
+        action_result = drive_participant_action(
+            self.deployment_backend,
+            self.action_specs,
+            participant_address,
+            state,
+            timestamp_factory=_utc_now,
+        )
         if action_result is not None:
-            (
-                success,
-                action_events,
-                diagnostics,
-                action_entries,
-                shared_state_records,
-            ) = action_result
             self._behavior_history.setdefault(participant_address, []).extend(
-                action_events
+                action_result.behavior_events
             )
-            self._shared_state_records.update(shared_state_records)
+            self._shared_state_records.update(action_result.shared_state_records)
             self._shared_state_history.update(
                 {
                     address: [dict(record)]
-                    for address, record in shared_state_records.items()
+                    for address, record in action_result.shared_state_records.items()
                 }
             )
             next_snapshot = _snapshot(
                 next_snapshot,
-                {**next_snapshot.entries, **action_entries},
+                {**next_snapshot.entries, **action_result.snapshot_entries},
                 self._results,
                 self._history,
                 self._behavior_history,
@@ -243,16 +191,16 @@ class AptlParticipantRuntime:
             changed.append(
                 f"runtime.snapshot.participant-behavior-history.{participant_address}"
             )
-            changed.extend(action_entries)
+            changed.extend(action_result.snapshot_entries)
             if hasattr(next_snapshot, "shared_state_records"):
                 changed.extend(
                     f"runtime.snapshot.shared-state-records.{address}"
-                    for address in shared_state_records
+                    for address in action_result.shared_state_records
                 )
             return ApplyResult(
-                success=success,
+                success=action_result.success,
                 snapshot=next_snapshot,
-                diagnostics=diagnostics,
+                diagnostics=action_result.diagnostics,
                 changed_addresses=changed,
             )
         return ApplyResult(
@@ -400,6 +348,8 @@ class AptlParticipantRuntime:
         action: ParticipantEpisodeControlAction,
         event_type: ParticipantEpisodeHistoryEventType,
     ) -> ApplyResult:
+        """Advance an initialized episode to a replacement running episode."""
+
         now = _utc_now()
         state = ParticipantEpisodeExecutionState(
             participant_address=current.participant_address,
@@ -431,6 +381,8 @@ class AptlParticipantRuntime:
         state: ParticipantEpisodeExecutionState,
         events: list[dict[str, object]],
     ) -> tuple[RuntimeSnapshot, list[str]]:
+        """Persist participant episode state and history in a new snapshot."""
+
         participant_address = state.participant_address
         self._results[participant_address] = state.to_payload()
         self._history.setdefault(participant_address, []).extend(events)
@@ -453,6 +405,8 @@ class AptlParticipantRuntime:
         participant_address: str,
         snapshot: RuntimeSnapshot,
     ) -> ParticipantEpisodeExecutionState | None:
+        """Return the in-memory or snapshot-backed participant episode state."""
+
         payload = self._results.get(
             participant_address
         ) or snapshot.participant_episode_results.get(participant_address)
@@ -460,8 +414,8 @@ class AptlParticipantRuntime:
             return None
         return ParticipantEpisodeExecutionState.from_payload(payload)
 
+    @staticmethod
     def _episode_event(
-        self,
         event_type: ParticipantEpisodeHistoryEventType,
         timestamp: str,
         state: ParticipantEpisodeExecutionState,
@@ -470,6 +424,8 @@ class AptlParticipantRuntime:
         terminal_reason: ParticipantEpisodeTerminalReason | None = None,
         details: dict[str, object] | None = None,
     ) -> dict[str, object]:
+        """Build a participant episode history event payload."""
+
         return ParticipantEpisodeHistoryEvent(
             event_type=event_type,
             timestamp=timestamp,
@@ -481,276 +437,22 @@ class AptlParticipantRuntime:
             details=dict(details or {}),
         ).to_payload()
 
-    def _drive_configured_action(
-        self,
-        participant_address: str,
-        state: ParticipantEpisodeExecutionState,
-    ) -> (
-        tuple[
-            bool,
-            list[dict[str, object]],
-            list[Diagnostic],
-            dict[str, SnapshotEntry],
-            dict[str, dict[str, object]],
-        ]
-        | None
-    ):
-        spec = self.action_specs.get(participant_address)
-        if spec is None:
-            return None
-        action_instance_id = f"{participant_address}.{uuid4().hex}"
-        started_at = _utc_now()
-        attempted = _action_attempted_event(spec, state, action_instance_id, started_at)
-        diagnostics = []
-        stdout = ""
-        stderr = ""
-        returncode = 1
-        try:
-            result = self.deployment_backend.container_exec(
-                spec.source_container,
-                list(spec.command),
-                timeout=spec.timeout_seconds,
-            )
-            stdout = redact(str(getattr(result, "stdout", "")))
-            stderr = redact(str(getattr(result, "stderr", "")))
-            returncode = int(getattr(result, "returncode", 1))
-        except Exception as exc:  # noqa: BLE001 - backend boundary failure -> Diagnostic.
-            stderr = redact(f"{type(exc).__name__}: {exc}")
-            diagnostics.append(
-                _diagnostic(
-                    "aptl.participant-runtime.action-backend-failed",
-                    participant_address,
-                    "Participant action backend call failed: " + stderr,
-                )
-            )
-        finished_at = _utc_now()
-        combined = f"{stdout}\n{stderr}"
-        marker_ok = all(marker in combined for marker in spec.success_markers)
-        success = returncode == 0 and marker_ok
-        observed = _observation_event(
-            spec,
-            state,
-            action_instance_id,
-            finished_at,
-            returncode=returncode,
-            stdout=stdout,
-            stderr=stderr,
-            success=success,
-        )
-        if not success:
-            diagnostics.append(
-                _diagnostic(
-                    "aptl.participant-runtime.action-failed",
-                    participant_address,
-                    (
-                        "Participant action did not observe the expected lab result "
-                        f"(returncode={returncode}, markers={spec.success_markers})."
-                    ),
-                )
-            )
-        return (
-            success,
-            [attempted, observed],
-            diagnostics,
-            _action_snapshot_entries(spec, action_instance_id, success),
-            _shared_state_records(spec, action_instance_id, success),
-        )
-
+    @staticmethod
     def _failed(
-        self,
         snapshot: RuntimeSnapshot,
         participant_address: str,
         message: str,
     ) -> ApplyResult:
+        """Return a failed participant transition result."""
+
         return ApplyResult(
             success=False,
             snapshot=snapshot,
             diagnostics=[
-                _diagnostic(
+                participant_action_diagnostic(
                     "aptl.participant-runtime.invalid-transition",
                     participant_address,
                     message,
                 )
             ],
         )
-
-
-def _action_attempted_event(
-    spec: ParticipantActionSpec,
-    state: ParticipantEpisodeExecutionState,
-    action_instance_id: str,
-    timestamp: str,
-) -> dict[str, object]:
-    return {
-        "event_type": ParticipantBehaviorHistoryEventType.ACTION_ATTEMPTED.value,
-        "timestamp": timestamp,
-        "participant_address": state.participant_address,
-        "episode_id": state.episode_id,
-        "action_instance_id": action_instance_id,
-        "action_contract_address": spec.action_contract_address,
-        "observation_boundary_address": None,
-        "observation_status": None,
-        "actor_provenance": spec.actor_provenance,
-        "lifecycle_phase": ParticipantRuntimeLifecyclePhase.EXECUTION_ATTEMPT.value,
-        "phase_realization": ParticipantPhaseRealization.RUNTIME_MEDIATED.value,
-        "admission_disposition": None,
-        "operation_ref": f"container_exec:{spec.source_container}",
-        "operation_state": ParticipantLifecycleOperationState.RUNNING.value,
-        "state_transition_kind": None,
-        "post_state_digest": None,
-        "joint_action_set_id": None,
-        "realized_order": None,
-        "interaction_ref": None,
-        "interaction_class": "shared_state_change",
-        "shared_state_refs": list(spec.target_refs),
-        "details": {
-            "source_container": spec.source_container,
-            "command": list(spec.command),
-            "target_refs": list(spec.target_refs),
-        },
-    }
-
-
-def _observation_event(
-    spec: ParticipantActionSpec,
-    state: ParticipantEpisodeExecutionState,
-    action_instance_id: str,
-    timestamp: str,
-    *,
-    returncode: int,
-    stdout: str,
-    stderr: str,
-    success: bool,
-) -> dict[str, object]:
-    digest = hashlib.sha256(f"{stdout}\n{stderr}".encode("utf-8")).hexdigest()
-    return {
-        "event_type": ParticipantBehaviorHistoryEventType.OBSERVATION_EMITTED.value,
-        "timestamp": timestamp,
-        "participant_address": state.participant_address,
-        "episode_id": state.episode_id,
-        "action_instance_id": action_instance_id,
-        "action_contract_address": spec.action_contract_address,
-        "observation_boundary_address": spec.observation_boundary_address,
-        "observation_status": ParticipantObservationStatus.TERMINAL.value,
-        "actor_provenance": spec.actor_provenance,
-        "lifecycle_phase": ParticipantRuntimeLifecyclePhase.OBSERVATION_EMISSION.value,
-        "phase_realization": ParticipantPhaseRealization.OBSERVED.value,
-        "admission_disposition": None,
-        "operation_ref": None,
-        "operation_state": None,
-        "state_transition_kind": None,
-        "post_state_digest": f"sha256:{digest}",
-        "joint_action_set_id": None,
-        "realized_order": None,
-        "interaction_ref": None,
-        "interaction_class": "shared_state_change",
-        "shared_state_refs": list(spec.target_refs),
-        "details": {
-            "returncode": returncode,
-            "success": success,
-            "stdout_excerpt": stdout[:2000],
-            "stderr_excerpt": stderr[:2000],
-            "success_markers": list(spec.success_markers),
-        },
-    }
-
-
-def _action_snapshot_entries(
-    spec: ParticipantActionSpec,
-    action_instance_id: str,
-    success: bool,
-) -> dict[str, SnapshotEntry]:
-    return {
-        PARTICIPANT_BEHAVIOR_ADDRESS: SnapshotEntry(
-            address=PARTICIPANT_BEHAVIOR_ADDRESS,
-            domain=RuntimeDomain.PARTICIPANT,
-            resource_type="participant-behavior",
-            payload={
-                "action_contract_addresses": [spec.action_contract_address],
-                "observation_boundary_addresses": [
-                    spec.observation_boundary_address
-                ],
-                "shared_state_refs": list(spec.target_refs),
-            },
-        ),
-        spec.action_contract_address: SnapshotEntry(
-            address=spec.action_contract_address,
-            domain=RuntimeDomain.PARTICIPANT,
-            resource_type="participant-action-contract",
-            payload={
-                "name": "APTL Kali victim SSH probe",
-                "action_name": "kali-victim-ssh-probe",
-                "semantic_version": "1.0.0",
-                "lifecycle_state": "active",
-                "behavioral_granularity": "single-command",
-                "interaction_classes": ["shared_state_change"],
-                "shared_state_refs": list(spec.target_refs),
-                "source_container": spec.source_container,
-                "command": list(spec.command),
-                "success_markers": list(spec.success_markers),
-                "target_refs": list(spec.target_refs),
-            },
-        ),
-        spec.observation_boundary_address: SnapshotEntry(
-            address=spec.observation_boundary_address,
-            domain=RuntimeDomain.PARTICIPANT,
-            resource_type="participant-observation-boundary",
-            payload={
-                "name": "APTL Kali victim SSH observation boundary",
-                "boundary_name": "kali-victim-ssh-probe-output",
-                "projection_basis": "nmap grepable output excerpt",
-                "observable_refs": list(spec.target_refs),
-                "evidence_refs": [action_instance_id],
-                "disclosed_refs": list(spec.target_refs),
-                "realized_view_disclosure": "terminal-observation",
-                "source_container": spec.source_container,
-                "target_refs": list(spec.target_refs),
-            },
-        ),
-        action_instance_id: SnapshotEntry(
-            address=action_instance_id,
-            domain=RuntimeDomain.PARTICIPANT,
-            resource_type="participant-action-instance",
-            payload={
-                "action_contract_address": spec.action_contract_address,
-                "observation_boundary_address": spec.observation_boundary_address,
-                "actor_provenance": spec.actor_provenance,
-                "success": success,
-            },
-            ordering_dependencies=(spec.action_contract_address,),
-            refresh_dependencies=(spec.observation_boundary_address,),
-            status="ready" if success else "failed",
-        ),
-    }
-
-
-def _shared_state_records(
-    spec: ParticipantActionSpec,
-    action_instance_id: str,
-    success: bool,
-) -> dict[str, dict[str, object]]:
-    records: dict[str, dict[str, object]] = {}
-    for ref in spec.target_refs:
-        state_kind = "network-service" if ref.startswith("tcp:") else "container"
-        digest = hashlib.sha256(
-            f"{ref}:{action_instance_id}:{success}".encode("utf-8")
-        ).hexdigest()
-        records[ref] = {
-            "state_address": ref,
-            "state_scope": "aptl-techvault-live-range",
-            "state_kind": state_kind,
-            "ordering_basis": "participant-action-observation",
-            "conflict_policy": "single-writer-observation",
-            "provenance": spec.actor_provenance,
-            "digest": f"sha256:{digest}",
-            "accesses": [
-                {
-                    "state_address": ref,
-                    "access_kind": "read",
-                    "read_digest": f"sha256:{digest}",
-                    "operation_ref": f"container_exec:{spec.source_container}",
-                }
-            ],
-            "evidence_refs": [action_instance_id],
-        }
-    return records

--- a/src/aptl/backends/aces_participant_runtime.py
+++ b/src/aptl/backends/aces_participant_runtime.py
@@ -32,7 +32,7 @@ from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotE
 
 from aptl.backends.aces_participant_actions import (
     DEFAULT_PARTICIPANT_ACTIONS,
-    PARTICIPANT_ACTION_ADDRESS,
+    PARTICIPANT_ACTION_ADDRESS as _PARTICIPANT_ACTION_ADDRESS,
     ParticipantActionSpec,
     drive_participant_action,
     participant_action_diagnostic,
@@ -40,6 +40,8 @@ from aptl.backends.aces_participant_actions import (
 
 if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
+
+PARTICIPANT_ACTION_ADDRESS = _PARTICIPANT_ACTION_ADDRESS
 
 
 def _utc_now() -> str:

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -43,8 +43,7 @@ _OUTCOME_HEADLINES: dict[StartupOutcome, str] = {
         "should still run."
     ),
     StartupOutcome.DEGRADED_UNUSABLE: (
-        "Lab is degraded_unusable — some capabilities or SSH targets "
-        "are not reachable."
+        "Lab is degraded_unusable — some capabilities or SSH targets are not reachable."
     ),
     StartupOutcome.FAILED: "Lab start failed.",
 }
@@ -343,7 +342,7 @@ def validate_live(
         help="ACES SDL scenario (default: scenarios/techvault-operational.sdl.yaml).",
     ),
     profile: str = typer.Option(
-        "orchestration-evaluation",
+        "full-remote-control-plane",
         "--profile",
         help="ACES backend capability profile to validate against.",
     ),

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -203,9 +203,7 @@ def check_aces_driven_boot(
         state,
         scenario_path=scenario_path,
     )
-    return _check(
-        "aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, boot_diagnostics
-    )
+    return _check("aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, boot_diagnostics)
 
 
 # --------------------------------------------------------------------------- #
@@ -420,7 +418,7 @@ def check_run_archive_manifest(
         "snapshot": state.snapshot,
         "evidence": state.evidence,
         "evaluator_surfaces": {
-            "profile": "orchestration-evaluation",
+            "profile": "full-remote-control-plane",
             "contracts": [
                 "evaluation-result-envelope-v1",
                 "evaluation-history-event-stream-v1",
@@ -434,6 +432,15 @@ def check_run_archive_manifest(
                 "workflow-history-event-stream-v1",
             ],
             "execution_state_integration": "aptl.core.runtime.workflow_engine",
+        },
+        "participant_runtime_surfaces": {
+            "profile": "full-remote-control-plane",
+            "contracts": [
+                "participant-episode-state-envelope-v1",
+                "participant-episode-history-event-stream-v1",
+                "participant-behavior-history-event-stream-v1",
+            ],
+            "execution_state_integration": "aptl.backends.aces_participant_runtime",
         },
     }
 

--- a/src/aptl/validation/curated_live_proof.py
+++ b/src/aptl/validation/curated_live_proof.py
@@ -26,30 +26,8 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from aces_contracts.participant_behavior import (
-    iter_participant_behavior_snapshot_violations,
-)
-from aces_contracts.participant_episode import (
-    iter_participant_episode_snapshot_violations,
-)
-from aces_contracts.runtime_state import OperationState
-from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.manager import RuntimeManager
 from aces_sdl import parse_sdl_file
-
-try:
-    from aces_contracts.participant_concurrency import (
-        iter_participant_concurrency_snapshot_violations,
-    )
-except ImportError:  # pragma: no cover - compatibility with older ACES locks.
-    iter_participant_concurrency_snapshot_violations = None
-
-try:
-    from aces_contracts.participant_shared_state import (
-        iter_participant_shared_state_snapshot_violations,
-    )
-except ImportError:  # pragma: no cover - compatibility with older ACES locks.
-    iter_participant_shared_state_snapshot_violations = None
 
 from aptl.backends.aces import create_aptl_runtime_target
 from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS
@@ -63,8 +41,11 @@ from aptl.backends.aces_realization import interpret_provisioning_plan
 from aptl.core.config import AptlConfig
 from aptl.core.deployment import get_backend
 from aptl.core.snapshot import capture_snapshot
-from aptl.utils.redaction import redact
 from aptl.validation._gate_checks import _NoStartBackend
+from aptl.validation.participant_live_proof import (
+    run_participant_action_proof as _run_participant_action_proof,
+)
+from aptl.validation.range_snapshot_summary import summarize_snapshot
 
 
 @dataclass(frozen=True)
@@ -171,43 +152,6 @@ def _running_container_names(snapshot: Mapping[str, object]) -> list[str]:
     return names
 
 
-def summarize_snapshot(snapshot: Mapping[str, object]) -> dict[str, object]:
-    """Return an evidence-sized view of a range snapshot.
-
-    Keeps the operationally meaningful container and network fields (identity,
-    health, attachments, published ports) and drops the verbose Compose label
-    block, so a committed proof artifact stays reviewable. The source snapshot is
-    already redacted by ``capture_snapshot`` (ADR-029); this only trims noise.
-    """
-    containers = [
-        {
-            "name": container.get("name"),
-            "image": container.get("image"),
-            "status": container.get("status"),
-            "health": container.get("health"),
-            "networks": container.get("networks"),
-            "ports": container.get("ports"),
-        }
-        for container in _as_sequence(snapshot.get("containers"))
-        if isinstance(container, Mapping)
-    ]
-    networks = [
-        {
-            "name": network.get("name"),
-            "subnet": network.get("subnet"),
-            "gateway": network.get("gateway"),
-            "containers": network.get("containers"),
-        }
-        for network in _as_sequence(snapshot.get("networks"))
-        if isinstance(network, Mapping)
-    ]
-    return {
-        "timestamp": snapshot.get("timestamp"),
-        "containers": containers,
-        "networks": networks,
-    }
-
-
 def _snapshot_network_names(snapshot: Mapping[str, object]) -> list[str]:
     """Return network names from a range snapshot."""
     names: list[str] = []
@@ -306,259 +250,12 @@ def run_participant_action_proof(
     config: AptlConfig,
     participant_address: str = PARTICIPANT_ACTION_ADDRESS,
 ) -> dict[str, object]:
-    """Drive a participant action through the ACES control plane.
+    """Drive a participant action through the stable curated-proof entrypoint."""
 
-    The lab must already be realized by the public start path. This proof uses
-    the configured deployment backend, calls
-    ``RuntimeControlPlane.initialize_participant_episode()``, validates the
-    participant episode/behavior snapshot surfaces, captures a post-action range
-    snapshot, and returns a JSON-serializable evidence object.
-    """
-
-    backend = get_backend(config, project_dir)
-    target = create_aptl_runtime_target(
+    return _run_participant_action_proof(
         project_dir=project_dir,
         config=config,
-        backend=backend,
+        participant_address=participant_address,
+        backend_factory=get_backend,
+        snapshot_capture=capture_snapshot,
     )
-    control_plane = RuntimeControlPlane(target)
-    receipt = control_plane.initialize_participant_episode(participant_address)
-    status = control_plane.get_operation(receipt.operation_id)
-    snapshot = control_plane.snapshot
-
-    episode_violations = list(
-        iter_participant_episode_snapshot_violations(
-            snapshot.participant_episode_results,
-            snapshot.participant_episode_history,
-        )
-    )
-    behavior_violations = list(
-        iter_participant_behavior_snapshot_violations(
-            snapshot.participant_behavior_history,
-            participant_episode_results=snapshot.participant_episode_results,
-            participant_episode_history=snapshot.participant_episode_history,
-            metadata=snapshot.metadata,
-        )
-    )
-    shared_state_records = dict(getattr(snapshot, "shared_state_records", {}))
-    shared_state_history = {
-        address: list(records)
-        for address, records in getattr(snapshot, "shared_state_history", {}).items()
-    }
-    joint_action_records = dict(getattr(snapshot, "joint_action_records", {}))
-    time_management_contexts = dict(
-        getattr(snapshot, "time_management_contexts", {})
-    )
-    shared_state_violations = (
-        []
-        if iter_participant_shared_state_snapshot_violations is None
-        else list(
-            iter_participant_shared_state_snapshot_violations(
-                shared_state_records,
-                shared_state_history,
-                participant_behavior_history=snapshot.participant_behavior_history,
-                metadata=snapshot.metadata,
-            )
-        )
-    )
-    concurrency_violations = (
-        []
-        if iter_participant_concurrency_snapshot_violations is None
-        else list(
-            iter_participant_concurrency_snapshot_violations(
-                joint_action_records,
-                time_management_contexts,
-                participant_behavior_history=snapshot.participant_behavior_history,
-                shared_state_records=shared_state_records,
-                shared_state_history=shared_state_history,
-            )
-        )
-    )
-    capture_diagnostics: list[str] = []
-    range_snapshot_summary: dict[str, object] | None = None
-    try:
-        range_snapshot_summary = summarize_snapshot(
-            capture_snapshot(config_dir=project_dir, backend=backend).to_dict()
-        )
-    except Exception as exc:  # noqa: BLE001 - evidence-capture failure -> proof diagnostic.
-        capture_diagnostics.append(
-            redact(f"post-action range snapshot capture failed: {exc}")
-        )
-
-    operation_succeeded = (
-        status is not None and status.state == OperationState.SUCCEEDED
-    )
-    has_episode = participant_address in snapshot.participant_episode_results
-    has_episode_history = bool(
-        snapshot.participant_episode_history.get(participant_address)
-    )
-    has_behavior_history = bool(
-        snapshot.participant_behavior_history.get(participant_address)
-    )
-    passed = (
-        operation_succeeded
-        and has_episode
-        and has_episode_history
-        and has_behavior_history
-        and not episode_violations
-        and not behavior_violations
-        and not shared_state_violations
-        and not concurrency_violations
-        and not capture_diagnostics
-    )
-
-    proof = {
-        "schema": "aptl.participant-action-proof/v1",
-        "participant_address": participant_address,
-        "operation_receipt_contract": "operation-receipt-v1",
-        "operation_status_contract": "operation-status-v1",
-        "runtime_snapshot_contract": "runtime-snapshot-v1",
-        "operation_receipt": {
-            "operation_id": receipt.operation_id,
-            "domain": receipt.domain.value,
-            "accepted": receipt.accepted,
-            "submitted_at": receipt.submitted_at,
-            "diagnostics": _diagnostics_to_dicts(receipt.diagnostics),
-        },
-        "operation_status": (
-            None
-            if status is None
-            else {
-                "operation_id": status.operation_id,
-                "domain": status.domain.value,
-                "state": status.state.value,
-                "submitted_at": status.submitted_at,
-                "updated_at": status.updated_at,
-                "diagnostics": _diagnostics_to_dicts(status.diagnostics),
-                "changed_addresses": list(status.changed_addresses),
-            }
-        ),
-        "participant_runtime_status": target.participant_runtime.status()
-        if target.participant_runtime is not None
-        else None,
-        "participant_episode_results": dict(snapshot.participant_episode_results),
-        "participant_episode_history": {
-            address: list(events)
-            for address, events in snapshot.participant_episode_history.items()
-        },
-        "participant_behavior_history": {
-            address: list(events)
-            for address, events in snapshot.participant_behavior_history.items()
-        },
-        "participant_shared_state_records": shared_state_records,
-        "participant_shared_state_history": shared_state_history,
-        "participant_joint_action_records": joint_action_records,
-        "participant_time_management_contexts": time_management_contexts,
-        "participant_snapshot_entries": {
-            address: {
-                "domain": entry.domain.value,
-                "resource_type": entry.resource_type,
-                "status": entry.status,
-                "payload": dict(entry.payload),
-            }
-            for address, entry in snapshot.entries.items()
-            if entry.domain.value == "participant"
-        },
-        "post_action_range_snapshot": range_snapshot_summary,
-        "validation": {
-            "episode_violations": [
-                {"path": path, "message": message}
-                for path, message in episode_violations
-            ],
-            "behavior_violations": [
-                {"path": path, "message": message}
-                for path, message in behavior_violations
-            ],
-            "shared_state_violations": [
-                {"path": path, "message": message}
-                for path, message in shared_state_violations
-            ],
-            "concurrency_violations": [
-                {"path": path, "message": message}
-                for path, message in concurrency_violations
-            ],
-            "capture_diagnostics": capture_diagnostics,
-        },
-        "verdict": "PASS" if passed else "FAIL",
-    }
-    return _redact_volatile_proof_identifiers(proof, participant_address)
-
-
-def _diagnostics_to_dicts(diagnostics: Sequence[object]) -> list[dict[str, object]]:
-    """Return ACES diagnostics as JSON-serializable redacted dictionaries."""
-
-    result: list[dict[str, object]] = []
-    for diagnostic in diagnostics:
-        severity = getattr(diagnostic, "severity", "")
-        result.append(
-            {
-                "code": getattr(diagnostic, "code", ""),
-                "domain": getattr(diagnostic, "domain", ""),
-                "address": getattr(diagnostic, "address", ""),
-                "severity": getattr(severity, "value", severity),
-                "message": redact(str(getattr(diagnostic, "message", ""))),
-            }
-        )
-    return result
-
-
-def _redact_volatile_proof_identifiers(
-    proof: dict[str, object],
-    participant_address: str,
-) -> dict[str, object]:
-    """Normalize per-run IDs before evidence is committed.
-
-    Operation ids, episode ids, action-instance ids, and output digests prove
-    nothing by their raw value and look like secrets to external scanners. Keep
-    the references internally consistent while removing the high-entropy values.
-    """
-
-    replacements: dict[str, str] = {}
-    receipt = proof.get("operation_receipt")
-    if isinstance(receipt, Mapping):
-        operation_id = receipt.get("operation_id")
-        if isinstance(operation_id, str) and operation_id:
-            replacements[operation_id] = "operation-id-redacted"
-
-    results = proof.get("participant_episode_results")
-    if isinstance(results, Mapping):
-        for result in results.values():
-            if isinstance(result, Mapping):
-                episode_id = result.get("episode_id")
-                if isinstance(episode_id, str) and episode_id:
-                    replacements[episode_id] = "episode-id-redacted"
-
-    behavior_history = proof.get("participant_behavior_history")
-    if isinstance(behavior_history, Mapping):
-        for events in behavior_history.values():
-            if not isinstance(events, list):
-                continue
-            for event in events:
-                if isinstance(event, Mapping):
-                    action_instance_id = event.get("action_instance_id")
-                    if isinstance(action_instance_id, str) and action_instance_id:
-                        replacements[action_instance_id] = (
-                            f"{participant_address}.action-instance-redacted"
-                        )
-
-    return _replace_proof_strings(proof, replacements)
-
-
-def _replace_proof_strings(value: object, replacements: Mapping[str, str]) -> object:
-    if isinstance(value, str):
-        if value.startswith("sha256:") and len(value) > len("sha256:") + 16:
-            return "sha256:redacted-proof-digest"
-        result = value
-        for old, new in replacements.items():
-            result = result.replace(old, new)
-        return result
-    if isinstance(value, list):
-        return [_replace_proof_strings(item, replacements) for item in value]
-    if isinstance(value, dict):
-        return {
-            str(_replace_proof_strings(key, replacements)): _replace_proof_strings(
-                item, replacements
-            )
-            for key, item in value.items()
-        }
-    return value

--- a/src/aptl/validation/curated_live_proof.py
+++ b/src/aptl/validation/curated_live_proof.py
@@ -26,10 +26,19 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from aces_contracts.participant_behavior import (
+    iter_participant_behavior_snapshot_violations,
+)
+from aces_contracts.participant_episode import (
+    iter_participant_episode_snapshot_violations,
+)
+from aces_contracts.runtime_state import OperationState
+from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.manager import RuntimeManager
 from aces_sdl import parse_sdl_file
 
 from aptl.backends.aces import create_aptl_runtime_target
+from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS
 from aptl.backends.aces_profiles import (
     load_compose_profile_index,
     normalized_identifier_aliases,
@@ -38,6 +47,9 @@ from aptl.backends.aces_profiles import (
 )
 from aptl.backends.aces_realization import interpret_provisioning_plan
 from aptl.core.config import AptlConfig
+from aptl.core.deployment import get_backend
+from aptl.core.snapshot import capture_snapshot
+from aptl.utils.redaction import redact
 from aptl.validation._gate_checks import _NoStartBackend
 
 
@@ -273,3 +285,218 @@ def compare_to_snapshot(
         )
     )
     return (not diagnostics, diagnostics)
+
+
+def run_participant_action_proof(
+    project_dir: Path,
+    config: AptlConfig,
+    participant_address: str = PARTICIPANT_ACTION_ADDRESS,
+) -> dict[str, object]:
+    """Drive a participant action through the ACES control plane.
+
+    The lab must already be realized by the public start path. This proof uses
+    the configured deployment backend, calls
+    ``RuntimeControlPlane.initialize_participant_episode()``, validates the
+    participant episode/behavior snapshot surfaces, captures a post-action range
+    snapshot, and returns a JSON-serializable evidence object.
+    """
+
+    backend = get_backend(config, project_dir)
+    target = create_aptl_runtime_target(
+        project_dir=project_dir,
+        config=config,
+        backend=backend,
+    )
+    control_plane = RuntimeControlPlane(target)
+    receipt = control_plane.initialize_participant_episode(participant_address)
+    status = control_plane.get_operation(receipt.operation_id)
+    snapshot = control_plane.snapshot
+
+    episode_violations = list(
+        iter_participant_episode_snapshot_violations(
+            snapshot.participant_episode_results,
+            snapshot.participant_episode_history,
+        )
+    )
+    behavior_violations = list(
+        iter_participant_behavior_snapshot_violations(
+            snapshot.participant_behavior_history,
+            participant_episode_results=snapshot.participant_episode_results,
+            participant_episode_history=snapshot.participant_episode_history,
+            metadata=snapshot.metadata,
+        )
+    )
+    capture_diagnostics: list[str] = []
+    range_snapshot_summary: dict[str, object] | None = None
+    try:
+        range_snapshot_summary = summarize_snapshot(
+            capture_snapshot(config_dir=project_dir, backend=backend).to_dict()
+        )
+    except Exception as exc:  # noqa: BLE001 - evidence-capture failure -> proof diagnostic.
+        capture_diagnostics.append(
+            redact(f"post-action range snapshot capture failed: {exc}")
+        )
+
+    operation_succeeded = (
+        status is not None and status.state == OperationState.SUCCEEDED
+    )
+    has_episode = participant_address in snapshot.participant_episode_results
+    has_episode_history = bool(
+        snapshot.participant_episode_history.get(participant_address)
+    )
+    has_behavior_history = bool(
+        snapshot.participant_behavior_history.get(participant_address)
+    )
+    passed = (
+        operation_succeeded
+        and has_episode
+        and has_episode_history
+        and has_behavior_history
+        and not episode_violations
+        and not behavior_violations
+        and not capture_diagnostics
+    )
+
+    proof = {
+        "schema": "aptl.participant-action-proof/v1",
+        "participant_address": participant_address,
+        "operation_receipt_contract": "operation-receipt-v1",
+        "operation_status_contract": "operation-status-v1",
+        "runtime_snapshot_contract": "runtime-snapshot-v1",
+        "operation_receipt": {
+            "operation_id": receipt.operation_id,
+            "domain": receipt.domain.value,
+            "accepted": receipt.accepted,
+            "submitted_at": receipt.submitted_at,
+            "diagnostics": _diagnostics_to_dicts(receipt.diagnostics),
+        },
+        "operation_status": (
+            None
+            if status is None
+            else {
+                "operation_id": status.operation_id,
+                "domain": status.domain.value,
+                "state": status.state.value,
+                "submitted_at": status.submitted_at,
+                "updated_at": status.updated_at,
+                "diagnostics": _diagnostics_to_dicts(status.diagnostics),
+                "changed_addresses": list(status.changed_addresses),
+            }
+        ),
+        "participant_runtime_status": target.participant_runtime.status()
+        if target.participant_runtime is not None
+        else None,
+        "participant_episode_results": dict(snapshot.participant_episode_results),
+        "participant_episode_history": {
+            address: list(events)
+            for address, events in snapshot.participant_episode_history.items()
+        },
+        "participant_behavior_history": {
+            address: list(events)
+            for address, events in snapshot.participant_behavior_history.items()
+        },
+        "participant_snapshot_entries": {
+            address: {
+                "domain": entry.domain.value,
+                "resource_type": entry.resource_type,
+                "status": entry.status,
+                "payload": dict(entry.payload),
+            }
+            for address, entry in snapshot.entries.items()
+            if entry.domain.value == "participant"
+        },
+        "post_action_range_snapshot": range_snapshot_summary,
+        "validation": {
+            "episode_violations": [
+                {"path": path, "message": message}
+                for path, message in episode_violations
+            ],
+            "behavior_violations": [
+                {"path": path, "message": message}
+                for path, message in behavior_violations
+            ],
+            "capture_diagnostics": capture_diagnostics,
+        },
+        "verdict": "PASS" if passed else "FAIL",
+    }
+    return _redact_volatile_proof_identifiers(proof, participant_address)
+
+
+def _diagnostics_to_dicts(diagnostics: Sequence[object]) -> list[dict[str, object]]:
+    """Return ACES diagnostics as JSON-serializable redacted dictionaries."""
+
+    result: list[dict[str, object]] = []
+    for diagnostic in diagnostics:
+        severity = getattr(diagnostic, "severity", "")
+        result.append(
+            {
+                "code": getattr(diagnostic, "code", ""),
+                "domain": getattr(diagnostic, "domain", ""),
+                "address": getattr(diagnostic, "address", ""),
+                "severity": getattr(severity, "value", severity),
+                "message": redact(str(getattr(diagnostic, "message", ""))),
+            }
+        )
+    return result
+
+
+def _redact_volatile_proof_identifiers(
+    proof: dict[str, object],
+    participant_address: str,
+) -> dict[str, object]:
+    """Normalize per-run IDs before evidence is committed.
+
+    Operation ids, episode ids, action-instance ids, and output digests prove
+    nothing by their raw value and look like secrets to external scanners. Keep
+    the references internally consistent while removing the high-entropy values.
+    """
+
+    replacements: dict[str, str] = {}
+    receipt = proof.get("operation_receipt")
+    if isinstance(receipt, Mapping):
+        operation_id = receipt.get("operation_id")
+        if isinstance(operation_id, str) and operation_id:
+            replacements[operation_id] = "operation-id-redacted"
+
+    results = proof.get("participant_episode_results")
+    if isinstance(results, Mapping):
+        for result in results.values():
+            if isinstance(result, Mapping):
+                episode_id = result.get("episode_id")
+                if isinstance(episode_id, str) and episode_id:
+                    replacements[episode_id] = "episode-id-redacted"
+
+    behavior_history = proof.get("participant_behavior_history")
+    if isinstance(behavior_history, Mapping):
+        for events in behavior_history.values():
+            if not isinstance(events, list):
+                continue
+            for event in events:
+                if isinstance(event, Mapping):
+                    action_instance_id = event.get("action_instance_id")
+                    if isinstance(action_instance_id, str) and action_instance_id:
+                        replacements[action_instance_id] = (
+                            f"{participant_address}.action-instance-redacted"
+                        )
+
+    return _replace_proof_strings(proof, replacements)
+
+
+def _replace_proof_strings(value: object, replacements: Mapping[str, str]) -> object:
+    if isinstance(value, str):
+        if value.startswith("sha256:") and len(value) > len("sha256:") + 16:
+            return "sha256:redacted-proof-digest"
+        result = value
+        for old, new in replacements.items():
+            result = result.replace(old, new)
+        return result
+    if isinstance(value, list):
+        return [_replace_proof_strings(item, replacements) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(_replace_proof_strings(key, replacements)): _replace_proof_strings(
+                item, replacements
+            )
+            for key, item in value.items()
+        }
+    return value

--- a/src/aptl/validation/curated_live_proof.py
+++ b/src/aptl/validation/curated_live_proof.py
@@ -37,6 +37,20 @@ from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.manager import RuntimeManager
 from aces_sdl import parse_sdl_file
 
+try:
+    from aces_contracts.participant_concurrency import (
+        iter_participant_concurrency_snapshot_violations,
+    )
+except ImportError:  # pragma: no cover - compatibility with older ACES locks.
+    iter_participant_concurrency_snapshot_violations = None
+
+try:
+    from aces_contracts.participant_shared_state import (
+        iter_participant_shared_state_snapshot_violations,
+    )
+except ImportError:  # pragma: no cover - compatibility with older ACES locks.
+    iter_participant_shared_state_snapshot_violations = None
+
 from aptl.backends.aces import create_aptl_runtime_target
 from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS
 from aptl.backends.aces_profiles import (
@@ -326,6 +340,40 @@ def run_participant_action_proof(
             metadata=snapshot.metadata,
         )
     )
+    shared_state_records = dict(getattr(snapshot, "shared_state_records", {}))
+    shared_state_history = {
+        address: list(records)
+        for address, records in getattr(snapshot, "shared_state_history", {}).items()
+    }
+    joint_action_records = dict(getattr(snapshot, "joint_action_records", {}))
+    time_management_contexts = dict(
+        getattr(snapshot, "time_management_contexts", {})
+    )
+    shared_state_violations = (
+        []
+        if iter_participant_shared_state_snapshot_violations is None
+        else list(
+            iter_participant_shared_state_snapshot_violations(
+                shared_state_records,
+                shared_state_history,
+                participant_behavior_history=snapshot.participant_behavior_history,
+                metadata=snapshot.metadata,
+            )
+        )
+    )
+    concurrency_violations = (
+        []
+        if iter_participant_concurrency_snapshot_violations is None
+        else list(
+            iter_participant_concurrency_snapshot_violations(
+                joint_action_records,
+                time_management_contexts,
+                participant_behavior_history=snapshot.participant_behavior_history,
+                shared_state_records=shared_state_records,
+                shared_state_history=shared_state_history,
+            )
+        )
+    )
     capture_diagnostics: list[str] = []
     range_snapshot_summary: dict[str, object] | None = None
     try:
@@ -354,6 +402,8 @@ def run_participant_action_proof(
         and has_behavior_history
         and not episode_violations
         and not behavior_violations
+        and not shared_state_violations
+        and not concurrency_violations
         and not capture_diagnostics
     )
 
@@ -395,6 +445,10 @@ def run_participant_action_proof(
             address: list(events)
             for address, events in snapshot.participant_behavior_history.items()
         },
+        "participant_shared_state_records": shared_state_records,
+        "participant_shared_state_history": shared_state_history,
+        "participant_joint_action_records": joint_action_records,
+        "participant_time_management_contexts": time_management_contexts,
         "participant_snapshot_entries": {
             address: {
                 "domain": entry.domain.value,
@@ -414,6 +468,14 @@ def run_participant_action_proof(
             "behavior_violations": [
                 {"path": path, "message": message}
                 for path, message in behavior_violations
+            ],
+            "shared_state_violations": [
+                {"path": path, "message": message}
+                for path, message in shared_state_violations
+            ],
+            "concurrency_violations": [
+                {"path": path, "message": message}
+                for path, message in concurrency_violations
             ],
             "capture_diagnostics": capture_diagnostics,
         },

--- a/src/aptl/validation/curated_live_proof.py
+++ b/src/aptl/validation/curated_live_proof.py
@@ -45,7 +45,9 @@ from aptl.validation._gate_checks import _NoStartBackend
 from aptl.validation.participant_live_proof import (
     run_participant_action_proof as _run_participant_action_proof,
 )
-from aptl.validation.range_snapshot_summary import summarize_snapshot
+from aptl.validation.range_snapshot_summary import (
+    summarize_snapshot as _summarize_snapshot,
+)
 
 
 @dataclass(frozen=True)
@@ -150,6 +152,12 @@ def _running_container_names(snapshot: Mapping[str, object]) -> list[str]:
         if isinstance(name, str) and name and status.startswith("Up"):
             names.append(name)
     return names
+
+
+def summarize_snapshot(snapshot: Mapping[str, object]) -> dict[str, object]:
+    """Return an evidence-sized view of a range snapshot."""
+
+    return _summarize_snapshot(snapshot)
 
 
 def _snapshot_network_names(snapshot: Mapping[str, object]) -> list[str]:

--- a/src/aptl/validation/participant_live_proof.py
+++ b/src/aptl/validation/participant_live_proof.py
@@ -1,0 +1,493 @@
+"""Live proof that an ACES participant action works through APTL."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from aces_contracts.participant_behavior import (
+    iter_participant_behavior_snapshot_violations,
+)
+from aces_contracts.participant_episode import (
+    iter_participant_episode_snapshot_violations,
+)
+from aces_contracts.runtime_state import OperationState, RuntimeSnapshot
+from aces_runtime.control_plane import RuntimeControlPlane
+from aces_runtime.registry import RuntimeTarget
+
+try:
+    from aces_contracts.participant_concurrency import (
+        iter_participant_concurrency_snapshot_violations,
+    )
+except ImportError:
+    # Older ACES locks predate the participant concurrency snapshot contract.
+    iter_participant_concurrency_snapshot_violations = None
+
+try:
+    from aces_contracts.participant_shared_state import (
+        iter_participant_shared_state_snapshot_violations,
+    )
+except ImportError:
+    # Older ACES locks predate the participant shared-state snapshot contract.
+    iter_participant_shared_state_snapshot_violations = None
+
+from aptl.backends.aces import create_aptl_runtime_target
+from aptl.backends.aces_participant_actions import PARTICIPANT_ACTION_ADDRESS
+from aptl.core.config import AptlConfig
+from aptl.core.deployment import get_backend
+from aptl.core.snapshot import capture_snapshot
+from aptl.utils.redaction import redact
+from aptl.validation.range_snapshot_summary import summarize_snapshot
+
+if TYPE_CHECKING:
+    from aptl.core.deployment.backend import DeploymentBackend
+
+BackendFactory = Callable[[AptlConfig, Path], "DeploymentBackend"]
+SnapshotCapture = Callable[..., Any]
+SnapshotViolation = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class ParticipantSnapshotExtensions:
+    """Optional participant snapshot extensions emitted by current ACES."""
+
+    shared_state_records: dict[str, dict[str, object]]
+    shared_state_history: dict[str, list[dict[str, object]]]
+    joint_action_records: dict[str, dict[str, object]]
+    time_management_contexts: dict[str, dict[str, object]]
+
+
+@dataclass(frozen=True)
+class ParticipantSnapshotValidation:
+    """Validation results for participant episode and behavior surfaces."""
+
+    episode_violations: list[SnapshotViolation]
+    behavior_violations: list[SnapshotViolation]
+    shared_state_violations: list[SnapshotViolation]
+    concurrency_violations: list[SnapshotViolation]
+
+    def passed(self) -> bool:
+        """Return whether all participant snapshot validators passed."""
+
+        return not (
+            self.episode_violations
+            or self.behavior_violations
+            or self.shared_state_violations
+            or self.concurrency_violations
+        )
+
+    def to_payload(self, capture_diagnostics: Sequence[str]) -> dict[str, object]:
+        """Return the validation result as committed proof evidence."""
+
+        return {
+            "episode_violations": _violation_payload(self.episode_violations),
+            "behavior_violations": _violation_payload(self.behavior_violations),
+            "shared_state_violations": _violation_payload(self.shared_state_violations),
+            "concurrency_violations": _violation_payload(self.concurrency_violations),
+            "capture_diagnostics": list(capture_diagnostics),
+        }
+
+
+@dataclass(frozen=True)
+class ParticipantProofContext:
+    """Everything needed to render the participant action proof artifact."""
+
+    participant_address: str
+    receipt: object
+    status: object | None
+    target: RuntimeTarget
+    snapshot: RuntimeSnapshot
+    extensions: ParticipantSnapshotExtensions
+    validation: ParticipantSnapshotValidation
+    range_snapshot_summary: dict[str, object] | None
+    capture_diagnostics: list[str]
+
+
+def run_participant_action_proof(
+    project_dir: Path,
+    config: AptlConfig,
+    participant_address: str = PARTICIPANT_ACTION_ADDRESS,
+    *,
+    backend_factory: BackendFactory = get_backend,
+    snapshot_capture: SnapshotCapture = capture_snapshot,
+) -> dict[str, object]:
+    """Drive a participant action through the ACES control plane.
+
+    The lab must already be realized by the public start path. This proof uses
+    the configured deployment backend, calls
+    ``RuntimeControlPlane.initialize_participant_episode()``, validates the
+    participant episode/behavior snapshot surfaces, captures a post-action range
+    snapshot, and returns a JSON-serializable evidence object.
+    """
+
+    control_plane, target, backend = _participant_control_plane(project_dir, config, backend_factory)
+    receipt = control_plane.initialize_participant_episode(participant_address)
+    status = control_plane.get_operation(receipt.operation_id)
+    snapshot = control_plane.snapshot
+    extensions = _snapshot_extensions(snapshot)
+    validation = _validate_participant_snapshot(snapshot, extensions)
+    range_summary, capture_diagnostics = _capture_post_action_range(
+        project_dir, backend, snapshot_capture
+    )
+    context = ParticipantProofContext(
+        participant_address=participant_address,
+        receipt=receipt,
+        status=status,
+        target=target,
+        snapshot=snapshot,
+        extensions=extensions,
+        validation=validation,
+        range_snapshot_summary=range_summary,
+        capture_diagnostics=capture_diagnostics,
+    )
+    proof = _participant_proof_payload(context)
+    return _redact_volatile_proof_identifiers(proof, participant_address)
+
+
+def _participant_control_plane(
+    project_dir: Path,
+    config: AptlConfig,
+    backend_factory: BackendFactory,
+) -> tuple[RuntimeControlPlane, RuntimeTarget, "DeploymentBackend"]:
+    """Create the ACES control plane backed by the configured APTL backend."""
+
+    backend = backend_factory(config, project_dir)
+    target = create_aptl_runtime_target(project_dir=project_dir, config=config, backend=backend)
+    return RuntimeControlPlane(target), target, backend
+
+
+def _snapshot_extensions(snapshot: RuntimeSnapshot) -> ParticipantSnapshotExtensions:
+    """Read optional participant snapshot extensions defensively."""
+
+    return ParticipantSnapshotExtensions(
+        shared_state_records=dict(getattr(snapshot, "shared_state_records", {})),
+        shared_state_history={
+            address: list(records)
+            for address, records in getattr(snapshot, "shared_state_history", {}).items()
+        },
+        joint_action_records=dict(getattr(snapshot, "joint_action_records", {})),
+        time_management_contexts=dict(getattr(snapshot, "time_management_contexts", {})),
+    )
+
+
+def _validate_participant_snapshot(
+    snapshot: RuntimeSnapshot,
+    extensions: ParticipantSnapshotExtensions,
+) -> ParticipantSnapshotValidation:
+    """Run every available ACES participant snapshot validator."""
+
+    return ParticipantSnapshotValidation(
+        episode_violations=list(
+            iter_participant_episode_snapshot_violations(
+                snapshot.participant_episode_results,
+                snapshot.participant_episode_history,
+            )
+        ),
+        behavior_violations=list(
+            iter_participant_behavior_snapshot_violations(
+                snapshot.participant_behavior_history,
+                participant_episode_results=snapshot.participant_episode_results,
+                participant_episode_history=snapshot.participant_episode_history,
+                metadata=snapshot.metadata,
+            )
+        ),
+        shared_state_violations=_shared_state_violations(snapshot, extensions),
+        concurrency_violations=_concurrency_violations(snapshot, extensions),
+    )
+
+
+def _shared_state_violations(
+    snapshot: RuntimeSnapshot,
+    extensions: ParticipantSnapshotExtensions,
+) -> list[SnapshotViolation]:
+    """Return shared-state violations when the current ACES contract exists."""
+
+    if iter_participant_shared_state_snapshot_violations is None:
+        return []
+    return list(
+        iter_participant_shared_state_snapshot_violations(
+            extensions.shared_state_records,
+            extensions.shared_state_history,
+            participant_behavior_history=snapshot.participant_behavior_history,
+            metadata=snapshot.metadata,
+        )
+    )
+
+
+def _concurrency_violations(
+    snapshot: RuntimeSnapshot,
+    extensions: ParticipantSnapshotExtensions,
+) -> list[SnapshotViolation]:
+    """Return concurrency violations when the current ACES contract exists."""
+
+    if iter_participant_concurrency_snapshot_violations is None:
+        return []
+    return list(
+        iter_participant_concurrency_snapshot_violations(
+            extensions.joint_action_records,
+            extensions.time_management_contexts,
+            participant_behavior_history=snapshot.participant_behavior_history,
+            shared_state_records=extensions.shared_state_records,
+            shared_state_history=extensions.shared_state_history,
+        )
+    )
+
+
+def _capture_post_action_range(
+    project_dir: Path,
+    backend: "DeploymentBackend",
+    snapshot_capture: SnapshotCapture,
+) -> tuple[dict[str, object] | None, list[str]]:
+    """Capture a post-action range snapshot for proof evidence."""
+
+    diagnostics: list[str] = []
+    range_snapshot_summary: dict[str, object] | None = None
+    try:
+        range_snapshot_summary = summarize_snapshot(
+            snapshot_capture(config_dir=project_dir, backend=backend).to_dict()
+        )
+    except Exception as exc:
+        diagnostics.append(redact(f"post-action range snapshot capture failed: {exc}"))
+    return range_snapshot_summary, diagnostics
+
+
+def _participant_proof_payload(
+    context: ParticipantProofContext,
+) -> dict[str, object]:
+    """Render the participant proof as a JSON-serializable payload."""
+
+    snapshot = context.snapshot
+    extensions = context.extensions
+    return {
+        "schema": "aptl.participant-action-proof/v1",
+        "participant_address": context.participant_address,
+        "operation_receipt_contract": "operation-receipt-v1",
+        "operation_status_contract": "operation-status-v1",
+        "runtime_snapshot_contract": "runtime-snapshot-v1",
+        "operation_receipt": _receipt_payload(context.receipt),
+        "operation_status": _status_payload(context.status),
+        "participant_runtime_status": _participant_runtime_status(context.target),
+        "participant_episode_results": dict(snapshot.participant_episode_results),
+        "participant_episode_history": {
+            address: list(events)
+            for address, events in snapshot.participant_episode_history.items()
+        },
+        "participant_behavior_history": {
+            address: list(events)
+            for address, events in snapshot.participant_behavior_history.items()
+        },
+        "participant_shared_state_records": extensions.shared_state_records,
+        "participant_shared_state_history": extensions.shared_state_history,
+        "participant_joint_action_records": extensions.joint_action_records,
+        "participant_time_management_contexts": extensions.time_management_contexts,
+        "participant_snapshot_entries": _participant_snapshot_entries(snapshot),
+        "post_action_range_snapshot": context.range_snapshot_summary,
+        "validation": context.validation.to_payload(context.capture_diagnostics),
+        "verdict": "PASS" if _proof_passed(context) else "FAIL",
+    }
+
+
+def _proof_passed(context: ParticipantProofContext) -> bool:
+    """Return whether the participant proof satisfied every required surface."""
+
+    snapshot = context.snapshot
+    participant_address = context.participant_address
+    return (
+        _operation_succeeded(context.status)
+        and participant_address in snapshot.participant_episode_results
+        and bool(snapshot.participant_episode_history.get(participant_address))
+        and bool(snapshot.participant_behavior_history.get(participant_address))
+        and context.validation.passed()
+        and not context.capture_diagnostics
+    )
+
+
+def _operation_succeeded(status: object | None) -> bool:
+    """Return whether an ACES operation status succeeded."""
+
+    return status is not None and getattr(status, "state", None) == OperationState.SUCCEEDED
+
+
+def _receipt_payload(receipt: object) -> dict[str, object]:
+    """Return the operation receipt proof payload."""
+
+    domain = getattr(receipt, "domain")
+    return {
+        "operation_id": getattr(receipt, "operation_id"),
+        "domain": domain.value,
+        "accepted": getattr(receipt, "accepted"),
+        "submitted_at": getattr(receipt, "submitted_at"),
+        "diagnostics": _diagnostics_to_dicts(getattr(receipt, "diagnostics")),
+    }
+
+
+def _status_payload(status: object | None) -> dict[str, object] | None:
+    """Return the operation status proof payload."""
+
+    if status is None:
+        return None
+    domain = getattr(status, "domain")
+    state = getattr(status, "state")
+    return {
+        "operation_id": getattr(status, "operation_id"),
+        "domain": domain.value,
+        "state": state.value,
+        "submitted_at": getattr(status, "submitted_at"),
+        "updated_at": getattr(status, "updated_at"),
+        "diagnostics": _diagnostics_to_dicts(getattr(status, "diagnostics")),
+        "changed_addresses": list(getattr(status, "changed_addresses")),
+    }
+
+
+def _participant_runtime_status(target: RuntimeTarget) -> dict[str, object] | None:
+    """Return the participant runtime status when the target exposes one."""
+
+    participant_runtime = target.participant_runtime
+    if participant_runtime is None:
+        return None
+    return participant_runtime.status()
+
+
+def _participant_snapshot_entries(
+    snapshot: RuntimeSnapshot,
+) -> dict[str, dict[str, object]]:
+    """Return participant-domain snapshot entries as JSON-serializable payloads."""
+
+    return {
+        address: {
+            "domain": entry.domain.value,
+            "resource_type": entry.resource_type,
+            "status": entry.status,
+            "payload": dict(entry.payload),
+        }
+        for address, entry in snapshot.entries.items()
+        if entry.domain.value == "participant"
+    }
+
+
+def _diagnostics_to_dicts(diagnostics: Sequence[object]) -> list[dict[str, object]]:
+    """Return ACES diagnostics as JSON-serializable redacted dictionaries."""
+
+    result: list[dict[str, object]] = []
+    for diagnostic in diagnostics:
+        severity = getattr(diagnostic, "severity", "")
+        result.append(
+            {
+                "code": getattr(diagnostic, "code", ""),
+                "domain": getattr(diagnostic, "domain", ""),
+                "address": getattr(diagnostic, "address", ""),
+                "severity": getattr(severity, "value", severity),
+                "message": redact(str(getattr(diagnostic, "message", ""))),
+            }
+        )
+    return result
+
+
+def _violation_payload(
+    violations: Sequence[SnapshotViolation],
+) -> list[dict[str, str]]:
+    """Return snapshot validator violations as proof dictionaries."""
+
+    return [{"path": path, "message": message} for path, message in violations]
+
+
+def _redact_volatile_proof_identifiers(
+    proof: dict[str, object],
+    participant_address: str,
+) -> dict[str, object]:
+    """Normalize per-run IDs before evidence is committed."""
+
+    replacements = {}
+    replacements.update(_operation_id_replacements(proof))
+    replacements.update(_episode_id_replacements(proof))
+    replacements.update(_action_instance_replacements(proof, participant_address))
+    return _replace_proof_strings(proof, replacements)
+
+
+def _operation_id_replacements(proof: Mapping[str, object]) -> dict[str, str]:
+    """Return replacements for per-run operation ids."""
+
+    receipt = proof.get("operation_receipt")
+    replacements: dict[str, str] = {}
+    if isinstance(receipt, Mapping):
+        operation_id = receipt.get("operation_id")
+        if isinstance(operation_id, str) and operation_id:
+            replacements[operation_id] = "operation-id-redacted"
+    return replacements
+
+
+def _episode_id_replacements(proof: Mapping[str, object]) -> dict[str, str]:
+    """Return replacements for per-run participant episode ids."""
+
+    results = proof.get("participant_episode_results")
+    replacements: dict[str, str] = {}
+    if isinstance(results, Mapping):
+        for result in results.values():
+            if isinstance(result, Mapping):
+                episode_id = result.get("episode_id")
+                if isinstance(episode_id, str) and episode_id:
+                    replacements[episode_id] = "episode-id-redacted"
+    return replacements
+
+
+def _action_instance_replacements(
+    proof: Mapping[str, object],
+    participant_address: str,
+) -> dict[str, str]:
+    """Return replacements for per-run participant action-instance ids."""
+
+    replacements: dict[str, str] = {}
+    redacted = f"{participant_address}.action-instance-redacted"
+    for event in _iter_behavior_events(proof):
+        action_instance_id = event.get("action_instance_id")
+        if isinstance(action_instance_id, str) and action_instance_id:
+            replacements[action_instance_id] = redacted
+    return replacements
+
+
+def _iter_behavior_events(
+    proof: Mapping[str, object],
+) -> Iterable[Mapping[str, object]]:
+    """Yield behavior-history event mappings from the proof payload."""
+
+    behavior_history = proof.get("participant_behavior_history")
+    if not isinstance(behavior_history, Mapping):
+        return
+    for events in behavior_history.values():
+        if not isinstance(events, list):
+            continue
+        for event in events:
+            if isinstance(event, Mapping):
+                yield event
+
+
+def _replace_proof_strings(value: object, replacements: Mapping[str, str]) -> object:
+    """Apply redactions recursively across a proof payload."""
+
+    result = value
+    if isinstance(value, str):
+        result = _replace_string(value, replacements)
+    elif isinstance(value, list):
+        result = [_replace_proof_strings(item, replacements) for item in value]
+    elif isinstance(value, dict):
+        result = {
+            str(_replace_proof_strings(key, replacements)): _replace_proof_strings(
+                item, replacements
+            )
+            for key, item in value.items()
+        }
+    return result
+
+
+def _replace_string(value: str, replacements: Mapping[str, str]) -> str:
+    """Apply digest and identifier redactions to one string value."""
+
+    result = value
+    if value.startswith("sha256:") and len(value) > len("sha256:") + 16:
+        result = "sha256:redacted-proof-digest"
+    else:
+        for old, new in replacements.items():
+            result = result.replace(old, new)
+    return result

--- a/src/aptl/validation/range_snapshot_summary.py
+++ b/src/aptl/validation/range_snapshot_summary.py
@@ -1,0 +1,51 @@
+"""Evidence-sized range snapshot summaries."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+
+def summarize_snapshot(snapshot: Mapping[str, object]) -> dict[str, object]:
+    """Return an evidence-sized view of a range snapshot.
+
+    Keeps the operationally meaningful container and network fields (identity,
+    health, attachments, published ports) and drops the verbose Compose label
+    block, so a committed proof artifact stays reviewable. The source snapshot is
+    already redacted by ``capture_snapshot`` (ADR-029); this only trims noise.
+    """
+
+    containers = [
+        {
+            "name": container.get("name"),
+            "image": container.get("image"),
+            "status": container.get("status"),
+            "health": container.get("health"),
+            "networks": container.get("networks"),
+            "ports": container.get("ports"),
+        }
+        for container in _as_sequence(snapshot.get("containers"))
+        if isinstance(container, Mapping)
+    ]
+    networks = [
+        {
+            "name": network.get("name"),
+            "subnet": network.get("subnet"),
+            "gateway": network.get("gateway"),
+            "containers": network.get("containers"),
+        }
+        for network in _as_sequence(snapshot.get("networks"))
+        if isinstance(network, Mapping)
+    ]
+    return {
+        "timestamp": snapshot.get("timestamp"),
+        "containers": containers,
+        "networks": networks,
+    }
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    """Return a list/tuple value as a sequence, or an empty tuple otherwise."""
+
+    if isinstance(value, list | tuple):
+        return value
+    return ()

--- a/src/aptl/validation/techvault_gate.py
+++ b/src/aptl/validation/techvault_gate.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from aptl.core.config import AptlConfig
 
-DEFAULT_PROFILE = "orchestration-evaluation"
+DEFAULT_PROFILE = "full-remote-control-plane"
 DEFAULT_SCENARIO = Path("scenarios") / "techvault.sdl.yaml"
 DEFAULT_PARITY_INVENTORY = Path("docs") / "aces" / "parity-inventory.yaml"
 

--- a/src/aptl/validation/techvault_live_gate.py
+++ b/src/aptl/validation/techvault_live_gate.py
@@ -12,7 +12,7 @@ archive.
 Like the static gate, it is scenario-generic and parameterized by scenario
 path, backend profile, and project directory: TechVault is the proving input,
 never a hardcoded branch (ADR-035). The next scenario in APTL's
-``orchestration-evaluation`` expressivity class passes through by changing inputs.
+``full-remote-control-plane`` expressivity class passes through by changing inputs.
 
 The gate is inherently integration / live-run work: it requires Docker, the SOC
 stack's resources, real ``.env`` secrets, and minutes-long startup. It is wired
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from aptl.core.config import AptlConfig
     from aptl.core.runstore import RunStorageBackend
 
-DEFAULT_PROFILE = "orchestration-evaluation"
+DEFAULT_PROFILE = "full-remote-control-plane"
 
 # Stable failure categories (issue #323 acceptance: a failure must identify the
 # layer that broke). These map onto existing ACES diagnostics and APTL startup
@@ -132,9 +132,7 @@ class LiveGateReport(object):
             for diagnostic in check.diagnostics:
                 lines.append(f"        - {diagnostic}")
         if not self.passed:
-            lines.append(
-                "  failing layers: " + ", ".join(self.failure_categories())
-            )
+            lines.append("  failing layers: " + ", ".join(self.failure_categories()))
         return "\n".join(lines)
 
 
@@ -142,7 +140,7 @@ class LiveGateReport(object):
 class LiveGateOptions(object):
     """Tunable inputs for the live validation gate.
 
-    ``profile`` selects the backend capability profile (``orchestration-evaluation``).
+    ``profile`` selects the backend capability profile (``full-remote-control-plane``).
     ``clean_volumes`` runs the data-destroying ``stop -v`` cleanup before the
     boot; ``skip_clean_boot`` validates against an already-running lab without
     the destructive cleanup (operator opt-in for a non-destructive check). The

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -50,7 +50,9 @@ def _write_compose_graph(
         if dependencies:
             lines.append("    depends_on:")
             for dependency in dependencies:
-                lines.extend([f"      {dependency}:", "        condition: service_started"])
+                lines.extend(
+                    [f"      {dependency}:", "        condition: service_started"]
+                )
         service_networks = (networks or {}).get(service_name, [])
         if service_networks:
             lines.append("    networks:")
@@ -137,6 +139,7 @@ def test_create_runtime_target_accepts_aptl_manifest_shape(tmp_path):
 
     assert target.name == "aptl"
     assert target.manifest.name == "aptl"
+    assert target.participant_runtime is not None
 
 
 def test_public_start_profiles_match_start_lab_backend_call():
@@ -228,6 +231,9 @@ def test_create_aptl_manifest_is_canonical_backend_manifest_v2():
     assert payload["schema_version"] == "backend-manifest/v2"
     required = {
         "backend-manifest-v2",
+        "provisioning-plan-v1",
+        "orchestration-plan-v1",
+        "evaluation-plan-v1",
         "operation-receipt-v1",
         "operation-status-v1",
         "runtime-snapshot-v1",
@@ -235,13 +241,19 @@ def test_create_aptl_manifest_is_canonical_backend_manifest_v2():
         "workflow-history-event-stream-v1",
         "evaluation-result-envelope-v1",
         "evaluation-history-event-stream-v1",
+        "participant-episode-state-envelope-v1",
+        "participant-episode-history-event-stream-v1",
+        "participant-behavior-history-event-stream-v1",
     }
     assert required <= set(payload["supported_contract_versions"])
-    # orchestration-evaluation: orchestrator + evaluator declared; participant
-    # runtime remains out of scope.
     assert manifest.has_orchestrator is True
     assert manifest.has_evaluator is True
-    assert manifest.has_participant_runtime is False
+    assert manifest.has_participant_runtime is True
+    assert manifest.participant_runtime is not None
+    assert manifest.participant_runtime.supported_participant_roles == frozenset(
+        {"red"}
+    )
+    assert payload["capabilities"]["participant_runtime"] is not None
 
 
 def test_aptl_target_passes_provisioning_only_conformance(tmp_path):
@@ -287,6 +299,140 @@ def test_aptl_target_passes_orchestration_evaluation_conformance(tmp_path):
         for case in report.cases
         if not case.passed
     ]
+
+
+def test_aptl_target_passes_full_remote_control_plane_conformance(tmp_path):
+    from aces_conformance.conformance import run_target_conformance
+
+    from aptl.backends.aces import create_aptl_runtime_target
+
+    backend = MagicMock()
+    config = AptlConfig(lab={"name": "test"})
+    target = create_aptl_runtime_target(
+        project_dir=tmp_path,
+        config=config,
+        backend=backend,
+    )
+
+    report = run_target_conformance(target, profile="full-remote-control-plane")
+
+    assert report.passed is True, [d.code for d in report.diagnostics]
+    assert report.unsupported_contract_gaps == ()
+    assert report.unsupported_capability_gaps == ()
+    assert all(case.passed for case in report.cases), [
+        (case.name, [d.message for d in case.diagnostics])
+        for case in report.cases
+        if not case.passed
+    ]
+
+
+def test_participant_runtime_lifecycle_updates_control_plane_snapshot(tmp_path):
+    from aces_contracts.participant_episode import (
+        ParticipantEpisodeTerminalReason,
+        iter_participant_episode_snapshot_violations,
+    )
+    from aces_contracts.runtime_state import OperationState
+    from aces_runtime.control_plane import RuntimeControlPlane
+
+    from aptl.backends.aces import create_aptl_runtime_target
+
+    backend = MagicMock()
+    config = AptlConfig(lab={"name": "test"})
+    target = create_aptl_runtime_target(
+        project_dir=tmp_path,
+        config=config,
+        backend=backend,
+    )
+    control_plane = RuntimeControlPlane(target)
+    participant = "participant.conformance"
+
+    init = control_plane.initialize_participant_episode(participant)
+    reset = control_plane.reset_participant_episode(participant)
+    terminate = control_plane.terminate_participant_episode(
+        participant,
+        terminal_reason=ParticipantEpisodeTerminalReason.COMPLETED,
+    )
+    restart = control_plane.restart_participant_episode(participant)
+
+    for receipt in (init, reset, terminate, restart):
+        status = control_plane.get_operation(receipt.operation_id)
+        assert status is not None
+        assert status.state == OperationState.SUCCEEDED, status.diagnostics
+
+    snapshot = control_plane.snapshot
+    assert participant in snapshot.participant_episode_results
+    assert len(snapshot.participant_episode_history[participant]) >= 6
+    assert (
+        list(
+            iter_participant_episode_snapshot_violations(
+                snapshot.participant_episode_results,
+                snapshot.participant_episode_history,
+            )
+        )
+        == []
+    )
+
+
+def test_participant_runtime_action_drives_backend_and_records_behavior(tmp_path):
+    import subprocess
+
+    from aces_contracts.participant_behavior import (
+        iter_participant_behavior_snapshot_violations,
+    )
+    from aces_contracts.runtime_state import OperationState
+    from aces_runtime.control_plane import RuntimeControlPlane
+
+    from aptl.backends.aces import create_aptl_runtime_target
+    from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS
+
+    backend = MagicMock()
+    backend.container_exec.return_value = subprocess.CompletedProcess(
+        args=["nmap"],
+        returncode=0,
+        stdout="Host: 172.20.2.20 () Ports: 22/open/tcp//ssh///",
+        stderr="",
+    )
+    config = AptlConfig(lab={"name": "test"})
+    target = create_aptl_runtime_target(
+        project_dir=tmp_path,
+        config=config,
+        backend=backend,
+    )
+    control_plane = RuntimeControlPlane(target)
+
+    receipt = control_plane.initialize_participant_episode(PARTICIPANT_ACTION_ADDRESS)
+    status = control_plane.get_operation(receipt.operation_id)
+
+    assert status is not None
+    assert status.state == OperationState.SUCCEEDED, status.diagnostics
+    backend.container_exec.assert_called_once_with(
+        "aptl-kali",
+        ["nmap", "-p", "22", "-Pn", "--open", "172.20.2.20", "-oG", "-"],
+        timeout=120,
+    )
+    snapshot = control_plane.snapshot
+    behavior = snapshot.participant_behavior_history[PARTICIPANT_ACTION_ADDRESS]
+    assert [event["event_type"] for event in behavior] == [
+        "action_attempted",
+        "observation_emitted",
+    ]
+    assert behavior[-1]["actor_provenance"] == "codex-cli"
+    assert "22/open" in behavior[-1]["details"]["stdout_excerpt"]
+    assert any(
+        entry.resource_type == "participant-action-instance"
+        for entry in snapshot.entries.values()
+    )
+    assert (
+        list(
+            iter_participant_behavior_snapshot_violations(
+                snapshot.participant_behavior_history,
+                participant_episode_results=snapshot.participant_episode_results,
+                participant_episode_history=snapshot.participant_episode_history,
+                metadata=snapshot.metadata,
+            )
+        )
+        == []
+    )
 
 
 def test_start_aces_scenario_uses_parser_runtime_manager_and_backend(
@@ -400,10 +546,14 @@ def _workflow_orchestration_plan():
             """
         )
     )
-    return aces_plan(compile_runtime_model(scenario), create_aptl_manifest()).orchestration
+    return aces_plan(
+        compile_runtime_model(scenario), create_aptl_manifest()
+    ).orchestration
 
 
-def test_start_aces_scenario_submits_orchestration_for_workflow_scenario(mocker, tmp_path):
+def test_start_aces_scenario_submits_orchestration_for_workflow_scenario(
+    mocker, tmp_path
+):
     """A scenario carrying workflows routes through the control plane's
     orchestration submission (not just provisioning), and the lab still starts."""
     from aces_contracts.runtime_state import OperationState
@@ -413,7 +563,9 @@ def test_start_aces_scenario_submits_orchestration_for_workflow_scenario(mocker,
     _write_compose(tmp_path, {"victim": ["victim"]})
     mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=object())
     orchestration = _workflow_orchestration_plan()
-    assert orchestration.actionable_operations  # guard: the plan really carries workflows
+    assert (
+        orchestration.actionable_operations
+    )  # guard: the plan really carries workflows
 
     submit_calls: list[str] = []
 
@@ -537,7 +689,9 @@ def test_start_aces_scenario_fails_when_orchestration_fails(mocker, tmp_path):
     assert result.lab_result.error
 
 
-def test_start_aces_scenario_submits_evaluation_for_objective_scenario(mocker, tmp_path):
+def test_start_aces_scenario_submits_evaluation_for_objective_scenario(
+    mocker, tmp_path
+):
     """A scenario carrying objectives routes through the control plane's
     evaluation submission after provisioning and orchestration."""
     from aces_contracts.planning import ChangeAction, EvaluationOp, EvaluationPlan
@@ -681,6 +835,8 @@ def test_start_aces_scenario_drives_workflows_after_registration(mocker, tmp_pat
             )
 
     def fake_create_target(*, project_dir, config, backend):
+        from aptl.backends.aces_participant_runtime import AptlParticipantRuntime
+
         target = aces.RuntimeTarget(
             name=aces.APTL_ACES_TARGET_NAME,
             manifest=aces.create_aptl_manifest(),
@@ -691,6 +847,7 @@ def test_start_aces_scenario_drives_workflows_after_registration(mocker, tmp_pat
             ),
             orchestrator=RecordingOrchestrator(),
             evaluator=aces.AptlEvaluator(),
+            participant_runtime=AptlParticipantRuntime(deployment_backend=backend),
         )
         return target
 

--- a/tests/test_curated_live_proof.py
+++ b/tests/test_curated_live_proof.py
@@ -331,7 +331,7 @@ def test_participant_action_proof_uses_control_plane_and_records_behavior(
     ]
     assert behavior[-1]["actor_provenance"] == "codex-cli"
     assert any(
-        address.startswith("participant.techvault.kali-victim-ssh-probe.")
+        address.startswith(f"{PARTICIPANT_ACTION_ADDRESS}.")
         for address in proof["participant_snapshot_entries"]
     )
     assert proof["post_action_range_snapshot"]["containers"][0]["name"] == "aptl-kali"

--- a/tests/test_curated_live_proof.py
+++ b/tests/test_curated_live_proof.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import subprocess
 
 import pytest
 
@@ -20,6 +21,7 @@ from aptl.core.config import AptlConfig
 from aptl.validation.curated_live_proof import (
     compare_to_snapshot,
     expected_reduced_matrix,
+    run_participant_action_proof,
     summarize_snapshot,
 )
 
@@ -246,3 +248,90 @@ def test_variants_yield_distinct_reduced_surfaces():
         for v in VARIANTS
     }
     assert len(profile_sets) == len(VARIANTS)
+
+
+def test_participant_action_proof_uses_control_plane_and_records_behavior(
+    monkeypatch,
+    tmp_path,
+):
+    from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS
+    from aptl.validation import curated_live_proof
+
+    class FakeBackend:
+        def container_exec(self, name, cmd, *, timeout=None):
+            self.call = (name, cmd, timeout)
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="Host: 172.20.2.20 () Ports: 22/open/tcp//ssh///",
+                stderr="",
+            )
+
+    class FakeRangeSnapshot:
+        def to_dict(self):
+            return {
+                "timestamp": "2026-06-25T00:00:00+00:00",
+                "containers": [
+                    {
+                        "name": "aptl-kali",
+                        "image": "kalilinux/kali-rolling",
+                        "status": "Up 1m",
+                        "health": None,
+                        "networks": {"aptl_aptl-redteam": "172.20.4.10"},
+                        "ports": [],
+                    },
+                    {
+                        "name": "aptl-victim",
+                        "image": "aptl/victim",
+                        "status": "Up 1m",
+                        "health": "healthy",
+                        "networks": {"aptl_aptl-internal": "172.20.2.20"},
+                        "ports": [],
+                    },
+                ],
+                "networks": [
+                    {
+                        "name": "aptl_aptl-redteam",
+                        "subnet": "172.20.4.0/24",
+                        "gateway": "172.20.4.1",
+                        "containers": ["aptl-kali"],
+                    }
+                ],
+            }
+
+    backend = FakeBackend()
+    monkeypatch.setattr(curated_live_proof, "get_backend", lambda config, root: backend)
+    monkeypatch.setattr(
+        curated_live_proof,
+        "capture_snapshot",
+        lambda config_dir, backend: FakeRangeSnapshot(),
+    )
+
+    proof = run_participant_action_proof(
+        tmp_path,
+        AptlConfig(
+            lab={"name": "techvault"}, containers={"kali": True, "victim": True}
+        ),
+    )
+
+    assert proof["verdict"] == "PASS", proof["validation"]
+    assert proof["operation_status"]["state"] == "succeeded"
+    assert proof["operation_receipt_contract"] == "operation-receipt-v1"
+    assert proof["runtime_snapshot_contract"] == "runtime-snapshot-v1"
+    assert backend.call == (
+        "aptl-kali",
+        ["nmap", "-p", "22", "-Pn", "--open", "172.20.2.20", "-oG", "-"],
+        120,
+    )
+    assert PARTICIPANT_ACTION_ADDRESS in proof["participant_episode_results"]
+    behavior = proof["participant_behavior_history"][PARTICIPANT_ACTION_ADDRESS]
+    assert [event["event_type"] for event in behavior] == [
+        "action_attempted",
+        "observation_emitted",
+    ]
+    assert behavior[-1]["actor_provenance"] == "codex-cli"
+    assert any(
+        address.startswith("participant.techvault.kali-victim-ssh-probe.")
+        for address in proof["participant_snapshot_entries"]
+    )
+    assert proof["post_action_range_snapshot"]["containers"][0]["name"] == "aptl-kali"

--- a/tests/test_techvault_live_gate.py
+++ b/tests/test_techvault_live_gate.py
@@ -109,7 +109,9 @@ def _node(name, profiles, aliases=None, declared_health=None):
     }
 
 
-def _container(name, *, status="Up 2 minutes (healthy)", health="healthy", networks=None):
+def _container(
+    name, *, status="Up 2 minutes (healthy)", health="healthy", networks=None
+):
     return {
         "name": name,
         "status": status,
@@ -118,7 +120,9 @@ def _container(name, *, status="Up 2 minutes (healthy)", health="healthy", netwo
     }
 
 
-def _wire_boot(monkeypatch, *, outcome=StartupOutcome.READY, realization=None, snapshot=None):
+def _wire_boot(
+    monkeypatch, *, outcome=StartupOutcome.READY, realization=None, snapshot=None
+):
     """Monkeypatch the boot path's leaf dependencies for the happy path."""
     realization = realization or _Realization(
         [_node("webapp", ["dmz"])], ["dmz", "soc"]
@@ -196,17 +200,23 @@ def test_validate_live_deployment_composes_all_checks(monkeypatch):
     # (the `*a, **k` shape would silently mask a missing kwarg — the live smoke
     # run caught exactly that for `check_scenario_variation(state=...)`).
     def static(scenario_path, *, project_dir, config, options):
-        return object(), LiveGateCheck("static_prerequisite", CATEGORY_ACES_SPECIFICATION, True)
+        return object(), LiveGateCheck(
+            "static_prerequisite", CATEGORY_ACES_SPECIFICATION, True
+        )
 
     def inputs(scenario_path, *, project_dir, options):
-        return LiveGateCheck("boot_inputs_match_public_path", CATEGORY_BACKEND_INSTANTIATION, True)
+        return LiveGateCheck(
+            "boot_inputs_match_public_path", CATEGORY_BACKEND_INSTANTIATION, True
+        )
 
     def boot(scenario, *, project_dir, config, options, state, scenario_path):
         assert scenario_path == SCENARIO
         return LiveGateCheck("aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, True)
 
     def readiness(*, state):
-        return LiveGateCheck("defensive_stack_readiness", CATEGORY_DEFENSIVE_STACK_READINESS, True)
+        return LiveGateCheck(
+            "defensive_stack_readiness", CATEGORY_DEFENSIVE_STACK_READINESS, True
+        )
 
     def reachability(*, project_dir, config, state):
         return LiveGateCheck("kali_reachability", CATEGORY_KALI_REACHABILITY, True)
@@ -214,11 +224,15 @@ def test_validate_live_deployment_composes_all_checks(monkeypatch):
     def telemetry(*, project_dir, config, options, state):
         return LiveGateCheck("telemetry_evidence_path", CATEGORY_EVIDENCE_CAPTURE, True)
 
-    def archive(scenario_path, *, project_dir, config, run_store, run_id, state, prior_checks):
+    def archive(
+        scenario_path, *, project_dir, config, run_store, run_id, state, prior_checks
+    ):
         return LiveGateCheck("run_archive_manifest", CATEGORY_EVIDENCE_CAPTURE, True)
 
     def variation(*, project_dir, config, state):
-        return LiveGateCheck("scenario_variation", CATEGORY_BACKEND_INTERPRETATION, True)
+        return LiveGateCheck(
+            "scenario_variation", CATEGORY_BACKEND_INTERPRETATION, True
+        )
 
     monkeypatch.setattr(lgc, "check_static_prerequisite", static)
     monkeypatch.setattr(lgc, "check_boot_inputs_match_public_path", inputs)
@@ -254,7 +268,12 @@ def test_validate_live_deployment_short_circuits_on_static_failure(monkeypatch):
     monkeypatch.setattr(
         lgc,
         "check_static_prerequisite",
-        lambda *a, **k: (None, LiveGateCheck("static_prerequisite", CATEGORY_ACES_SPECIFICATION, False, ("bad",))),
+        lambda *a, **k: (
+            None,
+            LiveGateCheck(
+                "static_prerequisite", CATEGORY_ACES_SPECIFICATION, False, ("bad",)
+            ),
+        ),
     )
     report = validate_live_deployment(
         SCENARIO, project_dir=PROJECT_ROOT, config=_config()
@@ -267,19 +286,26 @@ def test_validate_live_deployment_records_archive_on_boot_failure(monkeypatch):
     monkeypatch.setattr(
         lgc,
         "check_static_prerequisite",
-        lambda *a, **k: (object(), LiveGateCheck("static_prerequisite", CATEGORY_ACES_SPECIFICATION, True)),
+        lambda *a, **k: (
+            object(),
+            LiveGateCheck("static_prerequisite", CATEGORY_ACES_SPECIFICATION, True),
+        ),
     )
     monkeypatch.setattr(
         lgc,
         "check_aces_driven_boot",
-        lambda *a, **k: LiveGateCheck("aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, False, ("boom",)),
+        lambda *a, **k: LiveGateCheck(
+            "aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, False, ("boom",)
+        ),
     )
     archive_calls = []
     monkeypatch.setattr(
         lgc,
         "check_run_archive_manifest",
-        lambda *a, **k: archive_calls.append(1)
-        or LiveGateCheck("run_archive_manifest", CATEGORY_EVIDENCE_CAPTURE, True),
+        lambda *a, **k: (
+            archive_calls.append(1)
+            or LiveGateCheck("run_archive_manifest", CATEGORY_EVIDENCE_CAPTURE, True)
+        ),
     )
     report = validate_live_deployment(
         SCENARIO, project_dir=PROJECT_ROOT, config=_config()
@@ -331,7 +357,11 @@ def test_check_aces_driven_boot_happy_populates_state(monkeypatch):
     _wire_boot(monkeypatch)
     state = LiveGateState()
     check = lgc.check_aces_driven_boot(
-        object(), project_dir=PROJECT_ROOT, config=_config(), options=LiveGateOptions(), state=state
+        object(),
+        project_dir=PROJECT_ROOT,
+        config=_config(),
+        options=LiveGateOptions(),
+        state=state,
     )
     assert check.passed and check.category == CATEGORY_BACKEND_INSTANTIATION
     assert state.realization_details["nodes"]
@@ -340,11 +370,17 @@ def test_check_aces_driven_boot_happy_populates_state(monkeypatch):
 
 
 def test_check_aces_driven_boot_fails_on_interpretation_error(monkeypatch):
-    bad = _Realization([_node("webapp", ["dmz"])], ["dmz"], diagnostics=(_Diag("error"),))
+    bad = _Realization(
+        [_node("webapp", ["dmz"])], ["dmz"], diagnostics=(_Diag("error"),)
+    )
     _wire_boot(monkeypatch, realization=bad)
     state = LiveGateState()
     check = lgc.check_aces_driven_boot(
-        object(), project_dir=PROJECT_ROOT, config=_config(), options=LiveGateOptions(), state=state
+        object(),
+        project_dir=PROJECT_ROOT,
+        config=_config(),
+        options=LiveGateOptions(),
+        state=state,
     )
     assert not check.passed and check.category == CATEGORY_BACKEND_INTERPRETATION
 
@@ -353,7 +389,11 @@ def test_check_aces_driven_boot_fails_on_empty_realization(monkeypatch):
     _wire_boot(monkeypatch, realization=_Realization([], []))
     state = LiveGateState()
     check = lgc.check_aces_driven_boot(
-        object(), project_dir=PROJECT_ROOT, config=_config(), options=LiveGateOptions(), state=state
+        object(),
+        project_dir=PROJECT_ROOT,
+        config=_config(),
+        options=LiveGateOptions(),
+        state=state,
     )
     assert not check.passed
     assert any("no ACES nodes" in d for d in check.diagnostics)
@@ -363,7 +403,11 @@ def test_check_aces_driven_boot_fails_on_boot_failed(monkeypatch):
     _wire_boot(monkeypatch, outcome=StartupOutcome.FAILED)
     state = LiveGateState()
     check = lgc.check_aces_driven_boot(
-        object(), project_dir=PROJECT_ROOT, config=_config(), options=LiveGateOptions(), state=state
+        object(),
+        project_dir=PROJECT_ROOT,
+        config=_config(),
+        options=LiveGateOptions(),
+        state=state,
     )
     assert not check.passed and check.category == CATEGORY_BACKEND_INSTANTIATION
     assert any("public lab start failed" in d for d in check.diagnostics)
@@ -375,8 +419,9 @@ def test_check_aces_driven_boot_skips_cleanup_and_reboot_when_requested(monkeypa
     monkeypatch.setattr(
         lgp,
         "clean_boot_lab",
-        lambda *a, **k: boots.append(1)
-        or LabResult(success=True, outcome=StartupOutcome.READY),
+        lambda *a, **k: (
+            boots.append(1) or LabResult(success=True, outcome=StartupOutcome.READY)
+        ),
     )
     state = LiveGateState()
     check = lgc.check_aces_driven_boot(
@@ -422,10 +467,10 @@ def test_check_aces_driven_boot_passes_selected_scenario_to_public_start(monkeyp
     monkeypatch.setattr(
         lgp,
         "clean_boot_lab",
-        lambda p, *, remove_volumes=True, scenario_path=None: boots.append(
-            (p, scenario_path)
-        )
-        or LabResult(success=True, outcome=StartupOutcome.READY),
+        lambda p, *, remove_volumes=True, scenario_path=None: (
+            boots.append((p, scenario_path))
+            or LabResult(success=True, outcome=StartupOutcome.READY)
+        ),
     )
     state = LiveGateState()
     selected = PROJECT_ROOT / "scenarios" / "custom.sdl.yaml"
@@ -472,7 +517,9 @@ def test_boot_inputs_pass_for_full_inventory_scenario_when_profile_matches():
 
 def test_boot_inputs_fail_for_mismatched_profile():
     check = lgc.check_boot_inputs_match_public_path(
-        SCENARIO, project_dir=PROJECT_ROOT, options=LiveGateOptions(profile="evaluation")
+        SCENARIO,
+        project_dir=PROJECT_ROOT,
+        options=LiveGateOptions(profile="evaluation"),
     )
     assert not check.passed
     assert any("capability profile" in d for d in check.diagnostics)
@@ -484,14 +531,19 @@ def test_validate_live_deployment_short_circuits_on_profile_mismatch(monkeypatch
     monkeypatch.setattr(
         lgc,
         "check_static_prerequisite",
-        lambda *a, **k: (object(), LiveGateCheck("static_prerequisite", CATEGORY_ACES_SPECIFICATION, True)),
+        lambda *a, **k: (
+            object(),
+            LiveGateCheck("static_prerequisite", CATEGORY_ACES_SPECIFICATION, True),
+        ),
     )
     booted = []
     monkeypatch.setattr(
         lgc,
         "check_aces_driven_boot",
-        lambda *a, **k: booted.append(1)
-        or LiveGateCheck("aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, True),
+        lambda *a, **k: (
+            booted.append(1)
+            or LiveGateCheck("aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, True)
+        ),
     )
     report = validate_live_deployment(
         PROJECT_ROOT / "scenarios" / "other.sdl.yaml",
@@ -562,7 +614,9 @@ def test_readiness_tolerates_unhealthy_non_node_infra():
         [_node("webapp", ["dmz"])],
         [
             _container("aptl-webapp"),
-            _container("aptl-otel-collector", status="Up 1m (unhealthy)", health="unhealthy"),
+            _container(
+                "aptl-otel-collector", status="Up 1m (unhealthy)", health="unhealthy"
+            ),
         ],
     )
     check = lgc.check_defensive_stack_readiness(state=state)
@@ -623,7 +677,11 @@ def test_readiness_fails_when_declared_healthy_but_health_unreported():
 def test_readiness_fails_when_declared_healthy_but_still_starting():
     state = _readiness_state(
         [_node("webapp", ["dmz"], declared_health="healthy")],
-        [_container("aptl-webapp", status="Up 5s (health: starting)", health="starting")],
+        [
+            _container(
+                "aptl-webapp", status="Up 5s (health: starting)", health="starting"
+            )
+        ],
     )
     check = lgc.check_defensive_stack_readiness(state=state)
     assert not check.passed
@@ -739,7 +797,9 @@ def test_telemetry_passes_when_traffic_evidence_collected(monkeypatch):
     monkeypatch.setattr(lgc, "get_backend", lambda c, p: _Backend())
     _patch_collect_no_sleep(monkeypatch)
     monkeypatch.setattr(
-        lgp, "collect_suricata_eve", lambda s, e, b: [{"event_type": "alert"}, {"event_type": "flow"}]
+        lgp,
+        "collect_suricata_eve",
+        lambda s, e, b: [{"event_type": "alert"}, {"event_type": "flow"}],
     )
     monkeypatch.setattr(lgp, "collect_wazuh_alerts", lambda s, e: [])
     state = _telemetry_state()
@@ -761,7 +821,9 @@ def test_telemetry_fails_on_stats_only_events(monkeypatch):
     monkeypatch.setattr(lgc, "get_backend", lambda c, p: _Backend())
     _patch_collect_no_sleep(monkeypatch)
     monkeypatch.setattr(
-        lgp, "collect_suricata_eve", lambda s, e, b: [{"event_type": "stats"}, {"event_type": "stats"}]
+        lgp,
+        "collect_suricata_eve",
+        lambda s, e, b: [{"event_type": "stats"}, {"event_type": "stats"}],
     )
     monkeypatch.setattr(lgp, "collect_wazuh_alerts", lambda s, e: [])
     state = _telemetry_state()
@@ -794,9 +856,14 @@ def test_telemetry_fails_when_no_evidence(monkeypatch):
 
 def test_telemetry_fails_without_target(monkeypatch):
     state = LiveGateState()
-    state.snapshot = {"containers": [_container("aptl-kali", networks={"n": "1.1.1.1"})]}
+    state.snapshot = {
+        "containers": [_container("aptl-kali", networks={"n": "1.1.1.1"})]
+    }
     check = lgc.check_telemetry_evidence_path(
-        project_dir=PROJECT_ROOT, config=_config(), options=LiveGateOptions(), state=state
+        project_dir=PROJECT_ROOT,
+        config=_config(),
+        options=LiveGateOptions(),
+        state=state,
     )
     assert not check.passed
 
@@ -850,7 +917,12 @@ def test_run_archive_writes_manifest_through_redacting_boundary():
     assert path == "live-gate/manifest.json"
     assert manifest["aces_provenance"]["realization"]["nodes"]
     assert manifest["aces_provenance"]["selected_profiles"] == ["dmz", "soc"]
-    assert manifest["evaluator_surfaces"]["profile"] == "orchestration-evaluation"
+    assert manifest["evaluator_surfaces"]["profile"] == "full-remote-control-plane"
+    assert manifest["participant_runtime_surfaces"]["contracts"] == [
+        "participant-episode-state-envelope-v1",
+        "participant-episode-history-event-stream-v1",
+        "participant-behavior-history-event-stream-v1",
+    ]
     assert manifest["scenario"]["name"] == "techvault-operational"
 
 
@@ -1027,7 +1099,9 @@ def test_variation_fails_without_two_distinct_nodes():
 def test_variation_fails_on_realization_error(monkeypatch):
     results = iter(
         [
-            _Realization([_node("kali", ["kali"])], ["kali"], diagnostics=(_Diag("error"),)),
+            _Realization(
+                [_node("kali", ["kali"])], ["kali"], diagnostics=(_Diag("error"),)
+            ),
             _Realization([_node("webapp", ["dmz"])], ["dmz"]),
         ]
     )
@@ -1054,9 +1128,7 @@ def test_live_gate_passes_on_techvault():
     from aptl.core.config import load_config
 
     config = load_config(PROJECT_ROOT / "aptl.json")
-    report = validate_live_deployment(
-        SCENARIO, project_dir=PROJECT_ROOT, config=config
-    )
+    report = validate_live_deployment(SCENARIO, project_dir=PROJECT_ROOT, config=config)
     assert report.passed, report.render()
 
 
@@ -1070,7 +1142,7 @@ def _patch_cli(mocker, *, passed=True):
 
     report = LiveGateReport(
         "scn",
-        "orchestration-evaluation",
+        "full-remote-control-plane",
         "rid",
         (LiveGateCheck("aces_driven_boot", CATEGORY_BACKEND_INSTANTIATION, passed),),
     )

--- a/tests/test_techvault_static_gate.py
+++ b/tests/test_techvault_static_gate.py
@@ -165,7 +165,10 @@ def test_target_conformance_fails_loudly_on_missing_corpus(tmp_path):
         project_dir=PROJECT_ROOT, config=config, backend=_NoStartBackend()
     )
     report = run_target_conformance(
-        target, profile="orchestration-evaluation", root=tmp_path, profiles_root=tmp_path
+        target,
+        profile="full-remote-control-plane",
+        root=tmp_path,
+        profiles_root=tmp_path,
     )
     assert not report.passed
 
@@ -178,7 +181,7 @@ def test_backend_conformance_fails_loudly_on_missing_corpus(tmp_path):
     check = check_backend_conformance(
         project_dir=PROJECT_ROOT,
         config=config,
-        profile="orchestration-evaluation",
+        profile="full-remote-control-plane",
         profiles_root=tmp_path,  # empty corpus root -> profile artifact not found
         fixtures_root=tmp_path,
     )
@@ -287,7 +290,9 @@ def test_parity_fails_closed_when_surface_entry_is_not_a_mapping(tmp_path):
 
 
 def test_parity_fails_when_deferred_without_issue(tmp_path):
-    coverage = _full_coverage(objectives={"status": "deferred", "blocking_followup": "n/a"})
+    coverage = _full_coverage(
+        objectives={"status": "deferred", "blocking_followup": "n/a"}
+    )
     check = _parity(tmp_path, coverage)
     assert not check.passed
     assert any("without a tracking issue" in d for d in check.diagnostics)
@@ -568,7 +573,9 @@ def test_check_import_lock_missing_and_unavailable(tmp_path, monkeypatch):
     scenario = tmp_path / "techvault.sdl.yaml"
     scenario.write_text("name: t\n")
     check = check_import_lock(scenario)
-    assert not check.passed and any("missing import lockfile" in d for d in check.diagnostics)
+    assert not check.passed and any(
+        "missing import lockfile" in d for d in check.diagnostics
+    )
 
     (tmp_path / "aces.lock.json").write_text("{}")
     monkeypatch.setattr(gc, "_run_aces", lambda *a, **k: None)
@@ -587,7 +594,9 @@ def test_check_provisioning_realization_handles_raise(monkeypatch):
 
     monkeypatch.setattr(gc, "create_aptl_runtime_target", _boom)
     details, check = check_provisioning_realization(
-        scenario=object(), project_dir=PROJECT_ROOT, config=AptlConfig(lab={"name": "t"})
+        scenario=object(),
+        project_dir=PROJECT_ROOT,
+        config=AptlConfig(lab={"name": "t"}),
     )
     assert details is None and not check.passed
 
@@ -643,10 +652,14 @@ def test_check_provisioning_realization_fails_on_profile_mismatch(tmp_path):
 
 def test_validate_scenario_composes_checks(monkeypatch, tmp_path):
     monkeypatch.setattr(gc, "check_parse", lambda p: ("scn", GateCheck("parse", True)))
-    monkeypatch.setattr(gc, "check_import_lock", lambda p: GateCheck("import_lock", True))
+    monkeypatch.setattr(
+        gc, "check_import_lock", lambda p: GateCheck("import_lock", True)
+    )
     monkeypatch.setattr(gc, "check_compile", lambda s: GateCheck("compile", True))
     monkeypatch.setattr(
-        gc, "check_backend_conformance", lambda **k: GateCheck("backend_conformance", True)
+        gc,
+        "check_backend_conformance",
+        lambda **k: GateCheck("backend_conformance", True),
     )
     monkeypatch.setattr(
         gc,


### PR DESCRIPTION
## Summary

Promote APTL's ACES target to the full remote-control-plane profile by adding a real participant runtime, then prove the TechVault red participant action through the ACES control plane and committed live evidence.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #554

## ADR Impact

- ADR-021
- ADR-029
- ADR-035
- ADR-038

## Changes

- Add `AptlParticipantRuntime` for participant episode lifecycle control and bounded Kali-to-victim action behavior history.
- Wire the participant runtime into `RuntimeTarget` and promote the backend manifest/default validation profile to `full-remote-control-plane`.
- Extend curated live proof tooling to boot without `--skip-seed`, drive the attacker-target participant action, and persist `participant-action.json` evidence.
- Update docs, live-gate archive metadata, changelog, and pytest coverage for manifest promotion, conformance, lifecycle control, and proof evidence.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification passed: `uv run pytest -n auto -k "not integration"`; `uv run pytest -n auto tests/test_techvault_static_gate.py -m integration`; `pre-commit run --all-files`; `docs/aces/techvault-curated-live-validation-gate/run-curated-live-proof.sh techvault-attacker-target` (boot PASS, participant_action PASS with 2 behavior events). Test-quality review was clean. Codex review cycle 1 found one aggregate-result issue in the proof script; fixed locally and reverified, with user authorization to proceed without an over-cap review.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #554 ← src/aptl/backends/aces_participant_runtime.py, Issue #554 ← src/aptl/backends/aces.py, Issue #554 ← src/aptl/backends/aces_manifest.py, Issue #554 ← src/aptl/validation/curated_live_proof.py, Issue #554 ← docs/aces/techvault-curated-live-validation-gate/techvault-attacker-target/participant-action.json
- TESTS: Issue #554 ← tests/test_aces_backend.py, Issue #554 ← tests/test_curated_live_proof.py, Issue #554 ← tests/test_techvault_static_gate.py, Issue #554 ← tests/test_techvault_live_gate.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/554.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
