### PR TITLE
fix: derive paper participant evidence surfaces

### DIFF
--- a/changelog.d/573.added.md
+++ b/changelog.d/573.added.md
@@ -1,3 +1,4 @@
 Added the ACES paper `paper-agent-loop` scenario, typed deployment realization
 spine, runtime-parsed participant action binding, and static coverage for
-participant, topology, and evaluator evidence surfaces.
+participant, topology, evaluator evidence, and runtime-derived participant
+snapshot surfaces.

--- a/docs/aces/paper-scenario-realization.md
+++ b/docs/aces/paper-scenario-realization.md
@@ -7,7 +7,8 @@ network, participant, and evaluator intent, then handed to `DeploymentBackend`
 for backend side effects. The paper participant action is also realized from
 compiled runtime content: the scenario carries an
 `aptl-participant-runtime-binding/v1` payload that APTL parses into the
-container command, success markers, and target evidence references.
+container command, success markers, target evidence references, and participant
+snapshot surfaces.
 
 Run it through the public path:
 
@@ -35,6 +36,12 @@ boundary markers for direct database and Wazuh API reachability. Those markers
 are participant-runtime evidence for the boundary; Wazuh evidence remains
 evaluator-only and is registered as pending evaluator/runtime state rather than
 participant-visible task context or a detection-quality claim.
+
+The participant behavior, action-contract, observation-boundary, action-instance,
+and shared-state snapshot entries are emitted from the runtime-selected
+participant/action/boundary addresses. They must not reuse the legacy TechVault
+SSH participant identifiers when the paper scenario supplies its own compiled
+runtime binding.
 
 ## Upstream Provenance
 

--- a/docs/adrs/adr-046-dynamic-aces-scenario-realization.md
+++ b/docs/adrs/adr-046-dynamic-aces-scenario-realization.md
@@ -127,9 +127,9 @@ Participant action realization must be compiled-artifact driven. The existing
 `DEFAULT_PARTICIPANT_ACTIONS` / `PARTICIPANT_ACTION_ADDRESS` TechVault SSH probe
 is not the paper-scenario contract. The `probe-customer-portal-login` action,
 its source participant, target address, command/interaction contract, success
-classification, and disclosed observation boundary must come from the compiled
-SDL/runtime artifacts. Scenario identity may select the scenario file; it must
-not select behavior.
+classification, disclosed observation boundary, participant snapshot entries,
+and shared-state scope must come from the compiled SDL/runtime artifacts.
+Scenario identity may select the scenario file; it must not select behavior.
 
 Wazuh evidence for the paper action is evaluator-only evidence. It may be made
 available through `AptlEvaluator`, `RuntimeSnapshot`, and `LocalRunStore`, but
@@ -246,6 +246,9 @@ support mode is static.
   driver for the paper scenario.
 - Extending `DEFAULT_PARTICIPANT_ACTIONS` with paper-scenario behavior instead
   of deriving participant action specs from compiled SDL/runtime artifacts.
+- Emitting participant snapshot entries or shared-state scopes with legacy
+  TechVault SSH identifiers after the runtime selected a different participant
+  action binding.
 - Calling `docker` or `docker compose`, or parsing compose output, from the
   interpret or driver stage instead of routing through `DeploymentBackend`.
 - Re-evaluating SEM-218 explicitness classes with a local model rather than

