### PR TITLE
added: surface narrow accessible terminal rejection reasons

### DIFF
--- a/changelog.d/566.added.md
+++ b/changelog.d/566.added.md
@@ -1,0 +1,11 @@
+### Added
+
+- Narrow, accessible terminal rejection reasons on the focused terminal
+  (`/terminal/[container]`) and inline workbench terminal blocks. The
+  backend already refuses unauthorized, cross-origin, unknown-container,
+  lab-stopped, unavailable-target, and unpinned-host-key connections at the
+  WebSocket relay (ADR-039 / ADR-040); the web UI now surfaces each of those
+  categories — plus SSH-connection-failed and disconnected — as an explicit,
+  screen-reader-visible status line outside the terminal canvas, instead of a
+  generic "connection closed". No secrets or raw server exceptions are
+  exposed, and terminal input/output is still never persisted.

--- a/docs/specs/web-gui-design-preflight.md
+++ b/docs/specs/web-gui-design-preflight.md
@@ -25,9 +25,9 @@ type, route contract, or workflow concept.
 | Web auth, auth env binding, project-dir binding | `src/aptl/api/deps.py` |
 | API response DTOs | `src/aptl/api/schemas.py` |
 | Svelte API fetch boundary and SSE subscription | `web/src/lib/api.ts` |
+| Browser session second factor | `web/src/lib/session.ts`, `src/aptl/api/session.py` |
+| Browser terminal carrier helpers | `web/src/lib/bff.ts`, `src/aptl/api/routers/terminal.py` |
 | Svelte wire-type mirror | `web/src/lib/types.ts` |
-| Legacy split-profile Svelte server-side bearer-token proxy | `web/src/hooks.server.ts` |
-| Legacy split-profile WebSocket token carrier data | `web/src/routes/+layout.server.ts` |
 | `aptl web serve` bind/runtime contract | `src/aptl/cli/web.py` |
 | Split web Compose profile | `docker-compose.yml` services `aptl-web-api` and `aptl-web-ui` |
 | Web build artifact contract | `web/package.json`, `web/svelte.config.js`, `web/vite.config.ts` |
@@ -310,6 +310,57 @@ parser, terminal authority, SIEM authority, scoring store, or replacement SDL.
   leak catalog paths or raw parser exceptions, unknown ids fail narrowly, block
   unions render exhaustively, terminal/SIEM blocks stay lazy, markdown is
   sanitized, and every `/api/*` fetch path carries the shared session header.
+
+## UI-008e Focused Terminal Guardrails
+
+UI-008e (`/terminal/[container]` and inline `TerminalBlock`) is a terminal
+surface over the existing ADR-039/ADR-040 relay. It must not become a generic
+command-execution API, a browser-owned container allow-list, or a second
+endpoint/trust registry.
+
+- Keep the terminal backend authority in `src/aptl/api/routers/terminal.py`.
+  The route must continue to pass the gates in this order before dialing SSH:
+  WebSocket auth ticket or direct token, strict same-origin upgrade, terminal
+  allow-list from `TERMINAL_CONTAINER_NAMES`, lab-running state, runtime
+  endpoint projection from `lab_terminal_ssh_endpoints()`, and pinned
+  `known_hosts` from `known_hosts_path()`.
+- Keep the browser carrier in `web/src/lib/bff.ts` and `web/src/lib/session.ts`.
+  The component fetches a short-lived ticket from the relative
+  `/api/terminal/ticket` endpoint with `sessionHeaders()`, then presents
+  `aptl-token.<ticket>` as the WebSocket subprotocol. Do not put API tokens,
+  tickets, or session factors in URL query strings, route data, local storage,
+  stores, examples, logs, or generated bundles.
+- Treat `TerminalBlock` and focused route params as requested targets only.
+  Inline blocks may name `container`, and container cards may show terminal
+  affordances, but the server-side allow-list and runtime inventory remain the
+  only authorization and reachability authority. Avoid a second hardcoded SSH
+  container set as anything more than a removable display hint.
+- Surface terminal rejection as narrow user-facing categories without leaking
+  secrets or validation internals: authentication/session unavailable,
+  same-origin policy rejected, unknown terminal target, lab not running,
+  container unavailable, host keys not pinned/verified, SSH connection failed,
+  and WebSocket disconnected. Prefer the existing WebSocket
+  `{type: "error", message}` envelope when the server can send one; use close
+  reason/code only as a fallback for pre-accept failures.
+- Preserve terminal side effects as explicit and bounded. Inline terminal
+  blocks stay lazy until user action, focused terminal opens one requested
+  session, resize/stdin are the only client-to-server message types, and
+  malformed messages are ignored rather than promoted to an execution surface.
+- Keep terminal output ephemeral in v1. Do not persist transcripts, command
+  history, terminal input/output, copied commands, error payloads, or SSH stream
+  data in `sessionStorage`, `localStorage`, run archives, scenario state, or
+  logs.
+- Use existing observability and redaction conventions: module-local
+  `get_logger(...)`, sanitized route parameters, validation-layer labels, and
+  no operator keystrokes, ticket values, bearer/session credentials, private
+  key material, raw exception payloads, or terminal bytes in logs.
+- Tests should extend the existing seams instead of adding a parallel harness:
+  `tests/test_api_terminal.py` for auth/origin/allow-list/lab-state/runtime
+  endpoint/known-hosts gates, `tests/test_host_keys.py` and
+  `tests/test_endpoints.py` for trust and endpoint projections,
+  `web/tests/lib/bff.test.ts` for carrier construction, and
+  `web/tests/components/Terminal.test.ts` plus workbench block tests for the
+  component states and lazy mounting.
 
 ## Extensibility Seams
 

