### PR TITLE
Issue web session cookie Secure flag by request scheme (remote/Tailscale access)

### DIFF
--- a/changelog.d/582.fixed.md
+++ b/changelog.d/582.fixed.md
@@ -1,0 +1,10 @@
+**`aptl web serve` now issues the session cookie's `Secure` flag based on the connection scheme, so the GUI works over HTTPS fronts and encrypted remote transports instead of only loopback.**
+UI-008a hardcoded `Secure=True`, which silently broke login over a plain-HTTP
+remote bind (for example a Tailscale interface): browsers withhold `Secure`
+cookies over non-loopback HTTP, so the two-factor session never completed. The
+flag now follows `request.url.scheme` — `Secure` over HTTPS, off over plain HTTP
+— and uvicorn honours `X-Forwarded-Proto` only from a loopback proxy, so a
+same-host TLS front (Tailscale Serve or a co-located Caddy) makes the cookie
+`Secure` and the CSRF origin gate match the browser's HTTPS origin. The default
+bind stays `127.0.0.1`; remote exposure remains opt-in via `--host`,
+`APTL_ALLOWED_HOSTS`, and `--public-origin`.

--- a/docs/specs/web-gui-design.md
+++ b/docs/specs/web-gui-design.md
@@ -203,6 +203,30 @@ when neither is present:
 `web_static` candidate is forward-compatible with a future combined-wheel delivery
 and resolves to nothing in the current clone-and-run / Docker models.
 
+**Remote access.** The default bind is `127.0.0.1`, and that loopback model is the
+intended path for almost all use. When an operator needs the GUI from another
+device (for example over a Tailscale tailnet), the recommended setup keeps the
+server on loopback and puts a same-host TLS proxy in front:
+
+1. Run `tailscale serve --bg https / http://127.0.0.1:8400` (or a co-located
+   Caddy) so the proxy terminates TLS and forwards to the loopback server.
+2. Start the server with the browser-facing origin and host allow-list:
+   `APTL_ALLOWED_HOSTS=<machine>.<tailnet>.ts.net aptl web serve
+   --public-origin https://<machine>.<tailnet>.ts.net`.
+
+The server trusts `X-Forwarded-Proto` only from a loopback proxy, so behind that
+TLS front `request.url.scheme` resolves to `https`: the session cookie is issued
+`Secure` and the CSRF origin gate matches the browser's `https` origin.
+
+A direct non-loopback bind without a TLS front (`aptl web serve --host
+<address>`) also works for an environment whose transport is already encrypted,
+such as a tailnet. It still needs `APTL_ALLOWED_HOSTS` and `--public-origin`. The
+session cookie's `Secure` flag follows the request scheme, so over plain HTTP the
+cookie is delivered without `Secure` (a `Secure` cookie would be withheld by the
+browser and the two-factor session would never complete). The launch token and
+two-factor session still gate every request, but confidentiality then depends on
+the transport, not on the application. Prefer the TLS-fronted setup above.
+
 ## Design Inputs and Visual Direction
 
 The visual target is a quiet operational workbench: readable, dense enough for

--- a/src/aptl/api/main.py
+++ b/src/aptl/api/main.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, RedirectResponse, Response
 
 from aptl.api.deps import (
@@ -88,7 +88,7 @@ def create_app() -> FastAPI:
         include_in_schema=False,
         responses={401: {"description": "Invalid or missing one-time launch token."}},
     )
-    async def login(token: str = "") -> Response:
+    async def login(request: Request, token: str = "") -> Response:
         """Exchange a valid launch token for the two-factor session, then redirect."""
         if not verify_launch_token(token):
             raise HTTPException(
@@ -100,16 +100,21 @@ def create_app() -> FastAPI:
             url=f"/#{SESSION_HEADER_PARAM}={session_header_value()}",
             status_code=303,
         )
-        # secure=True is correct for both delivery models: loopback origins
-        # (127.0.0.1) are "potentially trustworthy" secure contexts, so browsers
-        # set and return Secure cookies over the default loopback-http `aptl web
-        # serve`; and when the API is fronted by TLS (the split aptl-web-ui Caddy
-        # profile via --public-origin https://...) the flag is mandatory.
+        # The Secure flag follows the effective request scheme so the cookie is
+        # delivered correctly across every shipping model. Over HTTPS (a TLS
+        # front such as Tailscale Serve or the split aptl-web-ui Caddy profile,
+        # surfaced here via uvicorn's loopback-trusted X-Forwarded-Proto) it is
+        # mandatory. Over plain HTTP it must be OFF, or the browser withholds the
+        # cookie and the two-factor session never completes: that covers the
+        # default loopback `aptl web serve` (no wire to protect) and an opt-in
+        # remote bind whose confidentiality comes from the transport (e.g.
+        # Tailscale/WireGuard). request.url.scheme is trustworthy because
+        # forwarded headers are honoured only from a loopback proxy.
         resp.set_cookie(
             SESSION_COOKIE,
             session_cookie_value(),
             httponly=True,
-            secure=True,
+            secure=request.url.scheme == "https",
             samesite="strict",
             path="/",
         )

--- a/src/aptl/cli/web.py
+++ b/src/aptl/cli/web.py
@@ -142,6 +142,13 @@ def serve(
     # and terminal-ticket store are in-process and not shared across workers, so
     # multiple workers would reject each other's sessions and tickets. There is
     # deliberately no --workers flag.
+    #
+    # proxy_headers + forwarded_allow_ips="127.0.0.1" honour X-Forwarded-Proto/For
+    # ONLY from a same-host (loopback) TLS-terminating proxy — e.g. `tailscale
+    # serve` or a co-located Caddy. That makes request.url.scheme resolve to
+    # https behind such a proxy, so the session cookie is issued Secure and the
+    # CSRF origin gate matches the browser's https origin. A direct client cannot
+    # spoof these headers because it does not connect from 127.0.0.1.
     uvicorn.run(
         "aptl.api.main:app",
         host=host,
@@ -151,4 +158,6 @@ def serve(
         log_level="info",
         timeout_keep_alive=65,
         access_log=True,
+        proxy_headers=True,
+        forwarded_allow_ips="127.0.0.1",
     )

--- a/tests/test_api_bff.py
+++ b/tests/test_api_bff.py
@@ -363,14 +363,12 @@ class TestLoginHandshake:
 
         app = create_app()
         app.dependency_overrides[get_project_dir] = lambda: tmp_path
-        # The session cookie is issued with Secure=True. A real browser treats
-        # the loopback serve origin (http://127.0.0.1) as a "potentially
-        # trustworthy" secure context and so stores and resends the Secure
-        # cookie; a generic HTTP client only does so over https. Use an https
-        # base_url to model that browser behaviour for the handshake round-trip.
-        with TestClient(
-            app, base_url="https://testserver", raise_server_exceptions=True
-        ) as c:
+        # Default http base_url models the 98% case: `aptl web serve` on the
+        # loopback origin. The cookie's Secure flag follows the request scheme,
+        # so over http it is NOT Secure and the generic HTTP client stores and
+        # resends it (just as a browser does on loopback). The https path is
+        # covered separately by test_login_cookie_secure_flag_follows_scheme.
+        with TestClient(app, raise_server_exceptions=True) as c:
             yield c
 
     def test_valid_launch_token_sets_cookie_and_redirects(self, login_client):
@@ -391,13 +389,37 @@ class TestLoginHandshake:
         assert "aptl_session=" in set_cookie
         assert "httponly" in set_cookie.lower()
         assert "samesite=strict" in set_cookie.lower()
+        # Over plain http (loopback serve) the cookie must NOT be Secure, or the
+        # browser would withhold it and the two-factor session never completes.
+        assert "secure" not in set_cookie.lower()
+
+    def test_login_cookie_secure_flag_follows_scheme(self, tmp_path, _set_token):
+        """Over https the session cookie IS issued Secure (TLS-fronted deploys).
+
+        A real browser, or a same-host TLS proxy (Tailscale Serve / Caddy) whose
+        X-Forwarded-Proto uvicorn trusts from loopback, reaches the app over
+        https; the cookie must then carry Secure. Modelled with an https base_url.
+        """
+        from aptl.api.deps import get_project_dir
+        from aptl.api.main import create_app
+        from starlette.testclient import TestClient
+
+        app = create_app()
+        app.dependency_overrides[get_project_dir] = lambda: tmp_path
+        with TestClient(
+            app, base_url="https://testserver", raise_server_exceptions=True
+        ) as c:
+            resp = c.get(
+                f"/api/auth/login?token={_LAUNCH_TOKEN}", follow_redirects=False
+            )
+        assert resp.status_code == 303
+        assert "secure" in resp.headers.get("set-cookie", "").lower()
 
     def test_cookie_from_handshake_authenticates_api(self, login_client):
         """After the handshake, both issued factors authenticate /api/* calls.
 
-        TestClient persists the Secure Set-Cookie automatically (the fixture's
-        https base_url models the browser treating the loopback origin as a
-        secure context); a real browser also captures the header token from the
+        The client persists the (non-Secure, loopback-http) Set-Cookie
+        automatically; a real browser also captures the header token from the
         redirect fragment, which we simulate by sending ``X-APTL-Session``.
         """
         from aptl.api.session import session_header_value

--- a/tests/test_cli_web.py
+++ b/tests/test_cli_web.py
@@ -54,6 +54,8 @@ class TestWebServe:
             log_level="info",
             timeout_keep_alive=65,
             access_log=True,
+            proxy_headers=True,
+            forwarded_allow_ips="127.0.0.1",
         )
 
     @patch("uvicorn.run")


### PR DESCRIPTION
## Summary

Follow-up to #562 (UI-008a). The session cookie's `Secure` flag was hardcoded `True`, which silently broke `aptl web serve` login over a plain-HTTP remote bind (e.g. a Tailscale interface): browsers withhold `Secure` cookies over non-loopback HTTP, so the two-factor session never completed.

## Changes

- **Scheme-aware Secure flag** (`src/aptl/api/main.py`): the session cookie's `Secure` flag follows `request.url.scheme` — `Secure` over HTTPS, off over plain HTTP. Loopback-http (the default, 98% case) and any TLS-fronted deploy both work; plain-HTTP remote works too, relying on the transport for confidentiality.
- **Loopback-trusted proxy headers** (`src/aptl/cli/web.py`): uvicorn `proxy_headers=True, forwarded_allow_ips="127.0.0.1"`. A same-host TLS front (Tailscale Serve, co-located Caddy) makes the scheme resolve to `https` (→ Secure cookie + matching CSRF origin); a direct client cannot spoof `X-Forwarded-Proto` because it is not on loopback.
- **Docs** (`docs/specs/web-gui-design.md`): a "Remote access" subsection documenting the recommended Tailscale Serve (HTTPS) setup and the plain-HTTP-bind alternative.
- **Tests**: cover both the http (no Secure) and https (Secure) cookie paths; the handshake round-trip now runs over plain http (default loopback model).

## Security posture

The default bind stays `127.0.0.1`. Remote exposure is opt-in via `--host` + `APTL_ALLOWED_HOSTS` + `--public-origin`. The launch token and two-factor session gate every request on any interface; over plain HTTP, confidentiality depends on the transport (e.g. Tailscale/WireGuard), which is why TLS-fronting is documented as the recommended remote setup.

Closes #582.