### PR TITLE
feat: add ephemeral lifecycle policy enforcement (DEP-003)

### DIFF
--- a/changelog.d/467.added.md
+++ b/changelog.d/467.added.md
@@ -1,0 +1,10 @@
+### Added
+
+- Ephemeral lifecycle policy (DEP-003): a `lifecycle_policy` block in
+  `aptl.json` defines TTL-based auto-teardown, idle-based auto-teardown, and
+  scheduled provisioning for the range. `aptl lab enforce` runs one idempotent
+  evaluate-and-act tick (wire it to a systemd timer or cron), `aptl lab
+  monitor` runs the same tick in a single-owner loop, and `aptl lab policy
+  show` reports the resolved policy and current lifecycle state. Enforcement
+  reuses the existing start/stop/clean-boot path through the deployment
+  backend; see ADR-045.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -66,3 +66,4 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [042](adr-042-sidecar-owned-pty-master.md) | Sidecar-Owned PTY Master for Kali Transcript Authenticity | accepted | 2026-06-20 |
 | [043](adr-043-suricata-runtime-config-ownership-boundary.md) | Suricata Runtime Config Ownership Boundary | accepted | 2026-06-20 |
 | [044](adr-044-aces-aligned-run-reproducibility-record.md) | ACES-Aligned Run Reproducibility Record | accepted | 2026-06-25 |
+| [045](adr-045-ephemeral-lifecycle-policy-enforcement.md) | Ephemeral Lifecycle Policy Enforcement | accepted | 2026-06-28 |

--- a/docs/adrs/adr-045-ephemeral-lifecycle-policy-enforcement.md
+++ b/docs/adrs/adr-045-ephemeral-lifecycle-policy-enforcement.md
@@ -1,0 +1,105 @@
+# ADR-045: Ephemeral Lifecycle Policy Enforcement
+
+## Status
+
+accepted
+
+## Date
+
+2026-06-28
+
+## Context
+
+DEP-003 asks the platform to support "automated provisioning and teardown of
+complete range instances on demand, with defined lifecycle policies (TTL-based
+auto-teardown, idle detection, scheduled provisioning)."
+
+The on-demand half already exists. RNG-001 owns the destructive clean-boot seam
+through `orchestrate_lab_start()`, `stop_lab()`, and `clean_boot_lab()` in
+`src/aptl/core/lab.py`. What DEP-003 adds is a decision layer that chooses *when*
+to call those operations: tear a range down once it has lived past its TTL or
+gone idle, and provision a range on a schedule.
+
+The [DEP-003 preflight note](../architecture/dep-003-ephemeral-lifecycle-preflight.md)
+sets the binding guardrails: policy is a control-plane layer above lab
+operations, a "range instance" is the configured deployment project, lifecycle
+state is narrow data, and automated execution needs one owner per project so
+concurrent or restarted processes never double-run a destructive action.
+
+The open question the preflight leaves to this decision is the **process model**
+that drives enforcement. The pure policy evaluation (compare timestamps against a
+TTL, an idle timeout, and a schedule) is identical regardless of how it runs;
+only the surrounding process differs:
+
+1. A long-running daemon that owns a poll loop and a lockfile as its primary
+   artifact.
+2. A background task inside the API server lifespan, which enforces only while
+   that server runs.
+3. A single-shot tick that the operator schedules with an external timer.
+
+## Decision
+
+APTL enforces lifecycle policy with a **single-shot, idempotent tick**:
+`aptl lab enforce` performs exactly one evaluate-and-act cycle and exits. The
+operator owns cadence through a systemd timer or a cron entry. `aptl lab
+monitor` is a thin loop over the same tick for hosts without an external
+scheduler.
+
+The decision has four parts:
+
+- **No daemon and no API coupling.** Option 1 makes a long-lived process and its
+  lock the main artifact for what is a few timestamp comparisons. Option 2 stops
+  enforcing the moment the API server stops, which silently defeats TTL
+  teardown—the property operators most depend on for cost control. A
+  single-shot tick keeps the always-on concern where the host already solves it
+  (the timer) and keeps the codebase to pure evaluation plus a thin shell.
+- **The lab start path is unchanged.** Enforcement imports `lab_status()`,
+  `stop_lab()`, and `clean_boot_lab()`; it adds no step to `_LAB_START_STEPS`.
+  Each tick reconciles provisioning time against the observed running state, so
+  a range started by hand and a range started by a schedule age the same way.
+  The cost is that TTL counts from the first tick that observed the range
+  running rather than the exact start instant—bounded by one tick interval and
+  acceptable for teardown decisions measured in minutes to hours.
+- **Idle uses capture recency.** The idle signal is the most recent evidence
+  written under the active run directory (`resolve_active_run_dir`), falling back
+  to provisioning time when no scenario is active. Capture recency is a narrow
+  control-plane activity marker that needs no new heartbeat wiring across the MCP
+  servers.
+- **One owner, narrow state.** A `flock` on `.aptl/lifecycle/.lock` serializes
+  ticks, so a manual `enforce` and a running `monitor` cannot act at once. State
+  lives in `.aptl/lifecycle/state.json` at mode `0600` and holds only
+  timestamps, the last action and result, a redacted error label, and the
+  per-day fired-schedule markers. Every value passes through `redact()` at the
+  persist boundary (ADR-029).
+
+Policy is authored in `aptl.json` as a strict Pydantic model
+(`LabLifecyclePolicyConfig`, ADR-025): bounded positive `ttl_minutes` and
+`idle_timeout_minutes`, a `teardown_remove_volumes` cleanup flag, and a
+`schedule` list of `HH:MM` UTC times with an optional weekday filter and
+scenario id. `aptl lab policy show` renders the resolved policy and current
+state.
+
+## Consequences
+
+**Positive**
+
+- The always-on concern is one line of operator configuration, not a process to
+  supervise. The tick is trivially testable: the pure evaluators take timestamps
+  and return decisions with no clock, Docker, or filesystem.
+- TTL teardown keeps working whether or not the API server or web UI runs.
+- Reusing the RNG-001 lifecycle functions and the ADR-030 result envelope means
+  no second teardown path and no new error hierarchy.
+
+**Negative / risks**
+
+- Enforcement only happens when the operator's timer fires. A host with no timer
+  and no `monitor` running enforces nothing—the feature is opt-in by design,
+  but operators must wire the cadence.
+- TTL and idle resolve at tick granularity, so a short interval is needed for
+  tight timeouts.
+
+**Out of scope**
+
+- REST policy endpoints, multiple concurrent named ranges, and cron-grammar
+  schedules (daily plus weekday only). A future concurrent-instance design must
+  parameterize the range identity and state root, as the preflight notes.

--- a/docs/architecture/dep-003-ephemeral-lifecycle-preflight.md
+++ b/docs/architecture/dep-003-ephemeral-lifecycle-preflight.md
@@ -1,0 +1,198 @@
+# DEP-003 Ephemeral Lifecycle Policy Preflight
+
+This note is the architecture preflight for DEP-003 / issue #467. It is
+guidance, not an implementation plan. It extends
+[`RNG-001 Ephemeral Environments`](rng-001-ephemeral-environments-preflight.md):
+RNG-001 owns the destructive clean-boot seam; DEP-003 adds lifecycle policy
+decisions around when provisioning and teardown happen.
+
+Existing ADRs remain binding: ADR-013 and ADR-023 own deployment backends,
+ADR-025 owns first-party config shape, ADR-028 owns runtime-rendered config,
+ADR-029 owns secret handling, ADR-030 owns lab-result envelopes, ADR-031 owns
+orchestration contract guards, ADR-037 owns Docker Compose backend cohesion,
+ADR-039 owns web API auth, and ADR-044 owns ACES/run reproducibility records.
+
+## Architecture Decisions
+
+- Treat lifecycle policy as a control-plane decision layer above lab lifecycle.
+  TTL expiry, idle detection, and schedules decide when to invoke existing
+  lifecycle operations; they do not become new Docker, Compose, ACES, or web
+  lifecycle implementations.
+- Provisioning must reuse the public lab start path:
+  `orchestrate_lab_start()` for normal starts and `clean_boot_lab()` when the
+  policy requires clean state. Teardown must reuse `stop_lab()` through
+  `DeploymentBackend`; complete teardown means `remove_volumes=True` unless a
+  typed policy explicitly says otherwise.
+- A "range instance" is the configured deployment project, not an individual
+  container, scenario file, folder name, `lab.name`, GitHub issue, or run
+  archive. The current concrete identity is `DeploymentConfig.project_name`
+  plus the project directory/backend. Any future concurrent instances must
+  parameterize that identity and state root explicitly instead of relying on
+  Docker name prefixes.
+- Lifecycle policy state is data: `started_at`, `expires_at`,
+  `last_activity_at`, `next_provision_at`, policy name, action, result, and
+  narrow error labels. It must not carry `.env` values, bearer tokens, raw
+  Docker stderr, terminal content, generated config, or command lines.
+- Automated policy execution must have one owner per project/backend. Do not
+  hide timers in FastAPI request handlers, SSE loops, or web clients where
+  process restarts, multiple workers, or disconnected browsers can double-run
+  or miss destructive actions.
+- Lifecycle actions must be serialized per project/backend. A scheduled start,
+  TTL teardown, idle teardown, manual `aptl lab start --clean`, and API
+  start/stop must not overlap against the same Compose project.
+
+## Cross-Cutting Concerns To Reuse
+
+- Lab lifecycle: `clean_boot_lab()`, `orchestrate_lab_start()`,
+  `stop_lab(remove_volumes=True)`, `_LabStartContext`, `_LAB_START_STEPS`,
+  `LabResult`, `StartupOutcome`, and `StartupDiagnostic`.
+- Deployment boundary: `DeploymentBackend`, `DockerComposeBackend`,
+  `SSHComposeBackend`, `DeploymentConfig.project_name`, compose-project label
+  filters, SSH transport semantics, backend timeouts, `BackendTimeoutError`,
+  and `BackendSeedError`.
+- Config and env: `AptlConfig`, `DeploymentConfig`,
+  `ContainerSettings.enabled_profiles()`, `RunStorageConfig`, `load_config()`,
+  `load_dotenv()`, `EnvVars`, `env_vars_from_dict()`, and
+  `find_placeholder_env_values()`.
+- Scenario selection and ACES handoff: `resolve_scenario_selection()`,
+  `start_aces_scenario()`, `selected_profiles_for_scenario()`, ACES parser /
+  runtime manager gates, and the REP-001 run-record threading already in
+  lab start.
+- API and web surfaces: `verify_token`, `WebAuthSettings`,
+  `LabActionResponse`, `StartupDiagnosticModel`, `StartupOutcomeLiteral`,
+  `web/src/lib/types.ts`, and existing API projection style.
+- Observability and persistence: `get_logger()`, `redact()`,
+  `RangeSnapshot.to_dict()`, `LocalRunStore.write_json()`,
+  `write_jsonl()`, `append_jsonl()`, and the run archive/reference pattern
+  from ADR-044.
+- Live proof point: `src/aptl/validation/_live_gate_probes.py` already consumes
+  `clean_boot_lab()` instead of open-coding destructive stop/start.
+
+## Security And Validation Layers
+
+- **Auth surface:** any API trigger for provisioning, teardown, policy updates,
+  or policy status must remain behind ADR-039 bearer-token auth. Do not pass
+  API tokens, destructive intent, or policy payloads in query strings,
+  EventSource URLs, WebSocket subprotocol data beyond the existing terminal
+  token shape, logs, or redirects.
+- **Policy input shape:** durable lifecycle knobs belong in strict Pydantic
+  config models under `AptlConfig` only when they have a runtime consumer.
+  Transient CLI/API options may use boundary DTOs, but they must be typed,
+  range-checked, and `extra="forbid"` in the same style. Avoid unchecked dicts,
+  free-form shell commands, stringly typed cleanup modes, and duplicated
+  profile/scenario schemas.
+- **Time and schedule parsing:** use timezone-aware UTC instants for persisted
+  timestamps and simple bounded integer seconds for TTL/idle intervals. If a
+  cron-like schedule is required later, add one validated parser boundary; do
+  not interpret arbitrary schedule strings in multiple call sites.
+- **Environment binding:** lifecycle policy must not parse `.env` or service
+  config itself. Lab start continues through `load_dotenv()`,
+  `env_vars_from_dict()`, placeholder checks, generated config renderers, SOC
+  cert generation, Suricata seeding, and bind-mount validation.
+- **Deployment boundary:** policy actions call lifecycle functions that call
+  `DeploymentBackend`. Do not call `docker compose`, `docker ps`,
+  `docker volume rm`, `ssh`, or backend-private `_run()` methods directly from
+  policy, API, web, validation, or tests.
+- **Idle detection:** track narrow activity metadata only. Acceptable signals
+  are control-plane lifecycle actions, terminal/session activity timestamps,
+  scenario/orchestrator actions, runstore appends, or explicit heartbeat-style
+  markers routed through one activity boundary. Do not record terminal bytes,
+  command text, SOC payloads, packet contents, raw Docker logs, CPU load, or
+  network counters as the canonical idle signal.
+- **OS/process exposure:** schedulers and API workers must not put bearer
+  tokens, passwords, API keys, private keys, raw `.env`, rendered config, or
+  credential-bearing curl commands in argv or shell strings. Preserve argv-list
+  subprocess construction and existing `curl_safe` handling for SOC HTTP.
+- **Error envelopes:** lifecycle policy failures use existing `LabResult` /
+  `LabActionResponse` shapes. A failed TTL/idle teardown is not a new exception
+  hierarchy or readiness category. Redact backend stderr and unexpected
+  exception text before it reaches CLI, API, logs, telemetry, web, run
+  archives, or policy state.
+- **Persistence boundary:** policy events and action receipts that are part of
+  a run must use `LocalRunStore` redacting JSON/JSONL writes. Scheduler
+  checkpoint state, if needed, belongs under ignored `.aptl/` state with the
+  same ID/path validation and redaction discipline, not in checked-in config or
+  as mutable run-archive truth.
+
+## Extensibility Seam
+
+The seam belongs at a small lifecycle-policy boundary that evaluates typed
+policy data and emits one of the existing lifecycle actions: start, clean boot,
+or teardown. The first policy variants should be parameterized by:
+
+- instance identity: project directory, deployment backend, and
+  `deployment.project_name`;
+- lifecycle action: normal start, clean boot, or teardown;
+- cleanup policy: remove Compose-managed volumes or preserve them;
+- selected scenario: catalog id or explicit scenario path resolved by the
+  existing scenario-selection helper;
+- timing policy: TTL seconds, idle-timeout seconds, and scheduled UTC windows
+  or intervals;
+- activity source: a single last-activity marker that future terminal,
+  orchestrator, API, or MCP activity producers can update without re-editing
+  every policy evaluator.
+
+Future cloud, Kubernetes, classroom pool, quota, or queue semantics should
+extend this policy boundary and `DeploymentBackend` implementations. They
+should not duplicate lab-start ordering, Docker Compose command construction,
+config parsing, API schemas, or run-record assembly.
+
+## Whole-Repo Surface
+
+- `aptl.json`, `.env`, `.env.example`, `AptlConfig`,
+  `DeploymentConfig.project_name`, and `RunStorageConfig`.
+- `docker-compose.yml`, Compose profiles, top-level volumes, networks,
+  generated bind mounts, and compose-project labels.
+- `.aptl/` state, `.aptl/config/...`, `.aptl/runs/...`,
+  `config/soc_certs/...`, `config/suricata/...`, `keys/`, `.mcp.json`, and
+  run archives.
+- `src/aptl/core/lab.py`, `src/aptl/core/lab_types.py`,
+  `src/aptl/core/deployment/`, `src/aptl/core/config.py`,
+  `src/aptl/core/env.py`, `src/aptl/core/runstore.py`,
+  `src/aptl/core/snapshot.py`, and `src/aptl/backends/aces*.py`.
+- `src/aptl/cli/lab.py`, `src/aptl/api/routers/lab.py`,
+  `src/aptl/api/schemas.py`, `src/aptl/api/deps.py`,
+  `web/src/lib/api.ts`, and `web/src/lib/types.ts`.
+- Host/runtime layers: Docker daemon, SSH Docker transport, local process argv,
+  local filesystem permissions, API worker lifetime, scheduler lifetime, and
+  browser/web client disconnects.
+- Repo gates: `.gc/plan-rules.md`, `pytest`, and
+  `pre-commit run --all-files`.
+
+## Gotchas And Anti-Patterns
+
+- Adding a second `EphemeralInstance`, `RangeController`, Docker script, API
+  schema, exception hierarchy, or validation stack when existing lifecycle
+  results and deployment backends already own the behavior.
+- Treating TTL/idle/schedule policy as deployment-backend behavior. Backends
+  perform typed lifecycle operations; policy decides when to call them.
+- Treating clean state as a container restart while preserving service
+  volumes, SOC databases, generated rule volumes, stale API-key sync state, or
+  in-container credentials.
+- Inferring instance identity from container names, `aptl-*` prefixes,
+  scenario names, folder names, `lab.name`, GitHub issue ids, or ACES metadata.
+- Deleting `.env`, `.mcp.json`, `keys/`, checked-in `config/`, run archives,
+  or ACES inventory evidence as part of the default teardown guarantee.
+- Running timers in web clients, SSE loops, or request-local `asyncio` tasks and
+  calling that reliable automated teardown.
+- Scraping logs, terminal transcripts, Docker stats, packet captures, or SOC
+  payloads to decide idle state.
+- Returning raw Docker stderr, raw `icontract` messages, rendered config,
+  `.env` values, terminal content, or command lines in policy errors.
+- Weakening SSH-remote safety by assuming locally generated artifacts are
+  visible to a remote Docker daemon.
+
+## Non-Goals
+
+- Do not implement DEP-003 in this preflight.
+- Do not redesign Docker Compose, ACES SDL, deployment backends, run archive
+  layout, SOC seeding, Suricata rule semantics, terminal capture, web auth, or
+  startup readiness classification.
+- Do not add Kubernetes, Podman, Nomad, cloud account provisioning, quota
+  management, classroom pool scheduling, or multi-tenant billing semantics as
+  part of the first lifecycle policy boundary.
+- Do not guarantee byte-identical regenerated credentials, logs, timestamps,
+  Docker object IDs, network IDs, endpoint IDs, or image cache contents across
+  provisioned instances.
+- Do not make destructive TTL/idle teardown part of default fast CI or
+  pre-commit.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -157,3 +157,4 @@ The victim and kali containers publish no host ports; use
 ## Preflights
 
 - [RNG-001 Ephemeral Environments](rng-001-ephemeral-environments-preflight.md)
