### PR TITLE
added: composite MCP tool seam and kali_full_port_scan (ORC-003)

### DIFF
--- a/changelog.d/477.added.md
+++ b/changelog.d/477.added.md
@@ -1,0 +1,10 @@
+### Added
+
+- Composite MCP tools (ORC-003): a typed registration seam in
+  `aptl-mcp-common` lets a server expose a single MCP tool that orchestrates
+  several internal SSH/API steps over the existing primitives, with context
+  routed by declared kind rather than tool-name substrings (ADR-045). The
+  first composite, `kali_full_port_scan`, runs an nmap full TCP scan against a
+  lab-confined target, parses the XML output, and returns a compact open-ports
+  report — while keeping the underlying nmap command visible on the red
+  OCSF/capture path.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -66,3 +66,4 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [042](adr-042-sidecar-owned-pty-master.md) | Sidecar-Owned PTY Master for Kali Transcript Authenticity | accepted | 2026-06-20 |
 | [043](adr-043-suricata-runtime-config-ownership-boundary.md) | Suricata Runtime Config Ownership Boundary | accepted | 2026-06-20 |
 | [044](adr-044-aces-aligned-run-reproducibility-record.md) | ACES-Aligned Run Reproducibility Record | accepted | 2026-06-25 |
+| [045](adr-045-composite-mcp-tools.md) | Composite MCP Tool Orchestration Boundary | accepted | 2026-06-28 |

--- a/docs/adrs/adr-045-composite-mcp-tools.md
+++ b/docs/adrs/adr-045-composite-mcp-tools.md
@@ -1,0 +1,207 @@
+# ADR-045: Composite MCP Tool Orchestration Boundary
+
+## Status
+
+accepted
+
+## Date
+
+2026-06-28
+
+## Context
+
+ORC-003 / issue #477 asks the MCP layer to support composite tools: one MCP
+tool call that performs a common multi-step operation such as running an nmap
+scan, parsing its output, and returning a concise report.
+
+The design risk is not the existence of another MCP tool. The risk is creating
+a second command runner, second API client, second schema vocabulary, second
+redaction policy, second run-artifact layout, or an implicit red/blue bridge
+beside the already-established MCP boundary.
+
+Existing architectural owners already cover most of the required surface:
+
+- `mcp/aptl-mcp-common/src/server.ts` owns MCP server creation, tool
+  registration, `traceToolCall()`, and the `postToolHook` boundary.
+- `mcp/aptl-mcp-common/src/tools/definitions.ts` and `tools/handlers.ts` own
+  SSH tool schemas, handler envelopes, session-id validation, and
+  `SSHConnectionManager` use.
+- `mcp/aptl-mcp-common/src/tools/api-definitions.ts`,
+  `tools/api-handlers.ts`, `http.ts`, and `endpoint-url.ts` own API tool
+  schemas, endpoint validation, auth, TLS, and HTTP errors.
+- `mcp/mcp-red/src/index.ts`, `capture.ts`, `logger.ts`, `classifier.ts`, and
+  `extractor.ts` own red-team command capture, OCSF records, command
+  segmentation, and non-contaminating per-run sinks.
+- `mcp/aptl-mcp-common/src/runs.ts`, `captures.ts`, and
+  `src/aptl/core/runstore.py` own per-run artifact layout and identifier
+  contracts.
+- ADR-003, ADR-004, ADR-012, ADR-027, ADR-029, ADR-033, ADR-034, ADR-037,
+  ADR-041, and ADR-042 already define the common MCP, SSH, telemetry,
+  redaction, non-contamination, TLS, Docker, and capture boundaries.
+
+## Decision
+
+Composite MCP tools are **tool-boundary orchestrators over existing MCP common
+primitives**, not a new workflow engine and not a new execution substrate.
+
+A composite tool may expose a single MCP tool name and a compact result, but
+its internal steps must reuse the same canonical surfaces that a manually
+orchestrating agent would have used:
+
+- SSH execution goes through `SSHConnectionManager` / `PersistentSession` and
+  the existing handler response conventions.
+- API calls go through `HTTPClient`, `resolveApiRequestUrl()`, per-query TLS
+  and auth semantics, and the existing API handler envelope conventions.
+- MCP request/response tracing stays under `traceToolCall()`.
+- Red-team command-bearing steps stay visible to the red capture and OCSF
+  path. A composite must not make internal shell commands disappear from
+  `tool-calls.jsonl`, `ocsf.jsonl`, PTY tee, or Kali-side captures merely
+  because the agent made one top-level tool call.
+- Per-run artifacts stay under the existing run directory contract; new MCP
+  sidecar report files, if any, belong under the `mcp-side` tree with
+  restrictive permissions and ADR-029 redaction.
+
+Composite tool registration should remain centralized in
+`aptl-mcp-common`. Server-specific packages may opt into domain-specific
+composites, but they must do so through a typed common registration seam rather
+than by reimplementing MCP server startup, command execution, HTTP transport,
+or telemetry.
+
+The existing name-based context routing in `createMCPServer()` is too fragile
+for composites that are neither plain SSH tools nor predefined API queries.
+The extensibility seam is an explicit tool-kind/handler registry entry that
+declares whether the handler needs SSH, HTTP, or both contexts. Do not encode
+composite semantics in tool-name substrings or suffix collisions.
+
+## Security Layers
+
+- **MCP ingress schema:** every composite input must have a JSON Schema tool
+  definition. Inputs such as target, CIDR, ports, timing, output format, and
+  timeout must be typed and bounded. Do not accept free-form `extra_args`,
+  shell fragments, or arbitrary command templates as composite parameters.
+- **Domain validation:** command-building inputs must be parsed into
+  allowlisted primitives before assembly. For scan-style composites, validate
+  host/CIDR and port-range syntax, cap fan-out and timeout, and default to the
+  configured lab network. Any future non-lab target allowance needs an explicit
+  operator-facing policy seam; it must not be hidden in a convenience tool.
+- **Command execution:** shell execution still uses the existing SSH session
+  layer. Composite code must not spawn local `nmap`, `docker`, `curl`, or shell
+  processes from the MCP host to bypass the lab container boundary. When a
+  command string must be assembled for the remote shell, every user-controlled
+  part must have been validated or safely quoted; never concatenate raw input.
+- **Structured parsing:** parse machine-readable tool output when available
+  (for example nmap XML or another structured format) instead of scraping
+  human-formatted text with ad hoc regexes.
+- **Secret handling:** arguments, command lines, responses, errors, OCSF
+  fields, report artifacts, and traces pass through
+  `mcp/aptl-mcp-common/src/redaction.ts` at the established boundaries. Do not
+  add a composite-local sanitizer or weaken command redaction to preserve a
+  prettier report.
+- **Auth and TLS:** API-backed composite steps must reuse `HTTPClient`,
+  `endpoint-url.ts`, `verify_ssl`, `ca_cert_path`, and per-query auth
+  inheritance. API tokens and credentials stay in `.env` / MCP config
+  substitution, not in tool arguments, process argv, report text, or errors.
+- **Error envelopes:** use the existing MCP `{ success, ... }` JSON text
+  response style and existing `SSHError` / HTTP error handling. A partial
+  composite failure may report the failed step and sanitized diagnostics, but
+  must not introduce another exception hierarchy or leak raw stderr, tokens,
+  private keys, cookies, or full upstream response bodies.
+- **Observability:** keep one top-level MCP span for the composite call and
+  retain per-command/per-step evidence through the existing red capture,
+  OCSF, PTY tee, and Kali-side capture paths. Observability failures remain
+  best-effort and must not change command execution results.
+- **Non-contamination:** red-side composites must not query Wazuh, Suricata,
+  TheHive, MISP, Shuffle, or other blue/SOC APIs as a convenience report step.
+  Blue/SOC composites may summarize defender-visible APIs. Any future purple
+  composite that deliberately joins red evidence with blue observations needs a
+  separate design because it crosses the ADR-033 experiment boundary.
+- **Persistence and OS exposure:** composite report persistence, if added,
+  uses existing per-run directories and restrictive modes. Do not write reports
+  into the repo tree, `/tmp`, command-line arguments, unchecked Docker volumes,
+  or long-lived process environment variables.
+
+## Maintainability
+
+Implementations must build on these incumbents:
+
+- `LabConfig` loading and MCP `docker-lab-config.json` env substitution in
+  `mcp/aptl-mcp-common/src/config.ts`.
+- Tool definition and handler generation in `mcp/aptl-mcp-common/src/tools/*`.
+- `SSHConnectionManager`, `PersistentSession`, effective session mode,
+  session-id validation, and remote-close cleanup in `ssh.ts` and
+  `tools/handlers.ts`.
+- `HTTPClient`, `assertPathOnlyEndpoint()`, `resolveApiRequestUrl()`, and
+  query-specific auth/TLS inheritance in `http.ts`, `endpoint-url.ts`, and
+  `tools/api-handlers.ts`.
+- `traceToolCall()` and shared redaction in `telemetry.ts` and `redaction.ts`.
+- Red command classification, extraction, capture, and OCSF sinks in
+  `mcp/mcp-red/src/*` for command-bearing Kali composites.
+- Per-run path helpers and identifier validation in
+  `mcp/aptl-mcp-common/src/runs.ts`; do not create another run-id,
+  trace-id, or session-id convention.
+- The repo quality gates: MCP common changes require vitest coverage in
+  `mcp/aptl-mcp-common/tests`, affected server tests such as
+  `mcp/mcp-red/tests`, rebuilds for dependent MCPs, and
+  `pre-commit run --all-files` before completion.
+
+## Extensibility
+
+The next reasonable change is adding another named composite without editing
+the server factory's core dispatch logic. The seam is a typed composite
+registration entry with:
+
+- a stable tool name and description;
+- a JSON Schema input contract;
+- declared context needs (`ssh`, `api`, or both);
+- bounded per-step timeout and output-size policy;
+- a result formatter that produces a compact, redacted summary while leaving
+  raw evidence in the existing capture surfaces.
+
+Do not generalize this into a YAML workflow language, DAG executor, cross-MCP
+RPC bus, or agent-planning DSL for ORC-003. If later requirements need those,
+they should be designed separately with their own auth, validation,
+observability, and non-contamination analysis.
+
+## Non-Goals
+
+- Do not replace `*_run_command`, `*_session_command`, predefined API queries,
+  or persistent sessions.
+- Do not add a second MCP server framework or per-server startup pattern.
+- Do not create a Python-side MCP composite runner for TypeScript MCP tools.
+- Do not redesign OTel, OCSF, run archives, Kali capture, Docker Compose, or
+  SOC TLS as part of composite tools.
+- Do not make composite tools a hidden privilege escalation path from a
+  domain-specific tool to host Docker, local filesystem, or blue/SOC APIs.
+- Do not promise complete shell AST parsing or perfect semantic interpretation
+  of arbitrary tool output.
+
+## Anti-Patterns
+
+- A composite implemented as `child_process.exec("nmap " + target)` on the MCP
+  host.
+- A generic `run_steps` or `workflow` tool that accepts arbitrary commands,
+  URLs, headers, or JSON paths from the agent.
+- Duplicate `LabConfig`, API auth, TLS, session, run-id, or error-envelope
+  schemas under a composite directory.
+- Command output parsing by brittle text snippets when structured output is
+  available.
+- Hiding internal step commands from red capture or emitting a polished report
+  with no underlying evidence surface.
+- Combining Kali scan results with Wazuh/Suricata alerts in a red-side tool.
+- Logging raw composite args/results to stderr because the top-level tool is
+  "only a report."
+
+## References
+
+- ORC-003 / GitHub issue #477 - Composite MCP Tools.
+- [ADR-003](adr-003-mcp-common-library.md): MCP Common Library.
+- [ADR-004](adr-004-persistent-ssh-sessions.md): Persistent SSH Sessions.
+- [ADR-012](adr-012-opentelemetry-integration.md): OpenTelemetry Integration.
+- [ADR-027](adr-027-red-team-structured-logging.md): Red Team Structured
+  Logging Boundary.
+- [ADR-029](adr-029-control-plane-secret-handling.md): Control-Plane Secret
+  Handling.
+- [ADR-033](adr-033-agent-reasoning-trace-boundary.md): Red-Side Behavioural
+  Capture and Non-Contamination Boundary.
+- [ADR-034](adr-034-lab-managed-soc-tls-ca.md): Lab-Managed CA for Verified
+  SOC Stack TLS.

