### PR TITLE
docs: add web GUI design specification

### DIFF
--- a/changelog.d/540.added.md
+++ b/changelog.d/540.added.md
@@ -1,0 +1,1 @@
+**Added the APTL web GUI design specification.** The new spec records the v1 product scope, route map, page interaction design, component inventory, API contract gaps, security UX, and implementation checklist for the shipped web GUI surface.

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ aptl lab start
 
 ### Scenarios & Runs
 - [SOC Architecture Spec](specs/soc-feature-spec.md): Historical pre-SDL runtime spec retained for context
+- [Web GUI Design Specification](specs/web-gui-design.md): v1 product scope, route map, interaction design, component inventory, and implementation hand-off
 
 ### Testing
 - [Smoke Test Plan](testing/smoke-test-plan.md): Historical full-stack plan for the pre-SDL scenario engine

--- a/docs/specs/web-gui-design-preflight.md
+++ b/docs/specs/web-gui-design-preflight.md
@@ -68,10 +68,18 @@ The design specification must name how each in-scope page passes these layers.
 - Keep the ADR-011 notebook/workbench paradigm. Do not drift into an enterprise
   SOC dashboard: no mission-control tile wall, icon-only sidebar, status-dot
   matrix, or dense product-console chrome.
+- Keep the visual language specific to a local purple-team lab workbench. Do
+  not use marketing heroes, purple gradients, decorative glow, glassmorphism,
+  bento grids, nested card walls, fake analytics charts, or oversized rounded
+  icon tiles.
 - Reuse the current component families before inventing new ones:
   `NavBar`, `LabStatusBadge`, `ContainerGrid`, `LabStartNotice`, `Terminal`,
   and workbench blocks. If a new recurring UI primitive is needed, document
   which existing component pattern it extends.
+- Use Tailwind v4 tokens and a small APTL component kit as the design-system
+  base. External component primitives may be used for accessible behavior such
+  as dialogs, menus, popovers, tabs, and tooltips, but they must not replace
+  APTL's route structure, palette, density, or security copy.
 - Keep API DTOs server-owned. Add or change Python response models in
   `src/aptl/api/schemas.py` first, then mirror the stable wire shape in
   `web/src/lib/types.ts`; do not let the Svelte layer infer core state from
@@ -89,6 +97,18 @@ The design specification must name how each in-scope page passes these layers.
 - Keep page-local logic thin. Shared fetch behavior belongs in
   `web/src/lib/api.ts`, shared lab status in `web/src/lib/stores/lab.ts`, and
   scenario workbench shaping in `web/src/lib/workbench.ts`.
+- Target WCAG 2.2 AA for shipped routes. Keyboard access, visible focus,
+  target sizing, contrast, non-color status cues, accessible dialogs, and
+  screen-reader-safe live updates are implementation requirements, not polish.
+- Keep UI copy localization-ready even while v1 ships English-only. Centralize
+  user-facing strings, use shared date/time/count formatters, avoid sentence
+  concatenation, and avoid layouts that depend on English-length labels.
+- Treat persistent settings as browser-local non-secret preferences only. Do
+  not persist tokens, terminal input/output, copied commands, raw SIEM custom
+  queries, scenario answers, or investigation notes in v1.
+- Include a local-use and privacy notice before controlled actions. Do not add
+  cookie-consent or terms-wall patterns unless non-essential analytics,
+  third-party embeds, or legally approved terms text are introduced.
 
 ## Extensibility Seams
 