--- a/tests/test_api_terminal.py
+++ b/tests/test_api_terminal.py
@@ -705,6 +705,106 @@ class TestWsAcceptsTicketSubprotocol:
                     ws.receive_json()
 
 
+class TestTerminalRejectionContract:
+    """Lock the exact WS close reasons / error-frame messages the web UI maps.
+
+    ``web/src/lib/bff.ts`` (``describeTerminalClose`` / ``describeErrorFrame``)
+    surfaces these strings as narrow, accessible rejection categories. If the
+    backend ever renamed a reason or message, the frontend mapping would
+    silently fall back to a generic string — these tests fail loudly instead,
+    keeping the backend→frontend contract honest.
+    """
+
+    def test_unauthorized_close_reason(self, api_client):
+        """No token (valid origin) closes with code 1008 / reason 'Unauthorized'."""
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with api_client.websocket_connect(
+                "/api/terminal/ws/victim",
+                headers={**_VALID_ORIGIN},
+            ) as ws:
+                ws.receive_json()
+        assert exc.value.code == 1008
+        assert exc.value.reason == "Unauthorized"
+
+    def test_origin_not_allowed_close_reason(self, api_client):
+        """Valid token + bad origin closes with reason 'Origin not allowed'."""
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with api_client.websocket_connect(
+                "/api/terminal/ws/victim",
+                subprotocols=_VALID_WS_SUBPROTOCOLS,
+                headers={"origin": "http://evil.com"},
+            ) as ws:
+                ws.receive_json()
+        assert exc.value.code == 1008
+        assert exc.value.reason == "Origin not allowed"
+
+    @patch("aptl.api.routers.terminal.lab_status")
+    def test_unknown_container_close_reason(self, mock_status, api_client):
+        """An unknown container closes with reason 'Unknown container'."""
+        mock_status.return_value = _make_lab_status(running=True)
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with api_client.websocket_connect(
+                "/api/terminal/ws/nonexistent",
+                subprotocols=_VALID_WS_SUBPROTOCOLS,
+                headers={**_VALID_ORIGIN},
+            ) as ws:
+                ws.receive_json()
+        assert exc.value.code == 1008
+        assert exc.value.reason == "Unknown container"
+
+    @patch("aptl.api.routers.terminal.lab_status")
+    def test_lab_not_running_error_message_exact(self, mock_status, api_client):
+        """The lab-stopped error frame message is exactly 'Lab is not running'."""
+        mock_status.return_value = _make_lab_status(running=False)
+        with api_client.websocket_connect(
+            "/api/terminal/ws/victim",
+            subprotocols=_VALID_WS_SUBPROTOCOLS,
+            headers={**_VALID_ORIGIN},
+        ) as ws:
+            msg = ws.receive_json()
+            assert msg == {"type": "error", "message": "Lab is not running"}
+
+    @patch("aptl.api.routers.terminal.lab_terminal_ssh_endpoints")
+    @patch("aptl.api.routers.terminal.lab_status")
+    def test_container_not_available_error_message_exact(
+        self, mock_status, mock_endpoints, api_client, tmp_path
+    ):
+        """The unavailable-target error frame message is exact."""
+        mock_status.return_value = _make_lab_status(running=True)
+        mock_endpoints.return_value = {}
+        _pin_known_hosts(tmp_path)
+        with api_client.websocket_connect(
+            "/api/terminal/ws/victim",
+            subprotocols=_VALID_WS_SUBPROTOCOLS,
+            headers={**_VALID_ORIGIN},
+        ) as ws:
+            msg = ws.receive_json()
+            assert msg == {"type": "error", "message": "Container not available"}
+
+    @patch("aptl.api.routers.terminal.asyncssh")
+    @patch("aptl.api.routers.terminal.lab_terminal_ssh_endpoints")
+    @patch("aptl.api.routers.terminal.lab_status")
+    def test_host_keys_error_message_exact(
+        self, mock_status, mock_endpoints, mock_asyncssh, api_client, tmp_path
+    ):
+        """The unpinned-host-key error frame message is exact."""
+        mock_status.return_value = _make_lab_status(running=True)
+        mock_endpoints.return_value = {"victim": _VICTIM_ENDPOINT}
+        # Deliberately do NOT pin known_hosts.
+        mock_asyncssh.connect = AsyncMock()
+        mock_asyncssh.Error = Exception
+        with api_client.websocket_connect(
+            "/api/terminal/ws/victim",
+            subprotocols=_VALID_WS_SUBPROTOCOLS,
+            headers={**_VALID_ORIGIN},
+        ) as ws:
+            msg = ws.receive_json()
+            assert msg == {
+                "type": "error",
+                "message": "SSH host keys not pinned; restart the lab",
+            }
+
+
 class TestWsOriginAllowed:
     """_ws_origin_allowed enforces STRICT same-origin (Origin host == Host)."""
 

