### PR TITLE
docs: add ADR-046 dynamic ACES scenario realization

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -56,7 +56,7 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [032](adr-032-conversation-surface-hardening.md) | Conversation Surface Hardening | accepted | 2026-05-17 |
 | [033](adr-033-agent-reasoning-trace-boundary.md) | Red-Side Behavioural Capture and Non-Contamination Boundary | accepted | 2026-05-17 |
 | [034](adr-034-lab-managed-soc-tls-ca.md) | Lab-Managed CA for Verified SOC Stack TLS | accepted | 2026-05-18 |
-| [035](adr-035-aces-sdl-adoption.md) | Adopt ACES SDL as APTL's Scenario Authoring Surface | accepted | 2026-05-18 |
+| [035](adr-035-aces-sdl-adoption.md) | Adopt ACES SDL as APTL's Scenario Authoring Surface (realization model superseded by ADR-046) | accepted (amended) | 2026-05-18 |
 | [036](adr-036-snapshot-endpoint-registry.md) | Snapshot Endpoint Registry Boundary | accepted | 2026-05-18 |
 | [037](adr-037-docker-compose-backend-cohesion.md) | Docker Compose Backend Cohesion | accepted | 2026-05-18 |
 | [038](adr-038-docs-style-lint-and-published-site.md) | Documentation Style Lint and Published Docs Site | accepted | 2026-06-11 |
@@ -67,3 +67,4 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [043](adr-043-suricata-runtime-config-ownership-boundary.md) | Suricata Runtime Config Ownership Boundary | accepted | 2026-06-20 |
 | [044](adr-044-aces-aligned-run-reproducibility-record.md) | ACES-Aligned Run Reproducibility Record | accepted | 2026-06-25 |
 | [045](adr-045-ephemeral-lifecycle-policy-enforcement.md) | Ephemeral Lifecycle Policy Enforcement | accepted | 2026-06-28 |
+| [046](adr-046-dynamic-aces-scenario-realization.md) | Dynamic ACES Scenario Realization | accepted | 2026-06-29 |

--- a/docs/adrs/adr-035-aces-sdl-adoption.md
+++ b/docs/adrs/adr-035-aces-sdl-adoption.md
@@ -2,15 +2,31 @@
 
 ## Status
 
-accepted
+accepted (amended 2026-06-29 by [ADR-046](adr-046-dynamic-aces-scenario-realization.md))
 
 ## Date
 
-2026-05-18
+2026-05-18 (amended 2026-06-29)
 
 ## Last Updated
 
-2026-06-25
+2026-06-29
+
+## Status update—2026-06-29
+
+The realization model in this ADR (specifically the Parity Inventory Boundary's
+statement that topology, profiles, networks, static IPs, hostnames, volumes,
+health checks, published ports, and service dependencies come from
+`docker-compose.yml` and the `DeploymentBackend` inventory methods) is
+**superseded by [ADR-046](adr-046-dynamic-aces-scenario-realization.md)**.
+ADR-046 establishes that the compiled ACES `RuntimeModel`, interpreted through
+`interpret_provisioning_plan`, is the authoritative topology source;
+`docker-compose.yml` remains the realization vehicle selected by profile rather
+than the topology authority.
+
+What this ADR decided still stands: ACES SDL adoption as the canonical authoring
+surface, the backend-manifest and conformance model, the `DeploymentBackend`
+execution boundary, and the ACES backend integration guardrails are preserved.
 
 ## Context
 