--- a/docs/specs/web-gui-design-preflight.md
+++ b/docs/specs/web-gui-design-preflight.md
@@ -1,0 +1,150 @@
+# Web GUI Design Preflight Guardrails
+
+## Scope
+
+This note is the architecture preflight for UI-007. It is not the UI-007 design
+specification and does not define the final information architecture, route map,
+or page wireframes. The UI-007 design specification must derive those details
+from the approved UI-006 product scope and must leave a direct handoff target
+for UI-008 implementation.
+
+The design work must treat the current Svelte pages as an MVP surface, not as
+binding product authority. Existing architecture decisions and code boundaries
+remain binding.
+
+## Canonical Incumbents
+
+Use the existing owners below before adding a new schema, helper, exception
+type, route contract, or workflow concept.
+
+| Concern | Canonical owner |
+| --- | --- |
+| Web product paradigm | `docs/adrs/adr-011-web-ui.md` |
+| API assembly, CORS, route mounting | `src/aptl/api/main.py` |
+| Web auth, auth env binding, project-dir binding | `src/aptl/api/deps.py` |
+| API response DTOs | `src/aptl/api/schemas.py` |
+| Svelte API fetch boundary and SSE subscription | `web/src/lib/api.ts` |
+| Svelte wire-type mirror | `web/src/lib/types.ts` |
+| Svelte server-side bearer-token proxy | `web/src/hooks.server.ts` |
+| WebSocket terminal token carrier data | `web/src/routes/+layout.server.ts` |
+| Lab lifecycle and startup diagnostics | `src/aptl/core/lab.py`, `src/aptl/core/lab_types.py`, ADR-030 |
+| Endpoint display and terminal target metadata | `src/aptl/core/endpoints.py`, ADR-036, ADR-040 |
+| Docker and Docker Compose access | `src/aptl/core/deployment/`, ADR-023, ADR-037 |
+| Durable first-party config | `src/aptl/core/config.py`, ADR-025 |
+| Runtime environment and placeholder checks | `src/aptl/core/env.py`, `src/aptl/utils/placeholders.py`, `WebAuthSettings.from_env()` |
+| Secret redaction and serialization safety | `src/aptl/utils/redaction.py`, `mcp/aptl-mcp-common/src/redaction.ts`, ADR-029 |
+| Scenario catalog and SDL validation | `src/aptl/core/scenario_catalog.py`, ACES parser authority, ADR-035 |
+| Logging | `src/aptl/utils/logging.py` and module-local `get_logger(...)` |
+| Run artifact persistence | `src/aptl/core/runstore.py` |
+| Web component inventory | `web/src/lib/components/` and `web/src/lib/components/workbench/` |
+| Web tests | `web/tests/**` with `npm test` / `vitest run` |
+| Python API and core tests | `tests/test_api_*.py`, `tests/test_endpoints.py`, `pytest` |
+| Completion gate | `.ground-control.yaml`, `.gc/plan-rules.md`, `pre-commit run --all-files` |
+
+## Security Layers
+
+The design specification must name how each in-scope page passes these layers.
+
+| Layer | Required fit |
+| --- | --- |
+| Auth surface | All `/api/*` HTTP and SSE traffic stays behind `verify_token` through `src/aptl/api/main.py`. Browser REST/SSE calls go through the SvelteKit proxy in `web/src/hooks.server.ts`; the browser must not place the API token in fetch headers or URLs. |
+| WebSocket terminal auth | Terminal access uses ADR-039's `Sec-WebSocket-Protocol` token convention from `web/src/routes/+layout.server.ts` and `verify_ws_token(...)`. `Origin` remains an extra browser defense, not a credential. |
+| Secret handling | API tokens, cookies, private keys, generated config secrets, and replayable session identifiers remain ADR-029 control-plane secrets. Designs must not show secret values in examples, error states, logs, screenshots, run artifacts, OpenAPI examples, or route URLs. |
+| Env binding | Web control-plane settings stay runtime-env owned. `APTL_API_TOKEN`, `APTL_API_URL`, `APTL_API_HOST`, and `APTL_ALLOWED_ORIGINS` are not `aptl.json` fields. Durable non-secret config goes through `AptlConfig`. |
+| Config validation | Any first-party config surfaced in the UI must come from `load_config()` / `AptlConfig` projections. Unknown first-party fields are errors under ADR-025; do not add pass-through config dictionaries for UI convenience. |
+| OS/process exposure | Tokens, passwords, cookies, private keys, and generated secret content must not appear in process argv, query strings, shell strings, access-log-visible paths, or terminal prefill text. Docker actions stay typed backend calls, not raw command submission. |
+| Error envelopes | HTTP auth failures use the generic FastAPI `401` envelope with `WWW-Authenticate: Bearer`; proxy errors stay narrow; terminal errors use the existing WebSocket error message shape; lab actions use `LabActionResponse`. |
+| Terminal trust | Interactive terminals must satisfy ADR-040: container allow-list, lab-running check, endpoint projection from `ENDPOINT_REGISTRY`, and pinned `known_hosts` before `asyncssh.connect`. |
+| Redaction and observability | Logs may name route, component, step, and validation layer, but not secret values or raw secret-bearing payloads. New persistence or export paths must use the existing redaction/runstore boundaries. |
+| Network exposure | The default operator web surface remains loopback-bound per ADR-039. Any non-loopback design must be explicit about the operator risk decision and must not rely on CORS as authorization. |
+
+## Design Guardrails
+
+- Distinguish human-investigation surfaces from read-only status surfaces in
+  the spec. Terminals, SIEM exploration, command execution, lab start/stop, and
+  kill flows are control or investigation surfaces; lab status badges,
+  container summaries, startup diagnostics, and config summaries are read-only
+  status surfaces unless the page explicitly defines a mutation.
+- Keep the ADR-011 notebook/workbench paradigm. Do not drift into an enterprise
+  SOC dashboard: no mission-control tile wall, icon-only sidebar, status-dot
+  matrix, or dense product-console chrome.
+- Reuse the current component families before inventing new ones:
+  `NavBar`, `LabStatusBadge`, `ContainerGrid`, `LabStartNotice`, `Terminal`,
+  and workbench blocks. If a new recurring UI primitive is needed, document
+  which existing component pattern it extends.
+- Keep API DTOs server-owned. Add or change Python response models in
+  `src/aptl/api/schemas.py` first, then mirror the stable wire shape in
+  `web/src/lib/types.ts`; do not let the Svelte layer infer core state from
+  English messages.
+- Treat startup state as ADR-030 structured data. Do not collapse
+  `ready`, `degraded_usable`, `degraded_unusable`, and `failed` into a single
+  boolean or a color-only badge.
+- Treat endpoint metadata as display and reachability projection only.
+  `ENDPOINT_REGISTRY` does not authorize terminal access and does not own
+  host-published ports or credentials.
+- Treat ACES SDL and `scenario_catalog.py` as scenario authority. The legacy
+  `/api/scenarios` endpoints are intentionally absent today; a design that
+  includes scenario browsing must define a new canonical API projection instead
+  of resurrecting the removed in-tree scenario schema by accident.
+- Keep page-local logic thin. Shared fetch behavior belongs in
+  `web/src/lib/api.ts`, shared lab status in `web/src/lib/stores/lab.ts`, and
+  scenario workbench shaping in `web/src/lib/workbench.ts`.
+
+## Extensibility Seams
+
+The design specification should include a compact page contract table for each
+route. Each row should state:
+
+- route path and page purpose;
+- surface class: read-only status, human investigation, control action, or
+  terminal;
+- API data source and DTO owner;
+- mutation capability, if any;
+- auth carrier: proxy HTTP/SSE or terminal WebSocket subprotocol;
+- primary component family; and
+- future variation parameter.
+
+Use existing extension points for obvious follow-up changes:
+
+- new lifecycle or startup fields extend `LabResult` / `LabActionResponse`;
+- new endpoint display data extends `ENDPOINT_REGISTRY` by target port and
+  protocol, not host port;
+- new workbench content extends the `WorkbenchBlock` discriminated union and
+  block renderer;
+- new scenario browsing data uses a narrow ACES/catalog projection rather than
+  a local scenario parser; and
+- new runtime web settings extend the typed env settings boundary, not
+  `aptl.json`.
+
+## Anti-Patterns
+
+- Treating CORS, loopback binding, allowed origins, or "local lab" as
+  authentication.
+- Putting bearer tokens in URLs, WebSocket URLs, browser-visible examples,
+  shell snippets, process argv, logs, screenshots, or stored design fixtures.
+- Adding per-router auth snippets, duplicate bearer parsing, a new auth error
+  schema, or a second web-auth settings object.
+- Creating a duplicate route map in Svelte that disagrees with mounted FastAPI
+  routers or tests.
+- Reintroducing removed `/api/scenarios` behavior without an explicit ACES
+  projection contract.
+- Parsing `docker-compose.yml` from a UI route or Svelte page to discover
+  containers, ports, or terminal targets.
+- Mixing target fixture credentials with control-plane/operator secrets.
+- Adding UI-only booleans that reclassify startup readiness, terminal
+  availability, or degraded SOC telemetry.
+- Building a generic "run Docker command" or "run shell command" web endpoint.
+- Persisting user-entered commands, terminal output, API errors, or
+  investigation notes without a redaction and artifact-boundary design.
+
+## Non-Goals
+
+- Do not implement UI-007 or UI-008 in this preflight.
+- Do not choose the final UI-007 route map, wireframes, or per-page copy here.
+- Do not add multi-user accounts, RBAC, OAuth/OIDC, password login, or browser
+  sessions.
+- Do not redesign the deployment backend, Docker socket model, ACES SDL,
+  scenario startup, run archive layout, or endpoint registry.
+- Do not make the web GUI the source of truth for lab topology, scenario
+  semantics, credentials, or startup readiness.
+- Do not widen the current web control plane beyond the approved UI-006 scope.