--- a/web/src/lib/bff.ts
+++ b/web/src/lib/bff.ts
@@ -8,6 +8,50 @@
 
 import { sessionHeaders } from './session';
 
+/** Lifecycle phase of a terminal connection, surfaced to assistive tech. */
+export type TerminalStatusPhase = 'connecting' | 'connected' | 'closed' | 'error';
+
+/**
+ * A narrow, translation-ready description of the terminal connection state.
+ *
+ * `text` never carries a secret or a raw server exception — only the fixed,
+ * operator-facing rejection categories the backend already emits (ADR-039 /
+ * ADR-040) or a generic fallback. `isError` drives the accessible status
+ * region's styling and severity.
+ */
+export interface TerminalStatus {
+	phase: TerminalStatusPhase;
+	text: string;
+	isError: boolean;
+}
+
+/**
+ * Error thrown by {@link fetchTerminalTicket} on a non-ok response, carrying
+ * the HTTP status so the caller can distinguish an auth/session failure (401 /
+ * 403) from a generic start failure without echoing any server body.
+ */
+export class TerminalTicketError extends Error {
+	readonly status: number;
+	constructor(status: number) {
+		super(`Terminal ticket request failed (${status})`);
+		this.name = 'TerminalTicketError';
+		this.status = status;
+	}
+}
+
+// Fixed map from the backend's narrow WebSocket close reasons
+// (src/aptl/api/routers/terminal.py) to translation-ready operator copy. An
+// unmapped-but-present reason is surfaced verbatim (the server guarantees it is
+// a narrow, secret-free category); an absent reason falls back on the code.
+const CLOSE_REASON_TEXT: Record<string, string> = {
+	Unauthorized: 'Not authorized to open a terminal session.',
+	'Origin not allowed': 'The browser origin was rejected (same-origin policy).',
+	'Unknown container': 'That container is not an allowed terminal target.',
+	'Lab not running': 'The lab is not running.',
+	'Container not available': 'The container is not currently available.',
+	'Host keys not pinned': 'SSH host keys are not pinned — restart the lab.'
+};
+
 /**
  * Build the same-origin WebSocket URL for the given container terminal.
  *
@@ -17,6 +61,62 @@ import { sessionHeaders } from './session';
 export function terminalWsUrl(container: string): string {
 	const scheme = globalThis.location.protocol === 'https:' ? 'wss:' : 'ws:';
 	return `${scheme}//${globalThis.location.host}/api/terminal/ws/${container}`;
+}
+
+/**
+ * Narrow, translation-ready description of a failed terminal-ticket request.
+ *
+ * 401 / 403 mean the operator session is missing or expired; any other status
+ * is a generic start failure. No server response body is echoed — only the
+ * status drives the category, so no server detail leaks into the UI.
+ */
+export function describeTicketFailure(status: number): string {
+	if (status === 401 || status === 403) {
+		return 'Not authorized to open a terminal — your session may have expired.';
+	}
+	return 'Could not start the terminal session.';
+}
+
+/**
+ * Narrow description of a server terminal error frame (`{type:"error"}`).
+ *
+ * The backend already sends a fixed, secret-free category message (e.g. "Lab
+ * is not running", "SSH connection failed"), so it is surfaced verbatim.
+ */
+export function describeErrorFrame(message: string): TerminalStatus {
+	return { phase: 'error', text: message, isError: true };
+}
+
+/**
+ * Narrow description of a terminal WebSocket close.
+ *
+ * Prefers the server's explicit close reason (a fixed narrow category). When
+ * the reason is absent — pre-accept rejections (auth / origin) reach the
+ * browser as an abnormal 1006 close with no reason — it falls back on the code
+ * and whether the session ever carried data. Never echoes secrets.
+ */
+export function describeTerminalClose(
+	code: number,
+	reason: string,
+	receivedData: boolean
+): TerminalStatus {
+	const trimmed = reason.trim();
+	if (trimmed) {
+		return { phase: 'error', text: CLOSE_REASON_TEXT[trimmed] ?? trimmed, isError: true };
+	}
+	// A socket that never carried data and closed abnormally (anything but the
+	// normal 1000) was almost certainly refused at a pre-accept gate.
+	if (!receivedData && code !== 1000) {
+		return {
+			phase: 'error',
+			text: 'Terminal connection refused (unauthorized or blocked).',
+			isError: true
+		};
+	}
+	if (receivedData) {
+		return { phase: 'closed', text: 'Terminal session ended.', isError: false };
+	}
+	return { phase: 'closed', text: 'Terminal connection closed.', isError: false };
 }
 
 /**
@@ -31,7 +131,7 @@ export async function fetchTerminalTicket(): Promise<string> {
 	// injects the backend credential; the browser never sees an API token.
 	const res = await fetch('/api/terminal/ticket', { headers: sessionHeaders() });
 	if (!res.ok) {
-		throw new Error(`Terminal ticket request failed (${res.status})`);
+		throw new TerminalTicketError(res.status);
 	}
 	const { ticket } = (await res.json()) as { ticket: string; expires_in: number };
 	return ticket;

--- a/web/src/lib/components/Terminal.svelte
+++ b/web/src/lib/components/Terminal.svelte
@@ -4,13 +4,26 @@
 	import { FitAddon } from '@xterm/addon-fit';
 	import { WebLinksAddon } from '@xterm/addon-web-links';
 	import '@xterm/xterm/css/xterm.css';
-	import { fetchTerminalTicket, terminalWsUrl } from '$lib/bff';
+	import {
+		describeErrorFrame,
+		describeTerminalClose,
+		describeTicketFailure,
+		fetchTerminalTicket,
+		terminalWsUrl,
+		TerminalTicketError,
+		type TerminalStatus
+	} from '$lib/bff';
 
 	interface Props {
 		container: string;
+		/**
+		 * Optional callback invoked whenever the connection status changes, so a
+		 * host surface (e.g. the focused terminal header) can reflect the state.
+		 */
+		onstatechange?: (status: TerminalStatus) => void;
 	}
 
