### PR TITLE
feat: add Lab Home kill control, readiness headline, and scenario catalog API

### DIFF
--- a/changelog.d/564.added.md
+++ b/changelog.d/564.added.md
@@ -1,0 +1,8 @@
+### Added
+
+- Web Lab Home (`/`) now leads with a readiness-first status headline, adds an
+  emergency **Kill** control with a blast-radius confirmation dialog (processes
+  only, or also force-stop lab containers), and serializes start/stop/kill as
+  single-flight lifecycle actions, all built on the APTL component kit. A new
+  `GET /api/scenarios` endpoint projects the curated ACES scenario catalog into
+  card summaries so the Lab Home scenario entry points render. (#564)

--- a/docs/specs/web-gui-design-preflight.md
+++ b/docs/specs/web-gui-design-preflight.md
@@ -194,6 +194,66 @@ Tailwind surface, not a parallel design system.
 - A user-visible kit change needs a `changelog.d/<issue>.<type>.md` fragment.
   Docs-only preflight changes do not.
 
+## UI-008c Lab Home Guardrails
+
+UI-008c (`/`) is a composition of existing control-plane and component-kit
+boundaries. It must answer whether the lab is usable and what the operator can
+do next; it must not become a second lifecycle, scenario, terminal, or Docker
+authority.
+
+- Keep all HTTP and SSE traffic behind `web/src/lib/api.ts` and
+  `web/src/lib/stores/lab.ts`. Do not fetch authenticated `/api/*` routes
+  directly from `+page.ts` / route components unless the shared session-header
+  boundary is still used.
+- Keep `/api/lab/events` on fetch streaming with `X-APTL-Session`; do not switch
+  back to native `EventSource`, which cannot send the port-scoped session
+  factor.
+- `GET /api/lab/status` currently owns running/container/error state only.
+  `POST /api/lab/start` owns ADR-030 startup outcome and diagnostics. If Lab
+  Home needs startup diagnostics after a reload or from SSE, add that structured
+  field at the core/API DTO boundary first; do not infer readiness from
+  container health, colors, stale browser state, or English messages.
+- Reuse `LabActionResponse` for start/stop and add/use a mirrored
+  `KillActionResponse` for kill. Do not overload one action envelope with the
+  other's fields, and do not parse backend messages to decide success.
+- Lifecycle controls are single-flight from the UI perspective. Disable or
+  otherwise serialize start, stop, and kill while one action is pending, refresh
+  status from the shared store/API afterward, and avoid optimistic state changes
+  that contradict the next SSE event.
+- `POST /api/lab/kill` is the existing emergency path with the existing
+  `containers` scope parameter. The UI confirmation state belongs in a small
+  `KillConfirmDialog` built from the kit `Dialog` and `Button`; do not add a
+  generic command-confirmation system or a second modal primitive.
+- Scenario entry points must come from a new narrow ACES/catalog API projection
+  when this slice needs them. The current Python tests deliberately assert the
+  removed legacy `/api/scenarios` routes are absent, so UI-008c must replace
+  that absence with explicit DTOs in `src/aptl/api/schemas.py` backed by
+  `src/aptl/core/scenario_catalog.py` / the ACES parser, not by reviving the old
+  in-tree scenario model from `src/aptl/core/scenarios.py`.
+- Scenario summary DTOs should expose only card/list facts: id, name,
+  description, mode, difficulty, estimated time, tags, required containers, and
+  validation/status summary. Workbench detail, scoring, SIEM query execution,
+  and terminal session state stay out of the Lab Home summary contract.
+- Terminal links on container cards must remain a projection of
+  `ENDPOINT_REGISTRY` / terminal allow-list semantics. Do not hardcode a new
+  SSH container set in the route when the endpoint registry already owns
+  terminal target identity.
+- Use component-kit semantics for controls and status: `Button` variants for
+  primary/destructive actions, `Dialog` for confirmation, shared status/badge
+  tones, `LabStartNotice` for diagnostics, `ContainerGrid` for containers, and
+  `ScenarioCard` for scenario summaries. Do not add page-local color switch
+  statements or an alternate card/button system.
+- Catalog, status, and action error states need stable user-facing categories
+  and redacted details. API routes may name the route, validation layer,
+  scenario id, or component, but must not return raw stack traces, `.env`
+  values, bearer/session credentials, private keys, or secret-bearing command
+  output.
+- Tests for this slice should cover the route/component behavior, not only leaf
+  helpers: kill confirmation focus/escape/cancel/confirm, single-flight action
+  disabling, start diagnostics rendering for every ADR-030 outcome, catalog
+  loading/error/empty states, SSE-driven status updates, and the API client
+  carrying the session header on every `/api/*` call.
+
 ## Extensibility Seams
 
 The design specification should include a compact page contract table for each

--- a/src/aptl/api/main.py
+++ b/src/aptl/api/main.py
@@ -11,7 +11,7 @@ from aptl.api.deps import (
     verify_token,
 )
 from aptl.api.middleware.bff import BFFMiddleware
-from aptl.api.routers import config, kill, lab, terminal
+from aptl.api.routers import config, kill, lab, scenarios, terminal
 from aptl.api.session import (
     SESSION_COOKIE,
     SESSION_HEADER_PARAM,
@@ -64,6 +64,7 @@ def create_app() -> FastAPI:
     app.include_router(config.router, prefix="/api", dependencies=_auth)
     app.include_router(terminal.router, prefix="/api", dependencies=_auth)
     app.include_router(kill.router, prefix="/api", dependencies=_auth)
+    app.include_router(scenarios.router, prefix="/api", dependencies=_auth)
 
     @app.get("/api/health", dependencies=_auth)
     async def health() -> dict[str, str]:

--- a/src/aptl/api/routers/scenarios.py
+++ b/src/aptl/api/routers/scenarios.py
@@ -7,6 +7,7 @@ separate slice and stays absent here.
 
 import asyncio
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
@@ -45,7 +46,7 @@ def _load_scenario_summaries(project_dir: Path) -> list[ScenarioSummaryResponse]
 
 @router.get("/scenarios")
 async def list_scenarios(
-    project_dir: Path = Depends(get_project_dir),
+    project_dir: Annotated[Path, Depends(get_project_dir)],
 ) -> list[ScenarioSummaryResponse]:
     """List the curated ACES scenario catalog as card summaries."""
     log.info("GET /scenarios")

--- a/src/aptl/api/routers/scenarios.py
+++ b/src/aptl/api/routers/scenarios.py
@@ -1,0 +1,52 @@
+"""Scenario catalog summary API endpoint (UI-008c).
+
+Exposes the curated ACES scenario catalog as narrow card summaries for the Lab
+Home scenario entry points. Scenario *detail* (workbench) projection is a
+separate slice and stays absent here.
+"""
+
+import asyncio
+from pathlib import Path
+
+from fastapi import APIRouter, Depends
+
+from aptl.api.deps import get_project_dir
+from aptl.api.schemas import ScenarioSummaryResponse
+from aptl.core.scenario_catalog import CATALOG_RELATIVE_PATH, load_scenario_catalog
+from aptl.utils.logging import get_logger
+
+log = get_logger("api.scenarios")
+
+router = APIRouter(tags=["scenarios"])
+
+
+def _load_scenario_summaries(project_dir: Path) -> list[ScenarioSummaryResponse]:
+    """Project the curated scenario catalog into card-summary DTOs.
+
+    Returns an empty list when no catalog file is present (a lab need not ship
+    a curated catalog). A malformed or schema-invalid catalog is logged and also
+    degrades to an empty list, so Lab Home shows "No scenarios found" rather than
+    failing the whole page on a config error.
+    """
+    if not (project_dir / CATALOG_RELATIVE_PATH).is_file():
+        return []
+    try:
+        catalog = load_scenario_catalog(project_dir)
+    except ValueError as exc:
+        log.warning("Scenario catalog unreadable; returning empty list: %s", exc)
+        return []
+    return [
+        ScenarioSummaryResponse(
+            id=entry.id, name=entry.name, description=entry.description
+        )
+        for entry in catalog.scenarios
+    ]
+
+
+@router.get("/scenarios")
+async def list_scenarios(
+    project_dir: Path = Depends(get_project_dir),
+) -> list[ScenarioSummaryResponse]:
+    """List the curated ACES scenario catalog as card summaries."""
+    log.info("GET /scenarios")
+    return await asyncio.to_thread(_load_scenario_summaries, project_dir)

--- a/src/aptl/api/schemas.py
+++ b/src/aptl/api/schemas.py
@@ -136,6 +136,24 @@ class KillActionResponse(BaseModel):
     errors: list[str] = Field(default_factory=list)
 
 
+class ScenarioSummaryResponse(BaseModel):
+    """Card-summary projection of one curated scenario catalog entry.
+
+    Narrow by design: only the facts the curated catalog
+    (``scenarios/catalog.json`` / :class:`ScenarioCatalogEntry`) authoritatively
+    owns. Richer card facts (mode, difficulty, tags, estimated time, required
+    containers) are intentionally NOT modelled here — the ACES SDL does not own
+    those fields and the legacy in-tree scenario model that did is deliberately
+    not revived (see ``docs/specs/web-gui-design-preflight.md`` UI-008c). Those
+    belong to the scenario-detail/workbench projection, which is out of scope
+    for the Lab Home slice.
+    """
+
+    id: str
+    name: str
+    description: str = ""
+
+
 class ConfigResponse(BaseModel):
     """Response for GET /api/config."""
 

--- a/src/aptl/api/schemas.py
+++ b/src/aptl/api/schemas.py
@@ -1,6 +1,6 @@
 """API response models for the APTL web interface."""
 
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -63,7 +63,7 @@ class ContainerInfo(BaseModel):
     ports: list[str] = []
 
     @classmethod
-    def from_compose_dict(cls, data: dict) -> "ContainerInfo":
+    def from_compose_dict(cls, data: dict[str, Any]) -> "ContainerInfo":
         """Create from docker compose ps JSON output."""
         # docker compose ps --format json uses varying key names
         # across versions; handle common variants.

--- a/tests/test_api_scenarios.py
+++ b/tests/test_api_scenarios.py
@@ -1,4 +1,6 @@
-"""Tests for removed scenario API endpoints."""
+"""Tests for the scenario catalog summary API endpoint (UI-008c)."""
+
+import json
 
 import pytest
 
@@ -6,18 +8,18 @@ pytest.importorskip("fastapi", reason="Web dependencies not installed")
 
 
 @pytest.fixture
-def api_client():
-    """Create a FastAPI test client with auth bypassed.
+def api_client(tmp_path):
+    """FastAPI test client with auth bypassed and project_dir -> tmp_path.
 
     The /api/{full_path:path} catch-all (added by the BFF refactor) requires
-    authentication, so requests to truly absent routes now return 401 for
-    unauthenticated clients.  Bypass verify_token here so the test confirms
-    that the paths return 404 (route not registered), not 401 (no auth).
+    authentication, so requests to truly absent routes return 404 only once
+    verify_token is bypassed (otherwise unauthenticated clients get 401).
     """
-    from aptl.api.deps import verify_token
+    from aptl.api.deps import get_project_dir, verify_token
     from aptl.api.main import app
     from starlette.testclient import TestClient
 
+    app.dependency_overrides[get_project_dir] = lambda: tmp_path
     app.dependency_overrides[verify_token] = lambda: None
     try:
         with TestClient(app) as client:
@@ -26,12 +28,99 @@ def api_client():
         app.dependency_overrides.clear()
 
 
-class TestRemovedScenarioRoutes:
-    """The legacy scenario API should not remain mounted."""
+def _write_catalog(project_dir, scenarios):
+    catalog_dir = project_dir / "scenarios"
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    (catalog_dir / "catalog.json").write_text(
+        json.dumps({"version": 1, "scenarios": scenarios})
+    )
 
-    def test_list_endpoint_is_absent(self, api_client):
+
+class TestScenarioListEndpoint:
+    """GET /api/scenarios projects the curated catalog into card summaries."""
+
+    def test_list_returns_catalog_projection(self, api_client, tmp_path):
+        _write_catalog(
+            tmp_path,
+            [
+                {
+                    "id": "techvault-operational",
+                    "name": "TechVault Operational",
+                    "path": "scenarios/techvault-operational.sdl.yaml",
+                    "description": "Default public APTL startup scenario.",
+                },
+                {
+                    "id": "techvault-defensive-min",
+                    "name": "TechVault Defensive Minimum",
+                    "path": "scenarios/techvault-defensive-min.sdl.yaml",
+                    "description": "Wazuh manager, indexer, and dashboard.",
+                },
+            ],
+        )
+
         response = api_client.get("/api/scenarios")
-        assert response.status_code == 404
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [s["id"] for s in data] == [
+            "techvault-operational",
+            "techvault-defensive-min",
+        ]
+        assert data[0]["name"] == "TechVault Operational"
+        assert data[0]["description"] == "Default public APTL startup scenario."
+
+    def test_list_omits_internal_path_field(self, api_client, tmp_path):
+        # The summary contract is narrow: id/name/description only. The catalog
+        # ``path`` locator is internal and must not leak into the card DTO.
+        _write_catalog(
+            tmp_path,
+            [
+                {
+                    "id": "obs-core",
+                    "name": "Observability Core",
+                    "path": "scenarios/techvault-observability-core.sdl.yaml",
+                    "description": "Smallest bounded startup surface.",
+                }
+            ],
+        )
+
+        response = api_client.get("/api/scenarios")
+
+        assert response.status_code == 200
+        entry = response.json()[0]
+        assert set(entry.keys()) == {"id", "name", "description"}
+
+    def test_list_empty_when_no_catalog(self, api_client):
+        # A lab need not ship a curated catalog; Lab Home degrades to empty.
+        response = api_client.get("/api/scenarios")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_empty_on_malformed_catalog(self, api_client, tmp_path):
+        # A malformed catalog must not 500 the Lab Home page.
+        catalog_dir = tmp_path / "scenarios"
+        catalog_dir.mkdir(parents=True, exist_ok=True)
+        (catalog_dir / "catalog.json").write_text("{not: valid: yaml: ::}")
+
+        response = api_client.get("/api/scenarios")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_empty_on_schema_violation(self, api_client, tmp_path):
+        # Wrong catalog version is a schema violation -> degrade, do not 500.
+        catalog_dir = tmp_path / "scenarios"
+        catalog_dir.mkdir(parents=True, exist_ok=True)
+        (catalog_dir / "catalog.json").write_text(
+            json.dumps({"version": 2, "scenarios": []})
+        )
+
+        response = api_client.get("/api/scenarios")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestRemovedScenarioDetailRoute:
+    """The scenario *detail* (workbench) route stays absent in this slice."""
 
     def test_detail_endpoint_is_absent(self, api_client):
         response = api_client.get("/api/scenarios/example")

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type {
 	AppConfig,
+	KillActionResponse,
 	LabActionResponse,
 	LabStatus,
 	ScenarioDefinition,
@@ -10,10 +11,17 @@ import { sessionHeaders } from './session';
 const BASE = '/api';
 const MAX_ERROR_TEXT_LENGTH = 500;
 
-async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
+async function fetchJSON<T>(
+	path: string,
+	init?: RequestInit,
+	fetchFn: typeof fetch = fetch
+): Promise<T> {
 	// Every /api/* call carries the port-scoped session header (the second auth
 	// factor); the HttpOnly cookie rides along automatically. See ./session.
-	const res = await fetch(`${BASE}${path}`, {
+	// `fetchFn` defaults to the global `fetch` for browser-side calls; a
+	// SvelteKit `load` passes its own `event.fetch` so relative URLs resolve
+	// correctly in every load context (SSR/prerender included).
+	const res = await fetchFn(`${BASE}${path}`, {
 		...init,
 		headers: sessionHeaders(init?.headers)
 	});
@@ -39,8 +47,22 @@ export async function stopLab(): Promise<LabActionResponse> {
 	return fetchJSON<LabActionResponse>('/lab/stop', { method: 'POST' });
 }
 
-export async function getScenarios(): Promise<ScenarioSummary[]> {
-	return fetchJSON<ScenarioSummary[]>('/scenarios');
+/**
+ * Emergency kill switch. Always terminates MCP processes and clears session
+ * state; `containers` widens the blast radius to also force-stop every lab
+ * container. Returns the distinct `KillActionResponse` shape (not the
+ * start/stop `LabActionResponse`).
+ */
+export async function killLab(containers: boolean): Promise<KillActionResponse> {
+	return fetchJSON<KillActionResponse>(`/lab/kill?containers=${containers}`, {
+		method: 'POST'
+	});
+}
+
+export async function getScenarios(
+	fetchFn: typeof fetch = fetch
+): Promise<ScenarioSummary[]> {
+	return fetchJSON<ScenarioSummary[]>('/scenarios', undefined, fetchFn);
 }
 
 export async function getScenario(id: string): Promise<ScenarioDefinition> {

--- a/web/src/lib/components/KillConfirmDialog.svelte
+++ b/web/src/lib/components/KillConfirmDialog.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import Dialog from '$lib/components/kit/Dialog.svelte';
+	import Button from '$lib/components/kit/Button.svelte';
+	import { focusRing } from '$lib/components/kit/tone';
+
+	interface Props {
+		/** Open state. Bindable so the parent can also close it. */
+		open?: boolean;
+		/** Disable the confirm control while a kill is already in flight. */
+		pending?: boolean;
+		/** Confirm handler — receives the chosen blast radius. */
+		onConfirm: (containers: boolean) => void;
+		/** Cancel handler (Cancel button, Escape, or backdrop). */
+		onCancel?: () => void;
+	}
+
+	let { open = $bindable(false), pending = false, onConfirm, onCancel }: Props = $props();
+
+	/** Blast-radius choice: when true, kill also force-stops every lab container. */
+	let alsoStopContainers = $state(false);
+
+	// Reset the choice each time the dialog opens, so a previous selection never
+	// silently carries into the next confirmation.
+	$effect(() => {
+		if (open) alsoStopContainers = false;
+	});
+
+	function cancel(): void {
+		onCancel?.();
+	}
+
+	function confirm(): void {
+		onConfirm(alsoStopContainers);
+	}
+</script>
+
+<Dialog
+	bind:open
+	title="Emergency kill"
+	description="Immediately terminate all MCP server processes and clear scenario session state."
+	onClose={cancel}
+>
+	{#snippet body()}
+		<p>
+			This stops every running MCP server process and clears the active scenario
+			session and trace context. Running agent activity is terminated at once.
+		</p>
+		<label class="mt-4 flex items-start gap-2 {focusRing} rounded-md">
+			<input
+				type="checkbox"
+				bind:checked={alsoStopContainers}
+				class="mt-0.5 h-4 w-4 accent-aptl-red"
+			/>
+			<span>
+				Also force-stop all lab containers
+				<span class="mt-0.5 block text-xs text-aptl-text-muted">
+					{alsoStopContainers
+						? 'Blast radius: MCP processes and every lab container will be stopped.'
+						: 'Blast radius: MCP processes only — lab containers keep running.'}
+				</span>
+			</span>
+		</label>
+	{/snippet}
+	{#snippet footer()}
+		<Button variant="secondary" onclick={cancel}>Cancel</Button>
+		<Button variant="danger" disabled={pending} onclick={confirm}>
+			{alsoStopContainers ? 'Kill + stop containers' : 'Kill processes'}
+		</Button>
+	{/snippet}
+</Dialog>

--- a/web/src/lib/components/LabStatusBadge.svelte
+++ b/web/src/lib/components/LabStatusBadge.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import StatusBadge from '$lib/components/kit/StatusBadge.svelte';
+
 	interface Props {
 		running: boolean;
 	}
@@ -6,16 +8,13 @@
 	let { running }: Props = $props();
 </script>
 
-<div
-	role="status"
-	aria-label="Lab is {running ? 'running' : 'stopped'}"
-	class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium
-		{running
-		? 'bg-aptl-green/10 text-aptl-green'
-		: 'bg-aptl-text-muted/10 text-aptl-text-muted'}"
->
-	<span
-		class="h-2 w-2 rounded-full {running ? 'bg-aptl-green animate-pulse' : 'bg-aptl-text-muted'}"
-	></span>
-	{running ? 'Running' : 'Stopped'}
-</div>
+<!--
+	Compact running/stopped status, built on the component-kit StatusBadge so the
+	status palette and the live-pulse/reduced-motion behaviour stay centralised.
+	Colour is never the only cue — the text label carries the state.
+-->
+<StatusBadge
+	tone={running ? 'success' : 'neutral'}
+	label={running ? 'Lab running' : 'Lab stopped'}
+	pulse={running}
+/>

--- a/web/src/lib/components/ScenarioCard.svelte
+++ b/web/src/lib/components/ScenarioCard.svelte
@@ -6,69 +6,14 @@
 	}
 
 	let { scenario }: Props = $props();
-
-	const modeColor = $derived.by(() => {
-		switch (scenario.mode) {
-			case 'red':
-				return 'bg-aptl-violet/10 text-aptl-violet';
-			case 'blue':
-				return 'bg-aptl-teal/10 text-aptl-teal';
-			case 'purple':
-				return 'bg-aptl-indigo/10 text-aptl-indigo';
-			default:
-				return 'bg-aptl-text-muted/10 text-aptl-text-muted';
-		}
-	});
-
-	const difficultyColor = $derived.by(() => {
-		switch (scenario.difficulty) {
-			case 'beginner':
-				return 'bg-aptl-green/10 text-aptl-green';
-			case 'intermediate':
-				return 'bg-aptl-amber/10 text-aptl-amber';
-			case 'advanced':
-				return 'bg-aptl-red/10 text-aptl-red';
-			case 'expert':
-				return 'bg-aptl-violet/10 text-aptl-violet';
-			default:
-				return 'bg-aptl-text-muted/10 text-aptl-text-muted';
-		}
-	});
 </script>
 
 <a
 	href="/scenarios/{scenario.id}"
-	class="block rounded-lg border border-aptl-border bg-aptl-surface p-5 transition-colors hover:bg-aptl-surface-hover"
+	class="block rounded-lg border border-aptl-border bg-aptl-surface p-5 transition-colors hover:bg-aptl-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aptl-focus focus-visible:ring-offset-2 focus-visible:ring-offset-aptl-bg"
 >
-	<div class="mb-3 flex flex-wrap items-center gap-2">
-		<span class="rounded-full px-2 py-0.5 text-xs font-medium {modeColor}">
-			{scenario.mode}
-		</span>
-		<span class="rounded-full px-2 py-0.5 text-xs font-medium {difficultyColor}">
-			{scenario.difficulty}
-		</span>
-	</div>
-
 	<h3 class="text-sm font-semibold text-aptl-text">{scenario.name}</h3>
-	<p class="mt-1 line-clamp-2 text-xs text-aptl-text-muted">{scenario.description}</p>
-
-	<div class="mt-3 flex items-center gap-3 text-xs text-aptl-text-muted">
-		<span>{scenario.estimated_minutes} min</span>
-		{#if scenario.tags.length > 0}
-			<span>&middot;</span>
-			<span>{scenario.tags.slice(0, 3).join(', ')}</span>
-		{/if}
-	</div>
-
-	{#if scenario.containers_required.length > 0}
-		<div class="mt-3 flex flex-wrap gap-1">
-			{#each scenario.containers_required as c}
-				<span
-					class="rounded bg-aptl-surface-hover px-1.5 py-0.5 font-mono text-xs text-aptl-text-muted"
-				>
-					{c}
-				</span>
-			{/each}
-		</div>
+	{#if scenario.description}
+		<p class="mt-1 line-clamp-3 text-xs text-aptl-text-muted">{scenario.description}</p>
 	{/if}
 </a>

--- a/web/src/lib/stores/lab.ts
+++ b/web/src/lib/stores/lab.ts
@@ -61,6 +61,26 @@ export function initLabStore(): void {
 	);
 }
 
+/**
+ * Re-fetch lab status once, without disturbing the existing SSE subscription.
+ * Used after a lifecycle action (start/stop/kill) so the UI reflects the new
+ * state immediately rather than waiting for the next SSE poll. Generation-guarded
+ * so a result that arrives after `destroyLabStore()` does not clobber the store.
+ */
+export async function refreshLabStatus(): Promise<void> {
+	const currentGeneration = generation;
+	try {
+		const status = await getLabStatus();
+		if (currentGeneration === generation) {
+			labStatus.set(status);
+		}
+	} catch (err) {
+		if (currentGeneration === generation) {
+			labStatus.update((s) => ({ ...s, error: String(err) }));
+		}
+	}
+}
+
 /** Stop SSE subscription. */
 export function destroyLabStore(): void {
 	generation++;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -52,16 +52,33 @@ export interface LabActionResponse {
 	diagnostics?: StartupDiagnostic[];
 }
 
-/** Scenario summary for listing. */
+/** Response for POST /api/lab/kill.
+ *
+ *  Mirrors `aptl.api.schemas.KillActionResponse`. Kept distinct from
+ *  `LabActionResponse` (start/stop) on purpose — kill reports its own
+ *  blast-radius outcome (processes killed, whether containers were also
+ *  stopped) rather than an ADR-030 startup outcome.
+ */
+export interface KillActionResponse {
+	success: boolean;
+	mcp_processes_killed: number;
+	containers_stopped: boolean;
+	session_cleared: boolean;
+	errors: string[];
+}
+
+/** Scenario summary for the Lab Home catalog entry points.
+ *
+ *  Narrow by design: mirrors `aptl.api.schemas.ScenarioSummaryResponse`, which
+ *  projects only the facts the curated catalog owns. Richer card facts
+ *  (mode, difficulty, tags, estimated time, required containers) are not part
+ *  of the summary contract — they live in the scenario-detail/workbench
+ *  projection, a separate slice.
+ */
 export interface ScenarioSummary {
 	id: string;
 	name: string;
 	description: string;
-	difficulty: string;
-	mode: string;
-	estimated_minutes: number;
-	tags: string[];
-	containers_required: string[];
 }
 
 // --- Full scenario definition types (mirrors Python core/scenarios.py) ---

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,95 +1,178 @@
 <script lang="ts">
-	import { labStatus, labLoading } from '$lib/stores/lab';
-	import { startLab, stopLab } from '$lib/api';
+	import { labStatus, labLoading, refreshLabStatus } from '$lib/stores/lab';
+	import { startLab, stopLab, killLab } from '$lib/api';
+	import Button from '$lib/components/kit/Button.svelte';
+	import StatusBadge from '$lib/components/kit/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/kit/tone';
 	import ContainerGrid from '$lib/components/ContainerGrid.svelte';
 	import LabStartNotice from '$lib/components/LabStartNotice.svelte';
+	import KillConfirmDialog from '$lib/components/KillConfirmDialog.svelte';
 	import ScenarioCard from '$lib/components/ScenarioCard.svelte';
-	import type { LabActionResponse, ScenarioSummary } from '$lib/types';
+	import type { LabActionResponse, KillActionResponse, ScenarioSummary } from '$lib/types';
 
-	let { data }: { data: { scenarios: ScenarioSummary[] } } = $props();
+	let { data }: { data: { scenarios: ScenarioSummary[]; scenariosError: boolean } } = $props();
 
-	let actionPending = $state(false);
+	/** Which lifecycle action is in flight, if any. Lifecycle controls are
+	 *  single-flight: while one action is pending, start/stop/kill are disabled. */
+	let pendingAction = $state<null | 'start' | 'stop' | 'kill'>(null);
+	let actionPending = $derived(pendingAction !== null);
 	let actionError = $state('');
-	/** Last /api/lab/start response — populated for both success and
-	 *  failure so the UI can render ADR-030 partial-readiness data
-	 *  (outcome + diagnostics), not only the legacy success boolean. */
+	/** Last /api/lab/start response — populated for both success and failure so
+	 *  the UI can render ADR-030 partial-readiness data (outcome + diagnostics)
+	 *  via `LabStartNotice`, not only the legacy success boolean. */
 	let startResult = $state<LabActionResponse | null>(null);
+	/** Last /api/lab/kill response — its own envelope (processes killed, whether
+	 *  containers were also stopped), distinct from the start/stop response. */
+	let killResult = $state<KillActionResponse | null>(null);
+	let killDialogOpen = $state(false);
 
-	async function handleStart() {
-		actionPending = true;
+	/** Readiness headline: leads with whether the lab is usable and what to do
+	 *  next. Derived from the running flag plus the in-session start outcome —
+	 *  never inferred from container health, colours, or backend message text
+	 *  (ADR-030 outcome lives only on the start response, by design). */
+	let readiness = $derived.by((): { tone: Tone; label: string; next: string } => {
+		if (pendingAction === 'start') {
+			return { tone: 'info', label: 'Starting…', next: 'Bringing the lab up — this can take a few minutes.' };
+		}
+		if (pendingAction === 'stop') {
+			return { tone: 'info', label: 'Stopping…', next: 'Shutting the lab down.' };
+		}
+		if (pendingAction === 'kill') {
+			return { tone: 'danger', label: 'Killing…', next: 'Terminating MCP processes and clearing session state.' };
+		}
+		const outcome = startResult?.outcome;
+		if (outcome === 'failed' || startResult?.success === false) {
+			return { tone: 'danger', label: 'Start failed', next: 'Review the diagnostics below, then try again.' };
+		}
+		if (outcome === 'degraded_unusable') {
+			return { tone: 'warning', label: 'Degraded — unusable', next: 'Some capabilities or SSH targets are unreachable; see diagnostics.' };
+		}
+		if (outcome === 'degraded_usable') {
+			return { tone: 'warning', label: 'Degraded — usable', next: 'Scenarios should still run; see diagnostics below.' };
+		}
+		if ($labStatus.running) {
+			return {
+				tone: 'success',
+				label: outcome === 'ready' ? 'Lab ready' : 'Lab running',
+				next: 'Pick a scenario below to begin.'
+			};
+		}
+		return { tone: 'neutral', label: 'Lab stopped', next: 'Start the lab to begin.' };
+	});
+
+	async function runAction(
+		action: 'start' | 'stop' | 'kill',
+		fn: () => Promise<void>
+	): Promise<void> {
+		if (actionPending) return;
+		pendingAction = action;
 		actionError = '';
-		startResult = null;
 		try {
-			// `LabStartNotice` owns the structured rendering for every
-			// non-trivial start outcome (ready-with-diagnostics,
-			// degraded_usable, degraded_unusable, failed). `actionError`
-			// is reserved for fetch/transport failures so the same error
-			// text never renders twice (codex review #202 cycle 3).
-			startResult = await startLab();
+			await fn();
 		} catch (err) {
 			actionError = String(err);
 		} finally {
-			actionPending = false;
+			pendingAction = null;
+			// Reconcile against the authoritative status after every action.
+			await refreshLabStatus();
 		}
 	}
 
-	async function handleStop() {
-		actionPending = true;
-		actionError = '';
+	function handleStart(): Promise<void> {
 		startResult = null;
-		try {
+		killResult = null;
+		return runAction('start', async () => {
+			// `LabStartNotice` owns the structured rendering for every non-trivial
+			// start outcome; `actionError` is reserved for fetch/transport failures.
+			startResult = await startLab();
+		});
+	}
+
+	function handleStop(): Promise<void> {
+		startResult = null;
+		killResult = null;
+		return runAction('stop', async () => {
 			const result = await stopLab();
 			if (!result.success) {
 				actionError = result.error || 'Lab stop failed';
 			}
-		} catch (err) {
-			actionError = String(err);
-		} finally {
-			actionPending = false;
-		}
+		});
 	}
+
+	function handleKillConfirm(containers: boolean): Promise<void> {
+		killDialogOpen = false;
+		startResult = null;
+		killResult = null;
+		return runAction('kill', async () => {
+			killResult = await killLab(containers);
+		});
+	}
+
+	let killSummary = $derived.by((): string => {
+		if (!killResult) return '';
+		const parts = [`${killResult.mcp_processes_killed} MCP process(es) terminated`];
+		parts.push(killResult.containers_stopped ? 'containers stopped' : 'containers left running');
+		if (killResult.session_cleared) parts.push('session cleared');
+		return parts.join(' · ');
+	});
 </script>
 
 <div class="mx-auto max-w-7xl space-y-8 px-6 py-8">
 	<!-- Lab Status Section -->
 	<section>
-		<div class="mb-4 flex items-center justify-between">
+		<div class="mb-4 flex flex-wrap items-start justify-between gap-3">
 			<div>
 				<h1 class="text-xl font-semibold text-aptl-text">Lab Home</h1>
-				<p class="mt-1 text-sm text-aptl-text-muted">
-					{$labStatus.running
-						? `${$labStatus.containers.length} containers running`
-						: 'Lab is stopped'}
-				</p>
+				<div class="mt-2 flex flex-wrap items-center gap-3">
+					<StatusBadge tone={readiness.tone} label={readiness.label} pulse={pendingAction !== null} />
+					<p class="text-sm text-aptl-text-muted">{readiness.next}</p>
+				</div>
 			</div>
-			<div class="flex items-center gap-3">
+			<div class="flex items-center gap-2">
 				{#if $labStatus.running}
-					<button
-						onclick={handleStop}
-						disabled={actionPending}
-						aria-label="Stop lab environment"
-						class="rounded-lg bg-aptl-red/10 px-4 py-2 text-sm font-medium text-aptl-red transition-colors hover:bg-aptl-red/20 disabled:opacity-50"
-					>
-						{actionPending ? 'Stopping...' : 'Stop Lab'}
-					</button>
+					<Button variant="secondary" disabled={actionPending} onclick={handleStop}>
+						{pendingAction === 'stop' ? 'Stopping…' : 'Stop'}
+					</Button>
 				{:else}
-					<button
-						onclick={handleStart}
-						disabled={actionPending}
-						aria-label="Start lab environment"
-						class="rounded-lg bg-aptl-indigo px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-aptl-indigo-hover disabled:opacity-50"
-					>
-						{actionPending ? 'Starting...' : 'Start Lab'}
-					</button>
+					<Button variant="primary" disabled={actionPending} onclick={handleStart}>
+						{pendingAction === 'start' ? 'Starting…' : 'Start'}
+					</Button>
 				{/if}
+				<Button
+					variant="danger"
+					disabled={actionPending}
+					onclick={() => (killDialogOpen = true)}
+				>
+					Kill
+				</Button>
 			</div>
 		</div>
 
 		{#if actionError}
 			<div
 				class="mb-4 rounded-lg border border-aptl-red/20 bg-aptl-red/5 p-3 text-sm text-aptl-red"
+				role="alert"
 			>
 				{actionError}
+			</div>
+		{/if}
+
+		{#if killResult}
+			<div
+				role="status"
+				aria-label="Kill result"
+				class="mb-4 rounded-lg border p-3 text-sm {killResult.success && killResult.errors.length === 0
+					? 'border-aptl-border bg-aptl-bg text-aptl-text'
+					: 'border-aptl-red/30 bg-aptl-red/5 text-aptl-red'}"
+			>
+				<p class="font-medium">Kill complete — {killSummary}</p>
+				{#if killResult.errors.length > 0}
+					<ul class="mt-1 space-y-0.5 text-xs">
+						{#each killResult.errors as err (err)}
+							<li>{err}</li>
+						{/each}
+					</ul>
+				{/if}
 			</div>
 		{/if}
 
@@ -98,11 +181,13 @@
 		{#if $labStatus.error != null && !actionError}
 			<div
 				class="mb-4 rounded-lg border border-aptl-amber/20 bg-aptl-amber/5 p-3 text-sm text-aptl-amber"
+				role="status"
 			>
 				{$labStatus.error}
 			</div>
 		{/if}
 
+		<h2 class="mb-3 text-lg font-semibold text-aptl-text">Containers</h2>
 		{#if $labLoading}
 			<div class="flex items-center justify-center py-12" role="status" aria-label="Loading lab status">
 				<div
@@ -119,12 +204,17 @@
 	<section>
 		<div class="mb-4">
 			<h2 class="text-lg font-semibold text-aptl-text">Scenarios</h2>
-			<p class="mt-1 text-sm text-aptl-text-muted">
-				Available attack and defense scenarios
-			</p>
+			<p class="mt-1 text-sm text-aptl-text-muted">Available attack and defense scenarios</p>
 		</div>
 
-		{#if data.scenarios.length === 0}
+		{#if data.scenariosError}
+			<div
+				class="rounded-lg border border-aptl-amber/20 bg-aptl-amber/5 p-8 text-center text-sm text-aptl-amber"
+				role="status"
+			>
+				Scenario catalog is currently unavailable.
+			</div>
+		{:else if data.scenarios.length === 0}
 			<div class="rounded-lg border border-dashed border-aptl-border p-8 text-center">
 				<p class="text-sm text-aptl-text-muted">No scenarios found</p>
 			</div>
@@ -137,3 +227,10 @@
 		{/if}
 	</section>
 </div>
+
+<KillConfirmDialog
+	bind:open={killDialogOpen}
+	pending={pendingAction === 'kill'}
+	onConfirm={handleKillConfirm}
+	onCancel={() => (killDialogOpen = false)}
+/>

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -1,14 +1,24 @@
+import { getScenarios } from '$lib/api';
 import type { ScenarioSummary } from '$lib/types';
 
-export async function load({ fetch }): Promise<{ scenarios: ScenarioSummary[] }> {
+/**
+ * Load the scenario catalog summary for the Lab Home entry points.
+ *
+ * Routes through `getScenarios()` (not a raw `fetch`) so the call carries the
+ * port-scoped `X-APTL-Session` header via the shared API boundary, and threads
+ * the load-provided `event.fetch` into it so the request resolves correctly in
+ * every load context (the SvelteKit-idiomatic load fetch) rather than reaching
+ * for a browser-only global. A failure (API unreachable, not-yet-authenticated,
+ * transport error) degrades to an empty list with an error flag so the page can
+ * show a stable catalog-error state rather than crashing the route.
+ */
+export async function load({ fetch }): Promise<{
+	scenarios: ScenarioSummary[];
+	scenariosError: boolean;
+}> {
 	try {
-		const res = await fetch('/api/scenarios');
-		if (res.ok) {
-			const scenarios: ScenarioSummary[] = await res.json();
-			return { scenarios };
-		}
+		return { scenarios: await getScenarios(fetch), scenariosError: false };
 	} catch {
-		// API may not be available during SSR build
+		return { scenarios: [], scenariosError: true };
 	}
-	return { scenarios: [] };
 }

--- a/web/tests/components/KillConfirmDialog.test.ts
+++ b/web/tests/components/KillConfirmDialog.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import KillConfirmDialog from '../../src/lib/components/KillConfirmDialog.svelte';
+
+function open(props: Record<string, unknown> = {}) {
+	return render(KillConfirmDialog, {
+		props: { open: true, onConfirm: vi.fn(), ...props }
+	});
+}
+
+describe('KillConfirmDialog', () => {
+	it('is not rendered when closed', () => {
+		render(KillConfirmDialog, { props: { open: false, onConfirm: vi.fn() } });
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+	it('exposes an accessible modal dialog with a title', async () => {
+		open();
+		const dialog = await screen.findByRole('dialog');
+		expect(dialog.getAttribute('aria-modal')).toBe('true');
+		const labelledBy = dialog.getAttribute('aria-labelledby');
+		expect(document.getElementById(labelledBy!)?.textContent).toContain('Emergency kill');
+	});
+
+	it('defaults to processes-only and names that blast radius', () => {
+		open();
+		expect(screen.getByText(/lab containers keep running/i)).toBeTruthy();
+		expect(screen.getByRole('button', { name: /kill processes/i })).toBeTruthy();
+	});
+
+	it('widens the blast-radius copy and button when containers are toggled on', async () => {
+		open();
+		const checkbox = screen.getByRole('checkbox', {
+			name: /also force-stop all lab containers/i
+		});
+		await fireEvent.click(checkbox);
+		expect(screen.getByText(/every lab container will be stopped/i)).toBeTruthy();
+		expect(screen.getByRole('button', { name: /kill \+ stop containers/i })).toBeTruthy();
+	});
+
+	it('confirms with containers=false by default', async () => {
+		const onConfirm = vi.fn();
+		open({ onConfirm });
+		await fireEvent.click(screen.getByRole('button', { name: /kill processes/i }));
+		expect(onConfirm).toHaveBeenCalledWith(false);
+	});
+
+	it('confirms with containers=true when toggled on', async () => {
+		const onConfirm = vi.fn();
+		open({ onConfirm });
+		await fireEvent.click(
+			screen.getByRole('checkbox', { name: /also force-stop all lab containers/i })
+		);
+		await fireEvent.click(screen.getByRole('button', { name: /kill \+ stop containers/i }));
+		expect(onConfirm).toHaveBeenCalledWith(true);
+	});
+
+	it('cancels via the Cancel button without confirming', async () => {
+		const onConfirm = vi.fn();
+		const onCancel = vi.fn();
+		open({ onConfirm, onCancel });
+		await fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+		expect(onCancel).toHaveBeenCalled();
+		expect(onConfirm).not.toHaveBeenCalled();
+	});
+
+	it('cancels on Escape', async () => {
+		const onCancel = vi.fn();
+		open({ onCancel });
+		const dialog = await screen.findByRole('dialog');
+		await fireEvent.keyDown(dialog, { key: 'Escape' });
+		await waitFor(() => expect(onCancel).toHaveBeenCalled());
+	});
+
+	it('disables confirm while a kill is pending', () => {
+		open({ pending: true });
+		expect(
+			(screen.getByRole('button', { name: /kill processes/i }) as HTMLButtonElement).disabled
+		).toBe(true);
+	});
+});

--- a/web/tests/components/LabStatusBadge.test.ts
+++ b/web/tests/components/LabStatusBadge.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import LabStatusBadge from '../../src/lib/components/LabStatusBadge.svelte';
+
+describe('LabStatusBadge', () => {
+	it('shows a running status with a text label (not colour-only)', () => {
+		render(LabStatusBadge, { props: { running: true } });
+		const status = screen.getByRole('status', { name: 'Lab running' });
+		expect(status.textContent).toContain('Lab running');
+	});
+
+	it('shows a stopped status with a text label', () => {
+		render(LabStatusBadge, { props: { running: false } });
+		const status = screen.getByRole('status', { name: 'Lab stopped' });
+		expect(status.textContent).toContain('Lab stopped');
+	});
+});

--- a/web/tests/components/ScenarioCard.test.ts
+++ b/web/tests/components/ScenarioCard.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ScenarioCard from '../../src/lib/components/ScenarioCard.svelte';
+import type { ScenarioSummary } from '../../src/lib/types';
+
+const SCENARIO: ScenarioSummary = {
+	id: 'techvault-operational',
+	name: 'TechVault Operational',
+	description: 'Default public APTL startup scenario backed by ACES SDL.'
+};
+
+describe('ScenarioCard', () => {
+	it('renders the name and description', () => {
+		render(ScenarioCard, { props: { scenario: SCENARIO } });
+		expect(screen.getByText('TechVault Operational')).toBeTruthy();
+		expect(screen.getByText(/Default public APTL startup scenario/)).toBeTruthy();
+	});
+
+	it('links to the scenario workbench route', () => {
+		render(ScenarioCard, { props: { scenario: SCENARIO } });
+		const link = screen.getByRole('link');
+		expect(link.getAttribute('href')).toBe('/scenarios/techvault-operational');
+	});
+
+	it('renders without a description', () => {
+		render(ScenarioCard, {
+			props: { scenario: { id: 'x', name: 'No Desc', description: '' } }
+		});
+		expect(screen.getByText('No Desc')).toBeTruthy();
+	});
+});

--- a/web/tests/lib/api.test.ts
+++ b/web/tests/lib/api.test.ts
@@ -34,6 +34,7 @@ import {
 	getLabStatus,
 	startLab,
 	stopLab,
+	killLab,
 	getScenarios,
 	getScenario,
 	getConfig,
@@ -89,6 +90,60 @@ describe('API client', () => {
 			'/api/lab/stop',
 			expect.objectContaining({ method: 'POST', headers: expect.any(Headers) })
 		);
+	});
+
+	it('killLab posts to /api/lab/kill without stopping containers by default', async () => {
+		const data = {
+			success: true,
+			mcp_processes_killed: 3,
+			containers_stopped: false,
+			session_cleared: true,
+			errors: []
+		};
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve(data)
+		});
+
+		const result = await killLab(false);
+		expect(result).toEqual(data);
+		expect(mockFetch).toHaveBeenCalledWith(
+			'/api/lab/kill?containers=false',
+			expect.objectContaining({ method: 'POST', headers: expect.any(Headers) })
+		);
+	});
+
+	it('killLab passes containers=true to widen the blast radius', async () => {
+		const data = {
+			success: true,
+			mcp_processes_killed: 1,
+			containers_stopped: true,
+			session_cleared: true,
+			errors: []
+		};
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve(data)
+		});
+
+		const result = await killLab(true);
+		expect(result.containers_stopped).toBe(true);
+		expect(mockFetch).toHaveBeenCalledWith(
+			'/api/lab/kill?containers=true',
+			expect.objectContaining({ method: 'POST', headers: expect.any(Headers) })
+		);
+	});
+
+	it('killLab carries the session header', async () => {
+		sessionStorage.setItem('aptl_session', 'tok-kill');
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve({ success: true })
+		});
+
+		await killLab(false);
+		const headers = mockFetch.mock.calls[0][1].headers as Headers;
+		expect(headers.get('X-APTL-Session')).toBe('tok-kill');
 	});
 
 	it('startLab carries ADR-030 outcome + diagnostics through fetch', async () => {

--- a/web/tests/lib/routes.test.ts
+++ b/web/tests/lib/routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('scenario [id] page load', () => {
 	it('fetches scenario by ID and returns it', async () => {
@@ -41,13 +41,24 @@ describe('scenario [id] page load', () => {
 
 		await expect(
 			load({ params: { id: 'missing' }, fetch: mockFetch } as any)
-		).rejects.toThrow();
+		).rejects.toMatchObject({
+			status: 404,
+			body: { message: expect.stringContaining('Not found') }
+		});
 	});
 });
 
 describe('home page load', () => {
-	it('fetches and returns scenarios list', async () => {
-		const scenarios = [{ id: 's1', name: 'Scenario 1' }];
+	// `load` routes through `getScenarios()` (shared API boundary, carries the
+	// X-APTL-Session header) and threads its load-provided `event.fetch` into it,
+	// so these pass a mock `fetch` via the load event and assert it is the one
+	// used to reach `/api/scenarios`.
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+
+	it('fetches and returns the scenario catalog summary', async () => {
+		const scenarios = [{ id: 's1', name: 'Scenario 1', description: 'first' }];
 		const mockFetch = vi.fn().mockResolvedValue({
 			ok: true,
 			json: () => Promise.resolve(scenarios)
@@ -57,26 +68,32 @@ describe('home page load', () => {
 		const result = await load({ fetch: mockFetch } as any);
 
 		expect(result.scenarios).toEqual(scenarios);
+		expect(result.scenariosError).toBe(false);
+		expect(mockFetch).toHaveBeenCalledWith(
+			'/api/scenarios',
+			expect.objectContaining({ headers: expect.any(Headers) })
+		);
 	});
 
-	it('returns empty array on fetch error', async () => {
+	it('degrades to an empty list with an error flag on fetch error', async () => {
 		const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
 		const { load } = await import('../../src/routes/+page');
 		const result = await load({ fetch: mockFetch } as any);
 
 		expect(result.scenarios).toEqual([]);
+		expect(result.scenariosError).toBe(true);
 	});
 
-	it('returns empty array on non-ok response', async () => {
-		const mockFetch = vi.fn().mockResolvedValue({
-			ok: false,
-			status: 500
-		});
+	it('degrades to an empty list with an error flag on non-ok response', async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('boom') });
 
 		const { load } = await import('../../src/routes/+page');
 		const result = await load({ fetch: mockFetch } as any);
 
 		expect(result.scenarios).toEqual([]);
+		expect(result.scenariosError).toBe(true);
 	});
 });

--- a/web/tests/lib/stores.test.ts
+++ b/web/tests/lib/stores.test.ts
@@ -182,6 +182,32 @@ describe('lab store', () => {
 		destroyLabStore();
 	});
 
+	it('refreshLabStatus re-fetches status without opening an SSE stream', async () => {
+		statusResponder = () =>
+			Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve({ running: true, containers: [], error: null })
+			});
+
+		const { labStatus, refreshLabStatus } = await import('../../src/lib/stores/lab');
+
+		await refreshLabStatus();
+
+		expect(get(labStatus).running).toBe(true);
+		// A status refresh must not spin up a new events subscription.
+		expect(eventsConns.length).toBe(0);
+	});
+
+	it('refreshLabStatus records a fetch error on the store', async () => {
+		statusResponder = () => Promise.reject(new Error('refresh boom'));
+
+		const { labStatus, refreshLabStatus } = await import('../../src/lib/stores/lab');
+
+		await refreshLabStatus();
+
+		expect(get(labStatus).error).toContain('refresh boom');
+	});
+
 	it('destroyLabStore is safe to call when no stream exists', async () => {
 		const { destroyLabStore } = await import('../../src/lib/stores/lab');
 

--- a/web/tests/routes/page.test.ts
+++ b/web/tests/routes/page.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import type { LabStatus } from '../../src/lib/types';
+
+const labStatus = writable<LabStatus>({ running: false, containers: [], error: null });
+const labLoading = writable(false);
+const refreshLabStatus = vi.fn().mockResolvedValue(undefined);
+const startLab = vi.fn();
+const stopLab = vi.fn();
+const killLab = vi.fn();
+
+vi.mock('$lib/stores/lab', () => ({ labStatus, labLoading, refreshLabStatus }));
+vi.mock('$lib/api', () => ({ startLab, stopLab, killLab }));
+
+async function renderPage(
+	data: { scenarios: { id: string; name: string; description: string }[]; scenariosError: boolean } = {
+		scenarios: [],
+		scenariosError: false
+	}
+) {
+	const Page = (await import('../../src/routes/+page.svelte')).default;
+	return render(Page, { props: { data } });
+}
+
+describe('Lab Home route', () => {
+	beforeEach(() => {
+		labStatus.set({ running: false, containers: [], error: null });
+		labLoading.set(false);
+		vi.clearAllMocks();
+		refreshLabStatus.mockResolvedValue(undefined);
+	});
+
+	it('leads with a stopped readiness headline and a Start control', async () => {
+		await renderPage();
+		expect(screen.getByRole('status', { name: 'Lab stopped' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Start' })).toBeTruthy();
+		expect(screen.queryByRole('button', { name: 'Stop' })).toBeNull();
+	});
+
+	it('shows a running readiness headline and a Stop control when running', async () => {
+		labStatus.set({ running: true, containers: [], error: null });
+		await renderPage();
+		expect(screen.getByRole('status', { name: 'Lab running' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Stop' })).toBeTruthy();
+	});
+
+	it('serializes lifecycle actions (single-flight) and renders ADR-030 start diagnostics', async () => {
+		let resolveStart: (v: unknown) => void = () => {};
+		startLab.mockReturnValue(new Promise((r) => (resolveStart = r)));
+
+		await renderPage();
+		const startBtn = screen.getByRole('button', { name: 'Start' }) as HTMLButtonElement;
+		await fireEvent.click(startBtn);
+
+		expect(startLab).toHaveBeenCalledOnce();
+		// While the start is in flight, every lifecycle control is disabled.
+		const killBtn = screen.getByRole('button', { name: 'Kill' }) as HTMLButtonElement;
+		await waitFor(() => expect(killBtn.disabled).toBe(true));
+		expect((screen.getByRole('button', { name: 'Starting…' }) as HTMLButtonElement).disabled).toBe(
+			true
+		);
+
+		resolveStart({
+			success: true,
+			message: '',
+			error: null,
+			outcome: 'degraded_usable',
+			diagnostics: [
+				{ step: 'wait_for_services', impact: 'telemetry', severity: 'warning', message: 'slow' }
+			]
+		});
+
+		await waitFor(() => expect(screen.getByText(/degraded_usable/i)).toBeTruthy());
+		await waitFor(() => expect(refreshLabStatus).toHaveBeenCalled());
+	});
+
+	it('confirms an emergency kill through the dialog (processes only by default)', async () => {
+		killLab.mockResolvedValue({
+			success: true,
+			mcp_processes_killed: 3,
+			containers_stopped: false,
+			session_cleared: true,
+			errors: []
+		});
+
+		await renderPage();
+		await fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+
+		const dialog = await screen.findByRole('dialog');
+		expect(dialog.getAttribute('aria-labelledby')).toBeTruthy();
+
+		await fireEvent.click(screen.getByRole('button', { name: /kill processes/i }));
+
+		expect(killLab).toHaveBeenCalledWith(false);
+		await waitFor(() => expect(screen.getByText(/Kill complete/i)).toBeTruthy());
+		expect(screen.getByText(/3 MCP process\(es\) terminated/)).toBeTruthy();
+		await waitFor(() => expect(refreshLabStatus).toHaveBeenCalled());
+	});
+
+	it('widens the kill blast radius when containers are toggled on', async () => {
+		killLab.mockResolvedValue({
+			success: true,
+			mcp_processes_killed: 1,
+			containers_stopped: true,
+			session_cleared: true,
+			errors: []
+		});
+
+		await renderPage();
+		await fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+		await screen.findByRole('dialog');
+		await fireEvent.click(
+			screen.getByRole('checkbox', { name: /also force-stop all lab containers/i })
+		);
+		await fireEvent.click(screen.getByRole('button', { name: /kill \+ stop containers/i }));
+
+		expect(killLab).toHaveBeenCalledWith(true);
+		await waitFor(() => expect(screen.getByText(/containers stopped/i)).toBeTruthy());
+	});
+
+	it('cancelling the kill dialog runs no action', async () => {
+		await renderPage();
+		await fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+		await screen.findByRole('dialog');
+		await fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+		await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+		expect(killLab).not.toHaveBeenCalled();
+	});
+
+	it('renders scenario cards from the catalog summary', async () => {
+		await renderPage({
+			scenarios: [
+				{ id: 's1', name: 'Scenario One', description: 'first' },
+				{ id: 's2', name: 'Scenario Two', description: 'second' }
+			],
+			scenariosError: false
+		});
+		expect(screen.getByText('Scenario One')).toBeTruthy();
+		expect(screen.getByText('Scenario Two')).toBeTruthy();
+		expect(screen.getByRole('link', { name: /Scenario One/ }).getAttribute('href')).toBe(
+			'/scenarios/s1'
+		);
+	});
+
+	it('shows an empty state when the catalog is empty', async () => {
+		await renderPage({ scenarios: [], scenariosError: false });
+		expect(screen.getByText(/No scenarios found/i)).toBeTruthy();
+	});
+
+	it('shows a catalog-unavailable state on load error', async () => {
+		await renderPage({ scenarios: [], scenariosError: true });
+		expect(screen.getByText(/catalog is currently unavailable/i)).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Summary

Implements UI-008c (Web GUI Lab Home `/`), a child of UI-008/#541. Lab Home now leads with a readiness-first status headline and adds an emergency Kill control with a blast-radius confirmation dialog (processes only, or also force-stop containers), with start/stop/kill serialized as single-flight lifecycle actions — all built on the APTL component kit. A new `GET /api/scenarios` endpoint projects the curated ACES catalog (`scenario_catalog.py`) into narrow card summaries so the scenario entry points render; scenario loading routes through the shared `getScenarios()` API boundary (session header). ADR-030 startup outcomes are preserved via `LabStartNotice`; the readiness headline derives from running state plus the in-session start outcome, never from container health or message text. The scenario-detail/workbench projection, SIEM, terminal, and config routes remain out of scope (separate child issues).

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #564

## ADR Impact

- ADR-021
- ADR-030

## Changes

- Backend: add `ScenarioSummaryResponse` DTO and a `GET /api/scenarios` router projecting the curated catalog (id/name/description); register it in `main.py`. Absent/malformed catalogs degrade to an empty list.
- Backend tests: rewrite `tests/test_api_scenarios.py` to assert the new list projection (present route, empty/malformed degradation), keeping the scenario-detail route asserted absent.
- Frontend: add `killLab(containers)` + `KillActionResponse` mirror; narrow `ScenarioSummary` to the honest catalog facts; thread SvelteKit `event.fetch` through `getScenarios()`.
- Frontend: new `KillConfirmDialog` (kit Dialog + Button, blast-radius toggle); rebase `LabStatusBadge` on kit `StatusBadge`; reshape `ScenarioCard` to name/description + link.
- Frontend: `+page.svelte` readiness-first headline, kit-Button lifecycle controls, kill flow with `KillActionResponse` rendering + status refresh, single-flight disabling; add `refreshLabStatus()` to the lab store.
- Tests: vitest for killLab, KillConfirmDialog, ScenarioCard, LabStatusBadge, the Lab Home route (single-flight, kill flow, catalog states, readiness, ADR-030 diagnostics), and the refresh store helper.
- Changelog: `changelog.d/564.added.md`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Full pytest (`-k "not integration"`) + the techvault integration static gate, full web vitest (167 tests), svelte-check (0 errors), and `pre-commit run --all-files` all green. Both pre-push reviewers (codex + test-quality) ran one cycle each; the single one-off finding from each was fixed and self-verified.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/564.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