--- a/docs/specs/web-gui-design.md
+++ b/docs/specs/web-gui-design.md
@@ -1,0 +1,426 @@
+# APTL Web GUI Design Specification
+
+## Purpose
+
+This document is the UI-007 design specification for the APTL web GUI. It also
+records the UI-006 product scope baseline that this design depends on, because
+the scope issue has no separate decision record yet.
+
+The implementation target is UI-008. This document is not an implementation
+ticket and does not add routes, components, or API endpoints by itself.
+
+Binding guardrails live in
+[Web GUI Design Preflight Guardrails](web-gui-design-preflight.md). In short:
+keep the ADR-011 workbench paradigm, keep ADR-039 web auth and loopback
+defaults, keep ADR-040 terminal trust gates, keep ADR-030 startup readiness
+semantics, and reuse the existing API, Svelte, endpoint, deployment, redaction,
+and logging owners.
+
+## Product Scope
+
+### Target User
+
+The v1 GUI is for one local lab operator who is actively running and
+investigating an APTL exercise. That user may be a learner, instructor,
+developer, or evaluator, but the interaction model is the same: one operator at
+one workstation, against a local lab.
+
+The GUI is not a shared SOC console, not a multi-user case system, and not the
+primary agent loop. The MCP loop and CLI remain the automation and scripting
+surfaces.
+
+### Jobs the GUI Serves
+
+The GUI exists where a browser workbench is materially better than the CLI or
+MCP loop:
+
+- See whether the lab is ready, degraded, stopped, or failed without reading
+  raw terminal output.
+- Start, stop, and kill local lab activity from a visible operator surface.
+- Browse the approved scenario catalog and open a scenario without knowing file
+  paths.
+- Work through a scenario as a notebook-style investigation: narrative,
+  terminal access, expected detections, objectives, hints, and live status in
+  one flow.
+- Run approved SIEM queries and inspect returned alerts without switching to a
+  separate dashboard for every check.
+- Open a controlled terminal to allowed lab containers when human
+  investigation needs direct shell access.
+- Review current non-secret configuration and service access facts.
+
+### V1 Capabilities
+
+V1 includes these capabilities:
+
+| Capability | Surface class | Notes |
+| --- | --- | --- |
+| Lab status and startup diagnostics | Read-only status | Preserve ADR-030 `ready`, `degraded_usable`, `degraded_unusable`, and `failed` outcomes. |
+| Lab start, stop, and emergency kill | Control action | Use existing typed API routes and narrow confirmation states. |
+| Scenario catalog browsing | Read-only status | Use a narrow ACES/catalog projection. Do not revive legacy in-tree scenario schemas by accident. |
+| Scenario workbench | Human investigation | Notebook-style route with narrative, step, objective, status, SIEM, and terminal blocks. |
+| Focused terminal | Terminal | Allowed containers only, with ADR-039 auth and ADR-040 host-key verification. |
+| Live SIEM query execution | Human investigation | Deliver DET-003 inside this surface as curated query execution and result inspection. |
+| Configuration summary | Read-only status | Show non-secret settings only. Do not display tokens, private keys, generated secrets, or raw `.env` values. |
+
+### Non-Goals for V1
+
+V1 does not include:
+
+- multi-user accounts, RBAC, OAuth, OIDC, password login, or long-lived browser
+  sessions;
+- remote shared deployment as a default mode;
+- generic Docker command, shell command, or arbitrary API execution endpoints;
+- full replacement of Wazuh Dashboard, TheHive, MISP, Shuffle, or Cortex;
+- in-browser editing of SDL or ACES artifacts;
+- persisted operator notes, terminal transcripts, or investigation notebooks;
+- case-management workflow;
+- raw run-archive browsing beyond a bounded status/history summary;
+- a dense enterprise SOC dashboard layout.
+
+### Shipping Model
+
+The shipped operator surface is `aptl web serve` on a single loopback origin.
+The implementation should mount built web assets through the FastAPI
+application and keep `/api/*` on the same origin. The current split
+`aptl-web-api` plus `aptl-web-ui` Compose profile remains useful for dev and
+preview work, but it is not the final operator delivery contract.
+
+The implementation must preserve the security posture from ADR-039:
+
+- default bind address is `127.0.0.1`;
+- all API routes require web control-plane auth before route logic;
+- browser REST and stream calls do not put the API token in URLs;
+- terminal WebSocket auth uses the existing non-URL subprotocol carrier or an
+  equivalent same-origin server carrier;
+- mutating requests have a CSRF/origin gate before the server adds or accepts
+  control-plane authority.
+
+If static asset mounting removes the current SvelteKit server hook, UI-008 must
+replace it with an equivalent same-origin backend-for-frontend boundary in
+FastAPI rather than pushing bearer-token handling into page code.
+
+## Information Architecture
+
+The v1 nav is deliberately small:
+
+- **Lab**: default route and operator status.
+- **Scenarios**: catalog access, surfaced on Lab Home and deep-linked by
+  scenario route.
+- **SIEM**: live detection query explorer.
+- **Config**: non-secret lab and web settings.
+- **Terminal**: not a global nav tab; opened from container cards or scenario
+  steps.
+
+No icon-only sidebar. Keep the top navigation pattern from `NavBar.svelte`.
+
+## Route Contracts
+
+| Route | Purpose | Surface class | API data source | Mutation | Auth carrier | Component family | Future variation |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `/` | Lab Home with readiness, lifecycle controls, key containers, and scenario entry points. | Read-only status plus control action. | `/api/lab/status`, `/api/lab/events`, `/api/lab/start`, `/api/lab/stop`, `/api/lab/kill`, catalog summary. DTOs in `src/aptl/api/schemas.py`; mirrors in `web/src/lib/types.ts`. | Start, stop, kill. | Same-origin HTTP/SSE proxy or equivalent FastAPI BFF. | `NavBar`, `LabStatusBadge`, `LabStartNotice`, `ContainerGrid`, `ScenarioCard`. | Add readiness filters or grouped container bands without changing lifecycle DTOs. |
+| `/scenarios/[id]` | Scenario workbench for the selected catalog item. | Human investigation with terminal blocks. | New narrow scenario detail projection from ACES/catalog authority; lab status stream; terminal WebSocket; SIEM query endpoint. | Terminal input; SIEM query execution; hint reveal is local unless scoring later persists it. | HTTP/SSE proxy for data; terminal subprotocol for PTY. | Workbench blocks: narrative, status, step, objective, SIEM query, terminal. | Extend `WorkbenchBlock` for new block types. |
+| `/siem` | Open-ended but bounded SIEM query explorer for approved queries. | Human investigation. | New `/api/siem/queries`, `/api/siem/query`, and result DTOs backed by the existing Wazuh/OpenSearch integration owner. | Execute query. | Same-origin HTTP proxy or equivalent FastAPI BFF. | `SiemQueryBlock` extended into query list, editor, results, and alert detail components. | Add saved query packs by ID, not arbitrary shell or raw OpenSearch passthrough. |
+| `/terminal/[container]` | Focused terminal for an allowed target. | Terminal. | `/api/terminal/ws/{container}` and endpoint registry projection. | PTY input and resize only. | WebSocket subprotocol token carrier or equivalent same-origin terminal carrier. | `Terminal` and `TerminalBlock`. | Add split panes only after session lifecycle and redaction boundaries are designed. |
+| `/config` | Non-secret configuration and web profile status. | Read-only status. | `/api/config`, web serve metadata, allowed-origin summary, service URL summaries with secrets removed. | None in v1. | Same-origin HTTP proxy or equivalent FastAPI BFF. | New summary rows that follow `ContainerCard` density and `LabStartNotice` severity language. | Later edit flow must use `AptlConfig` validation, not pass-through dictionaries. |
+
+## Page Designs
+
+### Lab Home
+
+Goal: answer "Can I use the lab now, and where do I start?"
+
+Low-fidelity layout:
+
+```text
++--------------------------------------------------------------+
+| APTL                  Lab | Scenarios | SIEM | Config  status |
++--------------------------------------------------------------+
+| Lab Home                                                     |
+| ready/degraded/stopped headline       [Start] [Stop] [Kill]  |
+| Startup diagnostics, grouped by impact, if present           |
+|                                                              |
+| Containers                                                   |
+| [security group] [dmz group] [internal group] [red team]      |
+|                                                              |
+| Scenarios                                                    |
+| [scenario card] [scenario card] [scenario card]               |
++--------------------------------------------------------------+
+```
+
+Interaction details:
+
+- Start and stop use existing `LabActionResponse` and render all diagnostic
+  severities. Do not reduce degraded states to a single yellow badge.
+- Emergency kill is a destructive action. It needs a modal confirmation that
+  names whether containers will also be stopped. It must not be a one-click
+  header button.
+- Container cards group by role or network when enough metadata exists. Until
+  then, keep the current responsive grid.
+- Terminal links appear only for registry-approved targets and only when the
+  lab state allows opening a terminal.
+- Scenario cards show name, mode, difficulty, time, tags, and required
+  containers. They link to `/scenarios/[id]`.
+
+States:
+
+- Stopped: primary action is Start; containers are absent; scenario catalog is
+  still browsable.
+- Starting: action buttons are disabled; the page keeps showing the last known
+  status plus progress copy.
+- Degraded usable: show the scenario entry point, but keep diagnostics visible.
+- Degraded unusable or failed: keep diagnostics and suggested operator action
+  visible above scenario cards.
+- Missing web token: show a narrow service-configuration error. Do not show the
+  token value or suggest putting it in a URL.
+
+### Scenario Workbench
+
+Goal: let a person investigate a scenario in one scrollable document.
+
+Low-fidelity layout:
+
+```text
++--------------------------------------------------------------+
+| <- Lab  Scenario name            mode  containers  points     |
++--------------------------------------------------------------+
+| Scenario title, summary, MITRE metadata                      |
+| Required container status pills                              |
+| Attack chain narrative                                       |
+|                                                              |
+| Step 1: technique                                            |
+| description                                                  |
+| commands + copy                                              |
+| expected detections                                          |
+| [Open terminal]                                              |
+|                                                              |
+| Objective: blue detection                                    |
+| query summary [Run Query] results inline                     |
+| hints                                                        |
++--------------------------------------------------------------+
+```
+
+Interaction details:
+
+- The workbench remains document-first. Use cards only for repeated blocks,
+  not for full page sections.
+- Steps use `AttackStepBlock`; objectives use `ObjectiveBlock`; query snippets
+  use `SiemQueryBlock`; terminals are lazy-mounted with `TerminalBlock`.
+- Command copy is local browser behavior. The GUI must not auto-run command
+  text in a shell.
+- Hint reveal stays local in v1 unless UI-008 adds a scoring persistence
+  contract.
+- Scenario loading uses a new backend projection from ACES/catalog authority.
+  The missing `/api/scenarios` routes are an implementation gap, not a reason
+  to resurrect old removed scenario models.
+
+States:
+
+- Unknown scenario: route-level 404 with a short message and Lab link.
+- Catalog parse error: page-level error that names the catalog source, not raw
+  stack traces.
+- Lab stopped: workbench content is readable; terminals and live queries are
+  disabled with a clear lab-stopped reason.
+- Query failure: inline query result error with a stable error kind and a
+  redacted detail string.
+
+### SIEM Explorer
+
+Goal: make DET-003 useful in the GUI without building a whole SIEM clone.
+
+Low-fidelity layout:
+
+```text
++--------------------------------------------------------------+
+| SIEM                                                         |
++------------------------------+-------------------------------+
+| Query packs                  | Results                       |
+| - scenario detections        | time | rule | host | severity |
+| - recent alerts              | expandable alert details      |
+| - custom bounded query       |                               |
++------------------------------+-------------------------------+
+```
+
+Interaction details:
+
+- Provide curated query packs first: current scenario objectives, recent Wazuh
+  alerts, Suricata-related events, and red-team command telemetry where
+  available.
+- A custom query mode may exist only if the backend owns validation, time-range
+  limits, row limits, and redaction. It must not expose raw OpenSearch
+  passthrough by default.
+- Results are tables with expandable detail rows. Keep raw JSON behind a
+  disclosure control.
+- Query execution belongs to a typed FastAPI route with pytest coverage and a
+  mirrored Svelte type. It is not a disabled button plus local mock.
+
+States:
+
+- SIEM offline: show dependency status and a next operator action.
+- No results: show query metadata and time range, not an error.
+- Partial results: show count, truncation, and time range.
+- Backend validation error: preserve user input enough to edit it, but do not
+  echo secrets or raw backend exception text.
+
+### Focused Terminal
+
+Goal: give controlled shell access for human investigation.
+
+Interaction details:
+
+- Entry points are container cards and scenario steps, not a global list of
+  every container.
+- The route uses the existing `Terminal` component.
+- The server validates token, origin, container allow-list, lab-running state,
+  runtime endpoint availability, and pinned `known_hosts` before SSH.
+- Error text stays narrow: unauthorized, origin rejected, lab stopped,
+  container unavailable, host keys missing, or SSH connection failed.
+- The GUI must not persist terminal input or output in v1.
+
+States:
+
+- Lab stopped or target unavailable: show the reason before attempting a PTY.
+- Host keys missing: tell the operator to restart the lab. Do not offer a
+  browser-side trust bypass.
+- WebSocket closed: preserve the terminal surface and show reconnect controls.
+
+### Config
+
+Goal: expose enough non-secret configuration for orientation.
+
+Interaction details:
+
+- Show lab name, network subnet, enabled container families, run storage
+  backend, web serve bind mode, allowed origin summary, and links to published
+  service URLs where those URLs are non-secret.
+- Do not show `APTL_API_TOKEN`, private key paths with sensitive context,
+  service passwords, cookies, generated secrets, or raw `.env` content.
+- This page is read-only in v1.
+
+## Component Inventory
+
+Existing components to reuse:
+
+| Component | Role in v1 |
+| --- | --- |
+| `NavBar` | Top-level navigation and lab status entry point. |
+| `LabStatusBadge` | Compact running/stopped status. Extend only if ADR-030 outcome labels are needed in a compact control. |
+| `LabStartNotice` | Authoritative startup/degraded/failure diagnostics rendering. |
+| `ContainerGrid` and `ContainerCard` | Lab Home container summary and terminal entry points. |
+| `ScenarioCard` | Catalog entry summary. |
+| `Terminal` | xterm.js terminal implementation. |
+| `WorkbenchStatusBar` | Sticky scenario context, container pills, points. |
+| `NarrativeBlock` | Markdown narrative. |
+| `AttackStepBlock` | Scenario step, copy command, detection expectations, lazy terminal. |
+| `ObjectiveBlock` and `HintToggle` | Red/blue objectives and progressive hints. |
+| `SiemQueryBlock` | Starting point for query display and live execution. |
+| `TerminalBlock` | Inline terminal frame within a scenario. |
+
+New or expanded components for UI-008:
+
+| Component | Purpose | Based on |
+| --- | --- | --- |
+| `RoleGroupedContainerGrid` | Group containers by lab role or network when endpoint metadata supports it. | `ContainerGrid`, `ContainerCard`. |
+| `KillConfirmDialog` | Confirm emergency kill scope. | Existing button and notice styling. |
+| `ScenarioCatalogFilters` | Filter scenario cards by tag, mode, and difficulty. | `ScenarioCard`. |
+| `SiemQueryExplorer` | Query pack list, editor, run control, and results shell. | `SiemQueryBlock`. |
+| `SiemResultsTable` | Bounded alert rows with expandable details. | Existing table/card density from workbench blocks. |
+| `ConfigSummaryList` | Read-only config facts with secret-safe omission states. | `ContainerCard` density and `LabStartNotice` severity language. |
+
+Do not introduce a component library reset or a new theme. Continue the current
+Tailwind v4 token names in `web/src/app.css`. The current palette is acceptable
+because it is already the repo's ADR-011 workbench identity; avoid expanding it
+into a one-color purple dashboard.
+
+## API and Data Contracts
+
+Existing contracts:
+
+| Contract | Status |
+| --- | --- |
+| `GET /api/health` | Exists and is bearer-protected. |
+| `GET /api/lab/status` | Exists; drives status, container cards, and SSE baseline. |
+| `GET /api/lab/events` | Exists; SSE stream for lab status changes. |
+| `POST /api/lab/start` | Exists; returns ADR-030 diagnostics. |
+| `POST /api/lab/stop` | Exists. |
+| `POST /api/lab/kill` | Exists; needs destructive UI confirmation. |
+| `GET /api/config` | Exists; returns non-secret configuration projection. |
+| `WS /api/terminal/ws/{container}` | Exists; validates auth, origin, allow-list, lab state, endpoint projection, and host-key pins. |
+
+Required UI-008 contracts:
+
+| Contract | Owner | Notes |
+| --- | --- | --- |
+| `GET /api/scenarios` | New FastAPI router with DTOs in `src/aptl/api/schemas.py`. | Narrow ACES/catalog summary projection. Include id, name, description, mode, difficulty, time, tags, required containers, and validation/status summary. |
+| `GET /api/scenarios/{id}` | Same router. | Workbench detail projection. Source stays ACES/catalog authority. |
+| `GET /api/siem/queries` | New or existing SIEM integration owner. | Curated query packs, including scenario-linked packs. |
+| `POST /api/siem/query` | Same owner. | Bounded query execution with validation, time range, row cap, stable errors, and redacted details. |
+| `GET /api/web/status` | Optional. | Read-only shipped web metadata such as bind mode and asset build version. Do not expose secrets. |
+
+Rules:
+
+- Python DTOs own the wire contract. Svelte types mirror them.
+- API routes call existing core helpers and typed deployment/backend owners.
+- No route accepts raw Docker args, raw shell args, or unbounded OpenSearch
+  query bodies.
+- All new Python routes get pytest coverage in `tests/`.
+- All new Svelte behavior gets vitest coverage in `web/tests/`.
+
+## Authentication and Security UX
+
+The GUI should make secure operation understandable without exposing secrets.
+
+Required states:
+
+- API token missing: show a service configuration error and a safe generation
+  hint. Never print the current value.
+- Unauthorized API request: show a generic auth-required state. Do not say
+  whether the token was missing, malformed, or wrong.
+- Cross-origin mutating request rejected: keep the generic proxy error text in
+  the browser path. The operator does not need attacker-origin details in UI.
+- Non-loopback bind, if a future mode supports it: show an explicit risk banner
+  that names the operator decision. This is not a default mode.
+- Terminal rejected: show one of the narrow terminal reasons listed above.
+
+Security invariants:
+
+- No token in URLs, route params, query strings, screenshots, examples, logs,
+  browser local storage, or command strings.
+- No private key contents or generated secret values in UI state.
+- No generic command execution from the browser.
+- No terminal trust bypass.
+- No CORS-as-auth claim.
+- No UI-only readiness reclassification.
+
+## UI-008 Acceptance Checklist
+
+The implementation issue can use this checklist:
+
+- `aptl web serve` serves the built GUI and API from a single loopback operator
+  origin.
+- `/` renders lab state, startup diagnostics, lifecycle controls, container
+  summary, and scenario entry points.
+- `/scenarios/[id]` renders the scenario workbench from a backend-owned
+  catalog projection.
+- `/siem` executes bounded live SIEM queries and renders results.
+- `/terminal/[container]` and inline terminal blocks preserve ADR-039 and
+  ADR-040 gates.
+- `/config` shows non-secret configuration only.
+- Destructive actions require confirmation.
+- Every new API DTO has a Svelte mirror and tests.
+- Every new source path has pytest or vitest coverage as required by
+  `.gc/plan-rules.md`.
+- Documentation and changelog fragments describe the shipped behavior.
+
+## Requirement Mapping
+
+| UI-007 clause | Design coverage |
+| --- | --- |
+| Information architecture | Information Architecture and Route Contracts sections. |
+| Route map | Route Contracts section. |
+| Per-page interaction design | Page Designs section. |
+| Human investigation versus read-only status | Product Scope, Route Contracts, and each page's surface class. |
+| Component inventory | Component Inventory section. |
+| Existing Svelte alignment | Component Inventory and API/Data Contracts reuse existing `web/src/lib` owners. |
+| Auth and security UX | Authentication and Security UX section. |
+| Derived from UI-006 | Product Scope section records the scope baseline. |
+| Build specification for UI-008 | UI-008 Acceptance Checklist and API/Data Contracts sections. |