--- a/src/aptl/backends/aces_participant_actions.py
+++ b/src/aptl/backends/aces_participant_actions.py
@@ -38,7 +38,6 @@ PARTICIPANT_ACTION_CONTRACT_ADDRESS = (
 PARTICIPANT_OBSERVATION_BOUNDARY_ADDRESS = (
     "participant.observation-boundary.aptl.kali-victim-ssh-probe"
 )
-PARTICIPANT_BEHAVIOR_ADDRESS = PARTICIPANT_ACTION_ADDRESS
 TECHVAULT_VICTIM_SSH_ADDRESS = ".".join(("172", "20", "2", "20"))
 TECHVAULT_VICTIM_SSH_REF = f"tcp:{TECHVAULT_VICTIM_SSH_ADDRESS}:22"
 
@@ -199,10 +198,10 @@ def drive_participant_action(
         behavior_events=[attempted, observed],
         diagnostics=diagnostics,
         snapshot_entries=_action_snapshot_entries(
-            spec, action_instance_id, observation.success
+            participant_address, spec, action_instance_id, observation.success
         ),
         shared_state_records=_shared_state_records(
-            spec, action_instance_id, observation.success
+            participant_address, spec, action_instance_id, observation.success
         ),
     )
 
@@ -330,18 +329,22 @@ def _observation_event(
 
 
 def _action_snapshot_entries(
+    participant_address: str,
     spec: ParticipantActionSpec,
     action_instance_id: str,
     success: bool,
 ) -> dict[str, SnapshotEntry]:
     """Build participant snapshot entries for the action contract and result."""
 
+    action_name = _address_leaf(spec.action_contract_address)
+    boundary_name = _address_leaf(spec.observation_boundary_address)
     return {
-        PARTICIPANT_BEHAVIOR_ADDRESS: SnapshotEntry(
-            address=PARTICIPANT_BEHAVIOR_ADDRESS,
+        participant_address: SnapshotEntry(
+            address=participant_address,
             domain=RuntimeDomain.PARTICIPANT,
             resource_type="participant-behavior",
             payload={
+                "participant_address": participant_address,
                 "action_contract_addresses": [spec.action_contract_address],
                 "observation_boundary_addresses": [
                     spec.observation_boundary_address
@@ -354,8 +357,8 @@ def _action_snapshot_entries(
             domain=RuntimeDomain.PARTICIPANT,
             resource_type="participant-action-contract",
             payload={
-                "name": "APTL Kali victim SSH probe",
-                "action_name": "kali-victim-ssh-probe",
+                "name": f"APTL participant action {action_name}",
+                "action_name": action_name,
                 "semantic_version": "1.0.0",
                 "lifecycle_state": "active",
                 "behavioral_granularity": "single-command",
@@ -372,9 +375,9 @@ def _action_snapshot_entries(
             domain=RuntimeDomain.PARTICIPANT,
             resource_type="participant-observation-boundary",
             payload={
-                "name": "APTL Kali victim SSH observation boundary",
-                "boundary_name": "kali-victim-ssh-probe-output",
-                "projection_basis": "nmap grepable output excerpt",
+                "name": f"APTL participant observation boundary {boundary_name}",
+                "boundary_name": boundary_name,
+                "projection_basis": "terminal command output excerpt",
                 "observable_refs": list(spec.target_refs),
                 "evidence_refs": [action_instance_id],
                 "disclosed_refs": list(spec.target_refs),
@@ -401,6 +404,7 @@ def _action_snapshot_entries(
 
 
 def _shared_state_records(
+    participant_address: str,
     spec: ParticipantActionSpec,
     action_instance_id: str,
     success: bool,
@@ -415,7 +419,7 @@ def _shared_state_records(
         ).hexdigest()
         records[ref] = {
             "state_address": ref,
-            "state_scope": "aptl-techvault-live-range",
+            "state_scope": participant_address,
             "state_kind": state_kind,
             "ordering_basis": "participant-action-observation",
             "conflict_policy": "single-writer-observation",
@@ -432,3 +436,9 @@ def _shared_state_records(
             "evidence_refs": [action_instance_id],
         }
     return records
+
+
+def _address_leaf(address: str) -> str:
+    """Return the terminal address segment for a runtime artifact."""
+
+    return address.rsplit(".", 1)[-1] if address else "runtime-artifact"

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -521,6 +521,25 @@ def test_paper_participant_action_uses_compiled_addresses_and_boundary_markers(
     assert behavior[0]["action_contract_address"] == action_contract_address
     assert behavior[-1]["observation_boundary_address"] == observation_boundary_address
     assert "boundary_db=blocked" in behavior[-1]["details"]["stdout_excerpt"]
+    entries = control_plane.snapshot.entries
+    assert (
+        entries[participant_address].payload["participant_address"]
+        == participant_address
+    )
+    assert entries[action_contract_address].payload["action_name"] == (
+        "probe-customer-portal-login"
+    )
+    assert entries[observation_boundary_address].payload["boundary_name"] == (
+        "paper-agent-view"
+    )
+    assert "Kali victim SSH" not in str(entries[action_contract_address].payload)
+    assert "kali-victim-ssh" not in str(entries[observation_boundary_address].payload)
+    shared_state_records = getattr(
+        control_plane.snapshot, "shared_state_records", {}
+    )
+    assert {
+        record["state_scope"] for record in shared_state_records.values()
+    } == {participant_address}
     assert participant_action_specs[participant_address].target_refs == (
         "container:aptl-kali",
         "container:aptl-webapp",


### PR DESCRIPTION
## Summary

Derive paper participant evidence surfaces from the runtime-selected binding instead of legacy TechVault participant identifiers.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #573

## ADR Impact

- ADR-046

## Changes

- Carry the runtime participant address into participant snapshot entries and shared-state records.
- Derive action-contract and observation-boundary snapshot labels from the selected runtime addresses.
- Strengthen the paper scenario test so legacy SSH participant identifiers cannot leak into paper evidence surfaces.
- Update the paper scenario docs, ADR-046, and changelog to describe runtime-derived participant snapshot surfaces.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused ACES/deployment suite passed: `.venv/bin/pytest tests/test_aces_backend.py tests/test_paper_scenario_static_gate.py tests/test_deployment_backend.py -q`. Full `pre-commit run --all-files` passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: tests/test_aces_backend.py::test_paper_participant_action_uses_compiled_addresses_and_boundary_markers

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/573.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.