--- a/mcp/aptl-mcp-common/src/index.ts
+++ b/mcp/aptl-mcp-common/src/index.ts
@@ -27,8 +27,21 @@ export {
   experimentNoRedactActive,
 } from './redaction.js';
 export type { LabConfig } from './config.js';
-export { loadLabConfig, substituteEnvVars, parseDotEnv } from './config.js';
+export { loadLabConfig, substituteEnvVars, parseDotEnv, getTargetCredentials } from './config.js';
 export type { ToolContext } from './tools/handlers.js';
+export { resolveCaptureContainer } from './tools/handlers.js';
+export {
+  generateCompositeToolDefinitions,
+  generateCompositeToolHandlers,
+  compositeContextKinds,
+} from './tools/composites.js';
+export type {
+  CompositeTool,
+  CompositeHandler,
+  CompositeContext,
+  CompositeContextKind,
+  CompositeStepRecord,
+} from './tools/composites.js';
 export {
   loadActiveTraceId,
   resolveActiveRunDir,

--- a/mcp/aptl-mcp-common/src/server.ts
+++ b/mcp/aptl-mcp-common/src/server.ts
@@ -22,6 +22,15 @@ import { generateToolDefinitions } from './tools/definitions.js';
 import { generateToolHandlers, type ToolHandler, type ToolContext } from './tools/handlers.js';
 import { generateAPIToolDefinitions } from './tools/api-definitions.js';
 import { generateAPIToolHandlers, type APIToolHandler, type APIToolContext } from './tools/api-handlers.js';
+import {
+  generateCompositeToolDefinitions,
+  generateCompositeToolHandlers,
+  compositeContextKinds,
+  type CompositeTool,
+  type CompositeHandler,
+  type CompositeContext,
+  type CompositeContextKind,
+} from './tools/composites.js';
 
 /**
  * Information passed to a `postToolHook` after a tool call resolves or rejects.
@@ -53,6 +62,14 @@ export interface CreateMCPServerOptions {
    * Defaults to 2000 ms; set to 0 to disable the timeout.
    */
   postToolHookTimeoutMs?: number;
+  /**
+   * Composite MCP tools (ORC-003 / ADR-045) this server opts into. A
+   * composite is a single MCP tool that orchestrates several internal SSH/API
+   * steps over the existing primitives. Domain composites live in the server
+   * package and are registered here through the typed common seam; common
+   * itself ships no domain composites.
+   */
+  composites?: CompositeTool[];
 }
 
 /**
@@ -99,7 +116,7 @@ export function createMCPServer(labConfig: LabConfig, options: CreateMCPServerOp
 
   // Pre-generate tools and handlers based on available capabilities
   let cachedTools: Tool[] = [];
-  let cachedHandlers: Record<string, ToolHandler | APIToolHandler> = {};
+  let cachedHandlers: Record<string, ToolHandler | APIToolHandler | CompositeHandler> = {};
 
   if (sshManager) {
     cachedTools.push(...generateToolDefinitions(labConfig.server));
@@ -111,6 +128,17 @@ export function createMCPServer(labConfig: LabConfig, options: CreateMCPServerOp
     const includeGeneric = !labConfig.queries || Object.keys(labConfig.queries).length === 0;
     cachedTools.push(...generateAPIToolDefinitions(labConfig.server, labConfig.queries, includeGeneric));
     Object.assign(cachedHandlers, generateAPIToolHandlers(labConfig.server, labConfig.queries, includeGeneric));
+  }
+
+  // Composite tools (ORC-003 / ADR-045) register through the typed common
+  // seam. Their context kind is tracked explicitly so dispatch routes SSH /
+  // HTTP context by declaration, never by tool-name substring.
+  const composites = options.composites ?? [];
+  let compositeKinds: Record<string, CompositeContextKind> = {};
+  if (composites.length > 0) {
+    cachedTools.push(...generateCompositeToolDefinitions(labConfig.server, composites));
+    Object.assign(cachedHandlers, generateCompositeToolHandlers(labConfig.server, composites));
+    compositeKinds = compositeContextKinds(labConfig.server, composites);
   }
 
   console.error(`[MCP] Initialized ${labConfig.server.name} with lab: ${labConfig.lab.name}`);
@@ -129,6 +157,44 @@ export function createMCPServer(labConfig: LabConfig, options: CreateMCPServerOp
     }
   );
 
+  // Build the composite context from the declared kind (ADR-045): routing is
+  // by declaration, never by tool-name substrings. A declared client that is
+  // unconfigured is a hard error before the handler runs.
+  const buildCompositeContext = (kind: CompositeContextKind): CompositeContext => {
+    const compositeContext: CompositeContext = { labConfig };
+    if (kind === 'ssh' || kind === 'both') {
+      if (!sshManager) {
+        throw new Error('Composite tool requires SSH but SSH manager not configured');
+      }
+      compositeContext.sshManager = sshManager;
+    }
+    if (kind === 'api' || kind === 'both') {
+      if (!httpClient) {
+        throw new Error('Composite tool requires API but HTTP client not configured');
+      }
+      compositeContext.httpClient = httpClient;
+    }
+    return compositeContext;
+  };
+
+  // Determine context type based on tool kind and available clients.
+  const resolveToolContext = (name: string): ToolContext | APIToolContext | CompositeContext => {
+    const compositeKind = compositeKinds[name];
+    if (compositeKind) {
+      return buildCompositeContext(compositeKind);
+    }
+    if (name.includes('_api_') || (labConfig.queries && Object.keys(labConfig.queries).some(q => name.endsWith(`_${q}`)))) {
+      if (!httpClient) {
+        throw new Error('API tool requested but HTTP client not configured');
+      }
+      return { httpClient, labConfig };
+    }
+    if (!sshManager) {
+      throw new Error('SSH tool requested but SSH manager not configured');
+    }
+    return { sshManager, labConfig };
+  };
+
   // Setup request handlers
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
@@ -144,28 +210,9 @@ export function createMCPServer(labConfig: LabConfig, options: CreateMCPServerOp
       throw new Error(`Unknown tool: ${name}`);
     }
 
-    // Determine context type based on tool name and available clients
-    let context: ToolContext | APIToolContext;
-
-    if (name.includes('_api_') || (labConfig.queries && Object.keys(labConfig.queries).some(q => name.endsWith(`_${q}`)))) {
-      // API tool context
-      if (!httpClient) {
-        throw new Error('API tool requested but HTTP client not configured');
-      }
-      context = {
-        httpClient,
-        labConfig,
-      };
-    } else {
-      // SSH tool context
-      if (!sshManager) {
-        throw new Error('SSH tool requested but SSH manager not configured');
-      }
-      context = {
-        sshManager,
-        labConfig,
-      };
-    }
+    // Context type is resolved by tool kind (composite/API/SSH) in a helper so
+    // the dispatch path stays within the repo's complexity budget.
+    const context = resolveToolContext(name);
 
     const safeArgs: Record<string, unknown> = args ?? {};
     const t0 = Date.now();

--- a/mcp/aptl-mcp-common/src/server.ts
+++ b/mcp/aptl-mcp-common/src/server.ts
@@ -106,6 +106,9 @@ async function runHookWithTimeout(
   }
 }
 
+/** Any handler a server can dispatch: plain SSH, API-backed, or composite. */
+type AnyToolHandler = ToolHandler | APIToolHandler | CompositeHandler;
+
 interface ServerClients {
   sshManager: SSHConnectionManager | null;
   httpClient: HTTPClient | null;
@@ -113,7 +116,7 @@ interface ServerClients {
 
 interface ToolRegistry {
   cachedTools: Tool[];
-  cachedHandlers: Record<string, ToolHandler | APIToolHandler | CompositeHandler>;
+  cachedHandlers: Record<string, AnyToolHandler>;
   compositeKinds: Record<string, CompositeContextKind>;
 }
 
@@ -124,7 +127,7 @@ interface ContextDeps {
 }
 
 interface CallToolDeps extends ContextDeps {
-  cachedHandlers: Record<string, ToolHandler | APIToolHandler | CompositeHandler>;
+  cachedHandlers: Record<string, AnyToolHandler>;
   postToolHook?: PostToolHook;
   hookTimeoutMs: number;
 }
@@ -136,7 +139,7 @@ function buildToolRegistry(
   composites: CompositeTool[],
 ): ToolRegistry {
   const cachedTools: Tool[] = [];
-  const cachedHandlers: Record<string, ToolHandler | APIToolHandler | CompositeHandler> = {};
+  const cachedHandlers: Record<string, AnyToolHandler> = {};
   let compositeKinds: Record<string, CompositeContextKind> = {};
 
   if (clients.sshManager) {

--- a/mcp/aptl-mcp-common/src/server.ts
+++ b/mcp/aptl-mcp-common/src/server.ts
@@ -106,43 +106,173 @@ async function runHookWithTimeout(
   }
 }
 
-export function createMCPServer(labConfig: LabConfig, options: CreateMCPServerOptions = {}) {
-  const { postToolHook } = options;
-  const hookTimeoutMs = options.postToolHookTimeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
-  // Initialize clients and OTel tracing based on config
-  const sshManager = labConfig.containers ? new SSHConnectionManager() : null;
-  const httpClient = labConfig.api ? new HTTPClient(labConfig.api) : null;
-  initTracing(labConfig.server.name);
+interface ServerClients {
+  sshManager: SSHConnectionManager | null;
+  httpClient: HTTPClient | null;
+}
 
-  // Pre-generate tools and handlers based on available capabilities
-  let cachedTools: Tool[] = [];
-  let cachedHandlers: Record<string, ToolHandler | APIToolHandler | CompositeHandler> = {};
+interface ToolRegistry {
+  cachedTools: Tool[];
+  cachedHandlers: Record<string, ToolHandler | APIToolHandler | CompositeHandler>;
+  compositeKinds: Record<string, CompositeContextKind>;
+}
 
-  if (sshManager) {
+interface ContextDeps {
+  labConfig: LabConfig;
+  clients: ServerClients;
+  compositeKinds: Record<string, CompositeContextKind>;
+}
+
+interface CallToolDeps extends ContextDeps {
+  cachedHandlers: Record<string, ToolHandler | APIToolHandler | CompositeHandler>;
+  postToolHook?: PostToolHook;
+  hookTimeoutMs: number;
+}
+
+/** Pre-generate tool definitions + handlers for every configured capability. */
+function buildToolRegistry(
+  labConfig: LabConfig,
+  clients: ServerClients,
+  composites: CompositeTool[],
+): ToolRegistry {
+  const cachedTools: Tool[] = [];
+  const cachedHandlers: Record<string, ToolHandler | APIToolHandler | CompositeHandler> = {};
+  let compositeKinds: Record<string, CompositeContextKind> = {};
+
+  if (clients.sshManager) {
     cachedTools.push(...generateToolDefinitions(labConfig.server));
     Object.assign(cachedHandlers, generateToolHandlers(labConfig.server));
   }
-
-  if (httpClient) {
+  if (clients.httpClient) {
     // Only include generic tools if no predefined queries exist
     const includeGeneric = !labConfig.queries || Object.keys(labConfig.queries).length === 0;
     cachedTools.push(...generateAPIToolDefinitions(labConfig.server, labConfig.queries, includeGeneric));
     Object.assign(cachedHandlers, generateAPIToolHandlers(labConfig.server, labConfig.queries, includeGeneric));
   }
-
-  // Composite tools (ORC-003 / ADR-045) register through the typed common
-  // seam. Their context kind is tracked explicitly so dispatch routes SSH /
-  // HTTP context by declaration, never by tool-name substring.
-  const composites = options.composites ?? [];
-  let compositeKinds: Record<string, CompositeContextKind> = {};
+  // Composite tools (ORC-003 / ADR-045) register through the typed common seam.
+  // Their context kind is tracked explicitly so dispatch routes SSH / HTTP
+  // context by declaration, never by tool-name substring.
   if (composites.length > 0) {
     cachedTools.push(...generateCompositeToolDefinitions(labConfig.server, composites));
     Object.assign(cachedHandlers, generateCompositeToolHandlers(labConfig.server, composites));
     compositeKinds = compositeContextKinds(labConfig.server, composites);
   }
 
+  return { cachedTools, cachedHandlers, compositeKinds };
+}
+
+/**
+ * Build the composite context from the declared kind (ADR-045): routing is by
+ * declaration, never by tool-name substrings. A declared client that is
+ * unconfigured is a hard error before the handler runs.
+ */
+function buildCompositeContext(kind: CompositeContextKind, deps: ContextDeps): CompositeContext {
+  const { labConfig, clients } = deps;
+  const compositeContext: CompositeContext = { labConfig };
+  if (kind === 'ssh' || kind === 'both') {
+    if (!clients.sshManager) {
+      throw new Error('Composite tool requires SSH but SSH manager not configured');
+    }
+    compositeContext.sshManager = clients.sshManager;
+  }
+  if (kind === 'api' || kind === 'both') {
+    if (!clients.httpClient) {
+      throw new Error('Composite tool requires API but HTTP client not configured');
+    }
+    compositeContext.httpClient = clients.httpClient;
+  }
+  return compositeContext;
+}
+
+/** Determine context type based on tool kind and available clients. */
+function resolveToolContext(name: string, deps: ContextDeps): ToolContext | APIToolContext | CompositeContext {
+  const { labConfig, clients, compositeKinds } = deps;
+  const compositeKind = compositeKinds[name];
+  if (compositeKind) {
+    return buildCompositeContext(compositeKind, deps);
+  }
+  if (name.includes('_api_') || (labConfig.queries && Object.keys(labConfig.queries).some(q => name.endsWith(`_${q}`)))) {
+    if (!clients.httpClient) {
+      throw new Error('API tool requested but HTTP client not configured');
+    }
+    return { httpClient: clients.httpClient, labConfig };
+  }
+  if (!clients.sshManager) {
+    throw new Error('SSH tool requested but SSH manager not configured');
+  }
+  return { sshManager: clients.sshManager, labConfig };
+}
+
+/** Build the CallTool request handler, including the best-effort post-tool hook. */
+function makeCallToolHandler(deps: CallToolDeps) {
+  return async (request: CallToolRequest) => {
+    const { name, arguments: args } = request.params;
+
+    const handler = deps.cachedHandlers[name];
+    if (!handler) {
+      throw new Error(`Unknown tool: ${name}`);
+    }
+
+    const context = resolveToolContext(name, deps);
+    const safeArgs: Record<string, unknown> = args ?? {};
+    const t0 = Date.now();
+    try {
+      const result = await traceToolCall<{ content: { type: string; text: string }[] }>(
+        name,
+        deps.labConfig.server.name,
+        safeArgs,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- handler union narrowed by resolveToolContext
+        () => (handler as any)(safeArgs, context),
+      );
+      if (deps.postToolHook) {
+        // Fire-and-forget: telemetry must NEVER add latency to the tool
+        // response. Errors and timeouts are logged to stderr so a bad hook is
+        // observable without blocking. The hook timeout still applies to the
+        // lifetime of the in-flight task — we don't await it on the response path.
+        void runHookWithTimeout(
+          deps.postToolHook,
+          { toolName: name, args: safeArgs, result, durationMs: Date.now() - t0 },
+          deps.hookTimeoutMs,
+        ).catch((hookErr) => {
+          console.error('[MCP] postToolHook error:', hookErr);
+        });
+      }
+      return result;
+    } catch (err) {
+      if (deps.postToolHook) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        void runHookWithTimeout(
+          deps.postToolHook,
+          { toolName: name, args: safeArgs, durationMs: Date.now() - t0, error },
+          deps.hookTimeoutMs,
+        ).catch((hookErr) => {
+          console.error('[MCP] postToolHook error:', hookErr);
+        });
+      }
+      throw err;
+    }
+  };
+}
+
+export function createMCPServer(labConfig: LabConfig, options: CreateMCPServerOptions = {}) {
+  const { postToolHook } = options;
+  const hookTimeoutMs = options.postToolHookTimeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
+  // Initialize clients and OTel tracing based on config
+  const clients: ServerClients = {
+    sshManager: labConfig.containers ? new SSHConnectionManager() : null,
+    httpClient: labConfig.api ? new HTTPClient(labConfig.api) : null,
+  };
+  const { sshManager } = clients;
+  initTracing(labConfig.server.name);
+
+  const { cachedTools, cachedHandlers, compositeKinds } = buildToolRegistry(
+    labConfig,
+    clients,
+    options.composites ?? [],
+  );
+
   console.error(`[MCP] Initialized ${labConfig.server.name} with lab: ${labConfig.lab.name}`);
-  console.error(`[MCP] Available capabilities: ${sshManager ? 'SSH' : ''}${sshManager && httpClient ? ' + ' : ''}${httpClient ? 'HTTP API' : ''}`);
+  console.error(`[MCP] Available capabilities: ${clients.sshManager ? 'SSH' : ''}${clients.sshManager && clients.httpClient ? ' + ' : ''}${clients.httpClient ? 'HTTP API' : ''}`);
 
   // Create MCP server
   const server = new Server(
@@ -157,44 +287,6 @@ export function createMCPServer(labConfig: LabConfig, options: CreateMCPServerOp
     }
   );
 
-  // Build the composite context from the declared kind (ADR-045): routing is
-  // by declaration, never by tool-name substrings. A declared client that is
-  // unconfigured is a hard error before the handler runs.
-  const buildCompositeContext = (kind: CompositeContextKind): CompositeContext => {
-    const compositeContext: CompositeContext = { labConfig };
-    if (kind === 'ssh' || kind === 'both') {
-      if (!sshManager) {
-        throw new Error('Composite tool requires SSH but SSH manager not configured');
-      }
-      compositeContext.sshManager = sshManager;
-    }
-    if (kind === 'api' || kind === 'both') {
-      if (!httpClient) {
-        throw new Error('Composite tool requires API but HTTP client not configured');
-      }
-      compositeContext.httpClient = httpClient;
-    }
-    return compositeContext;
-  };
-
-  // Determine context type based on tool kind and available clients.
-  const resolveToolContext = (name: string): ToolContext | APIToolContext | CompositeContext => {
-    const compositeKind = compositeKinds[name];
-    if (compositeKind) {
-      return buildCompositeContext(compositeKind);
-    }
-    if (name.includes('_api_') || (labConfig.queries && Object.keys(labConfig.queries).some(q => name.endsWith(`_${q}`)))) {
-      if (!httpClient) {
-        throw new Error('API tool requested but HTTP client not configured');
-      }
-      return { httpClient, labConfig };
-    }
-    if (!sshManager) {
-      throw new Error('SSH tool requested but SSH manager not configured');
-    }
-    return { sshManager, labConfig };
-  };
-
   // Setup request handlers
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
@@ -202,57 +294,10 @@ export function createMCPServer(labConfig: LabConfig, options: CreateMCPServerOp
     };
   });
 
-  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
-    const { name, arguments: args } = request.params;
-
-    const handler = cachedHandlers[name];
-    if (!handler) {
-      throw new Error(`Unknown tool: ${name}`);
-    }
-
-    // Context type is resolved by tool kind (composite/API/SSH) in a helper so
-    // the dispatch path stays within the repo's complexity budget.
-    const context = resolveToolContext(name);
-
-    const safeArgs: Record<string, unknown> = args ?? {};
-    const t0 = Date.now();
-    try {
-      // Context is narrowed to the correct type above based on tool name
-      const result = await traceToolCall<{ content: { type: string; text: string }[] }>(
-        name,
-        labConfig.server.name,
-        safeArgs,
-        () => (handler as any)(safeArgs, context),
-      );
-      if (postToolHook) {
-        // Fire-and-forget: telemetry must NEVER add latency to the tool
-        // response. Errors and timeouts are logged to stderr so a bad
-        // hook is observable without blocking. The hook timeout still
-        // applies to the lifetime of the in-flight task — we don't
-        // await it on the response path.
-        void runHookWithTimeout(
-          postToolHook,
-          { toolName: name, args: safeArgs, result, durationMs: Date.now() - t0 },
-          hookTimeoutMs,
-        ).catch((hookErr) => {
-          console.error('[MCP] postToolHook error:', hookErr);
-        });
-      }
-      return result;
-    } catch (err) {
-      if (postToolHook) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        void runHookWithTimeout(
-          postToolHook,
-          { toolName: name, args: safeArgs, durationMs: Date.now() - t0, error },
-          hookTimeoutMs,
-        ).catch((hookErr) => {
-          console.error('[MCP] postToolHook error:', hookErr);
-        });
-      }
-      throw err;
-    }
-  });
+  server.setRequestHandler(
+    CallToolRequestSchema,
+    makeCallToolHandler({ labConfig, clients, compositeKinds, cachedHandlers, postToolHook, hookTimeoutMs }),
+  );
 
   // Setup graceful shutdown handlers (once per process)
   let handlersSetup = false;

--- a/mcp/aptl-mcp-common/src/tools/composites.ts
+++ b/mcp/aptl-mcp-common/src/tools/composites.ts
@@ -1,0 +1,113 @@
+/**
+ * Composite MCP tool registration seam (ORC-003 / ADR-045).
+ *
+ * A composite tool exposes a single MCP tool name and a compact result, but
+ * its internal steps reuse the same canonical primitives a manually
+ * orchestrating agent would have used (SSH via `SSHConnectionManager`, API via
+ * `HTTPClient`). This module is ONLY the typed registration seam: it produces
+ * the MCP tool definitions, the handler map, and the per-tool context-kind map
+ * that `createMCPServer` consumes. It contains no domain logic and no
+ * server-specific (red/blue) behaviour — domain composites live in their own
+ * server package and are passed in via `CreateMCPServerOptions.composites`.
+ *
+ * Per ADR-045 the server routes composite context by the declared
+ * `contextKind`, NOT by tool-name substrings, so composites that are neither
+ * plain SSH tools nor predefined API queries dispatch unambiguously.
+ */
+
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { LabConfig } from '../config.js';
+import { SSHConnectionManager } from '../ssh.js';
+import { HTTPClient } from '../http.js';
+
+/** Which lab clients a composite handler needs at dispatch time. */
+export type CompositeContextKind = 'ssh' | 'api' | 'both';
+
+/**
+ * Context handed to a composite handler. `sshManager` / `httpClient` are
+ * populated according to the composite's declared `contextKind`; the server
+ * throws before invoking the handler if a declared client is unconfigured, so
+ * a handler that declared `ssh` can rely on `sshManager` being present.
+ */
+export interface CompositeContext {
+  labConfig: LabConfig;
+  sshManager?: SSHConnectionManager;
+  httpClient?: HTTPClient;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- MCP SDK provides untyped args; validated by the composite's JSON Schema before dispatch
+export type CompositeHandler = (args: any, context: CompositeContext) => Promise<{ content: { type: string; text: string }[] }>;
+
+/**
+ * One internal step a composite executed, surfaced in the composite's result
+ * envelope so command-bearing steps stay visible to the red capture / OCSF
+ * path (ADR-045). A composite must not make its internal shell commands
+ * disappear from `ocsf.jsonl` / `tool-calls.jsonl` merely because the agent
+ * made one top-level tool call.
+ */
+export interface CompositeStepRecord {
+  command: string;
+  exit_code?: number;
+  signal?: string;
+  success?: boolean;
+  session_id?: string;
+  duration_ms?: number;
+}
+
+/**
+ * A typed composite registration entry (ADR-045 extensibility seam). Adding a
+ * new composite is one of these plus an opt-in via `options.composites`; the
+ * server factory's core dispatch never changes.
+ */
+export interface CompositeTool {
+  /** Unprefixed tool-name suffix; the seam prefixes it with `toolPrefix`. */
+  name: string;
+  description: string;
+  /** JSON Schema for the composite's MCP ingress; typed and bounded inputs only. */
+  inputSchema: Tool['inputSchema'];
+  contextKind: CompositeContextKind;
+  handler: CompositeHandler;
+}
+
+function prefixedName(serverConfig: LabConfig['server'], composite: CompositeTool): string {
+  return `${serverConfig.toolPrefix}_${composite.name}`;
+}
+
+/** Build the MCP `Tool[]` definitions for a server's composites. */
+export function generateCompositeToolDefinitions(
+  serverConfig: LabConfig['server'],
+  composites: CompositeTool[],
+): Tool[] {
+  return composites.map((composite) => ({
+    name: prefixedName(serverConfig, composite),
+    description: composite.description,
+    inputSchema: composite.inputSchema,
+  }));
+}
+
+/** Build the prefixed-name → handler map for a server's composites. */
+export function generateCompositeToolHandlers(
+  serverConfig: LabConfig['server'],
+  composites: CompositeTool[],
+): Record<string, CompositeHandler> {
+  const handlers: Record<string, CompositeHandler> = {};
+  for (const composite of composites) {
+    handlers[prefixedName(serverConfig, composite)] = composite.handler;
+  }
+  return handlers;
+}
+
+/**
+ * Build the prefixed-name → context-kind map the server uses to route
+ * composite context explicitly (ADR-045: not by tool-name substring).
+ */
+export function compositeContextKinds(
+  serverConfig: LabConfig['server'],
+  composites: CompositeTool[],
+): Record<string, CompositeContextKind> {
+  const kinds: Record<string, CompositeContextKind> = {};
+  for (const composite of composites) {
+    kinds[prefixedName(serverConfig, composite)] = composite.contextKind;
+  }
+  return kinds;
+}

--- a/mcp/aptl-mcp-common/tests/composites.test.ts
+++ b/mcp/aptl-mcp-common/tests/composites.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateCompositeToolDefinitions,
+  generateCompositeToolHandlers,
+  compositeContextKinds,
+  type CompositeTool,
+} from '../src/tools/composites.js';
+
+const serverConfig = {
+  name: 'test-server',
+  version: '1.0.0',
+  description: 'Test - server',
+  toolPrefix: 'test',
+  targetName: 'Test Target',
+  configKey: 'test',
+};
+
+function makeComposite(overrides: Partial<CompositeTool> = {}): CompositeTool {
+  return {
+    name: 'demo',
+    description: 'A demo composite',
+    contextKind: 'ssh',
+    inputSchema: { type: 'object', properties: {} },
+    handler: async () => ({ content: [{ type: 'text', text: '{}' }] }),
+    ...overrides,
+  };
+}
+
+describe('generateCompositeToolDefinitions', () => {
+  it('prefixes the tool name with the server toolPrefix', () => {
+    const defs = generateCompositeToolDefinitions(serverConfig, [makeComposite()]);
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe('test_demo');
+    expect(defs[0].description).toBe('A demo composite');
+    expect(defs[0].inputSchema).toEqual({ type: 'object', properties: {} });
+  });
+
+  it('returns one definition per composite', () => {
+    const defs = generateCompositeToolDefinitions(serverConfig, [
+      makeComposite({ name: 'a' }),
+      makeComposite({ name: 'b' }),
+    ]);
+    expect(defs.map((d) => d.name)).toEqual(['test_a', 'test_b']);
+  });
+
+  it('returns an empty array for no composites', () => {
+    expect(generateCompositeToolDefinitions(serverConfig, [])).toEqual([]);
+  });
+});
+
+describe('generateCompositeToolHandlers', () => {
+  it('maps the prefixed tool name to the composite handler', async () => {
+    const handler = async () => ({ content: [{ type: 'text', text: 'ok' }] });
+    const handlers = generateCompositeToolHandlers(serverConfig, [makeComposite({ handler })]);
+    expect(Object.keys(handlers)).toEqual(['test_demo']);
+    const result = await handlers['test_demo']({}, { labConfig: {} as never });
+    expect(result.content[0].text).toBe('ok');
+  });
+});
+
+describe('compositeContextKinds', () => {
+  it('records each composite context kind under its prefixed name', () => {
+    const kinds = compositeContextKinds(serverConfig, [
+      makeComposite({ name: 'ssh_only', contextKind: 'ssh' }),
+      makeComposite({ name: 'api_only', contextKind: 'api' }),
+      makeComposite({ name: 'both_kinds', contextKind: 'both' }),
+    ]);
+    expect(kinds).toEqual({
+      test_ssh_only: 'ssh',
+      test_api_only: 'api',
+      test_both_kinds: 'both',
+    });
+  });
+});

--- a/mcp/aptl-mcp-common/tests/server-composite-dispatch.test.ts
+++ b/mcp/aptl-mcp-common/tests/server-composite-dispatch.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CompositeContext, CompositeTool } from '../src/tools/composites.js';
+
+// Capture the CallToolRequest handler registered by createMCPServer so the
+// test can drive composite dispatch without a real MCP transport. Mirrors
+// server-hook.test.ts.
+let registeredHandlers: Array<(req: unknown) => unknown>;
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
+  Server: vi.fn(function () {
+    return {
+      setRequestHandler: vi.fn((_schema: unknown, handler: (req: unknown) => unknown) => {
+        registeredHandlers.push(handler);
+      }),
+      connect: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: vi.fn(function () { return {}; }),
+}));
+
+vi.mock('../src/ssh.js', () => ({
+  SSHConnectionManager: vi.fn(function () { return { __kind: 'ssh' }; }),
+}));
+
+vi.mock('../src/http.js', () => ({
+  HTTPClient: vi.fn(function () { return { __kind: 'http' }; }),
+}));
+
+vi.mock('../src/telemetry.js', () => ({
+  initTracing: vi.fn(),
+  shutdownTracing: vi.fn().mockResolvedValue(undefined),
+  getTracer: vi.fn(),
+  traceToolCall: vi.fn(async (_n: unknown, _s: unknown, _a: unknown, fn: () => unknown) => fn()),
+}));
+
+const sshConfig = {
+  version: '1.0.0',
+  server: {
+    name: 'test-server',
+    version: '1.0.0',
+    description: 'Test',
+    toolPrefix: 'test',
+    targetName: 'Test',
+    configKey: 'test',
+  },
+  lab: { name: 'test-lab', network_subnet: '172.20.0.0/16' },
+  containers: {
+    test: { container_name: 't', container_ip: '127.0.0.1', ssh_key: '/k', ssh_user: 'u', ssh_port: 22, enabled: true },
+  },
+};
+
+const apiConfig = {
+  version: '1.0.0',
+  server: { name: 'api-server', version: '1.0.0', description: 'Test', toolPrefix: 'test', targetName: 'Test', configKey: '' },
+  lab: { name: 'test-lab', network_subnet: '172.20.0.0/16' },
+  api: { baseUrl: 'https://localhost:9200', auth: { type: 'basic', username: 'u', password: 'p' } },
+};
+
+async function loadCreateMCPServer() {
+  const mod = await import('../src/server.js');
+  return mod.createMCPServer;
+}
+
+function makeComposite(overrides: Partial<CompositeTool>): CompositeTool {
+  return {
+    name: 'demo',
+    description: 'demo',
+    contextKind: 'ssh',
+    inputSchema: { type: 'object', properties: {} },
+    handler: vi.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] })),
+    ...overrides,
+  };
+}
+
+describe('createMCPServer composite dispatch (ADR-045)', () => {
+  beforeEach(() => {
+    registeredHandlers = [];
+    vi.clearAllMocks();
+  });
+
+  it('registers the composite under its prefixed name and lists it', async () => {
+    const createMCPServer = await loadCreateMCPServer();
+    createMCPServer(sshConfig as any, { composites: [makeComposite({ name: 'full_port_scan' })] });
+    const listHandler = registeredHandlers[0];
+    const listed = (await listHandler({})) as { tools: { name: string }[] };
+    expect(listed.tools.some((t) => t.name === 'test_full_port_scan')).toBe(true);
+  });
+
+  it('routes an ssh composite with the SSH manager and no HTTP client', async () => {
+    const handler = vi.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+    const createMCPServer = await loadCreateMCPServer();
+    createMCPServer(sshConfig as any, { composites: [makeComposite({ name: 'scan', contextKind: 'ssh', handler })] });
+    const callHandler = registeredHandlers[1];
+    await callHandler({ params: { name: 'test_scan', arguments: { target: '172.20.4.30' } } });
+    expect(handler).toHaveBeenCalledTimes(1);
+    const ctx = handler.mock.calls[0][1] as CompositeContext;
+    expect(ctx.sshManager).toBeDefined();
+    expect(ctx.httpClient).toBeUndefined();
+    expect(ctx.labConfig).toBeDefined();
+  });
+
+  it('routes an api composite with the HTTP client and no SSH manager', async () => {
+    const handler = vi.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+    const createMCPServer = await loadCreateMCPServer();
+    createMCPServer(apiConfig as any, { composites: [makeComposite({ name: 'report', contextKind: 'api', handler })] });
+    const callHandler = registeredHandlers[1];
+    await callHandler({ params: { name: 'test_report', arguments: {} } });
+    const ctx = handler.mock.calls[0][1] as CompositeContext;
+    expect(ctx.httpClient).toBeDefined();
+    expect(ctx.sshManager).toBeUndefined();
+  });
+
+  it('throws when an ssh composite is dispatched on an api-only server', async () => {
+    const createMCPServer = await loadCreateMCPServer();
+    createMCPServer(apiConfig as any, { composites: [makeComposite({ name: 'scan', contextKind: 'ssh' })] });
+    const callHandler = registeredHandlers[1];
+    await expect(
+      callHandler({ params: { name: 'test_scan', arguments: {} } }),
+    ).rejects.toThrow(/SSH/);
+  });
+
+  it('fires the postToolHook exactly once for a composite call', async () => {
+    const createMCPServer = await loadCreateMCPServer();
+    const hook = vi.fn();
+    createMCPServer(sshConfig as any, { composites: [makeComposite({ name: 'scan' })], postToolHook: hook });
+    const callHandler = registeredHandlers[1];
+    await callHandler({ params: { name: 'test_scan', arguments: { target: '172.20.4.30' } } });
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(hook.mock.calls[0][0].toolName).toBe('test_scan');
+  });
+});