--- a/docs/specs/web-gui-design.md
+++ b/docs/specs/web-gui-design.md
@@ -48,6 +48,23 @@ MCP loop:
   investigation needs direct shell access.
 - Review current non-secret configuration and service access facts.
 
+### Representative User Stories
+
+The GUI must be designed from operator tasks rather than from generic dashboard
+widgets. UI-008 should use these stories as its first usability checklist:
+
+| User | Story | Design implication |
+| --- | --- | --- |
+| Learner | As a learner, I want to know whether the lab is usable before I start a scenario. | Lab Home must lead with readiness, startup diagnostics, and next action, not a chart wall. |
+| Learner | As a learner, I want scenario steps, terminal entry points, hints, and expected detections in one place. | Scenario Workbench stays document-first with lazy tools inside the flow. |
+| Instructor | As an instructor, I want to see which prerequisites and containers a scenario needs before recommending it. | Scenario cards and detail headers show required containers, mode, difficulty, duration, and validation state. |
+| Evaluator | As an evaluator, I want evidence that detections fired without switching among several products. | SIEM Explorer provides curated query packs, bounded live execution, and expandable alert details. |
+| Developer | As a developer, I want to debug a failed lab start from structured diagnostics. | Startup diagnostics preserve ADR-030 severity, component, and remediation detail. |
+| Operator | As an operator, I want destructive actions to be obvious and reversible only where the backend supports it. | Stop and kill are visually distinct, require confirmation, and name their blast radius. |
+| Keyboard user | As a keyboard-only user, I want every route and modal to work without pointer input. | Navigation, dialogs, tables, terminals, and disclosure controls must pass keyboard checks. |
+| Low-vision user | As a low-vision user, I want readable contrast, visible focus, and adjustable terminal text. | Theme tokens, focus rings, status labels, and terminal preferences are first-class requirements. |
+| Non-English future user | As a future localized user, I want UI copy, dates, numbers, and text direction to be adaptable. | Copy must be centralized and layout must avoid fixed text widths and direction-specific assumptions. |
+
 ### V1 Capabilities
 
 V1 includes these capabilities:
@@ -99,6 +116,205 @@ If static asset mounting removes the current SvelteKit server hook, UI-008 must
 replace it with an equivalent same-origin backend-for-frontend boundary in
 FastAPI rather than pushing bearer-token handling into page code.
 
+## Design Inputs and Visual Direction
+
+The visual target is a quiet operational workbench: readable, dense enough for
+repeated use, and specific to APTL's purple-team lab context. It should feel
+closer to a restrained developer/security tool than a marketing SaaS page.
+
+Use Tailwind v4 as the design-system foundation because the repo already ships
+Tailwind tokens in `web/src/app.css`. UI-008 should formalize those tokens into
+an APTL component kit rather than importing a wholesale admin template. Tailwind
+UI application-shell patterns are acceptable references for spacing, tables,
+forms, menus, dialogs, and responsive behavior, but the implementation must
+adapt them to APTL's content model and existing Svelte components.
+
+If UI-008 adds a component primitive library, choose one for accessible
+headless behavior only, such as dialogs, menus, popovers, tabs, and tooltips.
+Do not let a library replace APTL's route structure, palette, density, or
+security copy. Any new icon package should be small and purposeful; icons must
+support scannability and have text labels or accessible names.
+
+Design anti-patterns to avoid:
+
+- no full-screen hero, marketing headline, testimonial, pricing, or "unlock
+  the power" copy;
+- no purple gradient background, gradient text, decorative blobs, glow, neon,
+  glassmorphism, or fake depth;
+- no bento grid, nested cards, or "everything is a card" layout;
+- no oversized rounded tiles with giant icons above short headings;
+- no one-note purple/violet palette. Purple may remain an APTL accent, but
+  status and hierarchy must use semantic colors, spacing, and labels;
+- no fake analytics charts, mocked activity feeds, or decorative sparklines;
+- no low-contrast gray text on dark panels;
+- no icon-only sidebar or mystery controls;
+- no animations that imply progress when the backend has not reported it.
+
+Layout rules:
+
+- use a top app shell with constrained content width on document routes and
+  full-width utility regions only when the data needs it;
+- keep page sections unframed unless they are repeated records, dialogs, or
+  tool panes;
+- use tables for alert and config facts where comparison matters;
+- use compact cards only for scenario summaries, container summaries, and
+  repeated workbench blocks;
+- keep typography restrained: route headings are page-sized, panel headings are
+  compact, terminal and command text use the mono stack only where appropriate.
+
+Reference set for UI-008:
+
+- Tailwind UI application-shell and component patterns for practical Tailwind
+  layout references: <https://tailwindcss.com/plus>.
+- Nielsen Norman Group complex-application guidance for keeping expert tools
+  workflow-led: <https://www.nngroup.com/articles/complex-application-design/>.
+- W3C WCAG 2.2 for accessibility requirements:
+  <https://www.w3.org/TR/WCAG22/>.
+- WAI-ARIA modal dialog pattern for confirmation, settings, and notice dialogs:
+  <https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/>.
+- W3C internationalization guidance for language and direction metadata:
+  <https://www.w3.org/TR/international-specs/>.
+- Current AI-generated design anti-pattern discussions as a smell checklist,
+  not as product authority:
+  <https://uxplanet.org/how-to-spot-ai-generated-design-697aaabe76c8> and
+  <https://prg.sh/ramblings/Why-Your-AI-Keeps-Building-the-Same-Purple-Gradient-Website>.
+
+## Interaction Affordances
+
+The GUI should expose useful controls without turning into a command console.
+
+Required affordances:
+
+- global top navigation with current-route state and lab status summary;
+- breadcrumb or back link on scenario and terminal routes;
+- scenario search, tag filters, mode filter, difficulty filter, and clear
+  filter reset;
+- sort controls where lists can exceed one screen: scenario name, difficulty,
+  duration, and validation status;
+- copy buttons for command snippets with success/error feedback, but no
+  auto-run behavior;
+- inline refresh controls for status and SIEM results, with live updates when
+  SSE is active;
+- expandable raw JSON for SIEM alerts, hidden by default;
+- loading, empty, partial, offline, unauthorized, and stale-data states for
+  every data region;
+- clear destructive-action confirm dialogs for Stop and Kill;
+- persistent settings access from a small labeled control in `NavBar`, not a
+  primary top-level work route.
+
+Keyboard shortcuts may be added only after the visible controls exist. They
+must be discoverable from a Help or Shortcuts dialog and must not shadow
+terminal input while focus is inside `Terminal`.
+
+## Settings and Persistence
+
+Persistent settings make sense for local operator preferences, not for lab
+state. The app is accountless in v1, so settings should be browser-local and
+resettable.
+
+Add a settings dialog or drawer reachable from `NavBar`. Do not make Settings
+a primary route unless UI-008 finds that mobile layout or future settings volume
+requires it.
+
+Persist only non-secret UI preferences in a versioned browser key such as
+`aptl.web.preferences.v1`:
+
+| Setting | Values | Persistence rule |
+| --- | --- | --- |
+| Color mode | system, dark, light, high contrast | Local preference only; default to system. |
+| Density | comfortable, compact | Affects tables, lists, cards, and workbench blocks. |
+| Motion | system, reduced | Must honor `prefers-reduced-motion` even without a stored setting. |
+| Locale | browser default, explicit locale | Stores a locale tag only, not translated content. |
+| Time display | browser local time, UTC | Applies to SIEM alerts, run status, and diagnostics timestamps. |
+| SIEM default time range | bounded choices such as 15m, 1h, 24h | Backend still enforces maximums. |
+| SIEM row limit | bounded choices within backend cap | Backend remains authoritative. |
+| Terminal font size | bounded numeric range | Applies to xterm rendering only. |
+| Terminal scrollback | bounded choices | Must not persist terminal output. |
+| Legal notice acknowledgement | notice version and timestamp | Stores only that a local notice was acknowledged. |
+
+Do not persist API tokens, bearer headers, service credentials, terminal input,
+terminal output, raw SIEM custom queries, copied command history, scenario
+answers, hints viewed, or user notes in v1. If UI-008 introduces server-side
+preferences later, that is a new product and security scope decision.
+
+The settings store must be schema-versioned. Unknown keys are ignored or reset,
+and a visible "Reset preferences" action returns to defaults.
+
+## Accessibility
+
+UI-008 should target WCAG 2.2 AA for the shipped routes. The design work must
+make that practical:
+
+- all interactive targets meet WCAG 2.2 target-size guidance, with larger
+  targets for destructive and high-frequency controls;
+- every button, icon button, link, menu item, tab, disclosure, and terminal
+  control has an accessible name;
+- focus is visible, never hidden behind sticky headers or dialogs, and returns
+  to the invoking control after a modal closes;
+- modal dialogs trap focus while open, close through Escape where safe, and
+  expose title and description semantics;
+- color is never the only status cue. ADR-030 states, SIEM severity, and
+  terminal errors need text labels;
+- contrast is checked for normal text, muted text, borders used as state, focus
+  outlines, charts, and terminal themes;
+- live lab/SIEM updates use polite `aria-live` regions where useful, without
+  flooding screen readers during rapid event streams;
+- tables have captions or headings, column headers, and row expansion controls
+  with announced state;
+- terminal routes provide keyboard focus management, visible connection state,
+  and an accessible non-terminal error/log summary for connection failures;
+- copy-to-clipboard controls announce success and failure;
+- layouts must reflow at narrow widths without overlapping controls or hiding
+  essential state.
+
+Accessibility acceptance for UI-008 should include keyboard-only route walks,
+automated accessibility checks in web tests where practical, and manual review
+of the terminal, modal, and SIEM table flows.
+
+## Language and Locale Readiness
+
+The first implementation can ship English-only text, but it must not block
+localization.
+
+Rules for UI-008:
+
+- keep user-facing copy in a small message catalog or translation-ready module
+  rather than scattering strings through route components;
+- never concatenate translated sentence fragments around variables;
+- format dates, times, durations, counts, and severities through shared helpers;
+- store locale as a BCP 47 language tag preference when the user overrides the
+  browser default;
+- avoid fixed-width text containers for labels and buttons. German-length
+  labels and long scenario titles must wrap or truncate intentionally;
+- avoid layout assumptions that break right-to-left direction later. Direction
+  does not need to ship in v1, but spacing and icon placement should use
+  logical properties where practical;
+- keep operator-auth and security error copy short and translatable.
+
+## Legal and Privacy UX
+
+APTL is a local lab operator tool, not a public SaaS service. Do not add a
+marketing-style cookie banner or blocking terms wall by default.
+
+V1 should include a concise local-use notice and privacy notice:
+
+- a first-run "Authorized local lab use" acknowledgement before the first
+  mutating lab action or terminal launch, with the acknowledged notice version
+  stored as a non-secret preference;
+- a persistent Privacy link in Help or the footer area of the app shell;
+- notice text that states the browser stores local UI preferences, does not
+  store API tokens, and does not persist terminal input/output in v1;
+- notice text that explains local API/server logs may record route names,
+  timestamps, status codes, and redacted error categories;
+- no non-essential analytics, tracking pixels, or third-party scripts in v1.
+
+If future builds add analytics, crash reporting, third-party embeds, or
+non-essential cookies/local storage, then UI-008 or a follow-up issue must add a
+real consent manager with Accept, Reject, and Manage choices before collection
+starts. A consent banner is not required for strictly essential local storage
+such as the preference key above, but the privacy notice still has to disclose
+it.
+
 ## Information Architecture
 
 The v1 nav is deliberately small:
