### PR TITLE
chore: enable review-cap disposition gate in shadow mode (judge on)

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -15,6 +15,12 @@ workflow:
   completion_command: 'pytest -n auto -k "not integration" && pytest -n auto tests/test_techvault_static_gate.py -m integration'
   lint_command: pre-commit run --all-files
   format_command: pre-commit run --all-files
+  review_disposition:
+    enabled: true
+    mode: shadow
+    max_auto_overrides: 1
+    judge:
+      enabled: true
 sonarcloud:
   project_key: Brad-Edwards_aptl
   organization: brad-edwards


### PR DESCRIPTION
Enables the Ground Control review-cap disposition gate in **SHADOW mode** for this repo.

Adds under `workflow.review_disposition`:

```yaml
review_disposition:
  enabled: true
  mode: shadow
  max_auto_overrides: 1
  judge:
    enabled: true
```

In shadow mode the gate records its would-be cap-boundary disposition (with the judge on) but still escalates to the human — it takes **no auto-action**. The intent is to collect readiness data on how the gate would behave before ever giving it authority to act.

---

**DO NOT MERGE until autarchy-ai/Ground-Control#1246 is merged and the MCP server is restarted on that code — until then the older `.ground-control.yaml` parser rejects the `review_disposition` key and breaks `gc_get_repo_ground_control_context`.**

Do NOT merge.