-	let { container }: Props = $props();
+	let { container, onstatechange }: Props = $props();
 
 	let terminalDiv: HTMLDivElement;
 	let term: Terminal | null = null;
@@ -21,6 +34,33 @@
 	// that happened while the ticket request was in flight and avoid opening an
 	// orphan socket after the component is gone.
 	let destroyed = false;
+	// True once the session has carried real SSH output, so a subsequent close
+	// is reported as "session ended" rather than "refused".
+	let receivedData = false;
+
+	// Narrow, accessible connection status surfaced OUTSIDE the xterm canvas so
+	// assistive tech and sighted users both see rejection reasons (the xterm
+	// viewport is a canvas that screen readers cannot follow).
+	let status = $state<TerminalStatus>({
+		phase: 'connecting',
+		text: 'Connecting…',
+		isError: false
+	});
+
+	function setStatus(next: TerminalStatus): void {
+		status = next;
+		onstatechange?.(next);
+	}
+
+	const dotClass = $derived(
+		status.phase === 'connected'
+			? 'bg-aptl-green'
+			: status.phase === 'error'
+				? 'bg-aptl-red'
+				: status.phase === 'closed'
+					? 'bg-aptl-text-muted'
+					: 'bg-aptl-amber'
+	);
 
 	onMount(() => {
 		term = new Terminal({
@@ -77,9 +117,12 @@
 			let ticket: string;
 			try {
 				ticket = await fetchTerminalTicket();
-			} catch {
+			} catch (err) {
 				if (!destroyed) {
-					term?.write('\r\n\x1b[31mCould not start terminal session.\x1b[0m\r\n');
+					const httpStatus = err instanceof TerminalTicketError ? err.status : 0;
+					const text = describeTicketFailure(httpStatus);
+					setStatus({ phase: 'error', text, isError: true });
+					term?.write(`\r\n\x1b[31m${text}\x1b[0m\r\n`);
 				}
 				return;
 			}
@@ -101,6 +144,7 @@
 			}
 
 			ws.onopen = () => {
+				setStatus({ phase: 'connecting', text: `Connecting to ${container}…`, isError: false });
 				term?.write('\r\nConnecting to ' + container + '...\r\n');
 				// Send initial terminal size so the PTY is correctly sized from the start.
 				if (term) {
@@ -112,8 +156,13 @@
 				try {
 					const msg = JSON.parse(event.data);
 					if (msg.type === 'stdout') {
+						if (!receivedData) {
+							receivedData = true;
+							setStatus({ phase: 'connected', text: `Connected to ${container}.`, isError: false });
+						}
 						term?.write(msg.data);
 					} else if (msg.type === 'error') {
+						setStatus(describeErrorFrame(msg.message));
 						term?.write('\r\n\x1b[31mError: ' + msg.message + '\x1b[0m\r\n');
 					}
 				} catch {
@@ -122,10 +171,17 @@
 				}
 			};
 
-			ws.onclose = () => {
-				term?.write('\r\n\x1b[33mConnection closed.\x1b[0m\r\n');
+			ws.onclose = (event) => {
+				// Preserve a specific error already surfaced (e.g. a {type:"error"}
+				// frame) when the close carries no additional reason of its own.
+				if (!(status.isError && !(event.reason ?? '').trim())) {
+					setStatus(describeTerminalClose(event.code, event.reason ?? '', receivedData));
+				}
+				term?.write(`\r\n\x1b[33m${status.text}\x1b[0m\r\n`);
 			};
 
+			// Let onclose report the narrow reason; onerror only precedes it with no
+			// detail, so avoid overwriting a good reason with a generic error here.
 			ws.onerror = () => {
 				term?.write('\r\n\x1b[31mWebSocket error.\x1b[0m\r\n');
 			};
@@ -140,4 +196,17 @@
 	});
 </script>
 
-<div bind:this={terminalDiv} class="h-full w-full"></div>
+<div class="flex h-full w-full flex-col">
+	<div
+		class="flex items-center gap-2 border-b border-aptl-border bg-aptl-surface px-3 py-1.5 text-xs {status.isError
+			? 'text-aptl-red'
+			: 'text-aptl-text-muted'}"
+		role="status"
+		aria-live="polite"
+		data-phase={status.phase}
+	>
+		<span class="h-1.5 w-1.5 shrink-0 rounded-full {dotClass}" aria-hidden="true"></span>
+		<span>{status.text}</span>
+	</div>
+	<div bind:this={terminalDiv} class="min-h-0 w-full flex-1"></div>
+</div>

--- a/web/src/routes/terminal/[container]/+page.svelte
+++ b/web/src/routes/terminal/[container]/+page.svelte
@@ -1,8 +1,39 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import Terminal from '$lib/components/Terminal.svelte';
+	import type { TerminalStatus } from '$lib/bff';
 
 	const container = $derived($page.params.container ?? '');
+
+	let status = $state<TerminalStatus | null>(null);
+
+	// Short header label for the connection phase (the full, accessible status
+	// text lives in the Terminal component's status region).
+	const phaseLabel = $derived.by(() => {
+		switch (status?.phase) {
+			case 'connected':
+				return 'connected';
+			case 'error':
+				return 'error';
+			case 'closed':
+				return 'closed';
+			default:
+				return 'connecting…';
+		}
+	});
+
+	const phaseColor = $derived.by(() => {
+		switch (status?.phase) {
+			case 'connected':
+				return 'text-aptl-green';
+			case 'error':
+				return 'text-aptl-red';
+			case 'closed':
+				return 'text-aptl-text-muted';
+			default:
+				return 'text-aptl-amber';
+		}
+	});
 </script>
 
 <div class="flex h-[calc(100vh-3.5rem)] flex-col">
@@ -17,8 +48,9 @@
 		<h1 class="text-sm font-medium text-aptl-text">
 			Terminal: <span class="font-mono text-aptl-indigo">{container}</span>
 		</h1>
+		<span class="ml-auto text-xs font-medium {phaseColor}">{phaseLabel}</span>
 	</div>
 	<div class="flex-1 overflow-hidden bg-[#1a1d23] p-1">
-		<Terminal {container} />
+		<Terminal {container} onstatechange={(s) => (status = s)} />
 	</div>
 </div>

--- a/web/tests/components/Terminal.test.ts
+++ b/web/tests/components/Terminal.test.ts
@@ -119,6 +119,87 @@ describe('Terminal', () => {
 		expect(WSSpy).not.toHaveBeenCalled();
 	});
 
+	it('renders an accessible status region that starts in a connecting state', async () => {
+		const { getByRole } = render(Terminal, { props: { container: 'kali' } });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const status = getByRole('status');
+		expect(status).toBeTruthy();
+		expect(status.getAttribute('data-phase')).toBe('connecting');
+	});
+
+	it('surfaces an unauthorized ticket failure as a narrow accessible reason', async () => {
+		fetchMock.mockResolvedValue({ ok: false, status: 401 });
+
+		const { getByRole } = render(Terminal, { props: { container: 'kali' } });
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(WSSpy).not.toHaveBeenCalled();
+		const status = getByRole('status');
+		expect(status.getAttribute('data-phase')).toBe('error');
+		expect(status.textContent).toMatch(/not authorized/i);
+	});
+
+	it('surfaces a server error frame in the accessible status region', async () => {
+		const { getByRole } = render(Terminal, { props: { container: 'kali' } });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const wsInstance = WSSpy.mock.instances[0] as unknown as {
+			onmessage: (e: { data: string }) => void;
+		};
+		wsInstance.onmessage({ data: JSON.stringify({ type: 'error', message: 'Lab is not running' }) });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const status = getByRole('status');
+		expect(status.getAttribute('data-phase')).toBe('error');
+		expect(status.textContent).toMatch(/lab is not running/i);
+	});
+
+	it('surfaces a close reason (unknown container) in the accessible status region', async () => {
+		const { getByRole } = render(Terminal, { props: { container: 'bogus' } });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const wsInstance = WSSpy.mock.instances[0] as unknown as {
+			onclose: (e: { code: number; reason: string }) => void;
+		};
+		wsInstance.onclose({ code: 1008, reason: 'Unknown container' });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const status = getByRole('status');
+		expect(status.getAttribute('data-phase')).toBe('error');
+		expect(status.textContent).toMatch(/allowed terminal target/i);
+	});
+
+	it('reports the connected state after the first stdout chunk', async () => {
+		const { getByRole } = render(Terminal, { props: { container: 'kali' } });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const wsInstance = WSSpy.mock.instances[0] as unknown as {
+			onmessage: (e: { data: string }) => void;
+		};
+		wsInstance.onmessage({ data: JSON.stringify({ type: 'stdout', data: '$ ' }) });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const status = getByRole('status');
+		expect(status.getAttribute('data-phase')).toBe('connected');
+	});
+
+	it('invokes onstatechange when the connection status changes', async () => {
+		const onstatechange = vi.fn();
+		render(Terminal, { props: { container: 'kali', onstatechange } });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const wsInstance = WSSpy.mock.instances[0] as unknown as {
+			onmessage: (e: { data: string }) => void;
+		};
+		wsInstance.onmessage({ data: JSON.stringify({ type: 'error', message: 'SSH connection failed' }) });
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(onstatechange).toHaveBeenCalledWith(
+			expect.objectContaining({ phase: 'error', text: 'SSH connection failed' })
+		);
+	});
+
 	it('does not open an orphan WS if torn down during ticket fetch', async () => {
 		// Hold the ticket request in flight, tear the component down, THEN resolve.
 		let resolveTicket!: () => void;

--- a/web/tests/lib/bff.test.ts
+++ b/web/tests/lib/bff.test.ts
@@ -6,7 +6,14 @@
  * and returns the opaque ticket string; throws on non-ok response.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { terminalWsUrl, fetchTerminalTicket } from '../../src/lib/bff';
+import {
+	terminalWsUrl,
+	fetchTerminalTicket,
+	TerminalTicketError,
+	describeTicketFailure,
+	describeErrorFrame,
+	describeTerminalClose
+} from '../../src/lib/bff';
 
 // Helper: override window.location in jsdom for the duration of a test.
 function stubLocation(protocol: string, host: string) {
@@ -91,5 +98,88 @@ describe('fetchTerminalTicket', () => {
 		);
 
 		await expect(fetchTerminalTicket()).rejects.toThrow();
+	});
+
+	it('throws a TerminalTicketError carrying the HTTP status', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: false,
+				status: 401
+			})
+		);
+
+		await expect(fetchTerminalTicket()).rejects.toBeInstanceOf(TerminalTicketError);
+		await fetchTerminalTicket().catch((err) => {
+			expect(err).toBeInstanceOf(TerminalTicketError);
+			expect(err.status).toBe(401);
+			// No server body is echoed into the error message.
+			expect(err.message).not.toMatch(/detail|body|stack/i);
+		});
+	});
+});
+
+describe('describeTicketFailure', () => {
+	it('maps 401 to an auth/session-expired message', () => {
+		expect(describeTicketFailure(401)).toMatch(/not authorized/i);
+		expect(describeTicketFailure(401)).toMatch(/session/i);
+	});
+
+	it('maps 403 to the same auth category', () => {
+		expect(describeTicketFailure(403)).toMatch(/not authorized/i);
+	});
+
+	it('maps any other status to a generic start failure', () => {
+		expect(describeTicketFailure(503)).toMatch(/could not start/i);
+		expect(describeTicketFailure(0)).toMatch(/could not start/i);
+	});
+});
+
+describe('describeErrorFrame', () => {
+	it('surfaces the server error message verbatim as an error status', () => {
+		const s = describeErrorFrame('Lab is not running');
+		expect(s).toEqual({ phase: 'error', text: 'Lab is not running', isError: true });
+	});
+});
+
+describe('describeTerminalClose', () => {
+	it('maps each narrow server close reason to operator copy', () => {
+		expect(describeTerminalClose(1008, 'Unauthorized', false)).toMatchObject({
+			phase: 'error',
+			isError: true
+		});
+		expect(describeTerminalClose(1008, 'Origin not allowed', false).text).toMatch(/origin/i);
+		expect(describeTerminalClose(1008, 'Unknown container', false).text).toMatch(/allowed/i);
+		expect(describeTerminalClose(1008, 'Lab not running', false).text).toMatch(/not running/i);
+		expect(describeTerminalClose(1008, 'Container not available', false).text).toMatch(
+			/not currently available/i
+		);
+		expect(describeTerminalClose(1008, 'Host keys not pinned', false).text).toMatch(
+			/host keys.*restart/i
+		);
+	});
+
+	it('surfaces an unmapped but present reason verbatim', () => {
+		const s = describeTerminalClose(1008, 'Some new backend reason', false);
+		expect(s).toEqual({ phase: 'error', text: 'Some new backend reason', isError: true });
+	});
+
+	it('reports an abnormal close with no reason and no data as refused', () => {
+		const s = describeTerminalClose(1006, '', false);
+		expect(s.phase).toBe('error');
+		expect(s.text).toMatch(/refused|unauthorized|blocked/i);
+	});
+
+	it('reports a close after data as a graceful session end', () => {
+		const s = describeTerminalClose(1000, '', true);
+		expect(s.phase).toBe('closed');
+		expect(s.isError).toBe(false);
+		expect(s.text).toMatch(/ended/i);
+	});
+
+	it('reports a normal close with no data as a plain closed state', () => {
+		const s = describeTerminalClose(1000, '', false);
+		expect(s.phase).toBe('closed');
+		expect(s.isError).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

UI-008e completes the focused-terminal surface (`/terminal/[container]` and inline workbench terminal blocks) by surfacing the backend's already-enforced rejection reasons as narrow, accessible categories. The WebSocket relay and its gates (auth ticket/token, strict same-origin, allow-list, lab-running, runtime endpoint, pinned known_hosts) and the non-URL subprotocol carrier already existed from prior UI-008 work; the gap was that `Terminal.svelte` swallowed the WebSocket close code/reason and wrote all output only into the (screen-reader-invisible) xterm canvas, so unauthorized / origin / unknown-container / lab-stopped / unavailable / host-key rejections all read as a generic "connection closed". No security gate is added, relaxed, or moved, and terminal I/O is still never persisted.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #566

## ADR Impact

- ADR-021
- ADR-039
- ADR-040

## Changes

- bff.ts: add pure, testable narrow-reason mappers (describeTicketFailure, describeErrorFrame, describeTerminalClose) and a status-carrying TerminalTicketError so a 401/403 ticket failure is distinguishable without echoing any server body
- Terminal.svelte: render an accessible role="status" region that surfaces the narrow rejection categories (unauthorized, origin rejected, unknown container, lab not running, container unavailable, host keys not pinned, SSH connection failed, disconnected) outside the xterm canvas; track receivedData to distinguish a refused connection from a graceful session end; add an optional onstatechange callback
- /terminal/[container]/+page.svelte: reflect the connection phase in the page header via onstatechange
- tests/test_api_terminal.py: add TestTerminalRejectionContract locking the exact WebSocket close reasons and error-frame messages the frontend maps against
- Extend web/tests/lib/bff.test.ts and web/tests/components/Terminal.test.ts for the mapping helpers and the accessible status-region behavior
- changelog.d/566.added.md

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Backend: `pytest -n auto -k "not integration"` (1849 passed) + techvault integration gate (4 passed). Web: `npx vitest run` (175 passed) and `npm run check` (svelte-check clean). Both pre-push reviewers (codex core+security, test-quality) returned clean on cycle 1.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #566 ← web/src/lib/bff.ts, #566 ← web/src/lib/components/Terminal.svelte, #566 ← web/src/routes/terminal/[container]/+page.svelte
- TESTS: #566 ← web/tests/lib/bff.test.ts, #566 ← web/tests/components/Terminal.test.ts, #566 ← tests/test_api_terminal.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/566.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
