### PR TITLE
Add APTL web component kit and Tailwind v4 design tokens

### DIFF
--- a/changelog.d/563.added.md
+++ b/changelog.d/563.added.md
@@ -1,0 +1,8 @@
+### Added
+
+- Web GUI component kit and documented Tailwind v4 design tokens: reusable
+  Svelte primitives (`Badge`, `StatusBadge`, `Button`, `Field`, `TextInput`,
+  `Select`, `Table`, accessible `Dialog`/drawer, and `Menu`) under
+  `web/src/lib/components/kit/`, plus formalized design tokens in
+  `web/src/app.css` (named focus token and global reduced-motion handling). See
+  `docs/specs/web-component-kit.md`.

--- a/docs/specs/web-component-kit.md
+++ b/docs/specs/web-component-kit.md
@@ -1,0 +1,116 @@
+# APTL web component kit
+
+The component kit is a small set of presentation and interaction primitives for
+the APTL web GUI. It formalizes the Tailwind v4 tokens already shipped in
+[`web/src/app.css`](https://github.com/Brad-Edwards/aptl/blob/main/web/src/app.css)
+into a documented design system and provides reusable Svelte components that the
+v1 routes assemble from, rather than ad-hoc markup or a wholesale admin
+template.
+
+This document implements issue UI-008b under the
+[Web GUI Design Specification](web-gui-design.md). It covers the token set and
+the kit primitives only. Page-level routes consume the kit in separate child
+issues.
+
+## Design tokens
+
+`web/src/app.css` is the single source for the design tokens. The `@theme`
+block defines custom properties that Tailwind v4 turns into `*-aptl-*`
+utilities, so a token named `--color-aptl-surface` produces utilities such as
+`bg-aptl-surface` and `border-aptl-surface`. The kit maps semantic intent to
+those utilities through shared recipes in
+[`web/src/lib/components/kit/tone.ts`](https://github.com/Brad-Edwards/aptl/blob/main/web/src/lib/components/kit/tone.ts).
+No token value is duplicated in JavaScript and the Tailwind configuration is not
+forked.
+
+### Token groups
+
+| Group | Tokens | Role |
+| --- | --- | --- |
+| Surface | `aptl-bg`, `aptl-surface`, `aptl-surface-hover`, `aptl-border` | Page background through raised surfaces and dividers. |
+| Text | `aptl-text`, `aptl-text-muted` | Primary copy and muted secondary copy. |
+| Accent and status | `aptl-indigo`, `aptl-indigo-hover`, `aptl-violet`, `aptl-teal`, `aptl-red`, `aptl-green`, `aptl-amber` | Purple stays an accent. Status meaning is carried by the semantic tones below, never by colour alone. |
+| Focus | `aptl-focus` | Named token for the shared focus-ring recipe, aliasing indigo so focus treatment is overridable in one place. |
+| Typography | `font-sans`, `font-mono` | Sans for interface copy with a system-font fallback, mono for terminal and command text. |
+
+### Reduced motion
+
+`app.css` honours the `prefers-reduced-motion` media query globally. Animations
+and transitions collapse to an instant change when the user asks for reduced
+motion, so an affordance such as the `StatusBadge` pulse never animates against
+that preference.
+
+### Density
+
+Density is a presentation choice exposed through component props, such as the
+`density` prop on `Table`. The kit does not persist a density preference. The
+browser-local preferences store that records operator settings is a separate
+concern under the settings dialog child issue.
+
+## Primitives
+
+The kit lives in
+[`web/src/lib/components/kit/`](https://github.com/Brad-Edwards/aptl/blob/main/web/src/lib/components/kit)
+and is re-exported from `index.ts`. Every component takes semantic props instead
+of arbitrary colour-class strings, and every interactive component carries the
+shared focus ring and an accessible name.
+
+| Component | Purpose | Key props |
+| --- | --- | --- |
+| `Badge` | Semantic pill for tags and labels. | `tone`, `dot`, `pulse`, `label` |
+| `StatusBadge` | Status pill with a dot and a visible text label. | `tone`, `label`, `pulse` |
+| `Button` | Action control; renders a link when `href` is set. | `variant`, `size`, `href`, `disabled`, `label` |
+| `Field` | Label, description, and error wrapper for a form control. | `label`, `description`, `error`, `required` |
+| `TextInput` | Text input that reads its wiring from a parent `Field`. | `value`, `type`, `invalid`, `ariaLabel` |
+| `Select` | Option select that reads its wiring from a parent `Field`. | `value`, `options`, `invalid`, `ariaLabel` |
+| `Table` | Captioned data table with a density option. | `caption`, `captionVisible`, `density` |
+| `Dialog` | Accessible modal dialog or side drawer. | `open`, `title`, `description`, `placement` |
+| `Menu` | Accessible dropdown menu with keyboard navigation. | `label`, `items`, `align` |
+
+### Semantic tones
+
+`Badge`, `StatusBadge`, and the form validation states share one `Tone` scale:
+`neutral`, `info`, `success`, `warning`, `danger`, and `accent`. The tone maps to
+the palette through `tone.ts`, which keeps status colours from drifting into a
+separate colour decision in each component.
+
+### Forms
+
+`Field` owns identifier generation and the relationship wiring. It associates
+its label with the control, exposes a description through `aria-describedby`,
+and announces a validation message through `role="alert"`. A control placed
+inside a `Field` reads that wiring from context, so a caller writes a field
+without threading identifiers by hand:
+
+```svelte
+<Field label="Row limit" description="The backend remains authoritative.">
+  <TextInput />
+</Field>
+```
+
+`TextInput` and `Select` fall back to their own props when used outside a
+`Field`, with `ariaLabel` providing the accessible name.
+
+### Overlays and accessibility
+
+`Dialog` and `Menu` manage keyboard focus directly rather than depending on a
+headless component library. Owning the behaviour keeps the kit small, avoids a
+new runtime dependency under the strict content-security policy, and lets the
+focus contract be tested.
+
+- `Dialog` exposes `role="dialog"` with `aria-modal`, a programmatic title and
+  description, a focus trap, Escape-to-close, a backdrop close, and focus return
+  to the control that opened it. The `placement` prop selects a centred modal or
+  a right-side drawer.
+- `Menu` exposes `role="menu"` with a trigger that reports its expanded state.
+  The arrow keys, Home, and End move focus across enabled items, Escape closes
+  the menu and returns focus to the trigger, and a click outside closes it.
+
+## Testing
+
+Every primitive has a Vitest suite in
+[`web/tests/components/kit/`](https://github.com/Brad-Edwards/aptl/blob/main/web/tests/components/kit)
+that asserts behaviour and accessibility rather than rendered snapshots: tone
+recipe mapping, focus-trap wrapping, label and description wiring, dialog focus
+return, and menu keyboard navigation. Run the suite with `npm test` in the `web`
+directory.

--- a/docs/specs/web-gui-design-preflight.md
+++ b/docs/specs/web-gui-design-preflight.md
@@ -137,6 +137,63 @@ The design specification must name how each in-scope page passes these layers.
   cookie-consent or terms-wall patterns unless non-essential analytics,
   third-party embeds, or legally approved terms text are introduced.
 
+## UI-008b Component Kit Guardrails
+
+UI-008b should create a small APTL component kit from the current Svelte and
+Tailwind surface, not a parallel design system.
+
+- Treat `web/src/app.css` as the canonical token source. Promote the existing
+  Tailwind v4 `@theme` variables into documented color, type, spacing, radius,
+  status, focus, and density conventions there or in adjacent design docs. Do
+  not introduce a second Tailwind config, JavaScript token mirror, CSS-in-TS
+  theme object, or copied admin-template token set.
+- The component kit is a presentation and interaction layer. It must not own
+  API fetching, auth carrier construction, DTO parsing, lifecycle semantics,
+  scenario shaping, terminal ticket flow, SIEM query validation, config
+  validation, logging, persistence, or redaction.
+- Keep the app shell anchored on `web/src/lib/components/NavBar.svelte` and
+  `web/src/routes/+layout.svelte`: top navigation, text labels, compact lab
+  status, and constrained content regions. Do not add an icon-only sidebar,
+  mission-control nav rail, or wholesale Tailwind UI shell.
+- Keep primitive props semantic and content-model-oriented. A status badge
+  should accept a known status/severity/label shape, not arbitrary color class
+  strings. Tables should accept rows, columns, captions, loading/empty/error
+  state, and bounded row actions; they should not infer backend states from
+  English messages.
+- Use existing component families as incumbents: `LabStatusBadge`,
+  `LabStartNotice`, `ContainerGrid`, `ContainerCard`, `ScenarioCard`,
+  `Terminal`, `TerminalBlock`, and the workbench blocks. New primitives should
+  factor repeated recipes out of those components without changing their data
+  authority.
+- Centralize repeated status styling currently duplicated across
+  `LabStatusBadge`, `ContainerCard`, `ScenarioCard`, `WorkbenchStatusBar`,
+  `ObjectiveBlock`, and `ContainerStatusBlock`. Reuse
+  `web/src/lib/container-state.ts` or evolve it into a narrow UI-state helper
+  instead of adding one-off switch statements per component.
+- Dialogs, drawers, menus, popovers, tabs, and tooltips need accessible
+  behavior. A small headless Svelte primitive or dependency is acceptable only
+  for focus management, ARIA semantics, keyboard handling, and portal/overlay
+  mechanics; the APTL kit still owns tokens, density, copy, and content
+  structure.
+- Treat `NarrativeBlock` plus `renderMarkdown()` / DOMPurify as the only
+  existing sanctioned raw-HTML path. Generic primitives should render text or
+  Svelte children, not add new `{@html}` surfaces.
+- Preserve SvelteKit's static SPA and strict CSP posture from
+  `web/src/routes/+layout.ts` and `web/svelte.config.js`: no remote assets,
+  no inline-script-dependent component behavior, no API token in route data,
+  generated bundles, local storage, examples, screenshots, or style tokens.
+- Kit tests belong under `web/tests/components/` and should assert behavior,
+  semantics, and variants: roles, accessible names, focus/keyboard behavior,
+  disabled/loading/empty/error states, non-color status labels, and density
+  class selection. Do not rely on snapshots as the only evidence.
+- If the kit adds local preferences such as density, color mode, motion, locale,
+  time display, or terminal font size, put the schema-versioned browser-local
+  preferences seam behind one helper/store. Persist only the non-secret keys
+  allowed by `web-gui-design.md`; never persist auth material, terminal I/O,
+  raw SIEM custom queries, copied command history, hints viewed, or notes.
+- A user-visible kit change needs a `changelog.d/<issue>.<type>.md` fragment.
+  Docs-only preflight changes do not.
+
 ## Extensibility Seams
 
 The design specification should include a compact page contract table for each

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ nav:
     - SOC Feature Spec: specs/soc-feature-spec.md
     - Web GUI Design Specification: specs/web-gui-design.md
     - Web GUI Design Preflight Guardrails: specs/web-gui-design-preflight.md
+    - Web Component Kit: specs/web-component-kit.md
   - Troubleshooting: troubleshooting/index.md
   - Records:
     - CI/CD Remote Deployment (removed): deployment/ci-cd-deploy.md

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -777,17 +777,21 @@ class TestRedactorBounds:
     fail CLOSED — they over-redact, never leak.
     """
 
-    # A budget that cleanly separates the linear path (milliseconds) from a
-    # reintroduced O(n^2) backtracking regression (tens of seconds at these
-    # input sizes), while staying loose enough never to flake on a busy CI.
+    # A CPU-time budget that cleanly separates the linear path (milliseconds of
+    # CPU) from a reintroduced O(n^2) backtracking regression (tens of seconds
+    # of CPU at these input sizes). Measured with process CPU time, not wall
+    # clock: an oversubscribed host that starves this process of scheduler time
+    # inflates wall-clock duration even for the linear path and would flake the
+    # test, whereas catastrophic backtracking burns CPU — which process_time
+    # captures and scheduling delay does not.
     _BUDGET_S = 3.0
 
     def _redact_within_budget(self, value):
         import time
 
-        start = time.monotonic()
+        start = time.process_time()
         out = redact(value)
-        return out, time.monotonic() - start
+        return out, time.process_time() - start
 
     def test_impacket_positional_no_at_is_linear_not_redos(self):
         # `user:value` with no terminating `@`: before the fix this drove

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,15 +1,28 @@
 @import 'tailwindcss';
 
+/*
+ * APTL design tokens — the canonical source for the web GUI's "quiet
+ * operational workbench" look. These `@theme` custom properties drive every
+ * Tailwind `*-aptl-*` utility (e.g. `bg-aptl-surface`, `text-aptl-text-muted`,
+ * `ring-aptl-focus`). This file is the single token source: the component kit
+ * (`web/src/lib/components/kit/`) maps semantic intent to these utilities
+ * through shared recipes in `kit/tone.ts` rather than duplicating values in JS
+ * or forking a Tailwind config. See `docs/specs/web-component-kit.md`.
+ */
 @theme {
-	/* APTL Purple Team palette */
+	/* Surface ramp — page background through raised surfaces and borders. */
 	--color-aptl-bg: #1a1d23;
 	--color-aptl-surface: #23272f;
 	--color-aptl-surface-hover: #2a2f38;
 	--color-aptl-border: #333842;
+
+	/* Text — primary copy and muted/secondary copy. */
 	--color-aptl-text: #e2e8f0;
 	--color-aptl-text-muted: #94a3b8;
 
-	/* Accent colors */
+	/* Accent + semantic status colors. Purple stays an APTL accent; status and
+	   hierarchy carry meaning through the semantic colors below, never colour
+	   alone (see kit `Tone`: info/success/warning/danger/accent/neutral). */
 	--color-aptl-indigo: #6366f1;
 	--color-aptl-indigo-hover: #818cf8;
 	--color-aptl-violet: #a855f7;
@@ -18,9 +31,29 @@
 	--color-aptl-green: #22c55e;
 	--color-aptl-amber: #f59e0b;
 
-	/* Typography */
+	/* Focus — named token for the shared focus-ring recipe (WCAG 2.2 visible
+	   focus). Aliases indigo so focus treatment is consistent and overridable
+	   in one place. */
+	--color-aptl-focus: #6366f1;
+
+	/* Typography — sans for UI copy (system-font fallback), mono for terminal
+	   and command text. */
 	--font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
 	--font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* Reduced-motion safety: honour `prefers-reduced-motion` globally so kit
+   affordances (e.g. the StatusBadge pulse) never animate against the user's
+   stated preference, even where a component forgets the `motion-safe:` guard. */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
 }
 
 body {

--- a/web/src/lib/components/kit/Badge.svelte
+++ b/web/src/lib/components/kit/Badge.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { toneSoft, toneDot, type Tone } from './tone';
+
+	interface Props {
+		/** Semantic colour intent. */
+		tone?: Tone;
+		/** Show a leading status dot. */
+		dot?: boolean;
+		/** Animate the dot (used for live/running states). Honours reduced motion. */
+		pulse?: boolean;
+		/**
+		 * Accessible name. When set, the badge is exposed as `role="status"` so
+		 * assistive tech announces it as a live status rather than inline text.
+		 */
+		label?: string;
+		children: Snippet;
+	}
+
+	let { tone = 'neutral', dot = false, pulse = false, label, children }: Props = $props();
+</script>
+
+<span
+	class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium {toneSoft[
+		tone
+	]}"
+	role={label ? 'status' : undefined}
+	aria-label={label}
+>
+	{#if dot}
+		<span
+			class="h-1.5 w-1.5 rounded-full {toneDot[tone]} {pulse ? 'motion-safe:animate-pulse' : ''}"
+			aria-hidden="true"
+		></span>
+	{/if}
+	{@render children()}
+</span>

--- a/web/src/lib/components/kit/Button.svelte
+++ b/web/src/lib/components/kit/Button.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { buttonVariant, buttonSize, focusRing, type ButtonVariant, type ButtonSize } from './tone';
+
+	interface Props {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+		type?: 'button' | 'submit' | 'reset';
+		/** When set, the button renders as a link (`<a>`). */
+		href?: string;
+		disabled?: boolean;
+		/** Accessible name; required when the content is icon-only. */
+		label?: string;
+		onclick?: (event: MouseEvent) => void;
+		children: Snippet;
+	}
+
+	let {
+		variant = 'primary',
+		size = 'md',
+		type = 'button',
+		href,
+		disabled = false,
+		label,
+		onclick,
+		children
+	}: Props = $props();
+
+	const base =
+		'inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
+	let cls = $derived(`${base} ${buttonSize[size]} ${buttonVariant[variant]} ${focusRing}`);
+
+	function handleAnchorClick(event: MouseEvent) {
+		if (disabled) {
+			event.preventDefault();
+			return;
+		}
+		onclick?.(event);
+	}
+</script>
+
+{#if href}
+	<a
+		href={disabled ? undefined : href}
+		class={cls}
+		aria-label={label}
+		aria-disabled={disabled || undefined}
+		tabindex={disabled ? -1 : undefined}
+		onclick={handleAnchorClick}
+	>
+		{@render children()}
+	</a>
+{:else}
+	<button {type} class={cls} {disabled} aria-label={label} {onclick}>
+		{@render children()}
+	</button>
+{/if}

--- a/web/src/lib/components/kit/Dialog.svelte
+++ b/web/src/lib/components/kit/Dialog.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { createFocusTrap, type FocusTrap } from './focus-trap';
+	import { focusRing } from './tone';
+	import { nextId } from './id';
+
+	interface Props {
+		/** Open state. Bindable so the parent can also close it. */
+		open?: boolean;
+		title: string;
+		description?: string;
+		/** `center` is a modal dialog; `right` is a side drawer. */
+		placement?: 'center' | 'right';
+		/** Called after the dialog closes (Escape, backdrop, or programmatic). */
+		onClose?: () => void;
+		body: Snippet;
+		footer?: Snippet;
+	}
+
+	let {
+		open = $bindable(false),
+		title,
+		description,
+		placement = 'center',
+		onClose,
+		body,
+		footer
+	}: Props = $props();
+
+	let dialogEl = $state<HTMLDivElement | null>(null);
+
+	const titleId = nextId('aptl-dialog-title');
+	const descId = nextId('aptl-dialog-desc');
+
+	function close(): void {
+		open = false;
+		onClose?.();
+	}
+
+	function onKeydown(event: KeyboardEvent): void {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			close();
+		}
+	}
+
+	$effect(() => {
+		if (!open || !dialogEl) return;
+		const previouslyFocused = document.activeElement as HTMLElement | null;
+		const trap: FocusTrap = createFocusTrap(dialogEl);
+		trap.activate();
+		dialogEl.focus();
+		return () => {
+			trap.deactivate();
+			previouslyFocused?.focus?.();
+		};
+	});
+</script>
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex {placement === 'center'
+			? 'items-center justify-center p-4'
+			: 'justify-end'}"
+	>
+		<button
+			type="button"
+			class="absolute inset-0 cursor-default bg-black/60"
+			aria-label="Close dialog"
+			tabindex="-1"
+			onclick={close}
+		></button>
+		<div
+			bind:this={dialogEl}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby={titleId}
+			aria-describedby={description ? descId : undefined}
+			tabindex="-1"
+			onkeydown={onKeydown}
+			class="relative border border-aptl-border bg-aptl-surface p-5 shadow-xl {placement ===
+			'center'
+				? 'w-full max-w-md rounded-lg'
+				: 'h-full w-full max-w-sm'} {focusRing}"
+		>
+			<h2 id={titleId} class="text-base font-semibold text-aptl-text">{title}</h2>
+			{#if description}
+				<p id={descId} class="mt-1 text-sm text-aptl-text-muted">{description}</p>
+			{/if}
+			<div class="mt-4 text-sm text-aptl-text">{@render body()}</div>
+			{#if footer}
+				<div class="mt-5 flex justify-end gap-2">{@render footer()}</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/web/src/lib/components/kit/Field.svelte
+++ b/web/src/lib/components/kit/Field.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setContext } from 'svelte';
+	import { nextId } from './id';
+	import { FIELD_CONTEXT_KEY, type FieldContext } from './field-context';
+
+	interface Props {
+		/** Visible label text, associated with the control via `for`/`id`. */
+		label: string;
+		/** Optional helper text wired as `aria-describedby`. */
+		description?: string;
+		/** Validation message; presence flips the control to the invalid state. */
+		error?: string;
+		required?: boolean;
+		/** Override the generated control id. */
+		id?: string;
+		/** The form control(s); read field wiring from context. */
+		children: Snippet;
+	}
+
+	let { label, description, error, required = false, id, children }: Props = $props();
+
+	let baseId = $derived(id ?? nextId('aptl-field'));
+	let descId = $derived(`${baseId}-desc`);
+	let errId = $derived(`${baseId}-err`);
+
+	let invalid = $derived(Boolean(error));
+	let describedById = $derived(
+		[description ? descId : null, error ? errId : null].filter(Boolean).join(' ') || undefined
+	);
+
+	const context: FieldContext = {
+		get id() {
+			return baseId;
+		},
+		get describedById() {
+			return describedById;
+		},
+		get invalid() {
+			return invalid;
+		},
+		get required() {
+			return required;
+		}
+	};
+	setContext(FIELD_CONTEXT_KEY, context);
+</script>
+
+<div class="flex flex-col gap-1">
+	<label for={baseId} class="text-sm font-medium text-aptl-text">
+		{label}{#if required}<span class="text-aptl-red" aria-hidden="true"> *</span>{/if}
+	</label>
+	{#if description}
+		<p id={descId} class="text-xs text-aptl-text-muted">{description}</p>
+	{/if}
+	{@render children()}
+	{#if error}
+		<p id={errId} class="text-xs text-aptl-red" role="alert">{error}</p>
+	{/if}
+</div>

--- a/web/src/lib/components/kit/Menu.svelte
+++ b/web/src/lib/components/kit/Menu.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { focusRing } from './tone';
+	import { nextId } from './id';
+
+	interface MenuItem {
+		label: string;
+		onSelect: () => void;
+		disabled?: boolean;
+	}
+
+	interface Props {
+		/** Trigger text and the menu's accessible name. */
+		label: string;
+		items: MenuItem[];
+		/** Horizontal alignment of the popup relative to the trigger. */
+		align?: 'left' | 'right';
+	}
+
+	let { label, items, align = 'left' }: Props = $props();
+
+	let open = $state(false);
+	let activeIndex = $state(-1);
+	let buttonEl = $state<HTMLButtonElement | null>(null);
+	let menuEl = $state<HTMLDivElement | null>(null);
+
+	const menuId = nextId('aptl-menu');
+
+	function enabledIndexes(): number[] {
+		return items.map((item, i) => (item.disabled ? -1 : i)).filter((i) => i >= 0);
+	}
+
+	function openMenu(focusLast = false): void {
+		open = true;
+		const enabled = enabledIndexes();
+		activeIndex = enabled.length ? (focusLast ? enabled[enabled.length - 1] : enabled[0]) : -1;
+	}
+
+	function closeMenu(restoreFocus = true): void {
+		open = false;
+		activeIndex = -1;
+		if (restoreFocus) buttonEl?.focus();
+	}
+
+	function moveActive(direction: 1 | -1): void {
+		const enabled = enabledIndexes();
+		if (!enabled.length) return;
+		const pos = enabled.indexOf(activeIndex);
+		activeIndex =
+			pos === -1
+				? direction === 1
+					? enabled[0]
+					: enabled[enabled.length - 1]
+				: enabled[(pos + direction + enabled.length) % enabled.length];
+	}
+
+	function selectItem(index: number): void {
+		const item = items[index];
+		if (!item || item.disabled) return;
+		item.onSelect();
+		closeMenu();
+	}
+
+	function focusEdge(edge: 'first' | 'last'): boolean {
+		const enabled = enabledIndexes();
+		if (!enabled.length) return false;
+		activeIndex = edge === 'first' ? enabled[0] : enabled[enabled.length - 1];
+		return true;
+	}
+
+	function activateActive(): boolean {
+		if (!open || activeIndex < 0) return false;
+		selectItem(activeIndex);
+		return true;
+	}
+
+	/**
+	 * Key handlers, split into a dispatch table to keep each path simple. Each
+	 * returns whether it handled the key, so the caller suppresses the default
+	 * only when it acted — leaving the trigger's native Enter/Space activation
+	 * intact while the menu is closed.
+	 */
+	const KEY_ACTIONS: Record<string, () => boolean> = {
+		ArrowDown: () => (open ? moveActive(1) : openMenu(), true),
+		ArrowUp: () => (open ? moveActive(-1) : openMenu(true), true),
+		Home: () => open && focusEdge('first'),
+		End: () => open && focusEdge('last'),
+		Escape: () => (open ? (closeMenu(), true) : false),
+		Enter: activateActive,
+		' ': activateActive
+	};
+
+	function onKeydown(event: KeyboardEvent): void {
+		if (KEY_ACTIONS[event.key]?.()) event.preventDefault();
+	}
+
+	function onWindowClick(event: MouseEvent): void {
+		if (!open) return;
+		const target = event.target as Node;
+		if (buttonEl?.contains(target) || menuEl?.contains(target)) return;
+		closeMenu(false);
+	}
+
+	$effect(() => {
+		if (open && menuEl && activeIndex >= 0) {
+			menuEl.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`)?.focus();
+		}
+	});
+</script>
+
+<svelte:window onclick={onWindowClick} />
+
+<div class="relative inline-block text-left">
+	<button
+		bind:this={buttonEl}
+		type="button"
+		aria-haspopup="menu"
+		aria-expanded={open}
+		aria-controls={open ? menuId : undefined}
+		onclick={() => (open ? closeMenu() : openMenu())}
+		onkeydown={onKeydown}
+		class="inline-flex items-center gap-1 rounded-md border border-aptl-border bg-aptl-surface px-3 py-1.5 text-sm text-aptl-text hover:bg-aptl-surface-hover {focusRing}"
+	>
+		{label}
+	</button>
+	{#if open}
+		<div
+			bind:this={menuEl}
+			id={menuId}
+			role="menu"
+			aria-label={label}
+			tabindex="-1"
+			onkeydown={onKeydown}
+			class="absolute z-40 mt-1 min-w-[10rem] rounded-md border border-aptl-border bg-aptl-surface p-1 shadow-lg {align ===
+			'right'
+				? 'right-0'
+				: 'left-0'}"
+		>
+			{#each items as item, index (item.label)}
+				<button
+					type="button"
+					role="menuitem"
+					data-index={index}
+					tabindex="-1"
+					disabled={item.disabled}
+					onclick={() => selectItem(index)}
+					class="block w-full rounded px-3 py-1.5 text-left text-sm text-aptl-text hover:bg-aptl-surface-hover disabled:cursor-not-allowed disabled:opacity-40 {focusRing}"
+				>
+					{item.label}
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/web/src/lib/components/kit/Select.svelte
+++ b/web/src/lib/components/kit/Select.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { focusRing } from './tone';
+	import { FIELD_CONTEXT_KEY, type FieldContext } from './field-context';
+
+	interface SelectOption {
+		value: string;
+		label: string;
+		disabled?: boolean;
+	}
+
+	interface Props {
+		id?: string;
+		value?: string;
+		options: SelectOption[];
+		disabled?: boolean;
+		invalid?: boolean;
+		describedById?: string;
+		required?: boolean;
+		/** Accessible name when no associated `Field`/`<label>` is present. */
+		ariaLabel?: string;
+	}
+
+	let {
+		id,
+		value = $bindable(''),
+		options,
+		disabled = false,
+		invalid,
+		describedById,
+		required,
+		ariaLabel
+	}: Props = $props();
+
+	const field = getContext<FieldContext | undefined>(FIELD_CONTEXT_KEY);
+
+	let resolvedId = $derived(id ?? field?.id);
+	let resolvedInvalid = $derived(invalid ?? field?.invalid ?? false);
+	let resolvedDescribedBy = $derived(describedById ?? field?.describedById);
+	let resolvedRequired = $derived(required ?? field?.required ?? false);
+
+	const base =
+		'w-full rounded-md border bg-aptl-surface px-3 py-2 text-sm text-aptl-text disabled:cursor-not-allowed disabled:opacity-50';
+	let cls = $derived(
+		`${base} ${resolvedInvalid ? 'border-aptl-red' : 'border-aptl-border'} ${focusRing}`
+	);
+</script>
+
+<select
+	id={resolvedId}
+	{disabled}
+	required={resolvedRequired}
+	aria-label={ariaLabel}
+	aria-invalid={resolvedInvalid || undefined}
+	aria-describedby={resolvedDescribedBy}
+	class={cls}
+	bind:value
+>
+	{#each options as option (option.value)}
+		<option value={option.value} disabled={option.disabled}>{option.label}</option>
+	{/each}
+</select>

--- a/web/src/lib/components/kit/StatusBadge.svelte
+++ b/web/src/lib/components/kit/StatusBadge.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import Badge from './Badge.svelte';
+	import type { Tone } from './tone';
+
+	interface Props {
+		/** Semantic colour intent for the status. */
+		tone?: Tone;
+		/** Visible, non-colour status text (colour is never the only cue). */
+		label: string;
+		/** Animate the dot for live/running states. Honours reduced motion. */
+		pulse?: boolean;
+	}
+
+	let { tone = 'neutral', label, pulse = false }: Props = $props();
+</script>
+
+<Badge {tone} dot {pulse} {label}>{label}</Badge>

--- a/web/src/lib/components/kit/Table.svelte
+++ b/web/src/lib/components/kit/Table.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { Density } from './tone';
+
+	interface Props {
+		/** Required table caption (WCAG: tables need a programmatic name). */
+		caption: string;
+		/** Render the caption visibly; otherwise it is screen-reader-only. */
+		captionVisible?: boolean;
+		/** Cell padding density. */
+		density?: Density;
+		/** `<tr>`/`<th>` markup for the header row. */
+		head: Snippet;
+		/** `<tr>`/`<td>` markup for the body rows. */
+		body: Snippet;
+	}
+
+	let { caption, captionVisible = false, density = 'comfortable', head, body }: Props = $props();
+</script>
+
+<table class="aptl-table density-{density} w-full border-collapse text-sm">
+	<caption
+		class={captionVisible
+			? 'mb-2 text-left text-sm font-medium text-aptl-text'
+			: 'sr-only'}
+	>
+		{caption}
+	</caption>
+	<thead class="border-b border-aptl-border text-left text-xs font-medium text-aptl-text-muted">
+		{@render head()}
+	</thead>
+	<tbody class="divide-y divide-aptl-border text-aptl-text">
+		{@render body()}
+	</tbody>
+</table>
+
+<style>
+	/* Density controls cell padding for plain <th>/<td> in the slotted markup,
+	   so consumers write semantic table rows without repeating padding classes. */
+	.aptl-table.density-comfortable :global(th),
+	.aptl-table.density-comfortable :global(td) {
+		padding: 0.625rem 1rem;
+	}
+	.aptl-table.density-compact :global(th),
+	.aptl-table.density-compact :global(td) {
+		padding: 0.375rem 0.75rem;
+	}
+</style>

--- a/web/src/lib/components/kit/TextInput.svelte
+++ b/web/src/lib/components/kit/TextInput.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { focusRing } from './tone';
+	import { FIELD_CONTEXT_KEY, type FieldContext } from './field-context';
+
+	interface Props {
+		id?: string;
+		value?: string;
+		type?: 'text' | 'search' | 'email' | 'url' | 'number' | 'password';
+		placeholder?: string;
+		disabled?: boolean;
+		invalid?: boolean;
+		describedById?: string;
+		required?: boolean;
+		/** Accessible name when no associated `Field`/`<label>` is present. */
+		ariaLabel?: string;
+	}
+
+	let {
+		id,
+		value = $bindable(''),
+		type = 'text',
+		placeholder,
+		disabled = false,
+		invalid,
+		describedById,
+		required,
+		ariaLabel
+	}: Props = $props();
+
+	const field = getContext<FieldContext | undefined>(FIELD_CONTEXT_KEY);
+
+	let resolvedId = $derived(id ?? field?.id);
+	let resolvedInvalid = $derived(invalid ?? field?.invalid ?? false);
+	let resolvedDescribedBy = $derived(describedById ?? field?.describedById);
+	let resolvedRequired = $derived(required ?? field?.required ?? false);
+
+	const base =
+		'w-full rounded-md border bg-aptl-surface px-3 py-2 text-sm text-aptl-text placeholder:text-aptl-text-muted disabled:cursor-not-allowed disabled:opacity-50';
+	let cls = $derived(
+		`${base} ${resolvedInvalid ? 'border-aptl-red' : 'border-aptl-border'} ${focusRing}`
+	);
+</script>
+
+<input
+	id={resolvedId}
+	{type}
+	{placeholder}
+	{disabled}
+	required={resolvedRequired}
+	aria-label={ariaLabel}
+	aria-invalid={resolvedInvalid || undefined}
+	aria-describedby={resolvedDescribedBy}
+	class={cls}
+	bind:value
+/>

--- a/web/src/lib/components/kit/field-context.ts
+++ b/web/src/lib/components/kit/field-context.ts
@@ -1,0 +1,16 @@
+/**
+ * Context contract shared between `Field` and the form controls it wraps
+ * (`TextInput`, `Select`). `Field` owns id generation and validation/described-by
+ * wiring; controls read it from context so a consumer writes
+ * `<Field label="…"><TextInput /></Field>` without threading ids by hand.
+ *
+ * Controls fall back to their own props when rendered outside a `Field`.
+ */
+export const FIELD_CONTEXT_KEY = Symbol('aptl-field');
+
+export interface FieldContext {
+	readonly id: string;
+	readonly describedById: string | undefined;
+	readonly invalid: boolean;
+	readonly required: boolean;
+}

--- a/web/src/lib/components/kit/focus-trap.ts
+++ b/web/src/lib/components/kit/focus-trap.ts
@@ -48,7 +48,7 @@ export function createFocusTrap(container: HTMLElement): FocusTrap {
 			return;
 		}
 		const first = focusable[0];
-		const last = focusable[focusable.length - 1];
+		const last = focusable.at(-1) ?? first;
 		const active = document.activeElement;
 		if (event.shiftKey && (active === first || active === container)) {
 			event.preventDefault();

--- a/web/src/lib/components/kit/focus-trap.ts
+++ b/web/src/lib/components/kit/focus-trap.ts
@@ -1,0 +1,70 @@
+/**
+ * Minimal focus-management utilities for the kit's overlay primitives
+ * (`Dialog`, `Menu`). Owning this behaviour — rather than pulling a headless
+ * component library — keeps the kit small, avoids a new runtime dependency
+ * under the strict `script-src 'self'` CSP, and lets the focus contract be
+ * tested directly.
+ */
+
+const FOCUSABLE_SELECTOR = [
+	'a[href]',
+	'button:not([disabled])',
+	'input:not([disabled])',
+	'select:not([disabled])',
+	'textarea:not([disabled])',
+	'[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+/**
+ * Focusable descendants of `container`, in DOM order. Elements explicitly
+ * hidden via the `hidden` attribute or `aria-hidden` are excluded. Layout-based
+ * visibility is intentionally not consulted (jsdom has no layout, and the kit's
+ * overlays mount their content unconditionally while open).
+ */
+export function getFocusable(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+		(el) => !el.hasAttribute('hidden') && el.getAttribute('aria-hidden') !== 'true'
+	);
+}
+
+export interface FocusTrap {
+	activate(): void;
+	deactivate(): void;
+}
+
+/**
+ * Confine Tab / Shift+Tab focus cycling to `container`. The container itself is
+ * treated as a valid focus position (it carries `tabindex="-1"` so the overlay
+ * can receive initial focus); Tab from the last element wraps to the first, and
+ * Shift+Tab from the first (or the container) wraps to the last.
+ */
+export function createFocusTrap(container: HTMLElement): FocusTrap {
+	function onKeydown(event: KeyboardEvent): void {
+		if (event.key !== 'Tab') return;
+		const focusable = getFocusable(container);
+		if (focusable.length === 0) {
+			event.preventDefault();
+			container.focus();
+			return;
+		}
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		const active = document.activeElement;
+		if (event.shiftKey && (active === first || active === container)) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && active === last) {
+			event.preventDefault();
+			first.focus();
+		}
+	}
+
+	return {
+		activate() {
+			container.addEventListener('keydown', onKeydown);
+		},
+		deactivate() {
+			container.removeEventListener('keydown', onKeydown);
+		}
+	};
+}

--- a/web/src/lib/components/kit/id.ts
+++ b/web/src/lib/components/kit/id.ts
@@ -1,0 +1,13 @@
+/**
+ * Deterministic, collision-free id generator for kit primitives.
+ *
+ * Components that wire ARIA relationships (`Field` → control, `Dialog` title /
+ * description, `Menu` trigger → menu) need stable ids without depending on
+ * `Math.random()`. A module-level counter is monotonic within a page load and
+ * keeps test output deterministic per render order.
+ */
+let counter = 0;
+
+export function nextId(prefix = 'aptl'): string {
+	return `${prefix}-${++counter}`;
+}

--- a/web/src/lib/components/kit/index.ts
+++ b/web/src/lib/components/kit/index.ts
@@ -1,0 +1,28 @@
+/**
+ * APTL web component kit — barrel export.
+ *
+ * Small, presentation/interaction-only primitives built on the Tailwind v4
+ * tokens in `web/src/app.css`. See `docs/specs/web-component-kit.md`.
+ */
+export { default as Badge } from './Badge.svelte';
+export { default as StatusBadge } from './StatusBadge.svelte';
+export { default as Button } from './Button.svelte';
+export { default as Field } from './Field.svelte';
+export { default as TextInput } from './TextInput.svelte';
+export { default as Select } from './Select.svelte';
+export { default as Table } from './Table.svelte';
+export { default as Dialog } from './Dialog.svelte';
+export { default as Menu } from './Menu.svelte';
+
+export {
+	toneSoft,
+	toneDot,
+	buttonVariant,
+	buttonSize,
+	focusRing,
+	type Tone,
+	type ButtonVariant,
+	type ButtonSize,
+	type Density
+} from './tone';
+export { FIELD_CONTEXT_KEY, type FieldContext } from './field-context';

--- a/web/src/lib/components/kit/tone.ts
+++ b/web/src/lib/components/kit/tone.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared semantic class recipes for the APTL component kit.
+ *
+ * This module is the single place semantic intent (a status, a button role, a
+ * table density) maps to Tailwind utility classes built on the tokens defined
+ * in `web/src/app.css`. Components consume these recipes through semantic props
+ * instead of accepting arbitrary colour-class strings, which keeps status
+ * colours from drifting into per-component `switch` statements.
+ *
+ * It deliberately mirrors *class recipes*, never token hex values — `app.css`
+ * stays the canonical token source (no JS token mirror, no Tailwind config
+ * fork).
+ */
+
+/** Semantic tone shared by badges, status pills, and form validation states. */
+export type Tone = 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 'accent';
+
+/** Soft pill treatment: tinted background plus a readable foreground colour. */
+export const toneSoft: Record<Tone, string> = {
+	neutral: 'bg-aptl-text-muted/10 text-aptl-text-muted',
+	info: 'bg-aptl-indigo/10 text-aptl-indigo',
+	success: 'bg-aptl-green/10 text-aptl-green',
+	warning: 'bg-aptl-amber/10 text-aptl-amber',
+	danger: 'bg-aptl-red/10 text-aptl-red',
+	accent: 'bg-aptl-violet/10 text-aptl-violet'
+};
+
+/** Solid status-dot colour per tone. */
+export const toneDot: Record<Tone, string> = {
+	neutral: 'bg-aptl-text-muted',
+	info: 'bg-aptl-indigo',
+	success: 'bg-aptl-green',
+	warning: 'bg-aptl-amber',
+	danger: 'bg-aptl-red',
+	accent: 'bg-aptl-violet'
+};
+
+/** Button visual role. `danger` is reserved for destructive actions. */
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+
+export const buttonVariant: Record<ButtonVariant, string> = {
+	primary: 'bg-aptl-indigo text-white hover:bg-aptl-indigo-hover',
+	secondary: 'border border-aptl-border bg-aptl-surface text-aptl-text hover:bg-aptl-surface-hover',
+	ghost: 'text-aptl-text-muted hover:bg-aptl-surface-hover hover:text-aptl-text',
+	danger: 'bg-aptl-red text-white hover:bg-aptl-red/90'
+};
+
+export type ButtonSize = 'sm' | 'md';
+
+export const buttonSize: Record<ButtonSize, string> = {
+	sm: 'h-8 px-3 text-xs',
+	md: 'h-10 px-4 text-sm'
+};
+
+/**
+ * Shared focus-ring recipe. Uses the named `--color-aptl-focus` token so focus
+ * treatment is consistent and visible (WCAG 2.2 focus-visible) across every
+ * interactive primitive.
+ */
+export const focusRing =
+	'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aptl-focus focus-visible:ring-offset-2 focus-visible:ring-offset-aptl-bg';
+
+/** Table / list / card density. Consumed via component props, not persisted here. */
+export type Density = 'comfortable' | 'compact';

--- a/web/tests/components/kit/Badge.test.ts
+++ b/web/tests/components/kit/Badge.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Badge from '../../../src/lib/components/kit/Badge.svelte';
+import { textSnippet } from './helpers';
+
+describe('Badge', () => {
+	it('renders its content', () => {
+		render(Badge, { props: { children: textSnippet('Ready') } });
+		expect(screen.getByText('Ready')).toBeTruthy();
+	});
+
+	it('applies the soft recipe for the given tone', () => {
+		const { container } = render(Badge, {
+			props: { tone: 'success', children: textSnippet('Healthy') }
+		});
+		const badge = container.querySelector('span');
+		expect(badge?.className).toContain('bg-aptl-green/10');
+		expect(badge?.className).toContain('text-aptl-green');
+	});
+
+	it('renders a decorative dot when requested', () => {
+		const { container } = render(Badge, {
+			props: { tone: 'danger', dot: true, children: textSnippet('Down') }
+		});
+		const dot = container.querySelector('span > span[aria-hidden="true"]');
+		expect(dot).toBeTruthy();
+		expect(dot?.className).toContain('bg-aptl-red');
+	});
+
+	it('exposes role=status with an accessible name when label is set', () => {
+		render(Badge, { props: { label: 'Lab running', children: textSnippet('Running') } });
+		expect(screen.getByRole('status', { name: 'Lab running' })).toBeTruthy();
+	});
+
+	it('only animates the dot under motion-safe', () => {
+		const { container } = render(Badge, {
+			props: { tone: 'success', dot: true, pulse: true, children: textSnippet('Running') }
+		});
+		const dot = container.querySelector('span > span[aria-hidden="true"]');
+		expect(dot?.className).toContain('motion-safe:animate-pulse');
+	});
+});

--- a/web/tests/components/kit/Button.test.ts
+++ b/web/tests/components/kit/Button.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Button from '../../../src/lib/components/kit/Button.svelte';
+import { textSnippet } from './helpers';
+
+describe('Button', () => {
+	it('renders a <button> by default and applies the variant recipe', () => {
+		const { container } = render(Button, {
+			props: { variant: 'danger', children: textSnippet('Kill') }
+		});
+		const button = screen.getByRole('button', { name: 'Kill' });
+		expect(button.tagName).toBe('BUTTON');
+		expect(container.querySelector('button')?.className).toContain('bg-aptl-red');
+	});
+
+	it('renders an <a> when href is provided', () => {
+		render(Button, { props: { href: '/terminal/victim', children: textSnippet('Terminal') } });
+		const link = screen.getByRole('link', { name: 'Terminal' });
+		expect(link.getAttribute('href')).toBe('/terminal/victim');
+	});
+
+	it('fires onclick', async () => {
+		const onclick = vi.fn();
+		render(Button, { props: { onclick, children: textSnippet('Go') } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+		expect(onclick).toHaveBeenCalledOnce();
+	});
+
+	it('is disabled and unclickable when disabled', () => {
+		render(Button, { props: { disabled: true, children: textSnippet('Start') } });
+		expect((screen.getByRole('button', { name: 'Start' }) as HTMLButtonElement).disabled).toBe(true);
+	});
+
+	it('is inert when disabled and rendered as a link', async () => {
+		const onclick = vi.fn();
+		const { container } = render(Button, {
+			props: { href: '/terminal/victim', disabled: true, onclick, children: textSnippet('Terminal') }
+		});
+		const link = container.querySelector('a') as HTMLAnchorElement;
+		expect(link.getAttribute('href')).toBe(null);
+		expect(link.getAttribute('aria-disabled')).toBe('true');
+		expect(link.getAttribute('tabindex')).toBe('-1');
+		await fireEvent.click(link);
+		expect(onclick).not.toHaveBeenCalled();
+	});
+
+	it('uses the label prop as an accessible name for icon-only content', () => {
+		render(Button, { props: { label: 'Refresh', children: textSnippet('⟳') } });
+		expect(screen.getByRole('button', { name: 'Refresh' })).toBeTruthy();
+	});
+});

--- a/web/tests/components/kit/Dialog.test.ts
+++ b/web/tests/components/kit/Dialog.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import DialogHarness from './fixtures/DialogHarness.svelte';
+
+async function open() {
+	const result = render(DialogHarness, {});
+	// Focus the trigger as a real keyboard/pointer interaction would, so the
+	// dialog captures it as the element to restore focus to on close.
+	const trigger = screen.getByTestId('trigger');
+	trigger.focus();
+	await fireEvent.click(trigger);
+	const dialog = await screen.findByRole('dialog');
+	return { ...result, dialog };
+}
+
+describe('Dialog', () => {
+	it('is not in the DOM until opened', () => {
+		render(DialogHarness, {});
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+	it('exposes modal semantics and a programmatic name/description', async () => {
+		const { dialog } = await open();
+		expect(dialog.getAttribute('aria-modal')).toBe('true');
+		const labelledBy = dialog.getAttribute('aria-labelledby');
+		const describedBy = dialog.getAttribute('aria-describedby');
+		expect(document.getElementById(labelledBy!)?.textContent).toContain('Confirm kill');
+		expect(document.getElementById(describedBy!)?.textContent).toContain('Containers will stop.');
+	});
+
+	it('moves focus into the dialog when opened', async () => {
+		const { dialog } = await open();
+		expect(dialog.contains(document.activeElement)).toBe(true);
+	});
+
+	it('closes on Escape and returns focus to the trigger', async () => {
+		const { dialog } = await open();
+		await fireEvent.keyDown(dialog, { key: 'Escape' });
+		await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+		expect(document.activeElement).toBe(screen.getByTestId('trigger'));
+	});
+
+	it('closes when the backdrop is clicked', async () => {
+		await open();
+		await fireEvent.click(screen.getByLabelText('Close dialog'));
+		await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+	});
+
+	it('invokes onClose when it closes', async () => {
+		const onClose = vi.fn();
+		render(DialogHarness, { props: { onClose } });
+		await fireEvent.click(screen.getByTestId('trigger'));
+		const dialog = await screen.findByRole('dialog');
+		await fireEvent.keyDown(dialog, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('supports a drawer placement', async () => {
+		render(DialogHarness, { props: { placement: 'right' } });
+		await fireEvent.click(screen.getByTestId('trigger'));
+		const dialog = await screen.findByRole('dialog');
+		expect(dialog.className).toContain('h-full');
+	});
+});

--- a/web/tests/components/kit/Field.test.ts
+++ b/web/tests/components/kit/Field.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import FieldHarness from './fixtures/FieldHarness.svelte';
+
+describe('Field', () => {
+	it('associates the label with the control via for/id', () => {
+		render(FieldHarness, { props: { label: 'Scenario name' } });
+		const input = screen.getByLabelText('Scenario name');
+		expect(input.tagName).toBe('INPUT');
+		expect(input.id).toBeTruthy();
+	});
+
+	it('wires the description through aria-describedby', () => {
+		render(FieldHarness, {
+			props: { label: 'Time range', description: 'Backend still enforces the maximum.' }
+		});
+		const input = screen.getByLabelText('Time range');
+		const describedBy = input.getAttribute('aria-describedby');
+		expect(describedBy).toBeTruthy();
+		const desc = document.getElementById(describedBy!.split(' ')[0]);
+		expect(desc?.textContent).toContain('Backend still enforces');
+	});
+
+	it('marks the control invalid and exposes the error as an alert', () => {
+		render(FieldHarness, { props: { label: 'Row limit', error: 'Above the backend cap.' } });
+		const input = screen.getByLabelText('Row limit');
+		expect(input.getAttribute('aria-invalid')).toBe('true');
+		const alert = screen.getByRole('alert');
+		expect(alert.textContent).toContain('Above the backend cap.');
+		expect(input.getAttribute('aria-describedby')).toContain(alert.id);
+	});
+
+	it('propagates required to the control', () => {
+		render(FieldHarness, { props: { label: 'Query', required: true } });
+		expect((screen.getByLabelText(/Query/) as HTMLInputElement).required).toBe(true);
+	});
+});

--- a/web/tests/components/kit/Menu.test.ts
+++ b/web/tests/components/kit/Menu.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import Menu from '../../../src/lib/components/kit/Menu.svelte';
+
+function items() {
+	return [
+		{ label: 'Comfortable', onSelect: vi.fn() },
+		{ label: 'Compact', onSelect: vi.fn(), disabled: true },
+		{ label: 'Reset', onSelect: vi.fn() }
+	];
+}
+
+describe('Menu', () => {
+	it('renders a trigger with menu button semantics', () => {
+		render(Menu, { props: { label: 'Density', items: items() } });
+		const trigger = screen.getByRole('button', { name: 'Density' });
+		expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
+		expect(trigger.getAttribute('aria-expanded')).toBe('false');
+	});
+
+	it('opens on click and focuses the first enabled item', async () => {
+		render(Menu, { props: { label: 'Density', items: items() } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Density' }));
+		const menu = screen.getByRole('menu', { name: 'Density' });
+		expect(menu).toBeTruthy();
+		await waitFor(() =>
+			expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Comfortable' }))
+		);
+	});
+
+	it('selects an item and closes, calling onSelect', async () => {
+		const list = items();
+		render(Menu, { props: { label: 'Density', items: list } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Density' }));
+		await fireEvent.click(screen.getByRole('menuitem', { name: 'Reset' }));
+		expect(list[2].onSelect).toHaveBeenCalledOnce();
+		await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+	});
+
+	it('skips the disabled item when navigating with ArrowDown', async () => {
+		render(Menu, { props: { label: 'Density', items: items() } });
+		const trigger = screen.getByRole('button', { name: 'Density' });
+		await fireEvent.click(trigger);
+		await fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+		await waitFor(() =>
+			expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Reset' }))
+		);
+	});
+
+	it('does not select a disabled item', async () => {
+		const list = items();
+		render(Menu, { props: { label: 'Density', items: list } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Density' }));
+		await fireEvent.click(screen.getByRole('menuitem', { name: 'Compact' }));
+		expect(list[1].onSelect).not.toHaveBeenCalled();
+	});
+
+	it('closes on Escape and restores focus to the trigger', async () => {
+		render(Menu, { props: { label: 'Density', items: items() } });
+		const trigger = screen.getByRole('button', { name: 'Density' });
+		await fireEvent.click(trigger);
+		await fireEvent.keyDown(trigger, { key: 'Escape' });
+		await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+		expect(document.activeElement).toBe(trigger);
+	});
+
+	it('closes when clicking outside', async () => {
+		render(Menu, { props: { label: 'Density', items: items() } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Density' }));
+		expect(screen.getByRole('menu')).toBeTruthy();
+		await fireEvent.click(document.body);
+		await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+	});
+});

--- a/web/tests/components/kit/Select.test.ts
+++ b/web/tests/components/kit/Select.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Select from '../../../src/lib/components/kit/Select.svelte';
+import SelectHarness from './fixtures/SelectHarness.svelte';
+
+const OPTIONS = [
+	{ value: '15m', label: 'Last 15 minutes' },
+	{ value: '1h', label: 'Last hour' },
+	{ value: '24h', label: 'Last 24 hours' }
+];
+
+describe('Select', () => {
+	it('renders all options', () => {
+		render(Select, { props: { ariaLabel: 'Time range', options: OPTIONS, value: '1h' } });
+		expect(screen.getByRole('option', { name: 'Last 15 minutes' })).toBeTruthy();
+		expect(screen.getAllByRole('option')).toHaveLength(3);
+	});
+
+	it('propagates the changed value through bind:value', async () => {
+		// Assert on the parent-owned bound value (surfaced via the harness), not the raw
+		// DOM `select.value` — fireEvent sets that property directly, so reading it back
+		// would be tautological and would stay green even if `bind:value` were dropped.
+		render(SelectHarness, { props: { ariaLabel: 'Time range', options: OPTIONS, value: '15m' } });
+		const select = screen.getByRole('combobox', { name: 'Time range' }) as HTMLSelectElement;
+		await fireEvent.change(select, { target: { value: '24h' } });
+		expect(screen.getByTestId('bound-value').textContent).toBe('24h');
+	});
+
+	it('reflects the invalid state', () => {
+		const { container } = render(Select, {
+			props: { ariaLabel: 'T', options: OPTIONS, invalid: true }
+		});
+		expect(container.querySelector('select')?.getAttribute('aria-invalid')).toBe('true');
+	});
+});

--- a/web/tests/components/kit/StatusBadge.test.ts
+++ b/web/tests/components/kit/StatusBadge.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import StatusBadge from '../../../src/lib/components/kit/StatusBadge.svelte';
+
+describe('StatusBadge', () => {
+	it('shows a visible text label (colour is never the only cue)', () => {
+		render(StatusBadge, { props: { tone: 'success', label: 'Running' } });
+		const status = screen.getByRole('status', { name: 'Running' });
+		expect(status.textContent).toContain('Running');
+	});
+
+	it('renders a status dot in the tone colour', () => {
+		const { container } = render(StatusBadge, { props: { tone: 'neutral', label: 'Stopped' } });
+		const dot = container.querySelector('span[aria-hidden="true"]');
+		expect(dot?.className).toContain('bg-aptl-text-muted');
+	});
+});

--- a/web/tests/components/kit/Table.test.ts
+++ b/web/tests/components/kit/Table.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import TableHarness from './fixtures/TableHarness.svelte';
+
+describe('Table', () => {
+	it('renders a captioned table with header and body cells', () => {
+		render(TableHarness, {});
+		const table = screen.getByRole('table', { name: 'Recent alerts' });
+		expect(table).toBeTruthy();
+		expect(screen.getByRole('columnheader', { name: 'Rule' })).toBeTruthy();
+		expect(screen.getByRole('cell', { name: 'auth-fail' })).toBeTruthy();
+	});
+
+	it('keeps the caption screen-reader-only by default', () => {
+		const { container } = render(TableHarness, {});
+		expect(container.querySelector('caption')?.className).toContain('sr-only');
+	});
+
+	it('renders the caption visibly when requested', () => {
+		const { container } = render(TableHarness, { props: { captionVisible: true } });
+		expect(container.querySelector('caption')?.className).not.toContain('sr-only');
+	});
+
+	it('applies the density class', () => {
+		const { container } = render(TableHarness, { props: { density: 'compact' } });
+		expect(container.querySelector('table')?.className).toContain('density-compact');
+	});
+});

--- a/web/tests/components/kit/TextInput.test.ts
+++ b/web/tests/components/kit/TextInput.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import TextInput from '../../../src/lib/components/kit/TextInput.svelte';
+import TextInputHarness from './fixtures/TextInputHarness.svelte';
+
+describe('TextInput', () => {
+	it('renders with an accessible name and propagates typed value through bind:value', async () => {
+		// Assert on the parent-owned bound value (surfaced via the harness), not the raw
+		// DOM `input.value` — fireEvent sets that property directly, so reading it back
+		// would be tautological and would stay green even if `bind:value` were dropped.
+		render(TextInputHarness, { props: { ariaLabel: 'Custom query', value: '' } });
+		const input = screen.getByRole('textbox', { name: 'Custom query' }) as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'rule.level:>=10' } });
+		expect(screen.getByTestId('bound-value').textContent).toBe('rule.level:>=10');
+	});
+
+	it('reflects the invalid state on aria-invalid and border', () => {
+		const { container } = render(TextInput, { props: { ariaLabel: 'Q', invalid: true } });
+		const input = container.querySelector('input');
+		expect(input?.getAttribute('aria-invalid')).toBe('true');
+		expect(input?.className).toContain('border-aptl-red');
+	});
+
+	it('omits aria-invalid when valid', () => {
+		const { container } = render(TextInput, { props: { ariaLabel: 'Q' } });
+		expect(container.querySelector('input')?.getAttribute('aria-invalid')).toBeNull();
+	});
+});

--- a/web/tests/components/kit/fixtures/DialogHarness.svelte
+++ b/web/tests/components/kit/fixtures/DialogHarness.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import Dialog from '../../../../src/lib/components/kit/Dialog.svelte';
+
+	interface Props {
+		placement?: 'center' | 'right';
+		onClose?: () => void;
+	}
+
+	let { placement = 'center', onClose }: Props = $props();
+	let open = $state(false);
+</script>
+
+<button data-testid="trigger" onclick={() => (open = true)}>Open</button>
+
+<Dialog bind:open title="Confirm kill" description="Containers will stop." {placement} {onClose}>
+	{#snippet body()}
+		<button data-testid="inner">Inner action</button>
+	{/snippet}
+	{#snippet footer()}
+		<button data-testid="cancel" onclick={() => (open = false)}>Cancel</button>
+	{/snippet}
+</Dialog>

--- a/web/tests/components/kit/fixtures/FieldHarness.svelte
+++ b/web/tests/components/kit/fixtures/FieldHarness.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import Field from '../../../../src/lib/components/kit/Field.svelte';
+	import TextInput from '../../../../src/lib/components/kit/TextInput.svelte';
+
+	interface Props {
+		label: string;
+		description?: string;
+		error?: string;
+		required?: boolean;
+	}
+
+	let { label, description, error, required = false }: Props = $props();
+</script>
+
+<Field {label} {description} {error} {required}>
+	<TextInput />
+</Field>

--- a/web/tests/components/kit/fixtures/SelectHarness.svelte
+++ b/web/tests/components/kit/fixtures/SelectHarness.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import Select from '../../../../src/lib/components/kit/Select.svelte';
+
+	interface SelectOption {
+		value: string;
+		label: string;
+		disabled?: boolean;
+	}
+
+	interface Props {
+		ariaLabel?: string;
+		options: SelectOption[];
+		value?: string;
+	}
+
+	let { ariaLabel, options, value = '' }: Props = $props();
+	// Seed the parent-owned bound value once; `bind:value` drives it thereafter.
+	let bound = $state(untrack(() => value));
+</script>
+
+<Select {ariaLabel} {options} bind:value={bound} />
+<span data-testid="bound-value">{bound}</span>

--- a/web/tests/components/kit/fixtures/TableHarness.svelte
+++ b/web/tests/components/kit/fixtures/TableHarness.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import Table from '../../../../src/lib/components/kit/Table.svelte';
+	import type { Density } from '../../../../src/lib/components/kit/tone';
+
+	interface Props {
+		density?: Density;
+		captionVisible?: boolean;
+	}
+
+	let { density = 'comfortable', captionVisible = false }: Props = $props();
+</script>
+
+<Table caption="Recent alerts" {density} {captionVisible}>
+	{#snippet head()}
+		<tr><th>Rule</th><th>Host</th></tr>
+	{/snippet}
+	{#snippet body()}
+		<tr><td>auth-fail</td><td>victim</td></tr>
+	{/snippet}
+</Table>

--- a/web/tests/components/kit/fixtures/TextInputHarness.svelte
+++ b/web/tests/components/kit/fixtures/TextInputHarness.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import TextInput from '../../../../src/lib/components/kit/TextInput.svelte';
+
+	interface Props {
+		ariaLabel?: string;
+		value?: string;
+	}
+
+	let { ariaLabel, value = '' }: Props = $props();
+	// Seed the parent-owned bound value once; `bind:value` drives it thereafter.
+	let bound = $state(untrack(() => value));
+</script>
+
+<TextInput {ariaLabel} bind:value={bound} />
+<span data-testid="bound-value">{bound}</span>

--- a/web/tests/components/kit/focus-trap.test.ts
+++ b/web/tests/components/kit/focus-trap.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getFocusable, createFocusTrap } from '../../../src/lib/components/kit/focus-trap';
+
+function mount(html: string): HTMLElement {
+	const container = document.createElement('div');
+	container.tabIndex = -1;
+	container.innerHTML = html;
+	document.body.appendChild(container);
+	return container;
+}
+
+describe('getFocusable', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('returns focusable elements in DOM order, skipping disabled and tabindex=-1', () => {
+		const container = mount(
+			`<button>a</button><button disabled>b</button><a href="#">c</a><div tabindex="-1">d</div><input />`
+		);
+		expect(getFocusable(container).map((el) => el.tagName)).toEqual(['BUTTON', 'A', 'INPUT']);
+	});
+
+	it('skips hidden and aria-hidden elements', () => {
+		const container = mount(
+			`<button hidden>a</button><button aria-hidden="true">b</button><button>c</button>`
+		);
+		const focusable = getFocusable(container);
+		expect(focusable).toHaveLength(1);
+		expect(focusable[0].textContent).toBe('c');
+	});
+});
+
+describe('createFocusTrap', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('wraps Tab from the last element to the first', () => {
+		const container = mount(
+			`<button id="first">f</button><button id="mid">m</button><button id="last">l</button>`
+		);
+		const trap = createFocusTrap(container);
+		trap.activate();
+
+		container.querySelector<HTMLElement>('#last')!.focus();
+		container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+		expect(document.activeElement).toBe(container.querySelector('#first'));
+		trap.deactivate();
+	});
+
+	it('wraps Shift+Tab from the first element to the last', () => {
+		const container = mount(
+			`<button id="first">f</button><button id="last">l</button>`
+		);
+		const trap = createFocusTrap(container);
+		trap.activate();
+
+		container.querySelector<HTMLElement>('#first')!.focus();
+		container.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true })
+		);
+		expect(document.activeElement).toBe(container.querySelector('#last'));
+		trap.deactivate();
+	});
+
+	it('deactivate removes the keydown handler', () => {
+		const container = mount(`<button id="first">f</button><button id="last">l</button>`);
+		const trap = createFocusTrap(container);
+		trap.activate();
+		trap.deactivate();
+
+		const last = container.querySelector<HTMLElement>('#last')!;
+		last.focus();
+		container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+		expect(document.activeElement).toBe(last);
+	});
+});

--- a/web/tests/components/kit/helpers.ts
+++ b/web/tests/components/kit/helpers.ts
@@ -1,0 +1,15 @@
+import { createRawSnippet } from 'svelte';
+
+/** A snippet that renders plain text (wrapped in a span) for kit children props. */
+export function textSnippet(text: string) {
+	return createRawSnippet(() => ({
+		render: () => `<span>${text}</span>`
+	}));
+}
+
+/** A snippet that renders a focusable button, for overlay focus tests. */
+export function buttonSnippet(label: string, testid = 'snippet-button') {
+	return createRawSnippet(() => ({
+		render: () => `<button data-testid="${testid}">${label}</button>`
+	}));
+}

--- a/web/tests/components/kit/tone.test.ts
+++ b/web/tests/components/kit/tone.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+	toneSoft,
+	toneDot,
+	buttonVariant,
+	buttonSize,
+	focusRing,
+	type Tone,
+	type ButtonVariant,
+	type ButtonSize
+} from '../../../src/lib/components/kit/tone';
+
+const TONES: Tone[] = ['neutral', 'info', 'success', 'warning', 'danger', 'accent'];
+
+describe('tone recipes', () => {
+	it('defines a soft and dot recipe for every tone, built on aptl tokens', () => {
+		for (const tone of TONES) {
+			expect(toneSoft[tone]).toBeTruthy();
+			expect(toneDot[tone]).toBeTruthy();
+			expect(toneSoft[tone]).toMatch(/aptl-/);
+			expect(toneDot[tone]).toMatch(/^bg-aptl-/);
+		}
+	});
+
+	it('maps semantic status to the expected palette tokens', () => {
+		expect(toneSoft.success).toContain('aptl-green');
+		expect(toneSoft.danger).toContain('aptl-red');
+		expect(toneSoft.warning).toContain('aptl-amber');
+		expect(toneSoft.info).toContain('aptl-indigo');
+		expect(toneSoft.accent).toContain('aptl-violet');
+		expect(toneDot.success).toBe('bg-aptl-green');
+	});
+
+	it('defines every button variant and size, with danger on the red token', () => {
+		const variants: ButtonVariant[] = ['primary', 'secondary', 'ghost', 'danger'];
+		const sizes: ButtonSize[] = ['sm', 'md'];
+		for (const variant of variants) expect(buttonVariant[variant]).toBeTruthy();
+		for (const size of sizes) expect(buttonSize[size]).toBeTruthy();
+		expect(buttonVariant.danger).toContain('aptl-red');
+		expect(buttonVariant.primary).toContain('aptl-indigo');
+	});
+
+	it('focus ring is keyboard-only and uses the named focus token', () => {
+		expect(focusRing).toContain('focus-visible:');
+		expect(focusRing).toContain('ring-aptl-focus');
+		expect(focusRing).not.toContain('focus:ring'); // not on mouse focus
+	});
+});


### PR DESCRIPTION
## Summary

Formalizes the existing web/src/app.css Tailwind v4 tokens into a documented APTL design-token set and adds a small, presentation/interaction-only Svelte component kit (UI-008b under #541) so the v1 routes assemble from consistent, accessible primitives instead of ad-hoc markup. The kit is scoped per the Step 2.5 architecture preflight: no API/auth/DTO/persistence/redaction/terminal logic, no new {@html} surfaces, app.css remains the single token source. Also hardens the redaction ReDoS timing tests against host load.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #563

## ADR Impact

- ADR-011

## Changes

- app.css: group and document the @theme token set, add the named --color-aptl-focus token, and add a global prefers-reduced-motion safety block
- kit/tone.ts: shared semantic-tone and button/focus class recipes (no JS token mirror) so badge/button/table variants never drift into per-component switch logic
- kit/focus-trap.ts: native focus-management util for the overlay primitives
- Primitives: Badge, StatusBadge, Button (link/disabled-inert), Field + TextInput + Select (context-wired ARIA), Table (captioned, density), accessible Dialog (modal + drawer with focus trap/return/Escape), Menu (roving focus, click-outside)
- Vitest behaviour/a11y coverage for every primitive in web/tests/components/kit/ (50 tests)
- docs/specs/web-component-kit.md documenting the tokens and primitives; mkdocs nav entry; changelog fragment
- tests/test_redaction.py: switch ReDoS linearity timing tests from wall-clock to process CPU time so an oversubscribed host cannot flake them

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Web: `cd web && npx vitest run` (139 pass incl. 50 kit tests) and `npm run check` (0 errors/warnings). Full gate: `pre-commit run --all-files` green; completion gate `pytest -n auto -k "not integration"` (1789 pass) + techvault static integration gate (4 pass). Both pre-push AI reviewers (codex, test-quality) clean after one fix each.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #563 (UI-008b) ← web/src/lib/components/kit/, #563 ← web/src/app.css
- TESTS: web/tests/components/kit/ ← kit primitive behaviour/a11y, tests/test_redaction.py ← ReDoS timing linearity (CPU-time)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/563.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