--- a/mcp/mcp-red/package-lock.json
+++ b/mcp/mcp-red/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.17.2",
                 "aptl-mcp-common": "file:../aptl-mcp-common",
+                "fast-xml-parser": "^5.2.5",
                 "zod": "^3.25.49"
             },
             "bin": {
@@ -801,6 +802,18 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/@nodable/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1622,6 +1635,18 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/aptl-mcp-common": {
             "resolved": "../aptl-mcp-common",
             "link": true
@@ -2359,6 +2384,45 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-xml-builder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+            "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@nodable/entities": "^2.2.0",
+                "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^1.0.1",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.4.1",
+                "xml-naming": "^0.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
         "node_modules/fastq": {
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -2709,6 +2773,18 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+        },
+        "node_modules/is-unsafe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+            "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -3119,6 +3195,21 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/path-expression-matcher": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+            "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/path-key": {
@@ -3609,6 +3700,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4025,6 +4131,21 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/zod": {
             "version": "3.25.76",

--- a/mcp/mcp-red/package.json
+++ b/mcp/mcp-red/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.2",
         "aptl-mcp-common": "file:../aptl-mcp-common",
+        "fast-xml-parser": "^5.2.5",
         "zod": "^3.25.49"
     },
     "devDependencies": {

--- a/mcp/mcp-red/src/composite-ocsf.ts
+++ b/mcp/mcp-red/src/composite-ocsf.ts
@@ -1,0 +1,80 @@
+/**
+ * OCSF visibility for composite tools (ORC-003 / ADR-045).
+ *
+ * A composite MCP tool (for example `kali_full_port_scan`) runs one or more
+ * internal shell commands but surfaces a single top-level tool call. ADR-045
+ * requires those internal commands to stay visible on the red OCSF path —
+ * they must not disappear from `ocsf.jsonl` merely because the agent made one
+ * top-level call. The composite handler emits each executed command as a
+ * `CompositeStepRecord` in its result envelope; this module turns those step
+ * records into per-step OCSF emissions, reusing the existing
+ * `logRedTeamCommandAsync` sink path (no second logging vocabulary).
+ *
+ * The raw `tool-calls.jsonl` capture already records the composite call (with
+ * its full step-bearing result) via the shared post-tool capture; this module
+ * adds the structured per-step OCSF attribution on top.
+ */
+
+import type { CompositeStepRecord } from 'aptl-mcp-common';
+import {
+  logRedTeamCommandAsync,
+  type RedTeamCommandContext,
+  type SiemSink,
+} from './logger.js';
+
+/** Composite tools whose internal commands need per-step OCSF attribution. */
+const COMPOSITE_TOOL_SUFFIXES = ['_full_port_scan'] as const;
+
+export function isCompositeTool(toolName: string): boolean {
+  return COMPOSITE_TOOL_SUFFIXES.some((suffix) => toolName.endsWith(suffix));
+}
+
+/**
+ * Pull the `steps[]` array out of a composite tool's result envelope. The
+ * composite returns `{ content: [{ type: 'text', text: <json> }] }` where the
+ * JSON carries `steps: CompositeStepRecord[]`. Best-effort: any shape that is
+ * not a step-bearing composite envelope yields an empty list.
+ */
+export function extractCompositeSteps(result: unknown): CompositeStepRecord[] {
+  try {
+    const text = (result as { content?: { text?: unknown }[] })?.content?.[0]?.text;
+    if (typeof text !== 'string') return [];
+    const parsed = JSON.parse(text) as { steps?: unknown };
+    if (!Array.isArray(parsed.steps)) return [];
+    return parsed.steps.filter(
+      (step): step is CompositeStepRecord =>
+        typeof (step as CompositeStepRecord)?.command === 'string' && (step as CompositeStepRecord).command.length > 0,
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Build one OCSF emission task per composite step. A step whose outcome is
+ * known (a `success` flag is present) emits Success/Failure with its exit
+ * code/signal; a step with no observed outcome emits Unknown.
+ */
+export function ocsfTasksForCompositeSteps(
+  toolName: string,
+  agentName: string,
+  steps: CompositeStepRecord[],
+  sink: SiemSink,
+): Promise<unknown>[] {
+  return steps.map((step) => {
+    const context: RedTeamCommandContext = {
+      tool_name: toolName,
+      agent_name: agentName,
+      session_id: step.session_id,
+      duration_ms: step.duration_ms,
+    };
+    if (typeof step.success === 'boolean') {
+      context.success = step.success;
+      if (typeof step.exit_code === 'number') context.exit_code = step.exit_code;
+      if (step.signal) context.signal = step.signal;
+    } else {
+      context.outcome_unknown = true;
+    }
+    return logRedTeamCommandAsync(step.command, context, sink);
+  });
+}

--- a/mcp/mcp-red/src/full-port-scan.ts
+++ b/mcp/mcp-red/src/full-port-scan.ts
@@ -175,7 +175,7 @@ export function validatePortSpec(ports: unknown): string {
     return '-p-';
   }
   if (typeof ports !== 'string') {
-    throw new Error(`invalid port spec (expected string): ${JSON.stringify(ports)}`);
+    throw new TypeError(`invalid port spec (expected string): ${JSON.stringify(ports)}`);
   }
   if (!PORT_SPEC_RE.test(ports)) {
     throw new Error(`invalid port spec: ${JSON.stringify(ports)}`);

--- a/mcp/mcp-red/src/full-port-scan.ts
+++ b/mcp/mcp-red/src/full-port-scan.ts
@@ -1,0 +1,393 @@
+/**
+ * `kali_full_port_scan` composite MCP tool (ORC-003 / ADR-045).
+ *
+ * A single MCP tool call that runs an nmap full TCP scan against a lab target,
+ * parses the structured XML output, and returns a compact open-ports report.
+ * It is the first consumer of the composite registration seam in
+ * `aptl-mcp-common` and the canonical example from ORC-003.
+ *
+ * Per ADR-045 this is a tool-boundary orchestrator over existing primitives,
+ * not a new command runner:
+ *  - execution stays inside the lab via `SSHConnectionManager` (no local
+ *    nmap/child_process on the MCP host);
+ *  - scan targets are validated to single hosts or bounded CIDRs inside the
+ *    configured lab network before any command is assembled;
+ *  - the executed nmap command and its outcome are surfaced as a
+ *    `CompositeStepRecord` so they stay visible to the red OCSF / capture path
+ *    (wired in `index.ts`);
+ *  - the command is built from validated, allowlisted primitives — no
+ *    free-form `extra_args` or raw shell concatenation;
+ *  - structured nmap XML is parsed instead of scraping human-formatted text.
+ */
+
+import { XMLParser } from 'fast-xml-parser';
+import {
+  getTargetCredentials,
+  harvestSession,
+  redact,
+  resolveCaptureContainer,
+  type CompositeContext,
+  type CompositeStepRecord,
+  type CompositeTool,
+  type LabConfig,
+} from 'aptl-mcp-common';
+
+/** Smallest CIDR prefix accepted — caps scan fan-out at 256 addresses (/24). */
+const MIN_CIDR_PREFIX = 24;
+const MAX_PORT = 65535;
+const DEFAULT_TIMEOUT_MS = 600_000; // full TCP scans are slow
+const MIN_TIMEOUT_MS = 1_000;
+const MAX_TIMEOUT_MS = 1_800_000;
+
+const PORT_SPEC_RE = /^\d+(-\d+)?(,\d+(-\d+)?)*$/;
+
+interface ReportPort {
+  port: number;
+  protocol: string;
+  state: string;
+  service?: string;
+}
+
+interface ReportHost {
+  ip: string;
+  ports: ReportPort[];
+}
+
+export interface PortScanReport {
+  hosts: ReportHost[];
+  open_port_count: number;
+}
+
+interface FullPortScanArgs {
+  target?: unknown;
+  ports?: unknown;
+  timeout_ms?: unknown;
+}
+
+function ipv4ToInt(ip: string): number {
+  const octets = ip.split('.');
+  if (octets.length !== 4) {
+    throw new Error(`invalid IPv4 address: ${JSON.stringify(ip)}`);
+  }
+  let value = 0;
+  for (const octet of octets) {
+    if (!/^\d{1,3}$/.test(octet)) {
+      throw new Error(`invalid IPv4 address: ${JSON.stringify(ip)}`);
+    }
+    const n = Number(octet);
+    if (n > 255) {
+      throw new Error(`invalid IPv4 address: ${JSON.stringify(ip)}`);
+    }
+    value = value * 256 + n;
+  }
+  return value >>> 0;
+}
+
+function intToIpv4(value: number): string {
+  const n = value >>> 0;
+  return [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff].join('.');
+}
+
+interface Cidr {
+  base: number;
+  prefix: number;
+}
+
+function maskForPrefix(prefix: number): number {
+  return prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+}
+
+function parseCidr(value: string): Cidr {
+  // Exactly one '/' separator. Splitting and ignoring extra slash-delimited
+  // data would silently drop a command-injection suffix (e.g.
+  // `172.20.4.0/24/; id`), so reject anything that is not strictly addr/prefix.
+  const parts = value.split('/');
+  if (parts.length !== 2) {
+    throw new Error(`not a CIDR: ${JSON.stringify(value)}`);
+  }
+  const [addr, prefixPart] = parts;
+  if (!/^\d{1,2}$/.test(prefixPart)) {
+    throw new Error(`invalid CIDR prefix: ${JSON.stringify(value)}`);
+  }
+  const prefix = Number(prefixPart);
+  if (prefix > 32) {
+    throw new Error(`invalid CIDR prefix: ${JSON.stringify(value)}`);
+  }
+  const base = (ipv4ToInt(addr) & maskForPrefix(prefix)) >>> 0;
+  return { base, prefix };
+}
+
+/**
+ * Validate that `target` is a single IPv4 host or a bounded IPv4 CIDR that
+ * lies entirely within the configured lab subnet, and return the canonical
+ * command-safe target string to use when assembling the nmap command. Throws
+ * on anything outside the lab network or wider than the fan-out cap. ADR-045
+ * requires scan targets to default to the lab network with no hidden non-lab
+ * allowance.
+ *
+ * The returned string is rebuilt from the validated numeric address (and, for
+ * CIDRs, the normalized network base), so any trailing shell metacharacters in
+ * the caller-supplied input cannot survive into the assembled command. Callers
+ * MUST build the command from this return value, not the raw target.
+ */
+export function assertTargetInLabNetwork(
+  target: string,
+  labSubnet: string,
+  minCidrPrefix: number = MIN_CIDR_PREFIX,
+): string {
+  const lab = parseCidr(labSubnet);
+  const labMask = maskForPrefix(lab.prefix);
+
+  if (target.includes('/')) {
+    const cidr = parseCidr(target);
+    if (cidr.prefix < minCidrPrefix) {
+      throw new Error(
+        `CIDR /${cidr.prefix} exceeds the scan fan-out cap (minimum /${minCidrPrefix})`,
+      );
+    }
+    // Whole-range containment: a target range only fits inside the lab range if
+    // it is no wider than the lab (prefix >= lab prefix) AND its network base,
+    // masked to the lab prefix, equals the lab base. Checking the base alone
+    // would accept a wider CIDR that merely shares the lab base (e.g. lab
+    // 172.20.4.0/25 vs target 172.20.4.0/24).
+    if (cidr.prefix < lab.prefix || ((cidr.base & labMask) >>> 0) !== lab.base) {
+      throw new Error(`target ${target} is outside the lab network ${labSubnet}`);
+    }
+    return `${intToIpv4(cidr.base)}/${cidr.prefix}`;
+  }
+
+  const host = ipv4ToInt(target);
+  if (((host & labMask) >>> 0) !== lab.base) {
+    throw new Error(`target ${target} is outside the lab network ${labSubnet}`);
+  }
+  return intToIpv4(host);
+}
+
+/**
+ * Validate the optional port spec and return the nmap `-p` flag. `all` (or a
+ * truly absent spec — `undefined`) scans every TCP port. A present-but-wrong-type
+ * value is rejected rather than silently widening the scan to all ports, since
+ * the MCP input schema is not a runtime guard. Otherwise only digit/comma/dash
+ * specs are accepted — never shell fragments.
+ */
+export function validatePortSpec(ports: unknown): string {
+  if (ports === undefined || ports === 'all') {
+    return '-p-';
+  }
+  if (typeof ports !== 'string') {
+    throw new Error(`invalid port spec (expected string): ${JSON.stringify(ports)}`);
+  }
+  if (!PORT_SPEC_RE.test(ports)) {
+    throw new Error(`invalid port spec: ${JSON.stringify(ports)}`);
+  }
+  for (const part of ports.split(',')) {
+    for (const bound of part.split('-')) {
+      if (Number(bound) > MAX_PORT) {
+        throw new Error(`port out of range (1-${MAX_PORT}): ${bound}`);
+      }
+    }
+  }
+  return `-p ${ports}`;
+}
+
+/** Assemble the nmap command from already-validated primitives. */
+export function buildScanCommand(target: string, portArg: string): string {
+  return `nmap -oX - -T4 --open ${portArg} ${target}`;
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+// Minimal typed view of the nmap XML attribute shape fast-xml-parser produces
+// with `attributeNamePrefix: '@_'`. Only the fields this report reads are
+// modelled; the single cast at the parser boundary keeps the rest of the
+// parse `any`-free.
+interface NmapAddress {
+  '@_addr'?: string;
+  '@_addrtype'?: string;
+}
+interface NmapPort {
+  '@_protocol'?: string;
+  '@_portid'?: string;
+  state?: { '@_state'?: string };
+  service?: { '@_name'?: string };
+}
+interface NmapHost {
+  address?: NmapAddress | NmapAddress[];
+  ports?: { port?: NmapPort | NmapPort[] };
+}
+interface NmapDoc {
+  nmaprun?: { host?: NmapHost | NmapHost[] };
+}
+
+/** Parse nmap XML (`-oX -`) into a compact open-ports report. */
+export function parseNmapXml(xml: string): PortScanReport {
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+  const parsed = parser.parse(xml) as NmapDoc;
+  const hosts: ReportHost[] = [];
+  let openPortCount = 0;
+
+  for (const host of toArray<NmapHost>(parsed?.nmaprun?.host)) {
+    const addresses = toArray<NmapAddress>(host.address);
+    const ipv4 = addresses.find((a) => a['@_addrtype'] === 'ipv4') ?? addresses[0];
+    const ip = ipv4?.['@_addr'] ?? 'unknown';
+    const ports: ReportPort[] = [];
+    for (const port of toArray<NmapPort>(host.ports?.port)) {
+      const state = port.state?.['@_state'] ?? 'unknown';
+      if (state !== 'open') continue;
+      openPortCount += 1;
+      ports.push({
+        port: Number(port['@_portid']),
+        protocol: port['@_protocol'] ?? 'tcp',
+        state,
+        service: port.service?.['@_name'],
+      });
+    }
+    hosts.push({ ip, ports });
+  }
+
+  return { hosts, open_port_count: openPortCount };
+}
+
+function failure(error: string, steps: CompositeStepRecord[] = []): { content: { type: string; text: string }[] } {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ tool: 'full_port_scan', success: false, error, steps }, null, 2) }],
+  };
+}
+
+async function bestEffortHarvest(labConfig: LabConfig, sessionId: string): Promise<void> {
+  const containerName = resolveCaptureContainer(labConfig);
+  if (!containerName) return;
+  try {
+    await harvestSession({ containerName }, sessionId);
+  } catch (err) {
+    console.error('[full_port_scan] capture harvest failed:', err);
+  }
+}
+
+async function fullPortScanHandler(
+  args: FullPortScanArgs,
+  context: CompositeContext,
+): Promise<{ content: { type: string; text: string }[] }> {
+  const { labConfig, sshManager } = context;
+  if (!sshManager) {
+    return failure('SSH manager not configured for full_port_scan');
+  }
+
+  const target = typeof args.target === 'string' ? args.target.trim() : '';
+  if (!target) {
+    return failure('target is required and must be a non-empty string');
+  }
+
+  let canonicalTarget: string;
+  let portArg: string;
+  let timeoutMs: number;
+  try {
+    canonicalTarget = assertTargetInLabNetwork(target, labConfig.lab.network_subnet);
+    portArg = validatePortSpec(args.ports);
+    timeoutMs = DEFAULT_TIMEOUT_MS;
+    if (typeof args.timeout_ms === 'number' && Number.isFinite(args.timeout_ms)) {
+      timeoutMs = Math.min(MAX_TIMEOUT_MS, Math.max(MIN_TIMEOUT_MS, Math.floor(args.timeout_ms)));
+    }
+  } catch (err) {
+    return failure(err instanceof Error ? err.message : 'invalid scan parameters');
+  }
+
+  // Build the command and report from the canonicalized target only — never the
+  // raw caller input — so no unvalidated bytes reach the remote shell.
+  const command = buildScanCommand(canonicalTarget, portArg);
+  const credentials = getTargetCredentials(labConfig);
+
+  const startedAt = Date.now();
+  let result;
+  try {
+    result = await sshManager.executeCommand(
+      credentials.target,
+      credentials.username,
+      credentials.sshKey,
+      command,
+      credentials.port,
+      timeoutMs,
+    );
+  } catch (err) {
+    const step: CompositeStepRecord = {
+      command: String(redact(command)),
+      success: false,
+      duration_ms: Date.now() - startedAt,
+    };
+    return failure(err instanceof Error ? err.message : 'nmap execution failed', [step]);
+  }
+
+  await bestEffortHarvest(labConfig, result.sessionId);
+
+  const succeeded = result.code === 0;
+  const step: CompositeStepRecord = {
+    command: String(redact(command)),
+    exit_code: result.code ?? undefined,
+    signal: result.signal ?? undefined,
+    success: succeeded,
+    session_id: result.sessionId,
+    duration_ms: Date.now() - startedAt,
+  };
+
+  if (!succeeded) {
+    return failure(`nmap exited with code ${result.code}: ${String(redact(result.stderr.trim()))}`, [step]);
+  }
+
+  // Parse failures must stay inside the composite envelope: nmap succeeded, so
+  // the step record is real evidence the red OCSF/capture path needs. Returning
+  // the failure envelope (success:false, steps:[step]) keeps per-step attribution
+  // (ADR-045) instead of rejecting the MCP call and dropping the step.
+  let report: PortScanReport;
+  try {
+    report = parseNmapXml(result.stdout);
+  } catch (err) {
+    return failure(
+      `failed to parse nmap XML output: ${err instanceof Error ? err.message : String(err)}`,
+      [step],
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          { tool: 'full_port_scan', success: true, target: canonicalTarget, ports: portArg, report, steps: [step] },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export const fullPortScanComposite: CompositeTool = {
+  name: 'full_port_scan',
+  description:
+    'Run a full TCP port scan (nmap) against a single lab host or bounded CIDR, parse the XML output, and return a compact open-ports report. Scans are confined to the configured lab network.',
+  contextKind: 'ssh',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      target: {
+        type: 'string',
+        description: 'Single IPv4 host or IPv4 CIDR (no wider than /24) inside the lab network to scan.',
+      },
+      ports: {
+        type: 'string',
+        description: "Port spec: 'all' (default — all 65535 TCP ports), a range like '1-1024', or a list like '22,80,443'.",
+        default: 'all',
+      },
+      timeout_ms: {
+        type: 'number',
+        description: 'Scan timeout in milliseconds (default 600000, clamped to 1000–1800000).',
+        default: DEFAULT_TIMEOUT_MS,
+      },
+    },
+    required: ['target'],
+  },
+  handler: fullPortScanHandler as CompositeTool['handler'],
+};

--- a/mcp/mcp-red/src/index.ts
+++ b/mcp/mcp-red/src/index.ts
@@ -14,6 +14,12 @@
 import { startServer, type PostToolHookInfo } from 'aptl-mcp-common';
 import { captureToolCall, type CaptureContext } from './capture.js';
 import { topLevelSegments } from './classifier.js';
+import {
+  isCompositeTool,
+  extractCompositeSteps,
+  ocsfTasksForCompositeSteps,
+} from './composite-ocsf.js';
+import { fullPortScanComposite } from './full-port-scan.js';
 import { isEffectiveRawCall, isOutcomeKnown } from './effective-mode.js';
 import {
   defaultRedTeamSinks,
@@ -155,6 +161,13 @@ async function postToolHook(info: PostToolHookInfo): Promise<void> {
         ),
       );
     }
+  } else if (isCompositeTool(toolName) && !info.error) {
+    // ADR-045: a composite's internal shell commands must stay visible on the
+    // OCSF path. Emit one OCSF record per executed step from the composite's
+    // result envelope so a single top-level tool call does not hide them.
+    ocsfTasks.push(
+      ...ocsfTasksForCompositeSteps(toolName, AGENT_NAME, extractCompositeSteps(info.result), ocsfSink),
+    );
   }
   // Run both sinks independently — a slow capture must not delay or
   // starve the OCSF emission and vice versa.