+- [DEP-003 Ephemeral Lifecycle Policy](dep-003-ephemeral-lifecycle-preflight.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -131,6 +131,52 @@ docker compose --profile wazuh --profile victim --profile kali stop
 docker compose --profile wazuh --profile victim --profile kali down -v
 ```
 
+## Lifecycle Policy
+
+The lab can auto-teardown on a TTL or idle timeout and provision on a schedule
+(DEP-003). Add a `lifecycle_policy` block to `aptl.json`:
+
+```json
+{
+  "lab": { "name": "aptl" },
+  "lifecycle_policy": {
+    "ttl_minutes": 240,
+    "idle_timeout_minutes": 60,
+    "teardown_remove_volumes": true,
+    "schedule": [
+      { "at": "08:00", "days": ["mon", "tue", "wed", "thu", "fri"], "scenario": null }
+    ]
+  }
+}
+```
+
+- `ttl_minutes` tears the range down once it has run that long.
+- `idle_timeout_minutes` tears the range down after no run capture activity for
+  that long.
+- `teardown_remove_volumes` controls whether an auto-teardown removes Compose
+  volumes (a full clean teardown).
+- `schedule` provisions a clean range at each `HH:MM` UTC time. `days` is an
+  optional weekday filter (empty means every day); `scenario` is an optional
+  curated scenario id.
+
+Enforcement is a single idempotent tick that you schedule yourself:
+
+```bash
+# One evaluate-and-act tick (wire to a systemd timer or cron)
+aptl lab enforce
+
+# Or run a single-owner loop on a host without a timer
+aptl lab monitor --interval 60
+
+# Inspect the resolved policy and current lifecycle state
+aptl lab policy show
+```
+
+The tick holds a per-project lock, so a manual `enforce` and a running
+`monitor` never act at once. See
+[ADR-045](adrs/adr-045-ephemeral-lifecycle-policy-enforcement.md) for the
+design.
+
 ## Troubleshooting
 
 ### Port Conflicts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - Networking: architecture/networking.md
     - Enterprise Infrastructure: architecture/enterprise-infrastructure.md
     - RNG-001 Ephemeral Environments Preflight: architecture/rng-001-ephemeral-environments-preflight.md
+    - DEP-003 Ephemeral Lifecycle Policy Preflight: architecture/dep-003-ephemeral-lifecycle-preflight.md
   - Deployment: deployment.md
   - Components:
     - Wazuh SIEM: components/wazuh-siem.md

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -1,6 +1,7 @@
 """CLI commands for lab lifecycle management."""
 
 import json
+from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
@@ -29,6 +30,18 @@ app = typer.Typer(help="Lab lifecycle management.")
 # module stays focused on lifecycle commands. Register it under `lab`
 # so the command stays at `aptl lab continuity-audit` (no UX change).
 app.command("continuity-audit")(continuity_audit)
+
+# Lifecycle-policy inspection (DEP-003). Authoring lives in `aptl.json`
+# (strict first-party config, ADR-025); this sub-group is read-only.
+policy_app = typer.Typer(help="Inspect the ephemeral lifecycle policy (DEP-003).")
+app.add_typer(policy_app, name="policy")
+
+_PROJECT_DIR_OPTION = typer.Option(
+    Path("."),
+    "--project-dir",
+    "-d",
+    help="Path to the APTL project directory.",
+)
 
 
 # Headline phrasing per outcome — kept beside the renderer so the CLI's
@@ -403,3 +416,126 @@ def validate_live(
     typer.echo(report.render())
     if not report.passed:
         raise typer.Exit(code=1)
+
+
+def _render_lifecycle_result(result: LabResult) -> None:
+    """Print a lifecycle enforcement result line plus any diagnostics."""
+    typer.echo(result.message)
+    for diag in result.diagnostics:
+        typer.echo(f"  {diag.message}")
+    if not result.success and result.error:
+        typer.echo(f"  error: {result.error}", err=True)
+
+
+@app.command()
+def enforce(
+    project_dir: Path = _PROJECT_DIR_OPTION,
+    grace_minutes: int = typer.Option(
+        60,
+        "--grace-minutes",
+        help=(
+            "How many minutes after a scheduled time a tick may still "
+            "provision (so a tick running late does not boot a stale window)."
+        ),
+    ),
+) -> None:
+    """Evaluate the lifecycle policy once and act (idempotent, DEP-003).
+
+    One evaluate-and-act tick: auto-teardown an expired (TTL) or idle range,
+    or provision a due scheduled range. Designed to be driven by a systemd
+    timer or cron entry. A no-op when no ``lifecycle_policy`` is configured.
+    """
+    from aptl.core.lifecycle_policy import LifecycleBusyError, enforce_once
+
+    try:
+        result = enforce_once(project_dir, grace_minutes=grace_minutes)
+    except LifecycleBusyError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    _render_lifecycle_result(result)
+    if not result.success:
+        raise typer.Exit(code=1)
+
+
+@app.command()
+def monitor(
+    project_dir: Path = _PROJECT_DIR_OPTION,
+    interval: int = typer.Option(
+        60, "--interval", help="Seconds to wait between enforcement ticks."
+    ),
+    max_ticks: Optional[int] = typer.Option(
+        None,
+        "--max-ticks",
+        help="Stop after this many ticks (default: run until interrupted).",
+    ),
+    grace_minutes: int = typer.Option(
+        60, "--grace-minutes", help="Scheduled-provisioning grace window in minutes."
+    ),
+) -> None:
+    """Run lifecycle enforcement in a single-owner loop (DEP-003).
+
+    A thin convenience wrapper over ``aptl lab enforce`` for hosts without a
+    systemd timer / cron. Holds the project lifecycle lock for its whole run,
+    so a second monitor (or a one-shot ``enforce``) cannot act concurrently.
+    """
+    from aptl.core.lifecycle_policy import LifecycleBusyError, run_monitor
+
+    try:
+        results = run_monitor(
+            project_dir,
+            interval_seconds=interval,
+            max_ticks=max_ticks,
+            grace_minutes=grace_minutes,
+        )
+    except LifecycleBusyError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+    except KeyboardInterrupt:
+        typer.echo("monitor stopped.")
+        raise typer.Exit(code=0)
+
+    for result in results:
+        _render_lifecycle_result(result)
+
+
+@policy_app.command("show")
+def policy_show(
+    project_dir: Path = _PROJECT_DIR_OPTION,
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit policy + state as machine-readable JSON."
+    ),
+) -> None:
+    """Show the resolved lifecycle policy and current lifecycle state."""
+    from aptl.cli._common import resolve_config_for_cli
+    from aptl.core.lifecycle_policy import load_state
+
+    config, project_root = resolve_config_for_cli(project_dir)
+    policy = config.lifecycle_policy
+    state = load_state(project_root)
+
+    if json_output:
+        payload = {
+            "policy": policy.model_dump(mode="json") if policy else None,
+            "state": asdict(state),
+        }
+        typer.echo(json.dumps(payload, indent=2))
+        return
+
+    if policy is None:
+        typer.echo("No lifecycle_policy configured.")
+    else:
+        typer.echo("Lifecycle policy:")
+        typer.echo(f"  ttl_minutes: {policy.ttl_minutes}")
+        typer.echo(f"  idle_timeout_minutes: {policy.idle_timeout_minutes}")
+        typer.echo(f"  teardown_remove_volumes: {policy.teardown_remove_volumes}")
+        typer.echo(f"  schedule entries: {len(policy.schedule)}")
+        for entry in policy.schedule:
+            days = ",".join(entry.days) if entry.days else "every day"
+            scenario = f" scenario={entry.scenario}" if entry.scenario else ""
+            typer.echo(f"    - {entry.at} UTC [{days}]{scenario}")
+
+    typer.echo("State:")
+    typer.echo(f"  provisioned_at: {state.provisioned_at}")
+    typer.echo(f"  last_action: {state.last_action} (result={state.last_result})")
+    typer.echo(f"  last_action_at: {state.last_action_at}")

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -1,12 +1,12 @@
 """CLI commands for lab lifecycle management."""
 
 import json
-from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
 import typer
 
+from aptl.cli import lifecycle
 from aptl.cli.continuity import continuity_audit
 from aptl.core.lab import (
     LabResult,
@@ -31,17 +31,10 @@ app = typer.Typer(help="Lab lifecycle management.")
 # so the command stays at `aptl lab continuity-audit` (no UX change).
 app.command("continuity-audit")(continuity_audit)
 
-# Lifecycle-policy inspection (DEP-003). Authoring lives in `aptl.json`
-# (strict first-party config, ADR-025); this sub-group is read-only.
-policy_app = typer.Typer(help="Inspect the ephemeral lifecycle policy (DEP-003).")
-app.add_typer(policy_app, name="policy")
-
-_PROJECT_DIR_OPTION = typer.Option(
-    Path("."),
-    "--project-dir",
-    "-d",
-    help="Path to the APTL project directory.",
-)
+# Ephemeral lifecycle policy commands (DEP-003) live in aptl.cli.lifecycle so
+# this module stays focused; register them under `lab` (no UX change:
+# `aptl lab enforce` / `monitor` / `policy show`).
+lifecycle.register(app)
 
 
 # Headline phrasing per outcome — kept beside the renderer so the CLI's
@@ -416,126 +409,3 @@ def validate_live(
     typer.echo(report.render())
     if not report.passed:
         raise typer.Exit(code=1)
-
-
-def _render_lifecycle_result(result: LabResult) -> None:
-    """Print a lifecycle enforcement result line plus any diagnostics."""
-    typer.echo(result.message)
-    for diag in result.diagnostics:
-        typer.echo(f"  {diag.message}")
-    if not result.success and result.error:
-        typer.echo(f"  error: {result.error}", err=True)
-
-
-@app.command()
-def enforce(
-    project_dir: Path = _PROJECT_DIR_OPTION,
-    grace_minutes: int = typer.Option(
-        60,
-        "--grace-minutes",
-        help=(
-            "How many minutes after a scheduled time a tick may still "
-            "provision (so a tick running late does not boot a stale window)."
-        ),
-    ),
-) -> None:
-    """Evaluate the lifecycle policy once and act (idempotent, DEP-003).
-
-    One evaluate-and-act tick: auto-teardown an expired (TTL) or idle range,
-    or provision a due scheduled range. Designed to be driven by a systemd
-    timer or cron entry. A no-op when no ``lifecycle_policy`` is configured.
-    """
-    from aptl.core.lifecycle_policy import LifecycleBusyError, enforce_once
-
-    try:
-        result = enforce_once(project_dir, grace_minutes=grace_minutes)
-    except LifecycleBusyError as exc:
-        typer.echo(f"error: {exc}", err=True)
-        raise typer.Exit(code=1)
-
-    _render_lifecycle_result(result)
-    if not result.success:
-        raise typer.Exit(code=1)
-
-
-@app.command()
-def monitor(
-    project_dir: Path = _PROJECT_DIR_OPTION,
-    interval: int = typer.Option(
-        60, "--interval", help="Seconds to wait between enforcement ticks."
-    ),
-    max_ticks: Optional[int] = typer.Option(
-        None,
-        "--max-ticks",
-        help="Stop after this many ticks (default: run until interrupted).",
-    ),
-    grace_minutes: int = typer.Option(
-        60, "--grace-minutes", help="Scheduled-provisioning grace window in minutes."
-    ),
-) -> None:
-    """Run lifecycle enforcement in a single-owner loop (DEP-003).
-
-    A thin convenience wrapper over ``aptl lab enforce`` for hosts without a
-    systemd timer / cron. Holds the project lifecycle lock for its whole run,
-    so a second monitor (or a one-shot ``enforce``) cannot act concurrently.
-    """
-    from aptl.core.lifecycle_policy import LifecycleBusyError, run_monitor
-
-    try:
-        results = run_monitor(
-            project_dir,
-            interval_seconds=interval,
-            max_ticks=max_ticks,
-            grace_minutes=grace_minutes,
-        )
-    except LifecycleBusyError as exc:
-        typer.echo(f"error: {exc}", err=True)
-        raise typer.Exit(code=1)
-    except KeyboardInterrupt:
-        typer.echo("monitor stopped.")
-        raise typer.Exit(code=0)
-
-    for result in results:
-        _render_lifecycle_result(result)
-
-
-@policy_app.command("show")
-def policy_show(
-    project_dir: Path = _PROJECT_DIR_OPTION,
-    json_output: bool = typer.Option(
-        False, "--json", help="Emit policy + state as machine-readable JSON."
-    ),
-) -> None:
-    """Show the resolved lifecycle policy and current lifecycle state."""
-    from aptl.cli._common import resolve_config_for_cli
-    from aptl.core.lifecycle_policy import load_state
-
-    config, project_root = resolve_config_for_cli(project_dir)
-    policy = config.lifecycle_policy
-    state = load_state(project_root)
-
-    if json_output:
-        payload = {
-            "policy": policy.model_dump(mode="json") if policy else None,
-            "state": asdict(state),
-        }
-        typer.echo(json.dumps(payload, indent=2))
-        return
-
-    if policy is None:
-        typer.echo("No lifecycle_policy configured.")
-    else:
-        typer.echo("Lifecycle policy:")
-        typer.echo(f"  ttl_minutes: {policy.ttl_minutes}")
-        typer.echo(f"  idle_timeout_minutes: {policy.idle_timeout_minutes}")
-        typer.echo(f"  teardown_remove_volumes: {policy.teardown_remove_volumes}")
-        typer.echo(f"  schedule entries: {len(policy.schedule)}")
-        for entry in policy.schedule:
-            days = ",".join(entry.days) if entry.days else "every day"
-            scenario = f" scenario={entry.scenario}" if entry.scenario else ""
-            typer.echo(f"    - {entry.at} UTC [{days}]{scenario}")
-
-    typer.echo("State:")
-    typer.echo(f"  provisioned_at: {state.provisioned_at}")
-    typer.echo(f"  last_action: {state.last_action} (result={state.last_result})")
-    typer.echo(f"  last_action_at: {state.last_action_at}")

--- a/src/aptl/cli/lifecycle.py
+++ b/src/aptl/cli/lifecycle.py
@@ -1,0 +1,153 @@
+"""CLI commands for ephemeral lifecycle policy (DEP-003).
+
+Registered onto the ``aptl lab`` Typer app by :func:`register`, so the commands
+stay at ``aptl lab enforce`` / ``aptl lab monitor`` / ``aptl lab policy show``.
+Policy authoring lives in ``aptl.json`` (strict first-party config, ADR-025);
+this surface is read-only inspection plus the enforcement entrypoints.
+"""
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from aptl.core.lab_types import LabResult
+
+_PROJECT_DIR_OPTION = typer.Option(
+    Path("."),
+    "--project-dir",
+    "-d",
+    help="Path to the APTL project directory.",
+)
+
+policy_app = typer.Typer(help="Inspect the ephemeral lifecycle policy (DEP-003).")
+
+
+def _render_lifecycle_result(result: LabResult) -> None:
+    """Print a lifecycle enforcement result line plus any diagnostics."""
+    typer.echo(result.message)
+    for diag in result.diagnostics:
+        typer.echo(f"  {diag.message}")
+    if not result.success and result.error:
+        typer.echo(f"  error: {result.error}", err=True)
+
+
+def enforce(
+    project_dir: Path = _PROJECT_DIR_OPTION,
+    grace_minutes: int = typer.Option(
+        60,
+        "--grace-minutes",
+        help=(
+            "How many minutes after a scheduled time a tick may still "
+            "provision (so a tick running late does not boot a stale window)."
+        ),
+    ),
+) -> None:
+    """Evaluate the lifecycle policy once and act (idempotent, DEP-003).
+
+    One evaluate-and-act tick: auto-teardown an expired (TTL) or idle range,
+    or provision a due scheduled range. Designed to be driven by a systemd
+    timer or cron entry. A no-op when no ``lifecycle_policy`` is configured.
+    """
+    from aptl.core.lifecycle_enforce import LifecycleBusyError, enforce_once
+
+    try:
+        result = enforce_once(project_dir, grace_minutes=grace_minutes)
+    except LifecycleBusyError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    _render_lifecycle_result(result)
+    if not result.success:
+        raise typer.Exit(code=1)
+
+
+def monitor(
+    project_dir: Path = _PROJECT_DIR_OPTION,
+    interval: int = typer.Option(
+        60, "--interval", help="Seconds to wait between enforcement ticks."
+    ),
+    max_ticks: Optional[int] = typer.Option(
+        None,
+        "--max-ticks",
+        help="Stop after this many ticks (default: run until interrupted).",
+    ),
+    grace_minutes: int = typer.Option(
+        60, "--grace-minutes", help="Scheduled-provisioning grace window in minutes."
+    ),
+) -> None:
+    """Run lifecycle enforcement in a single-owner loop (DEP-003).
+
+    A thin convenience wrapper over ``aptl lab enforce`` for hosts without a
+    systemd timer / cron. Holds the project lifecycle lock for its whole run,
+    so a second monitor (or a one-shot ``enforce``) cannot act concurrently.
+    """
+    from aptl.core.lifecycle_enforce import LifecycleBusyError, run_monitor
+
+    try:
+        results = run_monitor(
+            project_dir,
+            interval_seconds=interval,
+            max_ticks=max_ticks,
+            grace_minutes=grace_minutes,
+        )
+    except LifecycleBusyError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+    except KeyboardInterrupt:
+        typer.echo("monitor stopped.")
+        raise typer.Exit(code=0)
+
+    for result in results:
+        _render_lifecycle_result(result)
+
+
+@policy_app.command("show")
+def policy_show(
+    project_dir: Path = _PROJECT_DIR_OPTION,
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit policy + state as machine-readable JSON."
+    ),
+) -> None:
+    """Show the resolved lifecycle policy and current lifecycle state."""
+    from aptl.cli._common import resolve_config_for_cli
+    from aptl.core.lifecycle_policy import load_state
+
+    config, project_root = resolve_config_for_cli(project_dir)
+    policy = config.lifecycle_policy
+    state = load_state(project_root)
+
+    if json_output:
+        payload = {
+            "policy": policy.model_dump(mode="json") if policy else None,
+            "state": asdict(state),
+        }
+        typer.echo(json.dumps(payload, indent=2))
+        return
+
+    if policy is None:
+        typer.echo("No lifecycle_policy configured.")
+    else:
+        typer.echo("Lifecycle policy:")
+        typer.echo(f"  ttl_minutes: {policy.ttl_minutes}")
+        typer.echo(f"  idle_timeout_minutes: {policy.idle_timeout_minutes}")
+        typer.echo(f"  teardown_remove_volumes: {policy.teardown_remove_volumes}")
+        typer.echo(f"  schedule entries: {len(policy.schedule)}")
+        for entry in policy.schedule:
+            days = ",".join(entry.days) if entry.days else "every day"
+            scenario = f" scenario={entry.scenario}" if entry.scenario else ""
+            typer.echo(f"    - {entry.at} UTC [{days}]{scenario}")
+
+    typer.echo("State:")
+    typer.echo(f"  provisioned_at: {state.provisioned_at}")
+    typer.echo(f"  last_action: {state.last_action} (result={state.last_result})")
+    typer.echo(f"  last_action_at: {state.last_action_at}")
+
+
+def register(lab_app: typer.Typer) -> None:
+    """Register the lifecycle commands onto the ``aptl lab`` Typer app."""
+    lab_app.command("enforce")(enforce)
+    lab_app.command("monitor")(monitor)
+    lab_app.add_typer(policy_app, name="policy")

--- a/src/aptl/core/config.py
+++ b/src/aptl/core/config.py
@@ -68,10 +68,14 @@ class RunStorageConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    backend: str = "local"          # "local" or "s3" (s3 deferred)
-    local_path: str = "./runs"      # Relative to project dir
-    s3_bucket: str | None = None    # Future
-    s3_prefix: str = "runs/"        # Future
+    # "local" or "s3" (s3 deferred)
+    backend: str = "local"
+    # Relative to project dir
+    local_path: str = "./runs"
+    # Future
+    s3_bucket: str | None = None
+    # Future
+    s3_prefix: str = "runs/"
 
 
 class DeploymentConfig(BaseModel):
@@ -84,7 +88,8 @@ class DeploymentConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    provider: str = "docker-compose"    # "docker-compose" or "ssh-compose"
+    # "docker-compose" or "ssh-compose"
+    provider: str = "docker-compose"
     project_name: str = "aptl"
 
     # SSH-specific fields (only used when provider == "ssh-compose")

--- a/src/aptl/core/config.py
+++ b/src/aptl/core/config.py
@@ -106,6 +106,74 @@ class DeploymentConfig(BaseModel):
         return v
 
 
+_TIME_PATTERN = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+_WEEKDAYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+
+class LifecycleScheduleEntry(BaseModel):
+    """One scheduled-provisioning window (DEP-003).
+
+    ``at`` is a 24-hour ``HH:MM`` wall-clock time interpreted in **UTC**
+    (the platform stamps lifecycle timestamps as timezone-aware UTC, so
+    the schedule shares that frame). ``days`` is an optional weekday
+    filter (empty means every day). ``scenario`` optionally names a
+    curated ACES startup scenario id to boot with.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    at: str
+    days: list[str] = []
+    scenario: str | None = None
+
+    @field_validator("at")
+    @classmethod
+    def validate_at(cls, v: str) -> str:
+        if not _TIME_PATTERN.match(v):
+            raise ValueError(
+                f"Schedule 'at' must be a 24-hour HH:MM UTC time, got '{v}'."
+            )
+        return v
+
+    @field_validator("days")
+    @classmethod
+    def validate_days(cls, v: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for day in v:
+            lowered = day.lower()
+            if lowered not in _WEEKDAYS:
+                raise ValueError(
+                    f"Invalid weekday '{day}'. Use any of: {', '.join(_WEEKDAYS)}."
+                )
+            normalized.append(lowered)
+        return normalized
+
+
+class LabLifecyclePolicyConfig(BaseModel):
+    """Ephemeral lifecycle policy for the range (DEP-003).
+
+    Declarative policy consumed by ``aptl lab enforce`` / ``monitor`` to
+    auto-teardown an idle or expired range and to provision on a
+    schedule. Enforcement is a separate single-owner control-plane tick;
+    this model is just the strict, first-party policy shape (ADR-025).
+    All durations are bounded positive integers in minutes.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ttl_minutes: int | None = None
+    idle_timeout_minutes: int | None = None
+    teardown_remove_volumes: bool = True
+    schedule: list[LifecycleScheduleEntry] = []
+
+    @field_validator("ttl_minutes", "idle_timeout_minutes")
+    @classmethod
+    def validate_positive_minutes(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("must be a positive number of minutes")
+        return v
+
+
 class AptlConfig(BaseModel):
     """Top-level APTL configuration.
 
@@ -121,6 +189,7 @@ class AptlConfig(BaseModel):
     containers: ContainerSettings = ContainerSettings()
     deployment: DeploymentConfig = DeploymentConfig()
     run_storage: RunStorageConfig = RunStorageConfig()
+    lifecycle_policy: LabLifecyclePolicyConfig | None = None
 
 
 def load_config(path: Path) -> AptlConfig:

--- a/src/aptl/core/lifecycle_enforce.py
+++ b/src/aptl/core/lifecycle_enforce.py
@@ -1,0 +1,354 @@
+"""Ephemeral lifecycle enforcement runtime (DEP-003).
+
+The side-effecting half of the lifecycle feature: it observes the lab, computes
+the activity signal, resolves a decision via the pure evaluators in
+:mod:`aptl.core.lifecycle_policy`, acts through the existing deployment backend
+(``lab_status`` / ``stop_lab`` / ``clean_boot_lab``), and persists narrow state.
+
+``enforce_once`` is a single idempotent evaluate-and-act tick; ``run_monitor``
+is a thin single-owner loop over it. See ADR-045.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from aptl.core.config import (
+    AptlConfig,
+    LabLifecyclePolicyConfig,
+    find_config,
+    load_config,
+)
+from aptl.core.lab import clean_boot_lab, lab_status, stop_lab
+from aptl.core.lab_types import (
+    DiagnosticImpact,
+    DiagnosticSeverity,
+    LabResult,
+    StartupDiagnostic,
+    StartupOutcome,
+)
+from aptl.core.lifecycle_policy import (
+    LifecycleBusyError,
+    LifecycleDecision,
+    LifecycleState,
+    _parse_iso,
+    _to_utc,
+    decide,
+    load_state,
+    save_state,
+    state_path,
+)
+from aptl.core.runstore import resolve_active_run_dir
+from aptl.utils.logging import get_logger
+from aptl.utils.redaction import redact
+
+if TYPE_CHECKING:
+    from aptl.core.deployment.backend import DeploymentBackend
+
+log = get_logger("lifecycle_enforce")
+
+
+# ---------------------------------------------------------------------------
+# Activity signal + single-owner lock
+# ---------------------------------------------------------------------------
+
+
+def _newest_mtime(directory: Optional[Path]) -> Optional[datetime]:
+    """Return the newest file mtime (UTC) under ``directory``, or None."""
+    if directory is None or not directory.exists():
+        return None
+    newest: Optional[float] = None
+    for child in directory.rglob("*"):
+        try:
+            mtime = child.stat().st_mtime
+        except OSError:
+            continue
+        if newest is None or mtime > newest:
+            newest = mtime
+    return datetime.fromtimestamp(newest, tz=timezone.utc) if newest else None
+
+
+def _latest_activity_at(project_dir: Path, state: LifecycleState) -> Optional[datetime]:
+    """Newest of: provisioning time and most-recent capture under the active run.
+
+    Capture recency under the active run directory is the narrow
+    control-plane activity signal — when the red/blue MCP servers last wrote
+    evidence. Falls back to provisioning time when no scenario is active.
+    """
+    candidates: list[datetime] = []
+    provisioned = _parse_iso(state.provisioned_at)
+    if provisioned is not None:
+        candidates.append(provisioned)
+    active = resolve_active_run_dir(project_dir / ".aptl")
+    newest = _newest_mtime(active)
+    if newest is not None:
+        candidates.append(newest)
+    return max(candidates) if candidates else None
+
+
+@contextmanager
+def _single_owner_lock(project_dir: Path) -> Iterator[None]:
+    """Hold an exclusive non-blocking flock for the duration of a tick/loop.
+
+    Raises :class:`LifecycleBusyError` when another owner already holds it.
+    """
+    lock_path = state_path(project_dir).parent / ".lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("w")
+    try:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise LifecycleBusyError(
+                "another lifecycle owner is active (enforce/monitor lock held)"
+            ) from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
+# ---------------------------------------------------------------------------
+# Policy resolution
+# ---------------------------------------------------------------------------
+
+
+def _load_policy(
+    project_dir: Path,
+) -> tuple[Optional[AptlConfig], Optional[LabLifecyclePolicyConfig]]:
+    """Load the config and its lifecycle policy, or (None, None) with no config."""
+    config_path = find_config(project_dir)
+    if config_path is None:
+        return None, None
+    config = load_config(config_path)
+    return config, config.lifecycle_policy
+
+
+def _policy_or_failure(
+    project_dir: Path,
+) -> tuple[Optional[LabLifecyclePolicyConfig], Optional[LabResult]]:
+    """Resolve the policy, or a FAILED result when ``aptl.json`` is malformed.
+
+    A missing config (no ``aptl.json``) or an absent ``lifecycle_policy`` is a
+    legitimate no-op. A config that is present but invalid must NOT read as a
+    clean no-op — that would let a typo silently disable an unattended TTL or
+    idle timer — so it surfaces as a failed tick the scheduler can detect.
+    """
+    try:
+        _, policy = _load_policy(project_dir)
+    except (OSError, ValueError) as exc:
+        return None, LabResult(
+            success=False,
+            message="lifecycle: invalid configuration",
+            error=redact(f"invalid aptl.json: {exc}"),
+            outcome=StartupOutcome.FAILED,
+        )
+    return policy, None
+
+
+# ---------------------------------------------------------------------------
+# Action application
+# ---------------------------------------------------------------------------
+
+
+def _diag(message: str) -> StartupDiagnostic:
+    """Build a cosmetic/info lifecycle diagnostic with a redaction-safe message."""
+    return StartupDiagnostic(
+        step="lifecycle_enforce",
+        impact=DiagnosticImpact.COSMETIC,
+        severity=DiagnosticSeverity.INFO,
+        message=message,
+    )
+
+
+def _apply_teardown(
+    project_dir: Path,
+    policy: LabLifecyclePolicyConfig,
+    state: LifecycleState,
+    decision: LifecycleDecision,
+    now: datetime,
+    backend: Optional["DeploymentBackend"],
+) -> LabResult:
+    """Tear the range down via ``stop_lab`` and record the outcome in state."""
+    log.info("Lifecycle teardown (%s)", decision.reason)
+    result = stop_lab(
+        remove_volumes=policy.teardown_remove_volumes,
+        project_dir=project_dir,
+        backend=backend,
+    )
+    state.last_action = "teardown"
+    state.last_action_at = now.isoformat()
+    state.last_result = result.outcome.value
+    state.last_error_label = redact(result.error) if result.error else ""
+    if result.success:
+        state.provisioned_at = None
+    return LabResult(
+        success=result.success,
+        message=f"lifecycle: teardown ({decision.reason})",
+        error=result.error,
+        outcome=result.outcome,
+        diagnostics=[_diag(f"teardown triggered by {decision.policy} policy")],
+    )
+
+
+def _resolve_schedule_scenario(project_dir: Path, scenario: Optional[str]) -> Optional[Path]:
+    """Resolve an optional schedule scenario id to its SDL path."""
+    if not scenario:
+        return None
+    from aptl.core.scenario_catalog import resolve_scenario_selection
+
+    return resolve_scenario_selection(project_dir, scenario_id=scenario)
+
+
+def _apply_provision(
+    project_dir: Path,
+    state: LifecycleState,
+    decision: LifecycleDecision,
+    now: datetime,
+    backend: Optional["DeploymentBackend"],
+) -> LabResult:
+    """Provision a clean range via ``clean_boot_lab`` and record the outcome."""
+    log.info("Lifecycle scheduled provisioning (%s)", decision.schedule_key)
+    scenario_path = _resolve_schedule_scenario(project_dir, decision.scenario)
+    # Scheduled provisioning is an ephemeral clean boot: guarantee fresh state
+    # regardless of any residue from a prior run (RNG-001).
+    result = clean_boot_lab(
+        project_dir,
+        remove_volumes=True,
+        scenario_path=scenario_path,
+        backend=backend,
+    )
+    state.last_action = "provision"
+    state.last_action_at = now.isoformat()
+    state.last_result = result.outcome.value
+    state.last_error_label = redact(result.error) if result.error else ""
+    if result.success:
+        state.provisioned_at = now.isoformat()
+        # Only consume the day's fire marker on success, so a failed provision
+        # (transient backend/Docker/readiness fault) is retried by a later tick
+        # while the grace window is still open.
+        if decision.schedule_key:
+            state.fired_schedules[decision.schedule_key] = now.date().isoformat()
+    result.message = f"lifecycle: provision ({decision.reason})"
+    return result
+
+
+def _apply_decision(
+    project_dir: Path,
+    policy: LabLifecyclePolicyConfig,
+    state: LifecycleState,
+    decision: LifecycleDecision,
+    now: datetime,
+    backend: Optional["DeploymentBackend"],
+) -> LabResult:
+    """Dispatch a resolved decision to the matching action (or a no-op)."""
+    if decision.action == "teardown":
+        return _apply_teardown(project_dir, policy, state, decision, now, backend)
+    if decision.action == "provision":
+        return _apply_provision(project_dir, state, decision, now, backend)
+    return LabResult(success=True, message=f"lifecycle: no action ({decision.reason})")
+
+
+def _enforce_locked(
+    project_dir: Path,
+    policy: LabLifecyclePolicyConfig,
+    now: datetime,
+    backend: Optional["DeploymentBackend"],
+    grace_minutes: float,
+) -> LabResult:
+    """Run one evaluate-and-act tick assuming the owner lock is already held."""
+    state = load_state(project_dir)
+    status = lab_status(project_dir=project_dir, backend=backend)
+    running = status.running
+    # Reconcile provisioning time against observed reality so TTL/idle behave
+    # identically whether the lab was started manually or by a prior tick.
+    if running and not state.provisioned_at:
+        state.provisioned_at = now.isoformat()
+    elif not running and state.provisioned_at:
+        state.provisioned_at = None
+    last_activity = _latest_activity_at(project_dir, state)
+    decision = decide(policy, state, now, running, last_activity, grace_minutes)
+    result = _apply_decision(project_dir, policy, state, decision, now, backend)
+    save_state(project_dir, state)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoints
+# ---------------------------------------------------------------------------
+
+
+def enforce_once(
+    project_dir: Path,
+    *,
+    now: Optional[datetime] = None,
+    backend: Optional["DeploymentBackend"] = None,
+    grace_minutes: float = 60.0,
+) -> LabResult:
+    """Run exactly one lifecycle evaluate-and-act cycle.
+
+    Idempotent: at most one action (teardown or provision) per tick. A no-op
+    when no ``lifecycle_policy`` is configured, and a FAILED result when
+    ``aptl.json`` is malformed. Raises :class:`LifecycleBusyError` when another
+    owner holds the project lock.
+    """
+    now = datetime.now(timezone.utc) if now is None else _to_utc(now)
+    policy, failure = _policy_or_failure(project_dir)
+    if failure is not None:
+        return failure
+    if policy is None:
+        return LabResult(
+            success=True, message="lifecycle: no policy configured; nothing to enforce"
+        )
+    with _single_owner_lock(project_dir):
+        return _enforce_locked(project_dir, policy, now, backend, grace_minutes)
+
+
+def run_monitor(
+    project_dir: Path,
+    *,
+    interval_seconds: float,
+    max_ticks: Optional[int] = None,
+    backend: Optional["DeploymentBackend"] = None,
+    grace_minutes: float = 60.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> list[LabResult]:
+    """Run ``enforce`` in a single-owner loop until ``max_ticks`` (or forever).
+
+    Holds the project lock for the whole loop so a second monitor — or a
+    one-shot ``enforce`` — cannot interleave. Each tick reloads the policy so
+    edits to ``aptl.json`` take effect without a restart.
+    """
+    policy, failure = _policy_or_failure(project_dir)
+    if failure is not None:
+        return [failure]
+    if policy is None:
+        log.info("No lifecycle_policy configured; monitor has nothing to do")
+        return []
+    results: list[LabResult] = []
+    with _single_owner_lock(project_dir):
+        tick = 0
+        while max_ticks is None or tick < max_ticks:
+            policy, failure = _policy_or_failure(project_dir)
+            if failure is not None:
+                results.append(failure)
+                break
+            if policy is None:
+                break
+            now = datetime.now(timezone.utc)
+            results.append(
+                _enforce_locked(project_dir, policy, now, backend, grace_minutes)
+            )
+            tick += 1
+            if max_ticks is not None and tick >= max_ticks:
+                break
+            sleep(interval_seconds)
+    return results

--- a/src/aptl/core/lifecycle_policy.py
+++ b/src/aptl/core/lifecycle_policy.py
@@ -1,0 +1,553 @@
+"""Ephemeral lifecycle policy enforcement (DEP-003).
+
+A control-plane decision layer *above* the existing on-demand lifecycle
+(`orchestrate_lab_start` / `stop_lab` / `clean_boot_lab`, RNG-001). It does
+not reimplement Docker, SSH, or config parsing — it reads the declarative
+``lifecycle_policy`` from ``aptl.json`` and, on each enforcement tick, decides
+whether to auto-teardown (TTL or idle) or provision (schedule) the single
+project-scoped range, then acts through the same backend the manual commands
+use (ADR-013/037).
+
+Design (see ADR-045):
+
+- **Single-shot, idempotent tick.** ``enforce_once`` performs exactly one
+  evaluate-and-act cycle and returns; ``run_monitor`` is a thin loop over it.
+  Cadence is owned by the operator (systemd timer / cron) — there is no
+  long-lived daemon and the lab start path is not modified.
+- **Pure core, thin shell.** ``evaluate_ttl`` / ``evaluate_idle`` /
+  ``due_schedule_entries`` / ``decide`` are pure functions over timezone-aware
+  UTC timestamps. The IO shell observes status, computes the activity signal,
+  acts, and persists.
+- **Single owner.** A ``flock`` on ``.aptl/lifecycle/.lock`` serializes ticks
+  so a manual ``enforce`` and a running ``monitor`` cannot act concurrently.
+- **Narrow, redacted state.** ``.aptl/lifecycle/state.json`` (mode 0600) holds
+  only timestamps, the last action/result, a redacted error label, and the
+  fired-schedule dates (ADR-029). Every value passes through :func:`redact`
+  at the persist boundary.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import time
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterator, Optional
+
+from aptl.core.config import (
+    AptlConfig,
+    LabLifecyclePolicyConfig,
+    LifecycleScheduleEntry,
+    find_config,
+    load_config,
+)
+from aptl.core.lab import clean_boot_lab, lab_status, stop_lab
+from aptl.core.lab_types import (
+    DiagnosticImpact,
+    DiagnosticSeverity,
+    LabResult,
+    StartupDiagnostic,
+    StartupOutcome,
+)
+from aptl.core.runstore import resolve_active_run_dir
+from aptl.utils.logging import get_logger
+from aptl.utils.redaction import redact
+
+log = get_logger("lifecycle_policy")
+
+_STATE_DIR = Path(".aptl") / "lifecycle"
+_STATE_FILE = "state.json"
+_LOCK_FILE = ".lock"
+# Monday=0 .. Sunday=6, matching datetime.weekday().
+_WEEKDAY_NAMES = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+
+class LifecycleBusyError(RuntimeError):
+    """Raised when another lifecycle owner already holds the project lock."""
+
+
+@dataclass
+class LifecycleState:
+    """Persisted lifecycle state — narrow control-plane metadata only."""
+
+    provisioned_at: Optional[str] = None
+    last_action: str = "none"
+    last_action_at: Optional[str] = None
+    last_result: Optional[str] = None
+    last_error_label: str = ""
+    fired_schedules: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class LifecycleDecision:
+    """The single action a tick resolved to."""
+
+    action: str  # "none" | "teardown" | "provision"
+    reason: str  # short, secret-free label
+    policy: str = ""  # "ttl" | "idle" | "schedule" | ""
+    scenario: Optional[str] = None
+    schedule_key: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Pure evaluators
+# ---------------------------------------------------------------------------
+
+
+def _minutes_between(later: datetime, earlier: datetime) -> float:
+    return (later - earlier).total_seconds() / 60.0
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _to_utc(dt: datetime) -> datetime:
+    """Normalize a datetime to UTC (treating a naive value as already UTC).
+
+    Schedule times are an `HH:MM` UTC contract, so wall-clock comparisons,
+    weekday filters, and fired-date bookkeeping must happen in UTC regardless
+    of the timezone a caller's ``now`` carries.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def evaluate_ttl(
+    policy: LabLifecyclePolicyConfig,
+    provisioned_at: Optional[datetime],
+    now: datetime,
+) -> bool:
+    """True when a TTL is set and the range has lived at least that long."""
+    if policy.ttl_minutes is None or provisioned_at is None:
+        return False
+    return _minutes_between(now, provisioned_at) >= policy.ttl_minutes
+
+
+def evaluate_idle(
+    policy: LabLifecyclePolicyConfig,
+    last_activity_at: Optional[datetime],
+    now: datetime,
+) -> bool:
+    """True when an idle timeout is set and no activity within it."""
+    if policy.idle_timeout_minutes is None or last_activity_at is None:
+        return False
+    return _minutes_between(now, last_activity_at) >= policy.idle_timeout_minutes
+
+
+def schedule_entry_key(entry: LifecycleScheduleEntry) -> str:
+    """Stable identity for a schedule entry (used to dedup per-day firing)."""
+    return f"{entry.at}|{','.join(entry.days)}"
+
+
+def _entry_due(
+    entry: LifecycleScheduleEntry,
+    state: LifecycleState,
+    now: datetime,
+    grace_minutes: float,
+) -> bool:
+    now = _to_utc(now)
+    if entry.days and _WEEKDAY_NAMES[now.weekday()] not in entry.days:
+        return False
+    hour, minute = (int(p) for p in entry.at.split(":"))
+    scheduled = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if now < scheduled or _minutes_between(now, scheduled) > grace_minutes:
+        return False
+    return state.fired_schedules.get(schedule_entry_key(entry)) != now.date().isoformat()
+
+
+def due_schedule_entries(
+    policy: LabLifecyclePolicyConfig,
+    state: LifecycleState,
+    now: datetime,
+    grace_minutes: float,
+) -> list[tuple[LifecycleScheduleEntry, str]]:
+    """Schedule entries that should fire at ``now`` and have not fired today.
+
+    An entry is due when ``now`` is on or after its time today (and within
+    ``grace_minutes`` of it, so a tick hours late does not boot a stale
+    window), its optional weekday filter matches, and it has not already
+    fired on ``now``'s date.
+    """
+    return [
+        (entry, schedule_entry_key(entry))
+        for entry in policy.schedule
+        if _entry_due(entry, state, now, grace_minutes)
+    ]
+
+
+def _decide_running(
+    policy: LabLifecyclePolicyConfig,
+    state: LifecycleState,
+    now: datetime,
+    last_activity_at: Optional[datetime],
+) -> LifecycleDecision:
+    if evaluate_ttl(policy, _parse_iso(state.provisioned_at), now):
+        return LifecycleDecision("teardown", "ttl_exceeded", "ttl")
+    if evaluate_idle(policy, last_activity_at, now):
+        return LifecycleDecision("teardown", "idle_timeout", "idle")
+    return LifecycleDecision("none", "running_within_policy")
+
+
+def _decide_stopped(
+    policy: LabLifecyclePolicyConfig,
+    state: LifecycleState,
+    now: datetime,
+    grace_minutes: float,
+) -> LifecycleDecision:
+    due = due_schedule_entries(policy, state, now, grace_minutes)
+    if not due:
+        return LifecycleDecision("none", "stopped_no_schedule")
+    entry, key = due[0]
+    return LifecycleDecision(
+        "provision", "scheduled", "schedule",
+        scenario=entry.scenario, schedule_key=key,
+    )
+
+
+def decide(
+    policy: LabLifecyclePolicyConfig,
+    state: LifecycleState,
+    now: datetime,
+    running: bool,
+    last_activity_at: Optional[datetime],
+    grace_minutes: float,
+) -> LifecycleDecision:
+    """Resolve a tick to exactly one action.
+
+    Running ranges are checked for TTL (first) then idle expiry; stopped
+    ranges are checked for a due schedule entry. TTL takes precedence over
+    idle because an expired range must go regardless of recent activity.
+    """
+    if running:
+        return _decide_running(policy, state, now, last_activity_at)
+    return _decide_stopped(policy, state, now, grace_minutes)
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def state_path(project_dir: Path) -> Path:
+    return project_dir / _STATE_DIR / _STATE_FILE
+
+
+def _read_state_file(path: Path) -> Optional[dict]:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        log.warning("Unreadable lifecycle state at %s; starting fresh", path)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_state(project_dir: Path) -> LifecycleState:
+    """Load lifecycle state, returning a fresh default on absence/corruption."""
+    data = _read_state_file(state_path(project_dir))
+    if data is None:
+        return LifecycleState()
+    fired = data.get("fired_schedules")
+    return LifecycleState(
+        provisioned_at=data.get("provisioned_at"),
+        last_action=data.get("last_action", "none"),
+        last_action_at=data.get("last_action_at"),
+        last_result=data.get("last_result"),
+        last_error_label=data.get("last_error_label", ""),
+        fired_schedules=fired if isinstance(fired, dict) else {},
+    )
+
+
+def save_state(project_dir: Path, state: LifecycleState) -> None:
+    """Persist lifecycle state (mode 0600), redacted at the boundary."""
+    path = state_path(project_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = redact(asdict(state))
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    path.chmod(0o600)
+
+
+# ---------------------------------------------------------------------------
+# Activity signal + single-owner lock
+# ---------------------------------------------------------------------------
+
+
+def _newest_mtime(directory: Optional[Path]) -> Optional[datetime]:
+    if directory is None or not directory.exists():
+        return None
+    newest: Optional[float] = None
+    for child in directory.rglob("*"):
+        try:
+            mtime = child.stat().st_mtime
+        except OSError:
+            continue
+        if newest is None or mtime > newest:
+            newest = mtime
+    return datetime.fromtimestamp(newest, tz=timezone.utc) if newest else None
+
+
+def _latest_activity_at(project_dir: Path, state: LifecycleState) -> Optional[datetime]:
+    """Newest of: provisioning time and most-recent capture under the active run.
+
+    Capture recency under the active run directory is the narrow
+    control-plane activity signal — when the red/blue MCP servers last wrote
+    evidence. Falls back to provisioning time when no scenario is active.
+    """
+    candidates: list[datetime] = []
+    provisioned = _parse_iso(state.provisioned_at)
+    if provisioned is not None:
+        candidates.append(provisioned)
+    active = resolve_active_run_dir(project_dir / ".aptl")
+    newest = _newest_mtime(active)
+    if newest is not None:
+        candidates.append(newest)
+    return max(candidates) if candidates else None
+
+
+@contextmanager
+def _single_owner_lock(project_dir: Path) -> Iterator[None]:
+    lock_path = project_dir / _STATE_DIR / _LOCK_FILE
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("w")
+    try:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise LifecycleBusyError(
+                "another lifecycle owner is active (enforce/monitor lock held)"
+            ) from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
+# ---------------------------------------------------------------------------
+# IO shell
+# ---------------------------------------------------------------------------
+
+
+def _load_policy(project_dir: Path) -> tuple[Optional[AptlConfig], Optional[LabLifecyclePolicyConfig]]:
+    config_path = find_config(project_dir)
+    if config_path is None:
+        return None, None
+    config = load_config(config_path)
+    return config, config.lifecycle_policy
+
+
+def _policy_or_failure(
+    project_dir: Path,
+) -> tuple[Optional[LabLifecyclePolicyConfig], Optional[LabResult]]:
+    """Resolve the policy, or a FAILED result when ``aptl.json`` is malformed.
+
+    A missing config (no ``aptl.json``) or an absent ``lifecycle_policy`` is a
+    legitimate no-op. A config that is present but invalid must NOT read as a
+    clean no-op — that would let a typo silently disable an unattended TTL or
+    idle timer — so it surfaces as a failed tick the scheduler can detect.
+    """
+    try:
+        _, policy = _load_policy(project_dir)
+    except (OSError, ValueError) as exc:
+        return None, LabResult(
+            success=False,
+            message="lifecycle: invalid configuration",
+            error=redact(f"invalid aptl.json: {exc}"),
+            outcome=StartupOutcome.FAILED,
+        )
+    return policy, None
+
+
+def _diag(message: str) -> StartupDiagnostic:
+    return StartupDiagnostic(
+        step="lifecycle_enforce",
+        impact=DiagnosticImpact.COSMETIC,
+        severity=DiagnosticSeverity.INFO,
+        message=message,
+    )
+
+
+def _apply_teardown(
+    project_dir: Path,
+    policy: LabLifecyclePolicyConfig,
+    state: LifecycleState,
+    decision: LifecycleDecision,
+    now: datetime,
+    backend,
+) -> LabResult:
+    log.info("Lifecycle teardown (%s)", decision.reason)
+    result = stop_lab(
+        remove_volumes=policy.teardown_remove_volumes,
+        project_dir=project_dir,
+        backend=backend,
+    )
+    state.last_action = "teardown"
+    state.last_action_at = now.isoformat()
+    state.last_result = result.outcome.value
+    state.last_error_label = redact(result.error) if result.error else ""
+    if result.success:
+        state.provisioned_at = None
+    return LabResult(
+        success=result.success,
+        message=f"lifecycle: teardown ({decision.reason})",
+        error=result.error,
+        outcome=result.outcome,
+        diagnostics=[_diag(f"teardown triggered by {decision.policy} policy")],
+    )
+
+
+def _resolve_schedule_scenario(project_dir: Path, scenario: Optional[str]) -> Optional[Path]:
+    if not scenario:
+        return None
+    from aptl.core.scenario_catalog import resolve_scenario_selection
+
+    return resolve_scenario_selection(project_dir, scenario_id=scenario)
+
+
+def _apply_provision(
+    project_dir: Path,
+    state: LifecycleState,
+    decision: LifecycleDecision,
+    now: datetime,
+    backend,
+) -> LabResult:
+    log.info("Lifecycle scheduled provisioning (%s)", decision.schedule_key)
+    scenario_path = _resolve_schedule_scenario(project_dir, decision.scenario)
+    # Scheduled provisioning is an ephemeral clean boot: guarantee fresh state
+    # regardless of any residue from a prior run (RNG-001).
+    result = clean_boot_lab(
+        project_dir,
+        remove_volumes=True,
+        scenario_path=scenario_path,
+        backend=backend,
+    )
+    state.last_action = "provision"
+    state.last_action_at = now.isoformat()
+    state.last_result = result.outcome.value
+    state.last_error_label = redact(result.error) if result.error else ""
+    if result.success:
+        state.provisioned_at = now.isoformat()
+        # Only consume the day's fire marker on success, so a failed provision
+        # (transient backend/Docker/readiness fault) is retried by a later tick
+        # while the grace window is still open.
+        if decision.schedule_key:
+            state.fired_schedules[decision.schedule_key] = now.date().isoformat()
+    result.message = f"lifecycle: provision ({decision.reason})"
+    return result
+
+
+def _apply_decision(
+    project_dir: Path,
+    policy: LabLifecyclePolicyConfig,
+    state: LifecycleState,
+    decision: LifecycleDecision,
+    now: datetime,
+    backend,
+) -> LabResult:
+    if decision.action == "teardown":
+        return _apply_teardown(project_dir, policy, state, decision, now, backend)
+    if decision.action == "provision":
+        return _apply_provision(project_dir, state, decision, now, backend)
+    return LabResult(success=True, message=f"lifecycle: no action ({decision.reason})")
+
+
+def _enforce_locked(
+    project_dir: Path,
+    policy: LabLifecyclePolicyConfig,
+    now: datetime,
+    backend,
+    grace_minutes: float,
+) -> LabResult:
+    state = load_state(project_dir)
+    status = lab_status(project_dir=project_dir, backend=backend)
+    running = status.running
+    # Reconcile provisioning time against observed reality so TTL/idle behave
+    # identically whether the lab was started manually or by a prior tick.
+    if running and not state.provisioned_at:
+        state.provisioned_at = now.isoformat()
+    elif not running and state.provisioned_at:
+        state.provisioned_at = None
+    last_activity = _latest_activity_at(project_dir, state)
+    decision = decide(policy, state, now, running, last_activity, grace_minutes)
+    result = _apply_decision(project_dir, policy, state, decision, now, backend)
+    save_state(project_dir, state)
+    return result
+
+
+def enforce_once(
+    project_dir: Path,
+    *,
+    now: Optional[datetime] = None,
+    backend=None,
+    grace_minutes: float = 60.0,
+) -> LabResult:
+    """Run exactly one lifecycle evaluate-and-act cycle.
+
+    Idempotent: at most one action (teardown or provision) per tick. A no-op
+    when no ``lifecycle_policy`` is configured. Raises
+    :class:`LifecycleBusyError` when another owner holds the project lock.
+    """
+    now = _to_utc(now) if now is not None else datetime.now(timezone.utc)
+    policy, failure = _policy_or_failure(project_dir)
+    if failure is not None:
+        return failure
+    if policy is None:
+        return LabResult(
+            success=True, message="lifecycle: no policy configured; nothing to enforce"
+        )
+    with _single_owner_lock(project_dir):
+        return _enforce_locked(project_dir, policy, now, backend, grace_minutes)
+
+
+def run_monitor(
+    project_dir: Path,
+    *,
+    interval_seconds: float,
+    max_ticks: Optional[int] = None,
+    backend=None,
+    grace_minutes: float = 60.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> list[LabResult]:
+    """Run ``enforce`` in a single-owner loop until ``max_ticks`` (or forever).
+
+    Holds the project lock for the whole loop so a second monitor — or a
+    one-shot ``enforce`` — cannot interleave. Each tick reloads the policy so
+    edits to ``aptl.json`` take effect without a restart.
+    """
+    policy, failure = _policy_or_failure(project_dir)
+    if failure is not None:
+        return [failure]
+    if policy is None:
+        log.info("No lifecycle_policy configured; monitor has nothing to do")
+        return []
+    results: list[LabResult] = []
+    with _single_owner_lock(project_dir):
+        tick = 0
+        while max_ticks is None or tick < max_ticks:
+            policy, failure = _policy_or_failure(project_dir)
+            if failure is not None:
+                results.append(failure)
+                break
+            if policy is None:
+                break
+            now = datetime.now(timezone.utc)
+            results.append(
+                _enforce_locked(project_dir, policy, now, backend, grace_minutes)
+            )
+            tick += 1
+            if max_ticks is not None and tick >= max_ticks:
+                break
+            sleep(interval_seconds)
+    return results

--- a/src/aptl/core/lifecycle_policy.py
+++ b/src/aptl/core/lifecycle_policy.py
@@ -1,58 +1,24 @@
-"""Ephemeral lifecycle policy enforcement (DEP-003).
+"""Ephemeral lifecycle policy: model, pure evaluators, and state (DEP-003).
 
-A control-plane decision layer *above* the existing on-demand lifecycle
-(`orchestrate_lab_start` / `stop_lab` / `clean_boot_lab`, RNG-001). It does
-not reimplement Docker, SSH, or config parsing — it reads the declarative
-``lifecycle_policy`` from ``aptl.json`` and, on each enforcement tick, decides
-whether to auto-teardown (TTL or idle) or provision (schedule) the single
-project-scoped range, then acts through the same backend the manual commands
-use (ADR-013/037).
+This module is the side-effect-free half of the lifecycle feature: the policy
+decision model, the pure TTL/idle/schedule evaluators over timezone-aware UTC
+timestamps, and the narrow persisted state. The enforcement runtime that
+observes the lab and acts on a decision lives in
+:mod:`aptl.core.lifecycle_enforce`.
 
-Design (see ADR-045):
-
-- **Single-shot, idempotent tick.** ``enforce_once`` performs exactly one
-  evaluate-and-act cycle and returns; ``run_monitor`` is a thin loop over it.
-  Cadence is owned by the operator (systemd timer / cron) — there is no
-  long-lived daemon and the lab start path is not modified.
-- **Pure core, thin shell.** ``evaluate_ttl`` / ``evaluate_idle`` /
-  ``due_schedule_entries`` / ``decide`` are pure functions over timezone-aware
-  UTC timestamps. The IO shell observes status, computes the activity signal,
-  acts, and persists.
-- **Single owner.** A ``flock`` on ``.aptl/lifecycle/.lock`` serializes ticks
-  so a manual ``enforce`` and a running ``monitor`` cannot act concurrently.
-- **Narrow, redacted state.** ``.aptl/lifecycle/state.json`` (mode 0600) holds
-  only timestamps, the last action/result, a redacted error label, and the
-  fired-schedule dates (ADR-029). Every value passes through :func:`redact`
-  at the persist boundary.
+See ADR-045 for the overall design (single-shot idempotent tick, UTC schedule
+contract, capture-recency idle signal, single-owner lock, redacted state).
 """
 
 from __future__ import annotations
 
-import fcntl
 import json
-import time
-from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Iterator, Optional
+from typing import Optional
 
-from aptl.core.config import (
-    AptlConfig,
-    LabLifecyclePolicyConfig,
-    LifecycleScheduleEntry,
-    find_config,
-    load_config,
-)
-from aptl.core.lab import clean_boot_lab, lab_status, stop_lab
-from aptl.core.lab_types import (
-    DiagnosticImpact,
-    DiagnosticSeverity,
-    LabResult,
-    StartupDiagnostic,
-    StartupOutcome,
-)
-from aptl.core.runstore import resolve_active_run_dir
+from aptl.core.config import LabLifecyclePolicyConfig, LifecycleScheduleEntry
 from aptl.utils.logging import get_logger
 from aptl.utils.redaction import redact
 
@@ -83,11 +49,17 @@ class LifecycleState:
 
 @dataclass
 class LifecycleDecision:
-    """The single action a tick resolved to."""
+    """The single action a tick resolved to.
 
-    action: str  # "none" | "teardown" | "provision"
-    reason: str  # short, secret-free label
-    policy: str = ""  # "ttl" | "idle" | "schedule" | ""
+    ``action`` is one of ``none`` / ``teardown`` / ``provision``; ``reason`` is
+    a short, secret-free label; ``policy`` names the triggering policy
+    (``ttl`` / ``idle`` / ``schedule`` / empty). ``scenario`` and
+    ``schedule_key`` are populated only for a scheduled provision.
+    """
+
+    action: str
+    reason: str
+    policy: str = ""
     scenario: Optional[str] = None
     schedule_key: Optional[str] = None
 
@@ -98,10 +70,12 @@ class LifecycleDecision:
 
 
 def _minutes_between(later: datetime, earlier: datetime) -> float:
+    """Return the elapsed minutes from ``earlier`` to ``later``."""
     return (later - earlier).total_seconds() / 60.0
 
 
 def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp, returning None on absence or a bad value."""
     if not value:
         return None
     try:
@@ -155,6 +129,7 @@ def _entry_due(
     now: datetime,
     grace_minutes: float,
 ) -> bool:
+    """True when a single schedule entry is due at ``now`` and not fired today."""
     now = _to_utc(now)
     if entry.days and _WEEKDAY_NAMES[now.weekday()] not in entry.days:
         return False
@@ -191,6 +166,7 @@ def _decide_running(
     now: datetime,
     last_activity_at: Optional[datetime],
 ) -> LifecycleDecision:
+    """Resolve the action for a running range (TTL first, then idle)."""
     if evaluate_ttl(policy, _parse_iso(state.provisioned_at), now):
         return LifecycleDecision("teardown", "ttl_exceeded", "ttl")
     if evaluate_idle(policy, last_activity_at, now):
@@ -204,6 +180,7 @@ def _decide_stopped(
     now: datetime,
     grace_minutes: float,
 ) -> LifecycleDecision:
+    """Resolve the action for a stopped range (provision if a schedule is due)."""
     due = due_schedule_entries(policy, state, now, grace_minutes)
     if not due:
         return LifecycleDecision("none", "stopped_no_schedule")
@@ -239,10 +216,12 @@ def decide(
 
 
 def state_path(project_dir: Path) -> Path:
+    """Return the lifecycle state file path under the project's ``.aptl`` dir."""
     return project_dir / _STATE_DIR / _STATE_FILE
 
 
-def _read_state_file(path: Path) -> Optional[dict]:
+def _read_state_file(path: Path) -> Optional[dict[str, object]]:
+    """Read and JSON-parse the state file, or None on absence/corruption."""
     if not path.exists():
         return None
     try:
@@ -276,278 +255,3 @@ def save_state(project_dir: Path, state: LifecycleState) -> None:
     payload = redact(asdict(state))
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     path.chmod(0o600)
-
-
-# ---------------------------------------------------------------------------
-# Activity signal + single-owner lock
-# ---------------------------------------------------------------------------
-
-
-def _newest_mtime(directory: Optional[Path]) -> Optional[datetime]:
-    if directory is None or not directory.exists():
-        return None
-    newest: Optional[float] = None
-    for child in directory.rglob("*"):
-        try:
-            mtime = child.stat().st_mtime
-        except OSError:
-            continue
-        if newest is None or mtime > newest:
-            newest = mtime
-    return datetime.fromtimestamp(newest, tz=timezone.utc) if newest else None
-
-
-def _latest_activity_at(project_dir: Path, state: LifecycleState) -> Optional[datetime]:
-    """Newest of: provisioning time and most-recent capture under the active run.
-
-    Capture recency under the active run directory is the narrow
-    control-plane activity signal — when the red/blue MCP servers last wrote
-    evidence. Falls back to provisioning time when no scenario is active.
-    """
-    candidates: list[datetime] = []
-    provisioned = _parse_iso(state.provisioned_at)
-    if provisioned is not None:
-        candidates.append(provisioned)
-    active = resolve_active_run_dir(project_dir / ".aptl")
-    newest = _newest_mtime(active)
-    if newest is not None:
-        candidates.append(newest)
-    return max(candidates) if candidates else None
-
-
-@contextmanager
-def _single_owner_lock(project_dir: Path) -> Iterator[None]:
-    lock_path = project_dir / _STATE_DIR / _LOCK_FILE
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    handle = lock_path.open("w")
-    try:
-        try:
-            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError as exc:
-            raise LifecycleBusyError(
-                "another lifecycle owner is active (enforce/monitor lock held)"
-            ) from exc
-        try:
-            yield
-        finally:
-            fcntl.flock(handle, fcntl.LOCK_UN)
-    finally:
-        handle.close()
-
-
-# ---------------------------------------------------------------------------
-# IO shell
-# ---------------------------------------------------------------------------
-
-
-def _load_policy(project_dir: Path) -> tuple[Optional[AptlConfig], Optional[LabLifecyclePolicyConfig]]:
-    config_path = find_config(project_dir)
-    if config_path is None:
-        return None, None
-    config = load_config(config_path)
-    return config, config.lifecycle_policy
-
-
-def _policy_or_failure(
-    project_dir: Path,
-) -> tuple[Optional[LabLifecyclePolicyConfig], Optional[LabResult]]:
-    """Resolve the policy, or a FAILED result when ``aptl.json`` is malformed.
-
-    A missing config (no ``aptl.json``) or an absent ``lifecycle_policy`` is a
-    legitimate no-op. A config that is present but invalid must NOT read as a
-    clean no-op — that would let a typo silently disable an unattended TTL or
-    idle timer — so it surfaces as a failed tick the scheduler can detect.
-    """
-    try:
-        _, policy = _load_policy(project_dir)
-    except (OSError, ValueError) as exc:
-        return None, LabResult(
-            success=False,
-            message="lifecycle: invalid configuration",
-            error=redact(f"invalid aptl.json: {exc}"),
-            outcome=StartupOutcome.FAILED,
-        )
-    return policy, None
-
-
-def _diag(message: str) -> StartupDiagnostic:
-    return StartupDiagnostic(
-        step="lifecycle_enforce",
-        impact=DiagnosticImpact.COSMETIC,
-        severity=DiagnosticSeverity.INFO,
-        message=message,
-    )
-
-
-def _apply_teardown(
-    project_dir: Path,
-    policy: LabLifecyclePolicyConfig,
-    state: LifecycleState,
-    decision: LifecycleDecision,
-    now: datetime,
-    backend,
-) -> LabResult:
-    log.info("Lifecycle teardown (%s)", decision.reason)
-    result = stop_lab(
-        remove_volumes=policy.teardown_remove_volumes,
-        project_dir=project_dir,
-        backend=backend,
-    )
-    state.last_action = "teardown"
-    state.last_action_at = now.isoformat()
-    state.last_result = result.outcome.value
-    state.last_error_label = redact(result.error) if result.error else ""
-    if result.success:
-        state.provisioned_at = None
-    return LabResult(
-        success=result.success,
-        message=f"lifecycle: teardown ({decision.reason})",
-        error=result.error,
-        outcome=result.outcome,
-        diagnostics=[_diag(f"teardown triggered by {decision.policy} policy")],
-    )
-
-
-def _resolve_schedule_scenario(project_dir: Path, scenario: Optional[str]) -> Optional[Path]:
-    if not scenario:
-        return None
-    from aptl.core.scenario_catalog import resolve_scenario_selection
-
-    return resolve_scenario_selection(project_dir, scenario_id=scenario)
-
-
-def _apply_provision(
-    project_dir: Path,
-    state: LifecycleState,
-    decision: LifecycleDecision,
-    now: datetime,
-    backend,
-) -> LabResult:
-    log.info("Lifecycle scheduled provisioning (%s)", decision.schedule_key)
-    scenario_path = _resolve_schedule_scenario(project_dir, decision.scenario)
-    # Scheduled provisioning is an ephemeral clean boot: guarantee fresh state
-    # regardless of any residue from a prior run (RNG-001).
-    result = clean_boot_lab(
-        project_dir,
-        remove_volumes=True,
-        scenario_path=scenario_path,
-        backend=backend,
-    )
-    state.last_action = "provision"
-    state.last_action_at = now.isoformat()
-    state.last_result = result.outcome.value
-    state.last_error_label = redact(result.error) if result.error else ""
-    if result.success:
-        state.provisioned_at = now.isoformat()
-        # Only consume the day's fire marker on success, so a failed provision
-        # (transient backend/Docker/readiness fault) is retried by a later tick
-        # while the grace window is still open.
-        if decision.schedule_key:
-            state.fired_schedules[decision.schedule_key] = now.date().isoformat()
-    result.message = f"lifecycle: provision ({decision.reason})"
-    return result
-
-
-def _apply_decision(
-    project_dir: Path,
-    policy: LabLifecyclePolicyConfig,
-    state: LifecycleState,
-    decision: LifecycleDecision,
-    now: datetime,
-    backend,
-) -> LabResult:
-    if decision.action == "teardown":
-        return _apply_teardown(project_dir, policy, state, decision, now, backend)
-    if decision.action == "provision":
-        return _apply_provision(project_dir, state, decision, now, backend)
-    return LabResult(success=True, message=f"lifecycle: no action ({decision.reason})")
-
-
-def _enforce_locked(
-    project_dir: Path,
-    policy: LabLifecyclePolicyConfig,
-    now: datetime,
-    backend,
-    grace_minutes: float,
-) -> LabResult:
-    state = load_state(project_dir)
-    status = lab_status(project_dir=project_dir, backend=backend)
-    running = status.running
-    # Reconcile provisioning time against observed reality so TTL/idle behave
-    # identically whether the lab was started manually or by a prior tick.
-    if running and not state.provisioned_at:
-        state.provisioned_at = now.isoformat()
-    elif not running and state.provisioned_at:
-        state.provisioned_at = None
-    last_activity = _latest_activity_at(project_dir, state)
-    decision = decide(policy, state, now, running, last_activity, grace_minutes)
-    result = _apply_decision(project_dir, policy, state, decision, now, backend)
-    save_state(project_dir, state)
-    return result
-
-
-def enforce_once(
-    project_dir: Path,
-    *,
-    now: Optional[datetime] = None,
-    backend=None,
-    grace_minutes: float = 60.0,
-) -> LabResult:
-    """Run exactly one lifecycle evaluate-and-act cycle.
-
-    Idempotent: at most one action (teardown or provision) per tick. A no-op
-    when no ``lifecycle_policy`` is configured. Raises
-    :class:`LifecycleBusyError` when another owner holds the project lock.
-    """
-    now = _to_utc(now) if now is not None else datetime.now(timezone.utc)
-    policy, failure = _policy_or_failure(project_dir)
-    if failure is not None:
-        return failure
-    if policy is None:
-        return LabResult(
-            success=True, message="lifecycle: no policy configured; nothing to enforce"
-        )
-    with _single_owner_lock(project_dir):
-        return _enforce_locked(project_dir, policy, now, backend, grace_minutes)
-
-
-def run_monitor(
-    project_dir: Path,
-    *,
-    interval_seconds: float,
-    max_ticks: Optional[int] = None,
-    backend=None,
-    grace_minutes: float = 60.0,
-    sleep: Callable[[float], None] = time.sleep,
-) -> list[LabResult]:
-    """Run ``enforce`` in a single-owner loop until ``max_ticks`` (or forever).
-
-    Holds the project lock for the whole loop so a second monitor — or a
-    one-shot ``enforce`` — cannot interleave. Each tick reloads the policy so
-    edits to ``aptl.json`` take effect without a restart.
-    """
-    policy, failure = _policy_or_failure(project_dir)
-    if failure is not None:
-        return [failure]
-    if policy is None:
-        log.info("No lifecycle_policy configured; monitor has nothing to do")
-        return []
-    results: list[LabResult] = []
-    with _single_owner_lock(project_dir):
-        tick = 0
-        while max_ticks is None or tick < max_ticks:
-            policy, failure = _policy_or_failure(project_dir)
-            if failure is not None:
-                results.append(failure)
-                break
-            if policy is None:
-                break
-            now = datetime.now(timezone.utc)
-            results.append(
-                _enforce_locked(project_dir, policy, now, backend, grace_minutes)
-            )
-            tick += 1
-            if max_ticks is not None and tick >= max_ticks:
-                break
-            sleep(interval_seconds)
-    return results

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -1,0 +1,131 @@
+"""CLI tests for the DEP-003 lifecycle commands.
+
+Wiring tests only — the lifecycle logic itself is covered by
+``test_lifecycle_policy.py``. The core entrypoints (`enforce_once`,
+`run_monitor`) are patched so no Docker or real lab is touched.
+"""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from aptl.cli.main import app
+from aptl.core import lifecycle_policy as lp
+from aptl.core.lab_types import LabResult, StartupOutcome
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _write_config(tmp_path, lifecycle_policy=None):
+    payload = {"lab": {"name": "aptl"}}
+    if lifecycle_policy is not None:
+        payload["lifecycle_policy"] = lifecycle_policy
+    (tmp_path / "aptl.json").write_text(json.dumps(payload))
+
+
+class TestEnforceCommand:
+    def test_help(self, runner):
+        result = runner.invoke(app, ["lab", "enforce", "--help"])
+        assert result.exit_code == 0
+        assert "idempotent" in result.stdout.lower()
+
+    def test_success_prints_message(self, runner, monkeypatch):
+        monkeypatch.setattr(
+            lp, "enforce_once",
+            lambda *a, **k: LabResult(success=True, message="lifecycle: no action (x)"),
+        )
+        result = runner.invoke(app, ["lab", "enforce"])
+        assert result.exit_code == 0
+        assert "lifecycle: no action" in result.stdout
+
+    def test_passes_grace_minutes(self, runner, monkeypatch):
+        seen = {}
+
+        def fake(project_dir, **kwargs):
+            seen.update(kwargs)
+            return LabResult(success=True, message="ok")
+
+        monkeypatch.setattr(lp, "enforce_once", fake)
+        result = runner.invoke(app, ["lab", "enforce", "--grace-minutes", "15"])
+        assert result.exit_code == 0
+        assert seen["grace_minutes"] == 15
+
+    def test_failure_exits_nonzero(self, runner, monkeypatch):
+        monkeypatch.setattr(
+            lp, "enforce_once",
+            lambda *a, **k: LabResult(
+                success=False, message="lifecycle: teardown (ttl_exceeded)", error="boom"
+            ),
+        )
+        result = runner.invoke(app, ["lab", "enforce"])
+        assert result.exit_code == 1
+
+    def test_busy_exits_nonzero(self, runner, monkeypatch):
+        def raise_busy(*a, **k):
+            raise lp.LifecycleBusyError("locked")
+
+        monkeypatch.setattr(lp, "enforce_once", raise_busy)
+        result = runner.invoke(app, ["lab", "enforce"])
+        assert result.exit_code == 1
+        assert "locked" in result.stdout + result.stderr
+
+
+class TestMonitorCommand:
+    def test_help(self, runner):
+        result = runner.invoke(app, ["lab", "monitor", "--help"])
+        assert result.exit_code == 0
+
+    def test_wires_arguments(self, runner, monkeypatch):
+        seen = {}
+
+        def fake(project_dir, **kwargs):
+            seen.update(kwargs)
+            return [LabResult(success=True, message="tick")]
+
+        monkeypatch.setattr(lp, "run_monitor", fake)
+        result = runner.invoke(
+            app, ["lab", "monitor", "--interval", "30", "--max-ticks", "2"]
+        )
+        assert result.exit_code == 0
+        assert seen["interval_seconds"] == 30
+        assert seen["max_ticks"] == 2
+        assert "tick" in result.stdout
+
+
+class TestPolicyShowCommand:
+    def test_no_policy(self, runner, tmp_path):
+        _write_config(tmp_path)
+        result = runner.invoke(
+            app, ["lab", "policy", "show", "--project-dir", str(tmp_path)]
+        )
+        assert result.exit_code == 0
+        assert "No lifecycle_policy configured" in result.stdout
+
+    def test_renders_policy_fields(self, runner, tmp_path):
+        _write_config(
+            tmp_path,
+            {
+                "ttl_minutes": 240,
+                "schedule": [{"at": "08:00", "days": ["mon"], "scenario": "tv"}],
+            },
+        )
+        result = runner.invoke(
+            app, ["lab", "policy", "show", "--project-dir", str(tmp_path)]
+        )
+        assert result.exit_code == 0
+        assert "ttl_minutes: 240" in result.stdout
+        assert "08:00 UTC [mon] scenario=tv" in result.stdout
+
+    def test_json_output(self, runner, tmp_path):
+        _write_config(tmp_path, {"ttl_minutes": 60})
+        result = runner.invoke(
+            app, ["lab", "policy", "show", "--project-dir", str(tmp_path), "--json"]
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["policy"]["ttl_minutes"] == 60
+        assert payload["state"]["last_action"] == "none"

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -11,7 +11,7 @@ import pytest
 from typer.testing import CliRunner
 
 from aptl.cli.main import app
-from aptl.core import lifecycle_policy as lp
+from aptl.core import lifecycle_enforce as le
 from aptl.core.lab_types import LabResult, StartupOutcome
 
 
@@ -35,7 +35,7 @@ class TestEnforceCommand:
 
     def test_success_prints_message(self, runner, monkeypatch):
         monkeypatch.setattr(
-            lp, "enforce_once",
+            le, "enforce_once",
             lambda *a, **k: LabResult(success=True, message="lifecycle: no action (x)"),
         )
         result = runner.invoke(app, ["lab", "enforce"])
@@ -49,14 +49,14 @@ class TestEnforceCommand:
             seen.update(kwargs)
             return LabResult(success=True, message="ok")
 
-        monkeypatch.setattr(lp, "enforce_once", fake)
+        monkeypatch.setattr(le, "enforce_once", fake)
         result = runner.invoke(app, ["lab", "enforce", "--grace-minutes", "15"])
         assert result.exit_code == 0
         assert seen["grace_minutes"] == 15
 
     def test_failure_exits_nonzero(self, runner, monkeypatch):
         monkeypatch.setattr(
-            lp, "enforce_once",
+            le, "enforce_once",
             lambda *a, **k: LabResult(
                 success=False, message="lifecycle: teardown (ttl_exceeded)", error="boom"
             ),
@@ -66,9 +66,9 @@ class TestEnforceCommand:
 
     def test_busy_exits_nonzero(self, runner, monkeypatch):
         def raise_busy(*a, **k):
-            raise lp.LifecycleBusyError("locked")
+            raise le.LifecycleBusyError("locked")
 
-        monkeypatch.setattr(lp, "enforce_once", raise_busy)
+        monkeypatch.setattr(le, "enforce_once", raise_busy)
         result = runner.invoke(app, ["lab", "enforce"])
         assert result.exit_code == 1
         assert "locked" in result.stdout + result.stderr
@@ -86,7 +86,7 @@ class TestMonitorCommand:
             seen.update(kwargs)
             return [LabResult(success=True, message="tick")]
 
-        monkeypatch.setattr(lp, "run_monitor", fake)
+        monkeypatch.setattr(le, "run_monitor", fake)
         result = runner.invoke(
             app, ["lab", "monitor", "--interval", "30", "--max-ticks", "2"]
         )

--- a/tests/test_lifecycle_policy.py
+++ b/tests/test_lifecycle_policy.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from aptl.core import lifecycle_enforce as le
 from aptl.core import lifecycle_policy as lp
 from aptl.core.config import (
     AptlConfig,
@@ -273,19 +274,19 @@ def _write_policy_config(tmp_path, policy_dict):
 class TestEnforceOnce:
     def test_no_policy_is_noop(self, tmp_path):
         (tmp_path / "aptl.json").write_text(json.dumps({"lab": {"name": "aptl"}}))
-        result = lp.enforce_once(tmp_path)
+        result = le.enforce_once(tmp_path)
         assert result.success is True
 
     def test_no_config_is_noop(self, tmp_path):
-        result = lp.enforce_once(tmp_path)
+        result = le.enforce_once(tmp_path)
         assert result.success is True
 
     def test_running_within_policy_takes_no_action(self, tmp_path, monkeypatch):
         _write_policy_config(tmp_path, {"ttl_minutes": 240})
-        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=True))
+        monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=True))
         calls = []
-        monkeypatch.setattr(lp, "stop_lab", lambda **k: calls.append("stop") or LabResult(success=True))
-        result = lp.enforce_once(tmp_path, now=_now())
+        monkeypatch.setattr(le, "stop_lab", lambda **k: calls.append("stop") or LabResult(success=True))
+        result = le.enforce_once(tmp_path, now=_now())
         assert calls == []
         assert result.success is True
         # first observation of a running lab stamps provisioned_at
@@ -295,13 +296,13 @@ class TestEnforceOnce:
         _write_policy_config(tmp_path, {"ttl_minutes": 60, "teardown_remove_volumes": True})
         # seed state with an old provisioned_at so TTL is already exceeded
         lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=10).isoformat()))
-        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=True))
+        monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=True))
         seen = {}
         def fake_stop(**kwargs):
             seen.update(kwargs)
             return LabResult(success=True)
-        monkeypatch.setattr(lp, "stop_lab", fake_stop)
-        result = lp.enforce_once(tmp_path, now=_now(hour=12))
+        monkeypatch.setattr(le, "stop_lab", fake_stop)
+        result = le.enforce_once(tmp_path, now=_now(hour=12))
         assert seen.get("remove_volumes") is True
         assert result.success is True
         state = lp.load_state(tmp_path)
@@ -311,10 +312,10 @@ class TestEnforceOnce:
     def test_idle_expired_calls_stop_lab(self, tmp_path, monkeypatch):
         _write_policy_config(tmp_path, {"idle_timeout_minutes": 30})
         lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=10).isoformat()))
-        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=True))
+        monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=True))
         called = []
-        monkeypatch.setattr(lp, "stop_lab", lambda **k: called.append(True) or LabResult(success=True))
-        result = lp.enforce_once(tmp_path, now=_now(hour=12))
+        monkeypatch.setattr(le, "stop_lab", lambda **k: called.append(True) or LabResult(success=True))
+        result = le.enforce_once(tmp_path, now=_now(hour=12))
         assert called == [True]
         assert result.success is True
         state = lp.load_state(tmp_path)
@@ -323,13 +324,13 @@ class TestEnforceOnce:
 
     def test_scheduled_provision_calls_clean_boot(self, tmp_path, monkeypatch):
         _write_policy_config(tmp_path, {"schedule": [{"at": "08:00"}]})
-        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
         booted = []
         monkeypatch.setattr(
-            lp, "clean_boot_lab",
+            le, "clean_boot_lab",
             lambda *a, **k: booted.append(True) or LabResult(success=True, outcome=StartupOutcome.READY),
         )
-        result = lp.enforce_once(tmp_path, now=_now(hour=8, minute=5))
+        result = le.enforce_once(tmp_path, now=_now(hour=8, minute=5))
         assert booted == [True]
         assert result.success is True
         state = lp.load_state(tmp_path)
@@ -342,14 +343,14 @@ class TestEnforceOnce:
         # A failed provision must NOT consume the day's fire marker, so a
         # later tick inside the grace window retries it.
         _write_policy_config(tmp_path, {"schedule": [{"at": "08:00"}]})
-        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
         monkeypatch.setattr(
-            lp, "clean_boot_lab",
+            le, "clean_boot_lab",
             lambda *a, **k: LabResult(
                 success=False, error="boom", outcome=StartupOutcome.FAILED
             ),
         )
-        result = lp.enforce_once(tmp_path, now=_now(hour=8, minute=5))
+        result = le.enforce_once(tmp_path, now=_now(hour=8, minute=5))
         assert result.success is False
         state = lp.load_state(tmp_path)
         assert state.fired_schedules == {}
@@ -361,7 +362,7 @@ class TestEnforceOnce:
         (tmp_path / "aptl.json").write_text(
             json.dumps({"lab": {"name": "aptl"}, "lifecycle_policy": {"ttl_minutes": 0}})
         )
-        result = lp.enforce_once(tmp_path, now=_now())
+        result = le.enforce_once(tmp_path, now=_now())
         assert result.success is False
         assert result.outcome is StartupOutcome.FAILED
 
@@ -369,23 +370,23 @@ class TestEnforceOnce:
         _write_policy_config(tmp_path, {"ttl_minutes": 60})
         # Seed a stale provisioned_at from a range that has since gone down.
         lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=1).isoformat()))
-        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
-        monkeypatch.setattr(lp, "clean_boot_lab", lambda *a, **k: pytest.fail("should not boot"))
-        result = lp.enforce_once(tmp_path, now=_now())
+        monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
+        monkeypatch.setattr(le, "clean_boot_lab", lambda *a, **k: pytest.fail("should not boot"))
+        result = le.enforce_once(tmp_path, now=_now())
         assert result.success is True
         # stale provisioned_at is cleared when the lab is observed down
         assert lp.load_state(tmp_path).provisioned_at is None
 
     def test_raises_busy_when_lock_held(self, tmp_path, monkeypatch):
         _write_policy_config(tmp_path, {"ttl_minutes": 60})
-        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
         lock_path = lp.state_path(tmp_path).parent / ".lock"
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         holder = open(lock_path, "w")
         try:
             fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
             with pytest.raises(lp.LifecycleBusyError):
-                lp.enforce_once(tmp_path, now=_now())
+                le.enforce_once(tmp_path, now=_now())
         finally:
             fcntl.flock(holder, fcntl.LOCK_UN)
             holder.close()
@@ -402,9 +403,9 @@ class TestLatestActivity:
         recent = _now(hour=12).timestamp()
         import os
         os.utime(marker, (recent, recent))
-        monkeypatch.setattr(lp, "resolve_active_run_dir", lambda state_dir: active)
+        monkeypatch.setattr(le, "resolve_active_run_dir", lambda state_dir: active)
         state = lp.LifecycleState(provisioned_at=_now(hour=1).isoformat())
-        latest = lp._latest_activity_at(tmp_path, state)
+        latest = le._latest_activity_at(tmp_path, state)
         assert latest is not None
         assert abs((latest - _now(hour=12)).total_seconds()) < 2
 
@@ -412,9 +413,9 @@ class TestLatestActivity:
 class TestRunMonitor:
     def test_runs_bounded_ticks_without_sleeping_after_last(self, tmp_path, monkeypatch):
         _write_policy_config(tmp_path, {"ttl_minutes": 60})
-        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
         sleeps = []
-        results = lp.run_monitor(
+        results = le.run_monitor(
             tmp_path, interval_seconds=5, max_ticks=3, sleep=lambda s: sleeps.append(s)
         )
         assert len(results) == 3
@@ -423,12 +424,12 @@ class TestRunMonitor:
 
     def test_no_policy_returns_empty(self, tmp_path):
         (tmp_path / "aptl.json").write_text(json.dumps({"lab": {"name": "aptl"}}))
-        assert lp.run_monitor(tmp_path, interval_seconds=5, max_ticks=2) == []
+        assert le.run_monitor(tmp_path, interval_seconds=5, max_ticks=2) == []
 
     def test_invalid_config_yields_failed_result(self, tmp_path):
         (tmp_path / "aptl.json").write_text(
             json.dumps({"lab": {"name": "aptl"}, "lifecycle_policy": {"ttl_minutes": 0}})
         )
-        results = lp.run_monitor(tmp_path, interval_seconds=1, max_ticks=3)
+        results = le.run_monitor(tmp_path, interval_seconds=1, max_ticks=3)
         assert len(results) == 1
         assert results[0].success is False

--- a/tests/test_lifecycle_policy.py
+++ b/tests/test_lifecycle_policy.py
@@ -1,0 +1,434 @@
+"""Tests for DEP-003 ephemeral lifecycle policy.
+
+The pure evaluators (`evaluate_ttl`, `evaluate_idle`, `due_schedule_entries`,
+`decide`) take timezone-aware UTC datetimes and are deterministic — no clock,
+no Docker, no filesystem. The IO shell (`load_state`/`save_state`,
+`enforce_once`, `run_monitor`) is exercised against a `tmp_path` project with
+the lab functions monkeypatched, so the whole module runs in the fast
+(non-integration) suite.
+"""
+
+import fcntl
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from aptl.core import lifecycle_policy as lp
+from aptl.core.config import (
+    AptlConfig,
+    LabLifecyclePolicyConfig,
+    LifecycleScheduleEntry,
+    load_config,
+)
+from aptl.core.lab_types import LabResult, LabStatus, StartupOutcome
+
+
+UTC = timezone.utc
+
+
+def _now(year=2026, month=6, day=28, hour=12, minute=0):
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Config model validation
+# ---------------------------------------------------------------------------
+
+
+class TestLifecyclePolicyConfig:
+    def test_valid_policy_loads(self, tmp_path):
+        payload = {
+            "lab": {"name": "aptl"},
+            "lifecycle_policy": {
+                "ttl_minutes": 240,
+                "idle_timeout_minutes": 60,
+                "teardown_remove_volumes": True,
+                "schedule": [
+                    {"at": "08:00", "days": ["mon", "Fri"], "scenario": "techvault"}
+                ],
+            },
+        }
+        path = tmp_path / "aptl.json"
+        path.write_text(json.dumps(payload))
+        config = load_config(path)
+        assert config.lifecycle_policy is not None
+        assert config.lifecycle_policy.ttl_minutes == 240
+        # weekday filter is normalized to lowercase
+        assert config.lifecycle_policy.schedule[0].days == ["mon", "fri"]
+
+    def test_absent_policy_is_none(self):
+        assert AptlConfig().lifecycle_policy is None
+
+    @pytest.mark.parametrize("bad", [0, -5])
+    def test_rejects_non_positive_ttl(self, bad):
+        with pytest.raises(ValueError):
+            LabLifecyclePolicyConfig(ttl_minutes=bad)
+
+    def test_rejects_non_positive_idle(self):
+        with pytest.raises(ValueError):
+            LabLifecyclePolicyConfig(idle_timeout_minutes=0)
+
+    @pytest.mark.parametrize("bad", ["24:00", "8:00", "08:60", "noon", "0800"])
+    def test_rejects_bad_schedule_time(self, bad):
+        with pytest.raises(ValueError):
+            LifecycleScheduleEntry(at=bad)
+
+    def test_rejects_bad_weekday(self):
+        with pytest.raises(ValueError):
+            LifecycleScheduleEntry(at="08:00", days=["funday"])
+
+    def test_rejects_unknown_key(self):
+        with pytest.raises(ValueError):
+            LabLifecyclePolicyConfig(ttl_min=10)
+
+
+# ---------------------------------------------------------------------------
+# Pure evaluators
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateTtl:
+    def test_no_ttl_never_expires(self):
+        policy = LabLifecyclePolicyConfig()
+        assert lp.evaluate_ttl(policy, _now(hour=0), _now(hour=23)) is False
+
+    def test_unset_provisioned_at_never_expires(self):
+        policy = LabLifecyclePolicyConfig(ttl_minutes=10)
+        assert lp.evaluate_ttl(policy, None, _now()) is False
+
+    def test_expires_at_or_after_ttl(self):
+        policy = LabLifecyclePolicyConfig(ttl_minutes=60)
+        provisioned = _now(hour=12)
+        assert lp.evaluate_ttl(policy, provisioned, _now(hour=13)) is True
+        # boundary: exactly ttl minutes elapsed
+        assert lp.evaluate_ttl(
+            policy, provisioned, provisioned + timedelta(minutes=60)
+        ) is True
+
+    def test_not_expired_within_ttl(self):
+        policy = LabLifecyclePolicyConfig(ttl_minutes=60)
+        provisioned = _now(hour=12)
+        assert lp.evaluate_ttl(policy, provisioned, _now(hour=12, minute=59)) is False
+
+
+class TestEvaluateIdle:
+    def test_no_idle_never_triggers(self):
+        policy = LabLifecyclePolicyConfig()
+        assert lp.evaluate_idle(policy, _now(hour=0), _now(hour=23)) is False
+
+    def test_idle_triggers_after_timeout(self):
+        policy = LabLifecyclePolicyConfig(idle_timeout_minutes=30)
+        last = _now(hour=12)
+        assert lp.evaluate_idle(policy, last, _now(hour=12, minute=30)) is True
+        assert lp.evaluate_idle(policy, last, _now(hour=12, minute=29)) is False
+
+    def test_unset_activity_never_triggers(self):
+        policy = LabLifecyclePolicyConfig(idle_timeout_minutes=30)
+        assert lp.evaluate_idle(policy, None, _now()) is False
+
+
+class TestDueScheduleEntries:
+    def test_due_when_past_time_same_day_and_not_fired(self):
+        entry = LifecycleScheduleEntry(at="08:00")
+        policy = LabLifecyclePolicyConfig(schedule=[entry])
+        state = lp.LifecycleState()
+        due = lp.due_schedule_entries(policy, state, _now(hour=8, minute=10), 60)
+        assert [k for _, k in due] == [lp.schedule_entry_key(entry)]
+
+    def test_not_due_before_time(self):
+        policy = LabLifecyclePolicyConfig(schedule=[LifecycleScheduleEntry(at="08:00")])
+        due = lp.due_schedule_entries(policy, lp.LifecycleState(), _now(hour=7), 60)
+        assert due == []
+
+    def test_not_due_outside_grace_window(self):
+        policy = LabLifecyclePolicyConfig(schedule=[LifecycleScheduleEntry(at="08:00")])
+        # 23:00 is hours past the 08:00 window — do not boot late
+        due = lp.due_schedule_entries(policy, lp.LifecycleState(), _now(hour=23), 60)
+        assert due == []
+
+    def test_not_due_when_already_fired_today(self):
+        entry = LifecycleScheduleEntry(at="08:00")
+        policy = LabLifecyclePolicyConfig(schedule=[entry])
+        state = lp.LifecycleState(
+            fired_schedules={lp.schedule_entry_key(entry): "2026-06-28"}
+        )
+        due = lp.due_schedule_entries(policy, state, _now(hour=8, minute=5), 60)
+        assert due == []
+
+    def test_weekday_filter_excludes_other_days(self):
+        # 2026-06-28 is a Sunday
+        entry = LifecycleScheduleEntry(at="08:00", days=["mon"])
+        policy = LabLifecyclePolicyConfig(schedule=[entry])
+        due = lp.due_schedule_entries(policy, lp.LifecycleState(), _now(hour=8), 60)
+        assert due == []
+
+    def test_schedule_is_evaluated_in_utc_not_host_local(self):
+        # 08:05+02:00 is 06:05 UTC, which is BEFORE the 08:00 UTC window —
+        # a non-UTC `now` must not fire the schedule two hours early.
+        plus2 = timezone(timedelta(hours=2))
+        entry = LifecycleScheduleEntry(at="08:00")
+        policy = LabLifecyclePolicyConfig(schedule=[entry])
+        now = datetime(2026, 6, 28, 8, 5, tzinfo=plus2)
+        assert lp.due_schedule_entries(policy, lp.LifecycleState(), now, 60) == []
+
+    def test_weekday_filter_includes_matching_day(self):
+        # 2026-06-28 is a Sunday
+        entry = LifecycleScheduleEntry(at="08:00", days=["sun"])
+        policy = LabLifecyclePolicyConfig(schedule=[entry])
+        due = lp.due_schedule_entries(policy, lp.LifecycleState(), _now(hour=8), 60)
+        assert len(due) == 1
+
+
+class TestDecide:
+    def test_running_within_policy_is_noop(self):
+        policy = LabLifecyclePolicyConfig(ttl_minutes=240, idle_timeout_minutes=60)
+        state = lp.LifecycleState(provisioned_at=_now(hour=11, minute=30).isoformat())
+        decision = lp.decide(policy, state, _now(hour=12), True, _now(hour=11, minute=45), 60)
+        assert decision.action == "none"
+
+    def test_running_ttl_exceeded_tears_down(self):
+        policy = LabLifecyclePolicyConfig(ttl_minutes=60)
+        state = lp.LifecycleState(provisioned_at=_now(hour=10).isoformat())
+        decision = lp.decide(policy, state, _now(hour=12), True, _now(hour=12), 60)
+        assert decision.action == "teardown"
+        assert decision.policy == "ttl"
+
+    def test_running_idle_exceeded_tears_down(self):
+        policy = LabLifecyclePolicyConfig(idle_timeout_minutes=30)
+        state = lp.LifecycleState(provisioned_at=_now(hour=11).isoformat())
+        decision = lp.decide(policy, state, _now(hour=12), True, _now(hour=11), 60)
+        assert decision.action == "teardown"
+        assert decision.policy == "idle"
+
+    def test_ttl_takes_precedence_over_idle(self):
+        policy = LabLifecyclePolicyConfig(ttl_minutes=60, idle_timeout_minutes=30)
+        state = lp.LifecycleState(provisioned_at=_now(hour=10).isoformat())
+        decision = lp.decide(policy, state, _now(hour=12), True, _now(hour=10), 60)
+        assert decision.policy == "ttl"
+
+    def test_not_running_due_schedule_provisions(self):
+        entry = LifecycleScheduleEntry(at="08:00", scenario="techvault")
+        policy = LabLifecyclePolicyConfig(schedule=[entry])
+        decision = lp.decide(policy, lp.LifecycleState(), _now(hour=8, minute=5), False, None, 60)
+        assert decision.action == "provision"
+        assert decision.scenario == "techvault"
+
+    def test_not_running_no_schedule_is_noop(self):
+        policy = LabLifecyclePolicyConfig(ttl_minutes=60)
+        decision = lp.decide(policy, lp.LifecycleState(), _now(), False, None, 60)
+        assert decision.action == "none"
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+class TestState:
+    def test_load_missing_returns_default(self, tmp_path):
+        state = lp.load_state(tmp_path)
+        assert state == lp.LifecycleState()
+
+    def test_round_trip(self, tmp_path):
+        state = lp.LifecycleState(
+            provisioned_at=_now().isoformat(),
+            last_action="provision",
+            last_action_at=_now().isoformat(),
+            last_result="ready",
+            fired_schedules={"08:00|": "2026-06-28"},
+        )
+        lp.save_state(tmp_path, state)
+        assert lp.load_state(tmp_path) == state
+
+    def test_state_file_is_owner_only(self, tmp_path):
+        lp.save_state(tmp_path, lp.LifecycleState())
+        mode = lp.state_path(tmp_path).stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_corrupt_state_starts_fresh(self, tmp_path):
+        path = lp.state_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json")
+        assert lp.load_state(tmp_path) == lp.LifecycleState()
+
+    def test_error_label_is_redacted_on_save(self, tmp_path):
+        state = lp.LifecycleState(last_error_label="boom password=hunter2 done")
+        lp.save_state(tmp_path, state)
+        raw = lp.state_path(tmp_path).read_text()
+        assert "hunter2" not in raw
+        assert "[REDACTED]" in raw
+
+
+# ---------------------------------------------------------------------------
+# enforce_once IO shell
+# ---------------------------------------------------------------------------
+
+
+def _write_policy_config(tmp_path, policy_dict):
+    payload = {"lab": {"name": "aptl"}, "lifecycle_policy": policy_dict}
+    (tmp_path / "aptl.json").write_text(json.dumps(payload))
+
+
+class TestEnforceOnce:
+    def test_no_policy_is_noop(self, tmp_path):
+        (tmp_path / "aptl.json").write_text(json.dumps({"lab": {"name": "aptl"}}))
+        result = lp.enforce_once(tmp_path)
+        assert result.success is True
+
+    def test_no_config_is_noop(self, tmp_path):
+        result = lp.enforce_once(tmp_path)
+        assert result.success is True
+
+    def test_running_within_policy_takes_no_action(self, tmp_path, monkeypatch):
+        _write_policy_config(tmp_path, {"ttl_minutes": 240})
+        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=True))
+        calls = []
+        monkeypatch.setattr(lp, "stop_lab", lambda **k: calls.append("stop") or LabResult(success=True))
+        result = lp.enforce_once(tmp_path, now=_now())
+        assert calls == []
+        assert result.success is True
+        # first observation of a running lab stamps provisioned_at
+        assert lp.load_state(tmp_path).provisioned_at is not None
+
+    def test_ttl_expired_calls_stop_lab(self, tmp_path, monkeypatch):
+        _write_policy_config(tmp_path, {"ttl_minutes": 60, "teardown_remove_volumes": True})
+        # seed state with an old provisioned_at so TTL is already exceeded
+        lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=10).isoformat()))
+        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=True))
+        seen = {}
+        def fake_stop(**kwargs):
+            seen.update(kwargs)
+            return LabResult(success=True)
+        monkeypatch.setattr(lp, "stop_lab", fake_stop)
+        result = lp.enforce_once(tmp_path, now=_now(hour=12))
+        assert seen.get("remove_volumes") is True
+        assert result.success is True
+        state = lp.load_state(tmp_path)
+        assert state.last_action == "teardown"
+        assert state.provisioned_at is None
+
+    def test_idle_expired_calls_stop_lab(self, tmp_path, monkeypatch):
+        _write_policy_config(tmp_path, {"idle_timeout_minutes": 30})
+        lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=10).isoformat()))
+        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=True))
+        called = []
+        monkeypatch.setattr(lp, "stop_lab", lambda **k: called.append(True) or LabResult(success=True))
+        result = lp.enforce_once(tmp_path, now=_now(hour=12))
+        assert called == [True]
+        assert result.success is True
+        state = lp.load_state(tmp_path)
+        assert state.last_action == "teardown"
+        assert state.provisioned_at is None
+
+    def test_scheduled_provision_calls_clean_boot(self, tmp_path, monkeypatch):
+        _write_policy_config(tmp_path, {"schedule": [{"at": "08:00"}]})
+        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        booted = []
+        monkeypatch.setattr(
+            lp, "clean_boot_lab",
+            lambda *a, **k: booted.append(True) or LabResult(success=True, outcome=StartupOutcome.READY),
+        )
+        result = lp.enforce_once(tmp_path, now=_now(hour=8, minute=5))
+        assert booted == [True]
+        assert result.success is True
+        state = lp.load_state(tmp_path)
+        assert state.last_action == "provision"
+        assert state.provisioned_at is not None
+        # fired-today guard recorded
+        assert state.fired_schedules
+
+    def test_failed_scheduled_provision_is_not_marked_fired(self, tmp_path, monkeypatch):
+        # A failed provision must NOT consume the day's fire marker, so a
+        # later tick inside the grace window retries it.
+        _write_policy_config(tmp_path, {"schedule": [{"at": "08:00"}]})
+        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        monkeypatch.setattr(
+            lp, "clean_boot_lab",
+            lambda *a, **k: LabResult(
+                success=False, error="boom", outcome=StartupOutcome.FAILED
+            ),
+        )
+        result = lp.enforce_once(tmp_path, now=_now(hour=8, minute=5))
+        assert result.success is False
+        state = lp.load_state(tmp_path)
+        assert state.fired_schedules == {}
+        assert state.provisioned_at is None
+
+    def test_invalid_config_fails_the_tick(self, tmp_path):
+        # A malformed lifecycle policy must surface as a FAILED tick, not a
+        # silent no-op that hides a broken unattended timer.
+        (tmp_path / "aptl.json").write_text(
+            json.dumps({"lab": {"name": "aptl"}, "lifecycle_policy": {"ttl_minutes": 0}})
+        )
+        result = lp.enforce_once(tmp_path, now=_now())
+        assert result.success is False
+        assert result.outcome is StartupOutcome.FAILED
+
+    def test_not_running_no_schedule_is_noop(self, tmp_path, monkeypatch):
+        _write_policy_config(tmp_path, {"ttl_minutes": 60})
+        # Seed a stale provisioned_at from a range that has since gone down.
+        lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=1).isoformat()))
+        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        monkeypatch.setattr(lp, "clean_boot_lab", lambda *a, **k: pytest.fail("should not boot"))
+        result = lp.enforce_once(tmp_path, now=_now())
+        assert result.success is True
+        # stale provisioned_at is cleared when the lab is observed down
+        assert lp.load_state(tmp_path).provisioned_at is None
+
+    def test_raises_busy_when_lock_held(self, tmp_path, monkeypatch):
+        _write_policy_config(tmp_path, {"ttl_minutes": 60})
+        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        lock_path = lp.state_path(tmp_path).parent / ".lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        holder = open(lock_path, "w")
+        try:
+            fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with pytest.raises(lp.LifecycleBusyError):
+                lp.enforce_once(tmp_path, now=_now())
+        finally:
+            fcntl.flock(holder, fcntl.LOCK_UN)
+            holder.close()
+
+
+class TestLatestActivity:
+    def test_run_capture_recency_beats_provisioned_at(self, tmp_path, monkeypatch):
+        # Active run dir with a recent file should win over an old provisioned_at.
+        active = tmp_path / ".aptl" / "runs" / "trace1"
+        active.mkdir(parents=True)
+        marker = active / "mcp-side" / "ocsf.jsonl"
+        marker.parent.mkdir(parents=True)
+        marker.write_text("{}")
+        recent = _now(hour=12).timestamp()
+        import os
+        os.utime(marker, (recent, recent))
+        monkeypatch.setattr(lp, "resolve_active_run_dir", lambda state_dir: active)
+        state = lp.LifecycleState(provisioned_at=_now(hour=1).isoformat())
+        latest = lp._latest_activity_at(tmp_path, state)
+        assert latest is not None
+        assert abs((latest - _now(hour=12)).total_seconds()) < 2
+
+
+class TestRunMonitor:
+    def test_runs_bounded_ticks_without_sleeping_after_last(self, tmp_path, monkeypatch):
+        _write_policy_config(tmp_path, {"ttl_minutes": 60})
+        monkeypatch.setattr(lp, "lab_status", lambda **k: LabStatus(running=False))
+        sleeps = []
+        results = lp.run_monitor(
+            tmp_path, interval_seconds=5, max_ticks=3, sleep=lambda s: sleeps.append(s)
+        )
+        assert len(results) == 3
+        # sleeps between ticks only (not after the final tick)
+        assert sleeps == [5, 5]
+
+    def test_no_policy_returns_empty(self, tmp_path):
+        (tmp_path / "aptl.json").write_text(json.dumps({"lab": {"name": "aptl"}}))
+        assert lp.run_monitor(tmp_path, interval_seconds=5, max_ticks=2) == []
+
+    def test_invalid_config_yields_failed_result(self, tmp_path):
+        (tmp_path / "aptl.json").write_text(
+            json.dumps({"lab": {"name": "aptl"}, "lifecycle_policy": {"ttl_minutes": 0}})
+        )
+        results = lp.run_monitor(tmp_path, interval_seconds=1, max_ticks=3)
+        assert len(results) == 1
+        assert results[0].success is False


### PR DESCRIPTION
## Summary

Implements DEP-003 ephemeral lifecycle policy: a `lifecycle_policy` block in `aptl.json` defines TTL-based auto-teardown, idle detection, and scheduled provisioning for the range. Enforcement is a single idempotent `aptl lab enforce` tick (operator-scheduled via systemd timer/cron), with a thin `aptl lab monitor` loop and read-only `aptl lab policy show`. The on-demand provision/teardown half of DEP-003 already exists (RNG-001); this adds the decision layer above it, reusing the existing start/stop/clean-boot path through the deployment backend rather than introducing a second path. ADR-045 records the single-shot-tick enforcement model (no daemon, no API coupling), the UTC schedule contract, the capture-recency idle signal, and the single-owner lock.

## Requirement UIDs

- `DEP-003`

## Related Issues

Closes #467

## ADR Impact

- ADR-045

## Changes

- config: new strict `LabLifecyclePolicyConfig` + `LifecycleScheduleEntry` Pydantic models (extra='forbid', positive-minute and HH:MM-UTC/weekday validators) and an optional `lifecycle_policy` field on `AptlConfig`
- core: new `src/aptl/core/lifecycle_policy.py` — pure TTL/idle/schedule evaluators over UTC timestamps, narrow redacted state under `.aptl/lifecycle/state.json` (0600), per-project flock, and an idempotent `enforce_once` / `run_monitor` IO shell routed through `lab_status`/`stop_lab`/`clean_boot_lab`
- cli: `aptl lab enforce`, `aptl lab monitor --interval/--max-ticks`, and `aptl lab policy show`
- review fixes: failed scheduled provisions no longer consume the day's fire marker (retry within grace window); a malformed `aptl.json` now fails the tick instead of silently disabling enforcement; schedule evaluation normalizes to UTC; strengthened the idle-teardown test
- docs: ADR-045, a Lifecycle Policy section in docs/deployment.md, and the DEP-003 preflight note

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

New unit tests (fast, non-integration): pure evaluators (TTL/idle/schedule/decide), config validation, state round-trip + redaction + 0600, enforce_once branches (no-op/TTL/idle/schedule/invalid-config/busy-lock) with the backend mocked, UTC normalization, and CLI wiring via CliRunner. Full fast suite green (`pytest -n auto -k "not integration"`, 1704 passed); the techvault static gate (the integration half of the completion command) also passes.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: DEP-003 ← src/aptl/core/lifecycle_policy.py, DEP-003 ← src/aptl/core/config.py, DEP-003 ← src/aptl/cli/lab.py
- TESTS: DEP-003 ← tests/test_lifecycle_policy.py, DEP-003 ← tests/test_cli_lifecycle.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/467.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