--- a/docs/adrs/adr-046-dynamic-aces-scenario-realization.md
+++ b/docs/adrs/adr-046-dynamic-aces-scenario-realization.md
@@ -1,0 +1,220 @@
+# ADR-046: Dynamic ACES Scenario Realization
+
+## Status
+
+accepted
+
+## Date
+
+2026-06-29
+
+## Context
+
+ADR-035 adopted ACES SDL as APTL's scenario authoring surface and wired APTL in
+as a conformant ACES backend target. Under that decision the ACES runtime stack
+compiles an authored SDL document into a typed `RuntimeModel`, plans a composite
+`ExecutionPlan` (provisioning, orchestration, evaluation), and applies it
+against APTL's registered `RuntimeTarget`.
+
+ADR-035 also drew a Parity Inventory Boundary that named `docker-compose.yml`
+and the `DeploymentBackend` inventory methods as the canonical source for
+topology, profiles, networks, static IPs, hostnames, volumes, health checks,
+published ports, and service dependencies. That framing was correct for the
+cutover: APTL realized one scenario (TechVault), and the compose file was both
+the realization vehicle and the de facto topology authority.
+
+That framing no longer holds. APTL now realizes a compiled ACES `ExecutionPlan`
+whose `RuntimeModel` carries networks, node deployments, feature bindings,
+content placements, account placements, and, per SEM-218, typed realization
+requirements. The compiled scenario, not the static compose file, decides what
+the range contains. The compose file remains the realization vehicle, reached
+through a profile index, but it is no longer the source of truth for topology.
+
+The compiler emits these surfaces on `RuntimeModel`
+(`aces_processor/models.py`): networks, node deployments, feature bindings,
+content placements, account placements, and `realization_requirements`
+(`models.py:4264`). The last field is the SEM-218 contract: a tuple of
+`CompiledRealizationRequirement`, each carrying an `ExplicitnessClass` of
+`EXACT`, `CONSTRAINED`, or `OPEN` (`aces_processor/semantics/realization.py`).
+`EXACT` means the authored value must be honored precisely; `OPEN` is the
+open-taxonomy sentinel that a backend may satisfy loosely. The planner gates
+the manifest's declared realization support against each requirement through
+`realization_support_diagnostics` (`aces_processor/planner.py:957`).
+
+APTL must turn that compiled plan into a running range without reintroducing a
+second topology authority, a second SDL, a duplicate compose parser, or raw
+Docker calls. The owners that already exist are the ones this decision builds
+on, not new abstractions.
+
+## Decision
+
+APTL realizes a compiled ACES `ExecutionPlan` dynamically through an
+**interpret-then-driver** pattern. The compiled `RuntimeModel` is the
+authoritative interpretation input; `docker-compose.yml` is the realization
+vehicle selected by profile, not the topology authority.
+
+Two stages compose the realization:
+
+- **Interpret.** `interpret_provisioning_plan`
+  (`src/aptl/backends/aces_realization.py:56`) translates the `ProvisioningPlan`
+  carried on the `ExecutionPlan` into a typed `AptlRealization`
+  (`src/aptl/backends/aces_realization_model.py:77`). Nodes become
+  `NodeRealization`, networks become `NetworkRealization`, and feature
+  bindings, content placements, and account placements become
+  `PlacementRealization`. The interpreter recognizes the resource types in
+  `SUPPORTED_RESOURCE_TYPES` (`src/aptl/backends/aces_diagnostics.py:12`):
+  network, node, feature-binding, content-placement, and account-placement. An
+  unsupported resource type produces a diagnostic rather than a hard failure, so
+  a richer authored scenario degrades visibly instead of crashing the apply.
+
+- **Driver.** `select_backend_profiles`
+  (`src/aptl/backends/aces_profiles.py:205`) and `ComposeProfileIndex`
+  (`src/aptl/backends/aces_profiles.py:31`) map the interpreted realization onto
+  the ordered set of Docker Compose profiles to start, including the profile
+  dependency closure. `AptlProvisioner.apply`
+  (`src/aptl/backends/aces.py:335`) chains the two stages: interpret the plan,
+  select the profiles, then drive `DeploymentBackend.start_lab`.
+
+All container, network, and host operations route through the
+`DeploymentBackend` Protocol
+(`src/aptl/core/deployment/backend.py:33`). No ACES adapter code calls raw
+Docker or parses compose output directly. This binds the realization to ADR-037:
+the runner boundary is the extensibility seam, not a mixin hierarchy or a
+subprocess shortcut.
+
+The realization honors SEM-218 open and closed semantics. APTL consumes
+`RuntimeModel.realization_requirements` and declares its own realization support
+through the `RealizationSupportDeclaration` in `create_aptl_manifest`
+(`src/aptl/backends/aces_manifest.py:160`), which currently claims `CONSTRAINED`
+mode for the `runtime-realization` domain. The planner's
+`realization_support_diagnostics` gate decides whether that declaration
+satisfies each authored requirement; APTL does not re-evaluate the requirements
+with a local model.
+
+Realization evidence persists through the existing run-record owners, not a new
+record type. Selected profiles, profile dependency closure, and `AptlRealization`
+details are written through `LocalRunStore`
+(`src/aptl/core/runstore.py:125`) and referenced from `RangeSnapshot`
+(`src/aptl/core/snapshot.py:105`), consistent with ADR-044. Durable non-secret
+settings bind through strict `AptlConfig` (`src/aptl/core/config.py:182`, per
+ADR-025); secret-bearing runtime values stay in `EnvVars` and `.env`
+(`src/aptl/core/env.py:25`). The realization record stores digests and
+non-secret identities only.
+
+## Security Layers
+
+| Layer | Requirement |
+| --- | --- |
+| ACES parser and compiler gate | Authored scenarios enter through `aces_sdl.parse_sdl_file` and compile through the ACES compiler and planner. APTL does not structurally revalidate ACES SDL or recompile the `RuntimeModel` with local models. |
+| Realization requirement gate | SEM-218 open and closed semantics are enforced by the ACES planner's `realization_support_diagnostics` against APTL's `RealizationSupportDeclaration`. APTL reads `realization_requirements`; it does not re-derive explicitness classes locally. |
+| Deployment boundary gate | Profile selection drives `DeploymentBackend.start_lab`. No ACES adapter code calls raw Docker, `docker compose`, or parses compose output directly (ADR-037). |
+| Config and env binding | Non-secret realization knobs bind through strict `AptlConfig`; runtime secrets stay in `EnvVars` and `.env`. The realization record stores digests and non-secret identities, never `.env` values, rendered config, tokens, or key material. |
+| Persistence and redaction | Realization details and selected profiles enter JSON through `LocalRunStore` and `RangeSnapshot.to_dict()`, inheriting ADR-029 redaction and path-containment checks. |
+
+## Maintainability
+
+The canonical incumbents this decision builds on are:
+
+- `src/aptl/backends/aces.py` for the `RuntimeTarget` wiring and
+  `AptlProvisioner`.
+- `src/aptl/backends/aces_realization.py` and
+  `src/aptl/backends/aces_realization_model.py` for the interpret stage and its
+  typed output.
+- `src/aptl/backends/aces_profiles.py` for the driver stage (profile index and
+  selection).
+- `src/aptl/backends/aces_diagnostics.py` for the supported-resource-type set
+  and diagnostics.
+- `src/aptl/backends/aces_manifest.py` for the realization support declaration.
+- `src/aptl/core/deployment/` for every Docker, Compose, container, and host
+  operation.
+- `src/aptl/core/runstore.py`, `src/aptl/core/snapshot.py`,
+  `src/aptl/core/config.py`, and `src/aptl/core/env.py` for run persistence,
+  inventory evidence, config, and env binding.
+
+Tests extend the existing ACES backend and realization seams
+(`tests/test_aces_backend.py` and the realization-focused tests) rather than
+introducing a new harness.
+
+## Extensibility
+
+The extensibility seam is the boundary between the interpreted realization and
+the driver. Interpret produces a typed `AptlRealization` from the compiled plan;
+the driver maps that realization onto compose profiles. A new authored resource
+type is added by extending `SUPPORTED_RESOURCE_TYPES` and the interpreter, then
+mapping it in the profile index—without changing the driver's contract, adding a
+second topology authority, or branching on a specific scenario name.
+
+The design must stay parameterized by scenario identity and backend manifest
+version. It must not assume TechVault is the only scenario, that Docker Compose
+is the only possible realization vehicle, or that the current realization
+support mode is static.
+
+## Consequences
+
+### Positive
+
+- The compiled scenario, not a hand-edited compose file, decides range
+  topology. A new scenario realizes without editing `docker-compose.yml`.
+- SEM-218 open and closed semantics are honored through the ACES planner gate,
+  so APTL's realization claims are contract-validated rather than asserted.
+- Realization evidence rides the existing run record (ADR-044); there is no new
+  record type to maintain or redact.
+
+### Negative / costs
+
+- The profile index must track the compose file. A profile that exists in
+  `docker-compose.yml` but is unmapped, or mapped but absent, is a realization
+  gap the index and its tests must catch.
+- APTL's realization support declaration must stay honest. Widening the claimed
+  realization support without the interpreter and driver to back it would let
+  the planner gate pass scenarios APTL cannot actually realize.
+
+### Risks
+
+- An authored scenario can carry resource types APTL does not interpret. The
+  diagnostic-not-failure choice keeps the apply running, so the operator must
+  read realization diagnostics rather than assume a clean apply realized every
+  authored concern.
+
+## Non-Goals
+
+- This ADR does not replace `docker-compose.yml` as the realization vehicle. It
+  removes the file's role as topology authority, not the file.
+- This ADR does not define a new run-record type, scenario schema, or ACES
+  mirror model. Realization evidence rides ADR-044's record.
+- This ADR does not change APTL's backend profile claim. The manifest and
+  conformance gates remain the source of truth for that claim.
+
+## Anti-Patterns
+
+- Treating a scenario name as a profile selector instead of deriving profiles
+  from the interpreted realization.
+- Calling `docker` or `docker compose`, or parsing compose output, from the
+  interpret or driver stage instead of routing through `DeploymentBackend`.
+- Re-evaluating SEM-218 explicitness classes with a local model rather than
+  consuming `realization_requirements` and the planner gate.
+- Adding a second topology authority, a duplicate compose parser, or a local
+  `RuntimeModel` mirror.
+- Writing realization evidence to a new record type instead of `LocalRunStore`
+  and `RangeSnapshot`, or storing secret values rather than digests and
+  non-secret identities.
+
+## References
+
+- [ADR-025](adr-025-strict-first-party-config-schema.md): strict first-party
+  config schema for non-secret realization knobs.
+- [ADR-029](adr-029-control-plane-secret-handling.md): runstore and snapshot
+  redaction boundaries.
+- [ADR-035](adr-035-aces-sdl-adoption.md): ACES SDL adoption; this ADR
+  supersedes its Parity Inventory Boundary realization model while preserving
+  its SDL adoption and backend-manifest/conformance model.
+- [ADR-037](adr-037-docker-compose-backend-cohesion.md): all Docker and Compose
+  operations route through `DeploymentBackend`; the runner boundary is the
+  extensibility seam.
+- [ADR-044](adr-044-aces-aligned-run-reproducibility-record.md): realization
+  evidence rides the run reproducibility record rather than a new type.
+- SEM-218 (ACES compiled realization requirements) and RUN-314 / autarchy-ai/aces#197
+  (reference emulation backend).
+- Related issues: [#554](https://github.com/Brad-Edwards/aptl/issues/554),
+  [#556](https://github.com/Brad-Edwards/aptl/issues/556) (paper scenario);
+  DSL-008 / [#422](https://github.com/Brad-Edwards/aptl/issues/422).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,6 +207,10 @@ nav:
     - ADR-040 Terminal SSH Host-Key Verification: adrs/adr-040-terminal-ssh-host-key-verification.md
     - ADR-041 Kali Capture Sidecar Ownership Boundary: adrs/adr-041-kali-capture-sidecar-ownership-boundary.md
     - ADR-042 Sidecar-Owned PTY Master: adrs/adr-042-sidecar-owned-pty-master.md
+    - ADR-043 Suricata Runtime Config Ownership Boundary: adrs/adr-043-suricata-runtime-config-ownership-boundary.md
+    - ADR-044 ACES-Aligned Run Reproducibility Record: adrs/adr-044-aces-aligned-run-reproducibility-record.md
+    - ADR-045 Ephemeral Lifecycle Policy Enforcement: adrs/adr-045-ephemeral-lifecycle-policy-enforcement.md
+    - ADR-046 Dynamic ACES Scenario Realization: adrs/adr-046-dynamic-aces-scenario-realization.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary

Add ADR-046 documenting APTL's dynamic realization of compiled ACES ExecutionPlan scenarios through the interpret-then-driver pattern: interpret_provisioning_plan translates the ProvisioningPlan into a typed AptlRealization, and select_backend_profiles / ComposeProfileIndex drive Docker Compose profile selection through DeploymentBackend (no raw Docker, per ADR-037). The decision records that the compiled RuntimeModel, not docker-compose.yml, is the authoritative topology source, honoring SEM-218 open/closed semantics over RuntimeModel.realization_requirements and persisting realization evidence via LocalRunStore / RangeSnapshot (ADR-044). ADR-035's realization model is amended as superseded while its SDL adoption and backend-manifest/conformance model are preserved. Docs-only; no application source changes.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #572

## ADR Impact

- ADR-046
- ADR-035 (amended)

## Changes

- Add docs/adrs/adr-046-dynamic-aces-scenario-realization.md (interpret-then-driver realization, SEM-218 open/closed, DeploymentBackend boundary, run-record persistence)
- Amend docs/adrs/adr-035-aces-sdl-adoption.md: mark the realization model (Parity Inventory Boundary's docker-compose.yml-as-topology-authority framing) superseded by ADR-046; preserve SDL adoption and backend-manifest/conformance model
- Add the ADR-046 row to docs/adrs/README.md and mark ADR-035's amendment in the index
- Wire ADR-043/044/045/046 into the mkdocs Decisions nav, repairing the pre-existing nav gap (last wired was ADR-042)

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