@@ -162,7 +175,7 @@ async function postToolHook(info: PostToolHookInfo): Promise<void> {
 }
 
 try {
-  await startServer(import.meta.url, { postToolHook });
+  await startServer(import.meta.url, { postToolHook, composites: [fullPortScanComposite] });
 } catch (error) {
   console.error('[MCP] Fatal error:', error);
   process.exit(1);

--- a/mcp/mcp-red/tests/composite-ocsf.test.ts
+++ b/mcp/mcp-red/tests/composite-ocsf.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isCompositeTool,
+  extractCompositeSteps,
+  ocsfTasksForCompositeSteps,
+} from '../src/composite-ocsf.js';
+import type { SiemSink } from '../src/logger.js';
+
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] };
+}
+
+describe('isCompositeTool', () => {
+  it('recognizes the composite tool by suffix', () => {
+    expect(isCompositeTool('kali_full_port_scan')).toBe(true);
+  });
+  it('does not match plain command tools', () => {
+    expect(isCompositeTool('kali_run_command')).toBe(false);
+    expect(isCompositeTool('kali_session_command')).toBe(false);
+  });
+});
+
+describe('extractCompositeSteps', () => {
+  it('pulls the steps[] array out of the composite result envelope', () => {
+    const steps = extractCompositeSteps(
+      envelope({ success: true, steps: [{ command: 'nmap -oX - 172.20.4.40', success: true, exit_code: 0 }] }),
+    );
+    expect(steps).toHaveLength(1);
+    expect(steps[0].command).toContain('nmap');
+  });
+
+  it('drops step entries without a command string', () => {
+    const steps = extractCompositeSteps(envelope({ steps: [{ exit_code: 0 }, { command: 'nmap x' }] }));
+    expect(steps).toEqual([{ command: 'nmap x' }]);
+  });
+
+  it('returns [] for a malformed or non-composite result', () => {
+    expect(extractCompositeSteps(undefined)).toEqual([]);
+    expect(extractCompositeSteps({ content: [{ type: 'text', text: 'not json' }] })).toEqual([]);
+    expect(extractCompositeSteps(envelope({ success: true }))).toEqual([]);
+  });
+});
+
+describe('ocsfTasksForCompositeSteps', () => {
+  it('emits one Success-classified OCSF record per step through the sink', async () => {
+    const sink: SiemSink = vi.fn();
+    const tasks = ocsfTasksForCompositeSteps(
+      'kali_full_port_scan',
+      'aptl-kali-red',
+      [
+        { command: 'nmap -oX - -T4 --open -p- 172.20.4.40', success: true, exit_code: 0, session_id: 'exec-1', duration_ms: 12 },
+      ],
+      sink,
+    );
+    expect(tasks).toHaveLength(1);
+    await Promise.all(tasks);
+    expect(sink).toHaveBeenCalledTimes(1);
+    const record = (sink as any).mock.calls[0][0];
+    expect(record.status_id).toBe(1);
+    expect(record.status).toBe('Success');
+    expect(record.status_code).toBe('0');
+    expect(record.aptl).toMatchObject({ tool_name: 'kali_full_port_scan', session_id: 'exec-1' });
+    expect(record.duration).toBe(12);
+  });
+
+  it('marks the OCSF outcome unknown when a step has no success flag', async () => {
+    const sink: SiemSink = vi.fn();
+    await Promise.all(
+      ocsfTasksForCompositeSteps('kali_full_port_scan', 'aptl-kali-red', [{ command: 'nmap x' }], sink),
+    );
+    expect(sink).toHaveBeenCalledTimes(1);
+    const record = (sink as any).mock.calls[0][0];
+    expect(record.status_id).toBe(0);
+    expect(record.status).toBe('Unknown');
+  });
+
+  it('emits a Failure-classified record for a failed step (success:false)', async () => {
+    const records: any[] = [];
+    const sink: SiemSink = (r) => { records.push(r); };
+    await Promise.all(
+      ocsfTasksForCompositeSteps('kali_full_port_scan', 'aptl-kali-red', [
+        { command: 'nmap x', success: false, exit_code: 127 },
+      ], sink),
+    );
+    expect(records).toHaveLength(1);
+    expect(records[0].status_id).toBe(2);
+    expect(records[0].status).toBe('Failure');
+    expect(records[0].status_code).toBe('127');
+  });
+});