@@ -110,6 +326,8 @@ The v1 nav is deliberately small:
 - **Config**: non-secret lab and web settings.
 - **Terminal**: not a global nav tab; opened from container cards or scenario
   steps.
+- **Settings**: a dialog or drawer, not a primary route in v1.
+- **Help/Privacy**: a small secondary menu area, not a primary route.
 
 No icon-only sidebar. Keep the top navigation pattern from `NavBar.svelte`.
 
@@ -133,7 +351,7 @@ Low-fidelity layout:
 
 ```text
 +--------------------------------------------------------------+
-| APTL                  Lab | Scenarios | SIEM | Config  status |
+| APTL          Lab | Scenarios | SIEM | Config   Help Settings |
 +--------------------------------------------------------------+
 | Lab Home                                                     |
 | ready/degraded/stopped headline       [Start] [Stop] [Kill]  |
@@ -265,6 +483,22 @@ States:
 
 Goal: give controlled shell access for human investigation.
 
+Low-fidelity layout:
+
+```text
++--------------------------------------------------------------+
+| <- Scenario or Lab        Terminal: workstation     connected |
++--------------------------------------------------------------+
+| Target facts: container, role, lab state, host-key state      |
+| connection status / error reason                             |
+| +----------------------------------------------------------+ |
+| | terminal viewport                                        | |
+| |                                                          | |
+| +----------------------------------------------------------+ |
+| [Reconnect] [Copy selected text] [Settings: font/scrollback] |
++--------------------------------------------------------------+
+```
+
 Interaction details:
 
 - Entry points are container cards and scenario steps, not a global list of
@@ -287,6 +521,26 @@ States:
 
 Goal: expose enough non-secret configuration for orientation.
 
+Low-fidelity layout:
+
+```text
++--------------------------------------------------------------+
+| Config                                                       |
++--------------------------------------------------------------+
+| Lab profile                                                  |
+| name | subnet | run storage | enabled families               |
+|                                                              |
+| Web serve                                                    |
+| bind mode | allowed origins | build version | API origin      |
+|                                                              |
+| Service links                                                |
+| service | local URL | status | notes                         |
+|                                                              |
+| Secrets                                                      |
+| tokens and credentials are intentionally hidden              |
++--------------------------------------------------------------+
+```
+
 Interaction details:
 
 - Show lab name, network subnet, enabled container families, run storage
@@ -295,6 +549,79 @@ Interaction details:
 - Do not show `APTL_API_TOKEN`, private key paths with sensitive context,
   service passwords, cookies, generated secrets, or raw `.env` content.
 - This page is read-only in v1.
+
+### Settings Dialog
+
+Goal: let a local operator adapt the workbench without changing the lab.
+
+Low-fidelity layout:
+
+```text
++---------------- Settings ----------------+
+| Appearance                               |
+| color mode      [system v]              |
+| density         [comfortable v]         |
+| motion          [system v]              |
+|                                          |
+| Locale and time                          |
+| language        [browser default v]     |
+| time display    [local time v]          |
+|                                          |
+| SIEM defaults                            |
+| time range      [1 hour v]              |
+| row limit       [100 v]                 |
+|                                          |
+| Terminal                                 |
+| font size       [-] 14 [+]              |
+| scrollback      [1000 lines v]          |
+|                                          |
+| [Reset preferences]              [Done] |
++------------------------------------------+
+```
+
+Interaction details:
+
+- Settings open from `NavBar` and return focus to the triggering control when
+  closed.
+- The dialog is not a substitute for configuration. It changes local UI
+  presentation only.
+- Controls use selects, segmented controls, toggles, or steppers. Avoid free
+  text except where the value is naturally textual.
+- Preference writes are immediate, local, schema-versioned, and reversible
+  through Reset.
+- Invalid stored preferences fall back to defaults with no blocking error.
+
+### Local Use and Privacy Notice
+
+Goal: make local-lab privacy and authorized-use boundaries explicit without
+adding a SaaS consent pattern.
+
+Low-fidelity layout:
+
+```text
++---------- Authorized local lab use ----------+
+| APTL controls a local security lab. Use this |
+| surface only for authorized lab activity.    |
+|                                              |
+| This browser stores local UI preferences. It |
+| does not store API tokens or terminal output |
+| in v1. Server logs may contain redacted route |
+| and status metadata.                         |
+|                                              |
+| [Privacy details]             [Acknowledge] |
++----------------------------------------------+
+```
+
+Interaction details:
+
+- Show this notice before the first mutating lab action, terminal launch, or
+  SIEM query execution, not on every page load.
+- Acknowledgement stores only the notice version and timestamp in local
+  preferences.
+- Privacy details can be a help panel or static route. They must be reachable
+  after acknowledgement.
+- If the user resets preferences, the notice can appear again before the next
+  controlled action.
 
 ## Component Inventory
 
@@ -325,11 +652,16 @@ New or expanded components for UI-008:
 | `SiemQueryExplorer` | Query pack list, editor, run control, and results shell. | `SiemQueryBlock`. |
 | `SiemResultsTable` | Bounded alert rows with expandable details. | Existing table/card density from workbench blocks. |
 | `ConfigSummaryList` | Read-only config facts with secret-safe omission states. | `ContainerCard` density and `LabStartNotice` severity language. |
+| `SettingsDialog` | Local preferences for appearance, density, locale, time display, SIEM defaults, and terminal rendering. | `NavBar` action plus accessible dialog primitive. |
+| `LocalUseNoticeDialog` | First-run acknowledgement for authorized local lab use and privacy summary. | Accessible dialog primitive and existing notice severity language. |
+| `PrivacyDetailsPanel` | Persistent help/privacy disclosure for local storage and redacted server logging facts. | Help menu or secondary app-shell panel. |
 
 Do not introduce a component library reset or a new theme. Continue the current
 Tailwind v4 token names in `web/src/app.css`. The current palette is acceptable
 because it is already the repo's ADR-011 workbench identity; avoid expanding it
-into a one-color purple dashboard.
+into a one-color purple dashboard. UI-008 should also audit `web/src/app.css`
+for system-font fallback, contrast, semantic status colors, reduced-motion
+behavior, and high-contrast overrides before adding new visual tokens.
 
 ## API and Data Contracts
 
@@ -362,6 +694,8 @@ Rules:
 - API routes call existing core helpers and typed deployment/backend owners.
 - No route accepts raw Docker args, raw shell args, or unbounded OpenSearch
   query bodies.
+- Local preference settings do not need an API in v1. Keep them browser-local
+  unless a later issue explicitly scopes synchronized preferences.
 - All new Python routes get pytest coverage in `tests/`.
 - All new Svelte behavior gets vitest coverage in `web/tests/`.
 
@@ -405,7 +739,17 @@ The implementation issue can use this checklist:
 - `/terminal/[container]` and inline terminal blocks preserve ADR-039 and
   ADR-040 gates.
 - `/config` shows non-secret configuration only.
+- `SettingsDialog` persists only non-secret local UI preferences and offers a
+  reset control.
+- Local-use and privacy notice appears before the first controlled action and
+  remains reachable after acknowledgement.
 - Destructive actions require confirmation.
+- UI satisfies the accessibility requirements above, including keyboard route
+  walks, focus management, non-color status cues, contrast, target sizing, and
+  accessible modal behavior.
+- UI copy is translation-ready and date/time/count formatting goes through
+  shared helpers.
+- Visual implementation avoids the documented generic AI-design anti-patterns.
 - Every new API DTO has a Svelte mirror and tests.
 - Every new source path has pytest or vitest coverage as required by
   `.gc/plan-rules.md`.
@@ -422,5 +766,9 @@ The implementation issue can use this checklist:
 | Component inventory | Component Inventory section. |
 | Existing Svelte alignment | Component Inventory and API/Data Contracts reuse existing `web/src/lib` owners. |
 | Auth and security UX | Authentication and Security UX section. |
+| Accessibility and localization groundwork | Accessibility and Language/Locale Readiness sections. |
+| Persistent local settings | Settings and Persistence plus Settings Dialog sections. |
+| Terms/privacy UX | Legal and Privacy UX plus Local Use and Privacy Notice sections. |
+| Professional visual direction | Design Inputs and Visual Direction section. |
 | Derived from UI-006 | Product Scope section records the scope baseline. |
 | Build specification for UI-008 | UI-008 Acceptance Checklist and API/Data Contracts sections. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,8 @@ nav:
     - TechVault OSINT Readiness: reference/techvault-osint-readiness.md
     - Experiment Runs: reference/experiment-runs.md
     - SOC Feature Spec: specs/soc-feature-spec.md
+    - Web GUI Design Specification: specs/web-gui-design.md
+    - Web GUI Design Preflight Guardrails: specs/web-gui-design-preflight.md
   - Troubleshooting: troubleshooting/index.md
   - Records:
     - CI/CD Remote Deployment (removed): deployment/ci-cd-deploy.md


### PR DESCRIPTION
## Summary

Adds the UI-007 web GUI design specification and its architecture preflight guardrails so UI-008 can build the shipped web surface against a concrete scope, route map, interaction model, component inventory, API contract list, accessibility baseline, local preference model, privacy/use notice, and security UX.

## Requirement UIDs

- `UI-007`

## Related Issues

Closes #540

## ADR Impact

- ADR-011
- ADR-029
- ADR-030
- ADR-035
- ADR-036
- ADR-039
- ADR-040

## Changes

- Added the UI-007 design specification under `docs/specs/web-gui-design.md`, including the UI-006 product-scope baseline, representative user stories, v1 route contracts, page interaction designs, low-fidelity wireframes, component inventory, API gaps, auth/security UX, accessibility requirements, localization readiness, local settings persistence, legal/privacy UX, and UI-008 acceptance checklist.
- Added architecture preflight guardrails that bind the design to the existing ADR-011 workbench paradigm, ADR-039 auth boundary, ADR-040 terminal trust gate, ADR-030 readiness semantics, ACES scenario authority, existing Svelte/FastAPI owners, WCAG/i18n expectations, browser-local non-secret settings, and anti-generic-template visual constraints.
- Published both documents in the MkDocs Reference navigation and linked the design spec from the docs index.
- Added a changelog fragment for the new user-facing design specification.

## Test Plan

- [x] `tools/vale-lint-hook.sh docs/specs/web-gui-design.md docs/specs/web-gui-design-preflight.md docs/index.md`
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run --extra docs mkdocs build --strict`
- [x] `.venv/bin/pytest -n auto -k "not integration"`
- [x] `PATH="/home/atomik/src/aces-sdl/implementations/python/.venv/bin:$PATH" .venv/bin/pytest -n auto tests/test_techvault_static_gate.py -m integration`
- [x] `PATH="/home/atomik/src/aces-sdl/implementations/python/.venv/bin:$PATH" pre-commit run --all-files`

## Ground Control Checks

- [x] Architecture preflight recorded for issue #540.
- [x] GRC screening recorded as `no_baseline` for issue #540.
- [x] Quality gates passed for `UI-007`.
- [x] Codex review cycle clean: 0 findings.
- [x] Test-quality review cycle clean: 0 findings.
- [x] Post-push Codex review requested after UX hardening follow-up.

## Traceability

- Pre-merge readiness only. Post-merge Ground Control reconciliation will create and assert the final requirement traceability after the PR merges, per `/implement` Phase E ordering.

## Documentation

Updated: this PR is the UI-007 documentation/design handoff.