--- a/mcp/mcp-red/tests/full-port-scan.test.ts
+++ b/mcp/mcp-red/tests/full-port-scan.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stub the best-effort capture harvest so the handler test stays hermetic
+// (no docker exec). Everything else from common stays real.
+vi.mock('aptl-mcp-common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('aptl-mcp-common')>();
+  return { ...actual, harvestSession: vi.fn().mockResolvedValue(true) };
+});
+
+import {
+  fullPortScanComposite,
+  validatePortSpec,
+  assertTargetInLabNetwork,
+  buildScanCommand,
+  parseNmapXml,
+} from '../src/full-port-scan.js';
+
+const SAMPLE_XML = `<?xml version="1.0"?>
+<nmaprun scanner="nmap" args="nmap -oX - -T4 --open -p- 172.20.4.40">
+  <host>
+    <status state="up"/>
+    <address addr="172.20.4.40" addrtype="ipv4"/>
+    <ports>
+      <port protocol="tcp" portid="22"><state state="open"/><service name="ssh" product="OpenSSH" version="9.0p1"/></port>
+      <port protocol="tcp" portid="80"><state state="open"/><service name="http"/></port>
+    </ports>
+  </host>
+</nmaprun>`;
+
+const labConfig = {
+  version: '1.0.0',
+  server: {
+    name: 'kali-red-team',
+    version: '1.0.0',
+    description: 'test',
+    toolPrefix: 'kali',
+    targetName: 'Kali Linux',
+    configKey: 'kali',
+  },
+  lab: { name: 'aptl-local', network_subnet: '172.20.0.0/16' },
+  containers: {
+    kali: {
+      container_name: 'aptl-kali',
+      container_ip: '172.20.4.30',
+      ssh_key: '/home/u/.ssh/aptl_lab_key',
+      ssh_user: 'kali',
+      ssh_port: 22,
+      enabled: true,
+    },
+  },
+} as any;
+
+function makeContext(executeCommand: any) {
+  return { labConfig, sshManager: { executeCommand } };
+}
+
+async function runScan(args: any, executeCommand: any) {
+  const ctx = makeContext(executeCommand);
+  const result = await fullPortScanComposite.handler(args, ctx as any);
+  return JSON.parse(result.content[0].text);
+}
+
+describe('fullPortScanComposite metadata', () => {
+  it('declares an ssh composite named full_port_scan that requires a target', () => {
+    expect(fullPortScanComposite.name).toBe('full_port_scan');
+    expect(fullPortScanComposite.contextKind).toBe('ssh');
+    expect(fullPortScanComposite.inputSchema.required).toContain('target');
+  });
+});
+
+describe('validatePortSpec', () => {
+  it("maps 'all' (and the default) to the all-ports flag", () => {
+    expect(validatePortSpec('all')).toBe('-p-');
+    expect(validatePortSpec(undefined)).toBe('-p-');
+  });
+
+  it('accepts ranges and comma lists', () => {
+    expect(validatePortSpec('1-1024')).toBe('-p 1-1024');
+    expect(validatePortSpec('22,80,443')).toBe('-p 22,80,443');
+  });
+
+  it('rejects non-numeric / shell-bearing port specs', () => {
+    expect(() => validatePortSpec('abc')).toThrow();
+    expect(() => validatePortSpec('22; rm -rf /')).toThrow();
+    expect(() => validatePortSpec('70000')).toThrow();
+  });
+
+  it('rejects a present-but-wrong-type spec instead of widening to all ports', () => {
+    // A non-string value must NOT collapse to the all-ports default; only a
+    // truly absent (undefined) spec means "all".
+    expect(() => validatePortSpec(80 as unknown as string)).toThrow(/expected string/i);
+    expect(() => validatePortSpec(['80'] as unknown as string)).toThrow(/expected string/i);
+    expect(() => validatePortSpec(null as unknown as string)).toThrow(/expected string/i);
+    expect(() => validatePortSpec({} as unknown as string)).toThrow(/expected string/i);
+  });
+});
+
+describe('assertTargetInLabNetwork', () => {
+  it('accepts a single host inside the lab subnet', () => {
+    expect(() => assertTargetInLabNetwork('172.20.4.40', '172.20.0.0/16')).not.toThrow();
+  });
+
+  it('accepts a bounded CIDR (>= /24) inside the lab subnet', () => {
+    expect(() => assertTargetInLabNetwork('172.20.4.0/24', '172.20.0.0/16')).not.toThrow();
+  });
+
+  it('rejects a host outside the lab subnet', () => {
+    expect(() => assertTargetInLabNetwork('8.8.8.8', '172.20.0.0/16')).toThrow(/lab network/i);
+  });
+
+  it('rejects a CIDR wider than the fan-out cap', () => {
+    expect(() => assertTargetInLabNetwork('172.20.0.0/16', '172.20.0.0/16')).toThrow(/fan-out|\/24/i);
+  });
+
+  it('rejects malformed targets', () => {
+    expect(() => assertTargetInLabNetwork('not-an-ip', '172.20.0.0/16')).toThrow();
+    expect(() => assertTargetInLabNetwork('172.20.4.999', '172.20.0.0/16')).toThrow();
+    expect(() => assertTargetInLabNetwork('a.b.c.d', '172.20.0.0/16')).toThrow();
+  });
+
+  it('rejects a CIDR with a malformed prefix', () => {
+    expect(() => assertTargetInLabNetwork('172.20.4.0/33', '172.20.0.0/16')).toThrow();
+    expect(() => assertTargetInLabNetwork('172.20.4.0/xx', '172.20.0.0/16')).toThrow();
+  });
+
+  it('rejects a bounded CIDR that sits outside the lab subnet', () => {
+    expect(() => assertTargetInLabNetwork('10.0.0.0/24', '172.20.0.0/16')).toThrow(/lab network/i);
+  });
+
+  it('returns the canonical host/CIDR string from a valid target', () => {
+    expect(assertTargetInLabNetwork('172.20.4.40', '172.20.0.0/16')).toBe('172.20.4.40');
+    expect(assertTargetInLabNetwork('172.20.4.0/24', '172.20.0.0/16')).toBe('172.20.4.0/24');
+  });
+
+  it('normalizes a CIDR whose address has host bits set to its network base', () => {
+    expect(assertTargetInLabNetwork('172.20.4.55/24', '172.20.0.0/16')).toBe('172.20.4.0/24');
+  });
+
+  it('rejects a CIDR target carrying a command-injection suffix (extra slash)', () => {
+    // `parseCidr` must not split-and-drop trailing slash data; the suffix after
+    // the second slash would otherwise survive into the assembled command.
+    expect(() => assertTargetInLabNetwork('172.20.4.0/24/; id', '172.20.0.0/16')).toThrow();
+    expect(() => assertTargetInLabNetwork('172.20.4.0/24/', '172.20.0.0/16')).toThrow();
+  });
+
+  it('rejects a CIDR wider than the lab subnet even when it shares the lab base', () => {
+    // Whole-range containment: lab /25 must reject a target /24 sharing the base,
+    // since half the requested range falls outside the configured lab network.
+    expect(() => assertTargetInLabNetwork('172.20.4.0/24', '172.20.4.0/25')).toThrow(/lab network/i);
+  });
+});
+
+describe('buildScanCommand', () => {
+  it('assembles an XML-output nmap command from validated primitives', () => {
+    const cmd = buildScanCommand('172.20.4.40', '-p-');
+    expect(cmd).toMatch(/^nmap /);
+    expect(cmd).toContain('-oX -');
+    expect(cmd).toContain('--open');
+    expect(cmd).toContain('-p-');
+    expect(cmd.endsWith('172.20.4.40')).toBe(true);
+  });
+});
+
+describe('parseNmapXml', () => {
+  it('extracts hosts, open ports, and services into a compact report', () => {
+    const report = parseNmapXml(SAMPLE_XML);
+    expect(report.open_port_count).toBe(2);
+    expect(report.hosts).toHaveLength(1);
+    expect(report.hosts[0].ip).toBe('172.20.4.40');
+    const ports = report.hosts[0].ports;
+    expect(ports).toEqual([
+      { port: 22, protocol: 'tcp', state: 'open', service: 'ssh' },
+      { port: 80, protocol: 'tcp', state: 'open', service: 'http' },
+    ]);
+  });
+
+  it('returns an empty report for a scan with no hosts', () => {
+    const report = parseNmapXml('<?xml version="1.0"?><nmaprun></nmaprun>');
+    expect(report.hosts).toEqual([]);
+    expect(report.open_port_count).toBe(0);
+  });
+});
+
+describe('fullPortScanComposite.handler', () => {
+  let exec: any;
+  beforeEach(() => {
+    exec = vi.fn().mockResolvedValue({
+      stdout: SAMPLE_XML,
+      stderr: '',
+      code: 0,
+      signal: null,
+      sessionId: 'exec-abc',
+      mode: 'normal',
+    });
+  });
+
+  it('connects to the Kali container and scans the requested target', async () => {
+    const out = await runScan({ target: '172.20.4.40' }, exec);
+    expect(out.success).toBe(true);
+    // Connects to the kali container IP, not the scan target.
+    expect(exec.mock.calls[0][0]).toBe('172.20.4.30');
+    expect(exec.mock.calls[0][1]).toBe('kali');
+    // The executed command scans the requested target with all ports.
+    const command = exec.mock.calls[0][3];
+    expect(command).toContain('-p-');
+    expect(command).toContain('172.20.4.40');
+    expect(out.report.open_port_count).toBe(2);
+  });
+
+  it('threads a custom port spec into the nmap command', async () => {
+    await runScan({ target: '172.20.4.40', ports: '22,80' }, exec);
+    expect(exec.mock.calls[0][3]).toContain('-p 22,80');
+  });
+
+  it('surfaces the executed command and outcome as a step record', async () => {
+    const out = await runScan({ target: '172.20.4.40' }, exec);
+    expect(out.steps).toHaveLength(1);
+    expect(out.steps[0].command).toContain('nmap');
+    expect(out.steps[0].success).toBe(true);
+    expect(out.steps[0].exit_code).toBe(0);
+    expect(out.steps[0].session_id).toBe('exec-abc');
+  });
+
+  it('rejects an out-of-lab target before executing anything', async () => {
+    const out = await runScan({ target: '8.8.8.8' }, exec);
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/lab network/i);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wide CIDR before executing anything', async () => {
+    const out = await runScan({ target: '172.20.0.0/16' }, exec);
+    expect(out.success).toBe(false);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid port spec before executing anything', async () => {
+    const out = await runScan({ target: '172.20.4.40', ports: 'bad;rm' }, exec);
+    expect(out.success).toBe(false);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('rejects a present-but-wrong-type port spec instead of silently scanning all ports', async () => {
+    // `{ ports: 80 }` (number) must fail validation, not collapse to the
+    // all-ports (`-p-`) default — the input schema is not a runtime guard.
+    const out = await runScan({ target: '172.20.4.40', ports: 80 }, exec);
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/expected string/i);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('rejects a CIDR target with a command-injection suffix before executing anything', async () => {
+    const out = await runScan({ target: '172.20.4.0/24/; id' }, exec);
+    expect(out.success).toBe(false);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('scans the canonicalized network base, never the raw caller input', async () => {
+    const out = await runScan({ target: '172.20.4.55/24' }, exec);
+    expect(out.success).toBe(true);
+    const command = exec.mock.calls[0][3];
+    expect(command).toContain('172.20.4.0/24');
+    expect(command).not.toContain('172.20.4.55');
+    expect(out.target).toBe('172.20.4.0/24');
+  });
+
+  it('reports a failed nmap run as success:false with the failed step', async () => {
+    const failExec = vi.fn().mockResolvedValue({
+      stdout: '',
+      stderr: 'nmap: command not found',
+      code: 127,
+      signal: null,
+      sessionId: 'exec-fail',
+      mode: 'normal',
+    });
+    const out = await runScan({ target: '172.20.4.40' }, failExec);
+    expect(out.success).toBe(false);
+    expect(out.steps[0].exit_code).toBe(127);
+    expect(out.steps[0].success).toBe(false);
+  });
+
+  it('reports an SSH execution error as success:false with a step record', async () => {
+    const throwExec = vi.fn().mockRejectedValue(new Error('ssh connection refused'));
+    const out = await runScan({ target: '172.20.4.40' }, throwExec);
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/ssh connection refused/);
+    expect(out.steps[0].success).toBe(false);
+    expect(out.steps[0].command).toContain('nmap');
+  });
+
+  it('returns the failure envelope with the step when nmap XML cannot be parsed', async () => {
+    // nmap succeeded (exit 0) but emitted malformed/truncated XML. The handler
+    // must keep the composite envelope (success:false, steps:[step]) so the red
+    // OCSF/capture path still receives per-step attribution (ADR-045), rather
+    // than throwing and rejecting the MCP call.
+    const badXmlExec = vi.fn().mockResolvedValue({
+      stdout: '<nmaprun><host><ports><port', // truncated, unparseable
+      stderr: '',
+      code: 0,
+      signal: null,
+      sessionId: 'exec-badxml',
+      mode: 'normal',
+    });
+    const out = await runScan({ target: '172.20.4.40' }, badXmlExec);
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/parse nmap xml/i);
+    expect(out.steps).toHaveLength(1);
+    expect(out.steps[0].success).toBe(true);
+    expect(out.steps[0].exit_code).toBe(0);
+    expect(out.steps[0].session_id).toBe('exec-badxml');
+    expect(out.steps[0].command).toContain('nmap');
+  });
+
+  it('clamps an out-of-range timeout and passes it to executeCommand', async () => {
+    await runScan({ target: '172.20.4.40', timeout_ms: 10_000_000 }, exec);
+    expect(exec.mock.calls[0][5]).toBe(1_800_000);
+  });
+
+  it('honors an in-range custom timeout', async () => {
+    await runScan({ target: '172.20.4.40', timeout_ms: 5000 }, exec);
+    expect(exec.mock.calls[0][5]).toBe(5000);
+  });
+
+  it('fails when no sshManager is present in the context', async () => {
+    const result = await fullPortScanComposite.handler(
+      { target: '172.20.4.40' },
+      { labConfig } as any,
+    );
+    const out = JSON.parse(result.content[0].text);
+    expect(out.success).toBe(false);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('fails on a missing/blank target', async () => {
+    const out = await runScan({}, exec);
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/target is required/i);
+    expect(exec).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseNmapXml multi-host', () => {
+  const MULTI = `<?xml version="1.0"?>
+<nmaprun>
+  <host><address addr="172.20.4.40" addrtype="ipv4"/><ports>
+    <port protocol="tcp" portid="22"><state state="open"/><service name="ssh"/></port>
+    <port protocol="tcp" portid="23"><state state="closed"/></port>
+  </ports></host>
+  <host><address addr="172.20.4.41" addrtype="ipv4"/></host>
+</nmaprun>`;
+
+  it('handles multiple hosts and skips non-open ports', () => {
+    const report = parseNmapXml(MULTI);
+    expect(report.hosts).toHaveLength(2);
+    expect(report.open_port_count).toBe(1);
+    expect(report.hosts[0].ports).toEqual([{ port: 22, protocol: 'tcp', state: 'open', service: 'ssh' }]);
+    expect(report.hosts[1].ports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds composite MCP tool support (ORC-003): a typed registration seam in aptl-mcp-common lets a server expose a single MCP tool that orchestrates several internal SSH/API steps over the existing primitives, with dispatch context routed by declared kind rather than tool-name substrings (ADR-045). The first composite, kali_full_port_scan in mcp-red, validates the scan target to a single host or bounded CIDR inside the lab network, runs nmap via the existing SSH session layer (no local process on the MCP host), parses the structured XML output, and returns a compact open-ports report — while keeping the underlying nmap command visible on the red OCSF/capture path. ADR-045 (created at architecture preflight) is the binding security boundary for the design.

## Requirement UIDs

- `ORC-003`

## Related Issues

Closes #477

## ADR Impact

- ADR-045
- ADR-021

## Changes

- aptl-mcp-common: new tools/composites.ts seam (CompositeTool/CompositeContext/CompositeStepRecord types + generate/contextKinds helpers), re-exported from index.ts
- aptl-mcp-common: server.ts registers opted-in composites and routes their context by declared kind (ssh/api/both) before the legacy name-substring routing; context resolution extracted to keep the dispatch under the ESLint complexity gate
- mcp-red: new full-port-scan.ts composite — lab-network target validation (single host or CIDR no wider than /24, canonicalized to defeat shell-metacharacter injection), allowlisted port-spec, nmap XML parsing via fast-xml-parser, compact report
- mcp-red: index.ts opts the composite in via startServer and extends the postToolHook to emit per-step OCSF from the composite's step records (ADR-045 evidence-visibility)
- Tests: composite seam + dispatch (common), full-port-scan validation/parsing/handler + composite OCSF emission (mcp-red)
- Docs: ADR-045 Composite MCP Tool Orchestration Boundary + adrs index; changelog fragment

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

All fast unit tests (vitest), no live lab required: aptl-mcp-common 466 tests, mcp-red 260 tests. Two codex pre-push review cycles (cycle 2 user-authorized) fixed real security findings in CIDR validation (extra-slash command-injection rejection + whole-range lab containment) and correctness findings (present-but-wrong-type ports rejection; parse-failure stays inside the composite failure envelope); test-quality review strengthened the OCSF tests to assert outcome classification. Full Python completion gate (pytest + ACES static gate) green.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ORC-003 ← mcp/aptl-mcp-common/src/tools/composites.ts, ORC-003 ← mcp/aptl-mcp-common/src/server.ts, ORC-003 ← mcp/mcp-red/src/full-port-scan.ts, ORC-003 ← mcp/mcp-red/src/composite-ocsf.ts
- TESTS: ORC-003 ← mcp/aptl-mcp-common/tests/composites.test.ts, ORC-003 ← mcp/aptl-mcp-common/tests/server-composite-dispatch.test.ts, ORC-003 ← mcp/mcp-red/tests/full-port-scan.test.ts, ORC-003 ← mcp/mcp-red/tests/composite-ocsf.test.ts

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/477.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed