### PR TITLE
fixed: enforce ACES realization disclosure

### DIFF
--- a/changelog.d/599.fixed.md
+++ b/changelog.d/599.fixed.md
@@ -1,0 +1,3 @@
+Fixed ACES backend conformance truth-up by rejecting provisioning runs whose
+returned runtime snapshot omits exact realization requirements, and by recording
+realization provenance for honored concerns.

--- a/docs/aces/m1-aces-conformance-truth-up-preflight.md
+++ b/docs/aces/m1-aces-conformance-truth-up-preflight.md
@@ -1,0 +1,186 @@
+# M1 ACES Conformance Truth-Up Preflight
+
+This note is the architecture preflight for issue #599. It is guidance, not an
+implementation plan. ADR-035 remains the binding ACES adoption decision,
+ADR-046 remains the dynamic realization decision, and ADR-044 remains the run
+record boundary. This note narrows the guardrails for making APTL's
+`full-remote-control-plane` backend claim honest end to end.
+
+## Architecture Decisions
+
+- Treat M1 as a contract-honesty and live-proof milestone, not a new backend
+  framework. APTL already has one ACES runtime target:
+  `create_aptl_runtime_target()` with `AptlProvisioner`, `AptlOrchestrator`,
+  `AptlEvaluator`, and `AptlParticipantRuntime`.
+- `create_aptl_manifest()` is the only APTL source for the published backend
+  manifest. Do not add a checked-in manifest JSON, local capability schema, or
+  profile-specific shim.
+- Contract-first ordering is mandatory. A capability, controlled-vocabulary
+  term, contract id, score field, participant behavior feature, or profile
+  requirement must exist in the ACES repo/package before APTL references it.
+  APTL consumes ACES authorities; it does not front-run them.
+- A manifest capability is valid only when the same target realizes it through
+  live infrastructure or a contract-clean control-plane path. Conformance is a
+  verification boundary, not an assertion boundary.
+- Evaluation progression must be truthful. `AptlEvaluator` may publish
+  `PENDING`, `RUNNING`, terminal outcome, and score/progress fields only when
+  those values are driven from real RTE-001 objective/evaluation execution or
+  from an upstream ACES evaluation contract that defines the field.
+- Participant runtime live actions must be compiled-artifact and realization
+  driven. The legacy `DEFAULT_PARTICIPANT_ACTIONS` TechVault probe can remain a
+  compatibility fallback, but new live conformance behavior must use
+  `participant_action_specs_for_scenario()` and the interpreted realization
+  context rather than more hardcoded scenario branches.
+- Documentation truth-up is part of the contract surface. Current docs,
+  adapter docstrings, preflight notes, CI labels, and gate names must either
+  name `full-remote-control-plane` as the current claim or clearly mark older
+  `provisioning-only`, `orchestration-capable`, and
+  `orchestration-evaluation` text as historical.
+
+## Required Cross-Cutting Concerns
+
+- ACES authorities: `aces_sdl.parse_sdl_file`, `compile_runtime_model`,
+  `RuntimeManager`, `RuntimeControlPlane`, `RuntimeTarget`, `ExecutionPlan`,
+  `BackendManifest`, `backend_manifest_payload()`, `run_target_conformance()`,
+  `aces conformance backend --profile full-remote-control-plane`, and ACES
+  contract dataclasses for diagnostics, runtime snapshots, workflow,
+  evaluation, and participant runtime.
+- APTL ACES seams: `src/aptl/backends/aces.py`,
+  `aces_manifest.py`, `aces_diagnostics.py`, `aces_realization.py`,
+  `aces_realization_model.py`, `aces_profiles.py`, `aces_orchestrator.py`,
+  `aces_evaluator.py`, `aces_participant_runtime.py`,
+  `aces_participant_actions.py`, and `aces_participant_bindings.py`.
+- Runtime execution owners: `aptl.core.runtime.workflow_engine.WorkflowEngine`
+  for workflow progression and objective outcome propagation; do not publish
+  `aptl.core.runtime` records as ACES DTOs.
+- Deployment owners: `DeploymentBackend`, `DockerComposeBackend`,
+  `SSHComposeBackend`, `ComposeRealizationMixin`, `ComposeQueryMixin`,
+  project-name scoping, compose-project label filters, bounded
+  `container_exec()`, and typed image/network realization methods.
+- Config and secret owners: strict `AptlConfig`, `DeploymentConfig`,
+  `ContainerSettings.enabled_profiles()`, `load_config()`, `load_dotenv()`,
+  `env_vars_from_dict()`, `find_placeholder_env_values()`, ADR-028 generated
+  config, ADR-029 secret handling, and ADR-034 SOC TLS material.
+- Persistence and evidence owners: `LocalRunStore.write_json()` /
+  `write_jsonl()` / `append_jsonl()`, `RangeSnapshot.to_dict()`,
+  `build_reproducibility_record()`, `AptlRealization.details()`, and existing
+  curated/live-gate evidence directories.
+- Validation and workflow gates: `src/aptl/validation/techvault_gate.py`,
+  `src/aptl/validation/_gate_checks.py`,
+  `src/aptl/validation/techvault_live_gate.py`, `_live_gate_checks.py`,
+  `tests/test_aces_backend.py`, `tests/test_aces_evaluator.py`,
+  `tests/test_aces_orchestrator.py`, `tests/test_techvault_static_gate.py`,
+  `.pre-commit-config.yaml`, and `.github/workflows/checks.yml`.
+
+## Security And Validation Layers
+
+- **ACES parser/compiler gate:** authored scenarios enter through ACES parsing,
+  import verification, semantic compilation, planner diagnostics, and runtime
+  manager planning. APTL must not add local SDL, capability, workflow,
+  evaluation, participant, or scoring mirror schemas.
+- **Manifest/profile gate:** `create_aptl_manifest()` must serialize through
+  `backend_manifest_payload()` and pass both `run_target_conformance()` and the
+  published CLI profile. Missing ACES corpus/profile/CLI support is a failure,
+  not a waiver.
+- **Runtime target gate:** the target components must match the manifest:
+  provisioner, orchestrator, evaluator, and participant runtime all present,
+  method-compatible, and returning ACES `ApplyResult` / `RuntimeSnapshot`
+  payloads.
+- **Evaluation envelope gate:** result and history state must use ACES
+  evaluation dataclasses and diagnostics. Do not fabricate score progression,
+  terminal outcomes, or history events to satisfy conformance.
+- **Participant envelope gate:** episode state/history, behavior history,
+  shared state records, action contracts, and observation boundaries must use
+  ACES participant contracts and snapshot validators. A successful command exit
+  is not enough without contract-clean snapshot state.
+- **Deployment and OS exposure gate:** live actions, Docker, Compose, image,
+  network, container, and host operations stay behind `DeploymentBackend`.
+  Commands are argv lists with bounded timeouts. Do not pass tokens,
+  passwords, cookies, private keys, generated config, or rendered secret values
+  in argv, shell strings, URLs, logs, diagnostics, or persisted proof JSON.
+- **Config/env binding gate:** durable non-secret knobs belong in strict
+  `AptlConfig`; runtime secrets belong in `.env` / `EnvVars` with placeholder
+  checks. Diagnostics may name a variable, never its value.
+- **Isolation gate:** shared-daemon operations must remain project-scoped by
+  compose project labels and configured project name. Do not inspect or act on
+  unscoped `aptl-*` containers or networks.
+- **Error-envelope gate:** ACES-facing failures are ACES `Diagnostic` records
+  and operation-status details. APTL-facing failures remain `LabResult`,
+  `StartupDiagnostic`, `GateReport`, `LiveGateReport`, API schemas, or pytest
+  assertions. Every message crossing CLI/API/log/persistence boundaries must be
+  redacted with the existing redactor.
+- **Persistence gate:** structured conformance, live-proof, snapshot, and run
+  evidence uses `LocalRunStore` JSON/JSONL writers or existing redacted
+  snapshot summaries. `write_file()` / `copy_file()` are inappropriate for
+  secret-shaped structured data because they are intentionally pass-through.
+- **API/auth gate:** if any new proof or status surface is exposed through the
+  web API, it must use `verify_token`, `WebAuthSettings`, BFF CSRF/host gates,
+  and narrow Pydantic response projections. Do not expose raw ACES objects or
+  internal paths directly.
+
+## Extensibility Seam
+
+The seam is:
+
+`(scenario_path, backend_profile, target_name, manifest_contract_versions,
+execution_plan, realization_details, participant_action_descriptor,
+evaluation_address, objective_address, run_id, deployment_backend_provider)`.
+
+The next reasonable variation is another scenario, participant action,
+evaluation resource, or deployment provider. That should require adding a
+validated descriptor or typed backend parameter, not editing a TechVault branch,
+forking the manifest generator, adding a new conformance runner, or copying
+ACES schemas into APTL.
+
+## Whole-Repo View
+
+- Canonical configs: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `pyproject.toml`, `.pre-commit-config.yaml`, `.github/workflows/checks.yml`,
+  `aptl.json` via `AptlConfig`, `.env` via `EnvVars`, and
+  `docker-compose.yml`.
+- Canonical scripts/commands: `pytest`, `pre-commit run --all-files`,
+  manual `pre-commit run aces-scenario-gate --hook-stage manual`, and
+  `aces conformance backend --profile full-remote-control-plane`.
+- Canonical docs/records: ADR-035, ADR-044, ADR-046, this note,
+  `docs/aces/parity-inventory.yaml`, static/live validation gate docs, and
+  adapter docstrings.
+- Runtime layers touched: ACES parser/compiler/planner/control plane, APTL
+  ACES adapters, lab lifecycle, deployment backend, Docker/SSH Compose runner,
+  container exec, snapshot capture, runstore persistence, API/auth if exposed,
+  and CI/pre-commit gates.
+
+## Gotchas And Anti-Patterns
+
+- Declaring a manifest capability because conformance only checks component
+  shape, while live infrastructure cannot realize it.
+- Adding unsupported contract ids or vocabulary tokens locally before ACES
+  publishes them upstream.
+- Keeping adapter docstrings or docs that still describe APTL as merely
+  orchestration-capable without a historical label.
+- Treating evaluator registration as live score progression.
+- Treating participant episode lifecycle calls as lab start/stop operations.
+- Extending `DEFAULT_PARTICIPANT_ACTIONS` as the primary design instead of
+  using runtime-derived action bindings.
+- Calling raw `docker`, `docker compose`, `curl`, or `ssh` from ACES adapters
+  or proof code.
+- Creating duplicate DTOs, schemas, validation helpers, exception hierarchies,
+  redaction helpers, conformance scripts, run manifests, readiness taxonomies,
+  or API projections.
+- Branching on `techvault`, file names, compose profiles, or catalog ids inside
+  canonical adapter logic.
+- Flattening ACES workflow/evaluation/participant histories into summaries
+  before ACES validation and persistence boundaries have handled them.
+
+## Non-Goals
+
+- Do not implement issue #599 in this preflight.
+- Do not define new ACES contracts, profiles, controlled vocabulary, or
+  scenario language in APTL.
+- Do not redesign `RuntimeControlPlane`, `RuntimeTarget`, `DeploymentBackend`,
+  Docker Compose topology, startup ordering, generated config, SOC TLS, web
+  auth, terminal relay, snapshot registry, or run archive layout.
+- Do not make participant runtime a general shell-execution API.
+- Do not make evaluator scoring a simulated state machine detached from real
+  objective/evaluation observations.
+- Do not replace the static/live gates with a new M1-specific gate. Extend the
+  existing gate owners and profile parameters when implementation begins.

--- a/docs/aces/techvault-live-validation-gate.md
+++ b/docs/aces/techvault-live-validation-gate.md
@@ -11,7 +11,7 @@ the run archive. It implements requirement SCN-010 (issue #323).
 
 The gate is scenario-generic by construction. `validate_live_deployment()` takes
 a scenario path, a backend profile, the project directory, and a run id, so the
-next scenario in APTL's `orchestration-capable` expressivity class passes
+next scenario in APTL's `full-remote-control-plane` expressivity class passes
 through by changing inputs rather than by editing the gate. TechVault is the
 proving input, never a hardcoded branch (ADR-035).
 
@@ -33,7 +33,7 @@ layer that broke:
    than degrading to a warning.
 2. **Boot-input agreement** (`backend_instantiation`). The selected scenario is
    passed through to public startup. The profile under validation must still be
-   the public start path's capability profile (`orchestration-capable`). A
+   the public start path's capability profile (`full-remote-control-plane`). A
    profile mismatch is a hard failure raised before any destructive boot, so the
    gate never validates a profile the boot path will not realize.
 3. **ACES-driven boot** (`backend_interpretation` or `backend_instantiation`).
@@ -145,7 +145,7 @@ the prompt in automation, or `--skip-clean-boot` to validate an already-running
 lab without the destructive `stop -v` and reboot. `--scenario` accepts an
 explicit ACES SDL path for the live gate and is passed through to public lab
 startup. `--profile` must remain the public startup capability profile
-(`orchestration-capable`); profile mismatches fail the boot-input agreement
+(`full-remote-control-plane`); profile mismatches fail the boot-input agreement
 check before boot. `--run-id` sets the run-archive id.
 
 The same boot runs as the explicitly gated integration test:

--- a/docs/aces/techvault-static-validation-gate.md
+++ b/docs/aces/techvault-static-validation-gate.md
@@ -28,12 +28,12 @@ editing the gate. TechVault is the proving input, never a hardcoded branch.
    semantic validation against the concept-authority corpus and produces the
    runtime model.
 4. **Backend conformance.** APTL's canonical `backend-manifest-v2` target passes
-   `run_target_conformance()` for the `orchestration-capable` profile, and the
-   published `aces conformance backend --profile orchestration-capable` command
-   runs against the bundled contract corpus. A missing corpus, profile artifact,
-   or conformance command is a gate failure with an actionable diagnostic, never
-   a downgraded warning and never a reason to accept an APTL-local manifest
-   approximation.
+   `run_target_conformance()` for the `full-remote-control-plane` profile, and
+   the published `aces conformance backend --profile full-remote-control-plane`
+   command runs against the bundled contract corpus. A missing corpus, profile
+   artifact, or conformance command is a gate failure with an actionable
+   diagnostic, never a downgraded warning and never a reason to accept an
+   APTL-local manifest approximation.
 5. **Provisioning realization.** The interpreter realizes the provisioning plan
    with no errors and produces nodes, services, and networks. It computes the
    dependency closure for selected nodes from ACES provisioning dependencies
@@ -58,12 +58,12 @@ local dataclass approximation is not accepted as conformance evidence.
 ## Required surface coverage
 
 The parity inventory records, for each required surface, whether TechVault
-represents it today or defers it to a follow-up. Startup surfaces (nodes,
-services, vulnerabilities, features, Kali apparatus, defensive-stack configs,
-and health) are represented. Remaining evaluator and scenario-flow surfaces
-(injects, workflows, objectives, scoring, and evaluator run-archive evidence)
-are deferred to issue #312. A surface that is neither represented with evidence
-nor deferred with an issue fails the gate.
+represents it today or marks it as a historical gap with an issue reference.
+Startup, workflow/evaluation contract, and participant runtime surfaces are
+represented through the full remote-control-plane target. Evaluator live-score
+progression remains truth-labeled until it is driven by real execution state. A
+surface that is neither represented with evidence nor explicitly tracked fails
+the gate.
 
 ## Advisory in Phase A, blocking at cutover
 

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from aces_contracts.diagnostics import Diagnostic
-from aces_contracts.planning import ChangeAction, ProvisioningPlan
-from aces_contracts.runtime_state import ApplyResult, OperationState, RuntimeSnapshot
+from aces_contracts.runtime_state import OperationState, RuntimeSnapshot
 from aces_processor.semantics.realization import realization_disclosure
 from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.manager import RuntimeManager
@@ -17,11 +14,7 @@ from aces_runtime.registry import RuntimeTarget
 from aces_sdl import SDLError, parse_sdl_file
 
 from aptl.backends.aces_diagnostics import (
-    PROVISIONING_ADDRESS,
-    diagnostic,
-    has_error,
     render_aces_diagnostics,
-    snapshot_after_apply,
 )
 from aptl.backends.aces_manifest import APTL_ACES_TARGET_NAME, create_aptl_manifest
 from aptl.backends.aces_evaluator import AptlEvaluator
@@ -32,12 +25,11 @@ from aptl.backends.aces_participant_actions import (
     participant_action_specs_for_scenario,
 )
 from aptl.backends.aces_participant_runtime import AptlParticipantRuntime
+from aptl.backends.aces_provisioner import AptlProvisioner
 from aptl.backends.aces_realization import (
-    AptlRealization,
     interpret_provisioning_plan,
 )
 from aptl.backends.aces_profiles import (
-    load_compose_profile_index,
     select_backend_profiles,
 )
 from aptl.backends.aces_start_model import DEFAULT_ACES_SCENARIO, AcesStartOutcome
@@ -244,16 +236,57 @@ def _apply_provisioning_and_orchestration(
     the provisioner uses, so the reproducibility record carries real
     realization evidence rather than empty placeholders.
     """
-    realization_details, selected_profiles = _interpret_realization(target, execution_plan)
+    realization_details, selected_profiles = _interpret_realization(
+        target, execution_plan
+    )
+    failure = _run_control_plane_phases(control_plane, execution_plan)
+    if failure is None:
+        evaluation_results = _evaluation_results(target, execution_plan)
+        failure = _drive_orchestrator_workflows(
+            target.orchestrator,
+            evaluation_results,
+            run_store=run_store,
+            run_id=run_id,
+        )
+    return failure, realization_details, selected_profiles
+
+
+def _run_control_plane_phases(
+    control_plane: RuntimeControlPlane,
+    execution_plan: "ExecutionPlan",
+) -> LabResult | None:
+    """Apply provisioning, disclosure, orchestration, and evaluation phases."""
+
     failure = _apply_phase(
         control_plane,
         lambda: control_plane.submit_provisioning(execution_plan.provisioning),
     )
-    if failure is not None:
-        return failure, realization_details, selected_profiles
-    failure = _apply_realization_disclosure(control_plane, execution_plan)
-    if failure is not None:
-        return failure, realization_details, selected_profiles
+    if failure is None:
+        failure = _apply_realization_disclosure(control_plane, execution_plan)
+    if failure is None:
+        failure = _apply_optional_control_plane_phases(control_plane, execution_plan)
+    return failure
+
+
+def _apply_optional_control_plane_phases(
+    control_plane: RuntimeControlPlane,
+    execution_plan: "ExecutionPlan",
+) -> LabResult | None:
+    """Submit orchestration/evaluation phases only when the plan has work."""
+
+    failure = None
+    for submit in _optional_phase_submissions(control_plane, execution_plan):
+        failure = _apply_phase(control_plane, submit)
+        if failure is not None:
+            break
+    return failure
+
+
+def _optional_phase_submissions(
+    control_plane: RuntimeControlPlane,
+    execution_plan: "ExecutionPlan",
+) -> list[Callable[[], object]]:
+    """Build deferred submissions for optional ACES phases."""
 
     phases: list[Callable[[], object]] = []
     if execution_plan.orchestration.actionable_operations:
@@ -264,47 +297,71 @@ def _apply_provisioning_and_orchestration(
         phases.append(
             lambda: control_plane.submit_evaluation(execution_plan.evaluation),
         )
-    for submit in phases:
-        failure = _apply_phase(control_plane, submit)
-        if failure is not None:
-            return failure, realization_details, selected_profiles
-    evaluation_results: dict[str, dict[str, object]] = {}
+    return phases
+
+
+def _evaluation_results(
+    target: RuntimeTarget,
+    execution_plan: "ExecutionPlan",
+) -> dict[str, dict[str, object]]:
+    """Return evaluator results only when evaluation actions ran."""
+
+    results: dict[str, dict[str, object]] = {}
     if execution_plan.evaluation.actionable_operations and target.evaluator is not None:
-        evaluation_results = target.evaluator.results()
-    orchestrator = target.orchestrator
+        results = target.evaluator.results()
+    return results
+
+
+def _drive_orchestrator_workflows(
+    orchestrator: object,
+    evaluation_results: dict[str, dict[str, object]],
+    *,
+    run_store: RunStorageBackend | None = None,
+    run_id: str | None = None,
+) -> LabResult | None:
+    """Drive registered workflows and convert diagnostics to a lab failure."""
+
+    drive_diagnostics = []
     if isinstance(orchestrator, AptlOrchestrator) and orchestrator.results():
         drive_diagnostics = orchestrator.drive_workflows(
             evaluation_results=evaluation_results,
             run_store=run_store,
             run_id=run_id,
         )
-        if drive_diagnostics:
-            return (
-                LabResult(
-                    success=False,
-                    error=render_aces_diagnostics(drive_diagnostics),
-                ),
-                realization_details,
-                selected_profiles,
-            )
-    return None, realization_details, selected_profiles
+    failure = None
+    if drive_diagnostics:
+        failure = LabResult(
+            success=False,
+            error=render_aces_diagnostics(drive_diagnostics),
+        )
+    return failure
 
 
 def _current_runtime_snapshot(control_plane: object) -> RuntimeSnapshot:
     """Return the current control-plane snapshot across ACES API shapes."""
 
     snapshot = getattr(control_plane, "snapshot", None)
-    if isinstance(snapshot, RuntimeSnapshot):
-        return snapshot
+    if not isinstance(snapshot, RuntimeSnapshot):
+        snapshot = _snapshot_from_getter(control_plane)
+    if not isinstance(snapshot, RuntimeSnapshot):
+        snapshot = RuntimeSnapshot()
+    return snapshot
+
+
+def _snapshot_from_getter(control_plane: object) -> RuntimeSnapshot | None:
+    """Read a runtime snapshot from legacy/getter ACES control-plane APIs."""
+
+    snapshot = None
     get_snapshot = getattr(control_plane, "get_snapshot", None)
     if callable(get_snapshot):
         returned = get_snapshot()
         if isinstance(returned, RuntimeSnapshot):
-            return returned
-        envelope_snapshot = getattr(returned, "snapshot", None)
-        if isinstance(envelope_snapshot, RuntimeSnapshot):
-            return envelope_snapshot
-    return RuntimeSnapshot()
+            snapshot = returned
+        else:
+            snapshot = getattr(returned, "snapshot", None)
+    if not isinstance(snapshot, RuntimeSnapshot):
+        snapshot = None
+    return snapshot
 
 
 def _store_runtime_snapshot(control_plane: object, snapshot: RuntimeSnapshot) -> None:
@@ -407,171 +464,3 @@ def _apply_phase(
         list(status.diagnostics) if status is not None else list(receipt.diagnostics)
     )
     return LabResult(success=False, error=render_aces_diagnostics(diagnostics))
-
-
-@dataclass
-class AptlProvisioner(object):
-    """Provisioning-only ACES backend adapter for APTL."""
-
-    project_dir: Path
-    config: AptlConfig
-    deployment_backend: "DeploymentBackend"
-
-    def validate(self, plan: object) -> list[Diagnostic]:
-        """Validate that the ACES provisioning plan is APTL-realizable."""
-
-        if not isinstance(plan, ProvisioningPlan):
-            return [
-                diagnostic(
-                    "aptl.provisioner.invalid-plan",
-                    PROVISIONING_ADDRESS,
-                    "APTL provisioner expected an ACES ProvisioningPlan.",
-                )
-            ]
-
-        return list(self._realize_plan(plan).diagnostics)
-
-    def apply(self, plan: object, snapshot: object) -> ApplyResult:
-        """Apply an ACES provisioning plan via APTL's deployment backend."""
-
-        working_snapshot = (
-            snapshot if isinstance(snapshot, RuntimeSnapshot) else RuntimeSnapshot()
-        )
-        diagnostics = self._invalid_plan_diagnostics(plan)
-        result = ApplyResult(
-            success=False,
-            snapshot=working_snapshot,
-            diagnostics=diagnostics,
-        )
-        if isinstance(plan, ProvisioningPlan):
-            realization = self._realize_plan(plan)
-            diagnostics = list(realization.diagnostics)
-            if not has_error(diagnostics):
-                result = self._apply_valid_plan(
-                    plan,
-                    working_snapshot,
-                    diagnostics,
-                    realization,
-                )
-            else:
-                result = ApplyResult(
-                    success=False,
-                    snapshot=working_snapshot,
-                    diagnostics=diagnostics,
-                    details={"realization": realization.details()},
-                )
-        return result
-
-    def _apply_valid_plan(
-        self,
-        plan: ProvisioningPlan,
-        snapshot: RuntimeSnapshot,
-        diagnostics: list[Diagnostic],
-        realization: AptlRealization,
-    ) -> ApplyResult:
-        """Apply a validated ACES plan to the deployment backend."""
-        selected_profiles = select_backend_profiles(self.config, realization.profiles)
-        validity_diagnostics = self._compose_validity_diagnostics(selected_profiles)
-        if validity_diagnostics:
-            diagnostics.extend(validity_diagnostics)
-            return ApplyResult(
-                success=False,
-                snapshot=snapshot,
-                diagnostics=diagnostics,
-                details={
-                    "profiles": selected_profiles,
-                    "realization": realization.details(),
-                },
-            )
-        deployment_spec = realization.deployment_spec(selected_profiles)
-        start_result = self.deployment_backend.realize(deployment_spec)
-        if not start_result.success:
-            diagnostics.append(
-                diagnostic(
-                    "aptl.provisioner.backend-start-failed",
-                    PROVISIONING_ADDRESS,
-                    start_result.error or "APTL deployment backend failed.",
-                )
-            )
-            return ApplyResult(
-                success=False,
-                snapshot=snapshot,
-                diagnostics=diagnostics,
-                details={
-                    "profiles": selected_profiles,
-                    "realization": realization.details(),
-                },
-            )
-        return ApplyResult(
-            success=True,
-            snapshot=snapshot_after_apply(plan, snapshot),
-            diagnostics=diagnostics,
-            changed_addresses=_changed_addresses(plan),
-            details={
-                "profiles": selected_profiles,
-                "realization": realization.details(),
-            },
-        )
-
-    def _compose_validity_diagnostics(
-        self, selected_profiles: list[str]
-    ) -> list[Diagnostic]:
-        """Refuse to start when the selected profiles form an invalid project.
-
-        ``deployment_backend.start`` boots with ``docker compose --profile
-        <selected>``, which activates every service in each selected profile,
-        not just the declared ACES nodes. If an activated service depends on a
-        service the selection excludes, Compose rejects the project at ``up``
-        time. Catch that here so ``aptl lab start`` fails fast with an APTL
-        diagnostic instead of a raw Compose "undefined service" error.
-        """
-        try:
-            profile_index = load_compose_profile_index(self.project_dir)
-        except (OSError, ValueError) as exc:
-            return [
-                diagnostic(
-                    "aptl.provisioner.compose-profile-index-failed",
-                    PROVISIONING_ADDRESS,
-                    redact(str(exc)),
-                )
-            ]
-        gaps = profile_index.cross_profile_dependency_gaps(set(selected_profiles))
-        return [
-            diagnostic(
-                "aptl.provisioner.compose-project-invalid",
-                PROVISIONING_ADDRESS,
-                (
-                    "Selected APTL compose profiles form an invalid project: "
-                    f"service '{service_name}' depends on "
-                    f"{', '.join(dependencies)}, which the profile selection "
-                    "excludes. Declare the dependency's node or enable its "
-                    "profile."
-                ),
-            )
-            for service_name, dependencies in sorted(gaps.items())
-        ]
-
-    def _realize_plan(self, plan: ProvisioningPlan) -> AptlRealization:
-        """Interpret an ACES plan against APTL's supported contract."""
-        return interpret_provisioning_plan(
-            plan=plan,
-            project_dir=self.project_dir,
-            config=self.config,
-        )
-
-    @staticmethod
-    def _invalid_plan_diagnostics(plan: object) -> list[Diagnostic]:
-        if isinstance(plan, ProvisioningPlan):
-            return []
-        return [
-            diagnostic(
-                "aptl.provisioner.invalid-plan",
-                PROVISIONING_ADDRESS,
-                "APTL provisioner expected an ACES ProvisioningPlan.",
-            )
-        ]
-
-
-def _changed_addresses(plan: ProvisioningPlan) -> list[str]:
-    """Return addresses whose planned operation changes runtime state."""
-    return [op.address for op in plan.operations if op.action != ChangeAction.UNCHANGED]

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.planning import ChangeAction, ProvisioningPlan
 from aces_contracts.runtime_state import ApplyResult, OperationState, RuntimeSnapshot
+from aces_processor.semantics.realization import realization_disclosure
 from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.manager import RuntimeManager
 from aces_runtime.registry import RuntimeTarget
@@ -208,7 +209,7 @@ def _run_execution_plan(
     if failure is not None:
         return AcesStartOutcome(
             lab_result=failure,
-            final_snapshot=control_plane.get_snapshot(),
+            final_snapshot=_current_runtime_snapshot(control_plane),
             realization_details=realization_details,
             selected_profiles=selected_profiles,
             scenario_path=scenario_path,
@@ -218,7 +219,7 @@ def _run_execution_plan(
             success=True,
             message=f"Lab started through ACES runtime target '{APTL_ACES_TARGET_NAME}'",
         ),
-        final_snapshot=control_plane.get_snapshot(),
+        final_snapshot=_current_runtime_snapshot(control_plane),
         realization_details=realization_details,
         selected_profiles=selected_profiles,
         scenario_path=scenario_path,
@@ -244,9 +245,17 @@ def _apply_provisioning_and_orchestration(
     realization evidence rather than empty placeholders.
     """
     realization_details, selected_profiles = _interpret_realization(target, execution_plan)
-    phases: list[Callable[[], object]] = [
+    failure = _apply_phase(
+        control_plane,
         lambda: control_plane.submit_provisioning(execution_plan.provisioning),
-    ]
+    )
+    if failure is not None:
+        return failure, realization_details, selected_profiles
+    failure = _apply_realization_disclosure(control_plane, execution_plan)
+    if failure is not None:
+        return failure, realization_details, selected_profiles
+
+    phases: list[Callable[[], object]] = []
     if execution_plan.orchestration.actionable_operations:
         phases.append(
             lambda: control_plane.submit_orchestration(execution_plan.orchestration),
@@ -279,6 +288,83 @@ def _apply_provisioning_and_orchestration(
                 selected_profiles,
             )
     return None, realization_details, selected_profiles
+
+
+def _current_runtime_snapshot(control_plane: object) -> RuntimeSnapshot:
+    """Return the current control-plane snapshot across ACES API shapes."""
+
+    snapshot = getattr(control_plane, "snapshot", None)
+    if isinstance(snapshot, RuntimeSnapshot):
+        return snapshot
+    get_snapshot = getattr(control_plane, "get_snapshot", None)
+    if callable(get_snapshot):
+        returned = get_snapshot()
+        if isinstance(returned, RuntimeSnapshot):
+            return returned
+        envelope_snapshot = getattr(returned, "snapshot", None)
+        if isinstance(envelope_snapshot, RuntimeSnapshot):
+            return envelope_snapshot
+    return RuntimeSnapshot()
+
+
+def _store_runtime_snapshot(control_plane: object, snapshot: RuntimeSnapshot) -> None:
+    """Persist a replacement snapshot when the control-plane object supports it."""
+
+    public_snapshot = getattr(control_plane, "snapshot", None)
+    if isinstance(public_snapshot, RuntimeSnapshot):
+        try:
+            setattr(control_plane, "snapshot", snapshot)
+        except AttributeError:
+            pass
+    if hasattr(control_plane, "_snapshot"):
+        setattr(control_plane, "_snapshot", snapshot)
+    store = getattr(control_plane, "_store", None)
+    save_snapshot = getattr(store, "save_snapshot", None)
+    if callable(save_snapshot):
+        save_snapshot(snapshot)
+
+
+def _realization_requirements(execution_plan: object) -> tuple[object, ...]:
+    """Return compiled SEM-218 realization requirements when present."""
+
+    model = getattr(execution_plan, "model", None)
+    requirements = getattr(model, "realization_requirements", ())
+    try:
+        return tuple(requirements or ())
+    except TypeError:
+        return ()
+
+
+def _apply_realization_disclosure(
+    control_plane: object,
+    execution_plan: object,
+) -> LabResult | None:
+    """Run ACES non-approximation disclosure after provisioning applies."""
+
+    requirements = _realization_requirements(execution_plan)
+    if not requirements:
+        return None
+    snapshot = _current_runtime_snapshot(control_plane)
+    diagnostics, provenance = realization_disclosure(
+        requirements,
+        execution_plan.provisioning,
+        snapshot,
+    )
+    if diagnostics:
+        return LabResult(
+            success=False,
+            error=render_aces_diagnostics(list(diagnostics)),
+        )
+    if provenance:
+        next_snapshot = snapshot.with_entries(
+            dict(snapshot.entries),
+            realization_provenance=(
+                *snapshot.realization_provenance,
+                *provenance,
+            ),
+        )
+        _store_runtime_snapshot(control_plane, next_snapshot)
+    return None
 
 
 def _interpret_realization(

--- a/src/aptl/backends/aces_evaluator.py
+++ b/src/aptl/backends/aces_evaluator.py
@@ -1,9 +1,9 @@
 """APTL ACES evaluation adapter.
 
-Promotes APTL's ACES backend from ``orchestration-capable`` to
-``orchestration-evaluation`` (SCN-010 follow-on #312). APTL's scenario runtime
-engine (RTE-001) already evaluates conditions and objectives; this adapter
-exposes that surface through the *portable* ACES contracts
+APTL's full remote-control-plane backend includes this evaluation component for
+the objective/condition surface introduced by SCN-010 follow-on #312. APTL's
+scenario runtime engine (RTE-001) already evaluates conditions and objectives;
+this adapter exposes that surface through the *portable* ACES contracts
 ``evaluation-result-envelope-v1`` and ``evaluation-history-event-stream-v1``
 rather than APTL-native scoring shapes.
 
@@ -20,9 +20,10 @@ by #514), the same ``results()`` / ``history()`` surface will report the real
 ``RUNNING`` → terminal transitions and ``EvaluationHistoryEvent`` streams.
 ``stop()`` clears evaluation state.
 
-This keeps the orchestration-evaluation claim honest: APTL publishes the
-evaluation result/history *contract* surface and the loaded/registered run
-state, not a synthetic in-memory result that never progresses.
+This keeps the full remote-control-plane evaluation claim honest: APTL
+publishes the evaluation result/history *contract* surface and the
+loaded/registered run state, not a synthetic in-memory result that never
+progresses.
 """
 
 from __future__ import annotations
@@ -115,7 +116,7 @@ def _register_evaluation(
 
 @dataclass
 class AptlEvaluator(object):
-    """``orchestration-evaluation`` ACES backend adapter for APTL."""
+    """ACES evaluation adapter for APTL's full remote-control-plane target."""
 
     _results: dict[str, dict[str, object]] = field(default_factory=dict, init=False)
     _history: dict[str, list[dict[str, object]]] = field(default_factory=dict, init=False)

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -117,7 +117,8 @@ _ORCHESTRATOR = OrchestratorCapabilities(
 # conditions (healthchecks realized during provisioning) and objectives through
 # the portable evaluation result/history contracts. Scoring sections are
 # declared because SCN-007 scoring resources compile into the same evaluation
-# plan surface even though live score progression remains #514 follow-on work.
+# plan surface; live score progression must come from real execution state, not
+# synthetic registration state.
 _EVALUATOR = EvaluatorCapabilities(
     name="aptl-rte-evaluator",
     supported_sections=frozenset(

--- a/src/aptl/backends/aces_orchestrator.py
+++ b/src/aptl/backends/aces_orchestrator.py
@@ -1,11 +1,11 @@
 """APTL ACES orchestration adapter.
 
-Promotes APTL's ACES backend from ``provisioning-only`` to
-``orchestration-capable`` (SCN-010 follow-on #311). APTL's scenario runtime
-engine (RTE-001) drives scenario steps with state-machine semantics;
-this adapter exposes that drive surface through the *portable* ACES contracts
-``workflow-result-envelope-v1`` and ``workflow-history-event-stream-v1`` rather
-than APTL-native run-archive shapes.
+APTL's full remote-control-plane backend includes this orchestration component
+for the workflow surface first introduced by SCN-010 follow-on #311. APTL's
+scenario runtime engine (RTE-001) drives scenario steps with state-machine
+semantics; this adapter exposes that drive surface through the *portable* ACES
+contracts ``workflow-result-envelope-v1`` and
+``workflow-history-event-stream-v1`` rather than APTL-native run-archive shapes.
 
 The adapter is the ACES ``Orchestrator`` component published on APTL's
 ``RuntimeTarget``. ``start()`` loads an ACES ``OrchestrationPlan`` into runtime
@@ -118,7 +118,7 @@ def _objective_outcomes_from_evaluation(
 
 @dataclass
 class AptlOrchestrator(object):
-    """``orchestration-capable`` ACES backend adapter for APTL."""
+    """ACES orchestration adapter for APTL's full remote-control-plane target."""
 
     _engine: WorkflowEngine = field(default_factory=WorkflowEngine, init=False)
     _workflow_payloads: dict[str, dict[str, object]] = field(default_factory=dict, init=False)

--- a/src/aptl/backends/aces_provisioner.py
+++ b/src/aptl/backends/aces_provisioner.py
@@ -1,0 +1,199 @@
+"""Provisioning-only ACES backend adapter for APTL."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import ChangeAction, ProvisioningPlan
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
+
+from aptl.backends.aces_diagnostics import (
+    PROVISIONING_ADDRESS,
+    diagnostic,
+    has_error,
+    snapshot_after_apply,
+)
+from aptl.backends.aces_realization import (
+    AptlRealization,
+    interpret_provisioning_plan,
+)
+from aptl.backends.aces_profiles import (
+    load_compose_profile_index,
+    select_backend_profiles,
+)
+from aptl.core.config import AptlConfig
+from aptl.utils.redaction import redact
+
+if TYPE_CHECKING:
+    from aptl.core.deployment.backend import DeploymentBackend
+
+
+@dataclass
+class AptlProvisioner(object):
+    """Provisioning-only ACES backend adapter for APTL."""
+
+    project_dir: Path
+    config: AptlConfig
+    deployment_backend: "DeploymentBackend"
+
+    def validate(self, plan: object) -> list[Diagnostic]:
+        """Validate that the ACES provisioning plan is APTL-realizable."""
+
+        if not isinstance(plan, ProvisioningPlan):
+            return [
+                diagnostic(
+                    "aptl.provisioner.invalid-plan",
+                    PROVISIONING_ADDRESS,
+                    "APTL provisioner expected an ACES ProvisioningPlan.",
+                )
+            ]
+
+        return list(self._realize_plan(plan).diagnostics)
+
+    def apply(self, plan: object, snapshot: object) -> ApplyResult:
+        """Apply an ACES provisioning plan via APTL's deployment backend."""
+
+        working_snapshot = (
+            snapshot if isinstance(snapshot, RuntimeSnapshot) else RuntimeSnapshot()
+        )
+        diagnostics = self._invalid_plan_diagnostics(plan)
+        result = ApplyResult(
+            success=False,
+            snapshot=working_snapshot,
+            diagnostics=diagnostics,
+        )
+        if isinstance(plan, ProvisioningPlan):
+            realization = self._realize_plan(plan)
+            diagnostics = list(realization.diagnostics)
+            if not has_error(diagnostics):
+                result = self._apply_valid_plan(
+                    plan,
+                    working_snapshot,
+                    diagnostics,
+                    realization,
+                )
+            else:
+                result = ApplyResult(
+                    success=False,
+                    snapshot=working_snapshot,
+                    diagnostics=diagnostics,
+                    details={"realization": realization.details()},
+                )
+        return result
+
+    def _apply_valid_plan(
+        self,
+        plan: ProvisioningPlan,
+        snapshot: RuntimeSnapshot,
+        diagnostics: list[Diagnostic],
+        realization: AptlRealization,
+    ) -> ApplyResult:
+        """Apply a validated ACES plan to the deployment backend."""
+        selected_profiles = select_backend_profiles(self.config, realization.profiles)
+        validity_diagnostics = self._compose_validity_diagnostics(selected_profiles)
+        if validity_diagnostics:
+            diagnostics.extend(validity_diagnostics)
+            return ApplyResult(
+                success=False,
+                snapshot=snapshot,
+                diagnostics=diagnostics,
+                details={
+                    "profiles": selected_profiles,
+                    "realization": realization.details(),
+                },
+            )
+        deployment_spec = realization.deployment_spec(selected_profiles)
+        start_result = self.deployment_backend.realize(deployment_spec)
+        if not start_result.success:
+            diagnostics.append(
+                diagnostic(
+                    "aptl.provisioner.backend-start-failed",
+                    PROVISIONING_ADDRESS,
+                    start_result.error or "APTL deployment backend failed.",
+                )
+            )
+            return ApplyResult(
+                success=False,
+                snapshot=snapshot,
+                diagnostics=diagnostics,
+                details={
+                    "profiles": selected_profiles,
+                    "realization": realization.details(),
+                },
+            )
+        return ApplyResult(
+            success=True,
+            snapshot=snapshot_after_apply(plan, snapshot),
+            diagnostics=diagnostics,
+            changed_addresses=_changed_addresses(plan),
+            details={
+                "profiles": selected_profiles,
+                "realization": realization.details(),
+            },
+        )
+
+    def _compose_validity_diagnostics(
+        self, selected_profiles: list[str]
+    ) -> list[Diagnostic]:
+        """Refuse to start when the selected profiles form an invalid project.
+
+        ``deployment_backend.start`` boots with ``docker compose --profile
+        <selected>``, which activates every service in each selected profile,
+        not just the declared ACES nodes. If an activated service depends on a
+        service the selection excludes, Compose rejects the project at ``up``
+        time. Catch that here so ``aptl lab start`` fails fast with an APTL
+        diagnostic instead of a raw Compose "undefined service" error.
+        """
+        try:
+            profile_index = load_compose_profile_index(self.project_dir)
+        except (OSError, ValueError) as exc:
+            return [
+                diagnostic(
+                    "aptl.provisioner.compose-profile-index-failed",
+                    PROVISIONING_ADDRESS,
+                    redact(str(exc)),
+                )
+            ]
+        gaps = profile_index.cross_profile_dependency_gaps(set(selected_profiles))
+        return [
+            diagnostic(
+                "aptl.provisioner.compose-project-invalid",
+                PROVISIONING_ADDRESS,
+                (
+                    "Selected APTL compose profiles form an invalid project: "
+                    f"service '{service_name}' depends on "
+                    f"{', '.join(dependencies)}, which the profile selection "
+                    "excludes. Declare the dependency's node or enable its "
+                    "profile."
+                ),
+            )
+            for service_name, dependencies in sorted(gaps.items())
+        ]
+
+    def _realize_plan(self, plan: ProvisioningPlan) -> AptlRealization:
+        """Interpret an ACES plan against APTL's supported contract."""
+        return interpret_provisioning_plan(
+            plan=plan,
+            project_dir=self.project_dir,
+            config=self.config,
+        )
+
+    @staticmethod
+    def _invalid_plan_diagnostics(plan: object) -> list[Diagnostic]:
+        if isinstance(plan, ProvisioningPlan):
+            return []
+        return [
+            diagnostic(
+                "aptl.provisioner.invalid-plan",
+                PROVISIONING_ADDRESS,
+                "APTL provisioner expected an ACES ProvisioningPlan.",
+            )
+        ]
+
+
+def _changed_addresses(plan: ProvisioningPlan) -> list[str]:
+    """Return addresses whose planned operation changes runtime state."""
+    return [op.address for op in plan.operations if op.action != ChangeAction.UNCHANGED]

--- a/src/aptl/validation/_gate_checks.py
+++ b/src/aptl/validation/_gate_checks.py
@@ -63,6 +63,17 @@ class _NoStartBackend(object):
     """
 
     @staticmethod
+    def realize(realization: object, *, build: bool = True) -> LabResult:
+        """Acknowledge typed realization without starting Docker.
+
+        ACES target conformance probes submit provisioning through the runtime
+        control plane and require a mutated snapshot. The static gate validates
+        that APTL can interpret and represent the typed deployment, but it must
+        not actually start containers.
+        """
+        return LabResult(success=True, message="Static validation realization accepted")
+
+    @staticmethod
     def start(profiles: list[str], *, build: bool = True) -> LabResult:
         """Refuse to start the lab from a static validation gate."""
         raise RuntimeError("static validation gate must not start the lab")
@@ -135,6 +146,7 @@ def check_backend_conformance(
     profile: str,
     fixtures_root: Path | None,
     profiles_root: Path | None,
+    reference_scenario: Scenario | None = None,
 ) -> GateCheck:
     """Confirm APTL's canonical manifest passes target + published-CLI conformance."""
     try:
@@ -142,7 +154,11 @@ def check_backend_conformance(
             project_dir=project_dir, config=config, backend=_NoStartBackend()
         )
         report = run_target_conformance(
-            target, profile=profile, root=fixtures_root, profiles_root=profiles_root
+            target,
+            profile=profile,
+            root=fixtures_root,
+            profiles_root=profiles_root,
+            reference_scenario=reference_scenario,
         )
     # broad-except: ACES surfaces diverse errors
     except Exception as exc:

--- a/src/aptl/validation/techvault_gate.py
+++ b/src/aptl/validation/techvault_gate.py
@@ -153,6 +153,7 @@ def validate_scenario(
             profile=opts.profile,
             fixtures_root=opts.fixtures_root,
             profiles_root=opts.profiles_root,
+            reference_scenario=scenario,
         )
     )
 

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -17,6 +17,9 @@ from aces_contracts.runtime_state import RuntimeSnapshot
 from aptl.core.config import AptlConfig
 from aptl.core.lab_types import LabResult
 
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CONFORMANCE_SCENARIO = PROJECT_ROOT / "scenarios" / "techvault-defensive-min.sdl.yaml"
+
 
 def _write_compose(project_dir: Path, services: dict[str, list[str]]) -> None:
     lines = ["services:"]
@@ -286,7 +289,7 @@ def test_create_aptl_manifest_is_canonical_backend_manifest_v2():
     assert payload["capabilities"]["participant_runtime"] is not None
 
 
-def test_aptl_target_passes_provisioning_only_conformance(tmp_path):
+def test_aptl_target_passes_provisioning_only_conformance():
     from aces_conformance.conformance import run_target_conformance
 
     from aptl.backends.aces import create_aptl_runtime_target
@@ -294,19 +297,23 @@ def test_aptl_target_passes_provisioning_only_conformance(tmp_path):
     backend = MagicMock()
     config = AptlConfig(lab={"name": "test"})
     target = create_aptl_runtime_target(
-        project_dir=tmp_path,
+        project_dir=PROJECT_ROOT,
         config=config,
         backend=backend,
     )
 
-    report = run_target_conformance(target, profile="provisioning-only")
+    report = run_target_conformance(
+        target,
+        profile="provisioning-only",
+        reference_scenario=CONFORMANCE_SCENARIO,
+    )
 
     assert report.passed is True, [d.code for d in report.diagnostics]
     assert report.unsupported_contract_gaps == ()
     assert report.unsupported_capability_gaps == ()
 
 
-def test_aptl_target_passes_orchestration_evaluation_conformance(tmp_path):
+def test_aptl_target_passes_orchestration_evaluation_conformance():
     from aces_conformance.conformance import run_target_conformance
 
     from aptl.backends.aces import create_aptl_runtime_target
@@ -314,12 +321,16 @@ def test_aptl_target_passes_orchestration_evaluation_conformance(tmp_path):
     backend = MagicMock()
     config = AptlConfig(lab={"name": "test"})
     target = create_aptl_runtime_target(
-        project_dir=tmp_path,
+        project_dir=PROJECT_ROOT,
         config=config,
         backend=backend,
     )
 
-    report = run_target_conformance(target, profile="orchestration-evaluation")
+    report = run_target_conformance(
+        target,
+        profile="orchestration-evaluation",
+        reference_scenario=CONFORMANCE_SCENARIO,
+    )
 
     assert report.passed is True, [d.code for d in report.diagnostics]
     assert report.unsupported_contract_gaps == ()
@@ -331,7 +342,7 @@ def test_aptl_target_passes_orchestration_evaluation_conformance(tmp_path):
     ]
 
 
-def test_aptl_target_passes_full_remote_control_plane_conformance(tmp_path):
+def test_aptl_target_passes_full_remote_control_plane_conformance():
     from aces_conformance.conformance import run_target_conformance
 
     from aptl.backends.aces import create_aptl_runtime_target
@@ -339,12 +350,16 @@ def test_aptl_target_passes_full_remote_control_plane_conformance(tmp_path):
     backend = MagicMock()
     config = AptlConfig(lab={"name": "test"})
     target = create_aptl_runtime_target(
-        project_dir=tmp_path,
+        project_dir=PROJECT_ROOT,
         config=config,
         backend=backend,
     )
 
-    report = run_target_conformance(target, profile="full-remote-control-plane")
+    report = run_target_conformance(
+        target,
+        profile="full-remote-control-plane",
+        reference_scenario=CONFORMANCE_SCENARIO,
+    )
 
     assert report.passed is True, [d.code for d in report.diagnostics]
     assert report.unsupported_contract_gaps == ()

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -105,6 +105,30 @@ def _plan_for_nodes(*node_names: str) -> ProvisioningPlan:
     return _plan_for_resources(*map(_node_resource, node_names))
 
 
+def _execution_plan_with_realization_requirements():
+    from textwrap import dedent
+
+    from aces_processor.compiler import compile_runtime_model
+    from aces_processor.planner import plan
+    from aces_sdl.parser import parse_sdl
+
+    from aptl.backends.aces_manifest import create_aptl_manifest
+
+    scenario = parse_sdl(
+        dedent(
+            """
+            name: disclosure-test
+            nodes:
+              vm:
+                type: vm
+                os: linux
+                resources: {ram: 1 gib, cpu: 1}
+            """
+        )
+    )
+    return plan(compile_runtime_model(scenario), create_aptl_manifest())
+
+
 def _realize_profiles(call) -> list[str]:
     """Return profile names from a DeploymentRealizationSpec mock call."""
 
@@ -2331,3 +2355,87 @@ def test_apply_provisioning_populates_realization_and_profiles(tmp_path):
     assert "nodes" in realization_details
     assert len(realization_details["nodes"]) >= 1
     assert "victim" in selected_profiles
+
+
+def test_apply_provisioning_fails_closed_on_vacuous_realization_snapshot():
+    """Exact SEM-218 requirements must not pass on an empty returned snapshot."""
+    from unittest.mock import MagicMock as _MagicMock
+
+    from aces_contracts.runtime_state import OperationState
+
+    from aptl.backends.aces import _apply_provisioning_and_orchestration
+
+    execution_plan = _execution_plan_with_realization_requirements()
+
+    receipt = _MagicMock()
+    receipt.operation_id = "op-prov"
+    op_status = _MagicMock()
+    op_status.state = OperationState.SUCCEEDED
+    op_status.diagnostics = []
+
+    mock_cp = _MagicMock()
+    mock_cp.submit_provisioning.return_value = receipt
+    mock_cp.get_operation.return_value = op_status
+    mock_cp.snapshot = RuntimeSnapshot()
+
+    mock_target = _MagicMock()
+    mock_target.orchestrator = None
+    mock_target.evaluator = None
+    mock_target.provisioner = None
+
+    failure, _, _ = _apply_provisioning_and_orchestration(
+        mock_cp, execution_plan, mock_target
+    )
+
+    assert failure is not None
+    assert failure.success is False
+    assert "runtime.backend-contract-invalid" in (failure.error or "")
+
+
+def test_apply_provisioning_records_realization_provenance_when_honored():
+    """Honored exact requirements are disclosed on the runtime snapshot."""
+    from unittest.mock import MagicMock as _MagicMock
+
+    from aces_contracts.runtime_state import OperationState, SnapshotEntry
+
+    from aptl.backends.aces import _apply_provisioning_and_orchestration
+
+    execution_plan = _execution_plan_with_realization_requirements()
+    resource = next(iter(execution_plan.provisioning.resources.values()))
+    snapshot = RuntimeSnapshot(
+        entries={
+            resource.address: SnapshotEntry(
+                address=resource.address,
+                domain=resource.domain,
+                resource_type=resource.resource_type,
+                payload=resource.payload,
+            )
+        }
+    )
+
+    receipt = _MagicMock()
+    receipt.operation_id = "op-prov"
+    op_status = _MagicMock()
+    op_status.state = OperationState.SUCCEEDED
+    op_status.diagnostics = []
+
+    mock_cp = _MagicMock()
+    mock_cp.submit_provisioning.return_value = receipt
+    mock_cp.get_operation.return_value = op_status
+    mock_cp.snapshot = snapshot
+
+    mock_target = _MagicMock()
+    mock_target.orchestrator = None
+    mock_target.evaluator = None
+    mock_target.provisioner = None
+
+    failure, _, _ = _apply_provisioning_and_orchestration(
+        mock_cp, execution_plan, mock_target
+    )
+
+    assert failure is None
+    kinds = {
+        entry.requirement_kind
+        for entry in mock_cp.snapshot.realization_provenance
+    }
+    assert {"node-type", "os-family"} <= kinds

--- a/uv.lock
+++ b/uv.lock
@@ -5,7 +5,7 @@ requires-python = ">=3.11"
 [[package]]
 name = "aces-sdl"
 version = "0.3.0"
-source = { git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev#554a139fb62b4873ffea8141051520ef800df2cc" }
+source = { git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev#ce1bc07ab8bb80e7afaf6c304ac69f4a2e5dd8ec" }
 dependencies = [
     { name = "asyncssh" },
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Enforces non-vacuous ACES realization disclosure in the backend, updates evaluator/orchestrator conformance wording to match the current full-remote-control-plane target, and records the GRC threat-model coverage for false conformance evidence.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #599

## ADR Impact

- ADR-021

## Changes

- Fail closed when ACES realization requirements are not backed by runtime snapshot evidence, and persist realization provenance when snapshot entries satisfy node type and OS-family requirements.
- Correct final runtime snapshot capture for control-plane envelopes and add regression coverage for vacuous and honored realization snapshots.
- Truth-label ACES evaluator/orchestrator documentation and validation-gate docs so score progression is not overstated before real execution-state integration.
- Add ACTIVE threat model APTL-TM-014 with CODE links for the touched ACES conformance surfaces.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification passed: `uv run pytest -q tests/test_aces_backend.py tests/test_aces_evaluator.py tests/test_aces_orchestrator.py`; `pre-commit run --all-files`; `uv run pytest -n auto -k "not integration"`; and `uv run pytest -n auto tests/test_techvault_static_gate.py -m integration`. The configured bare `pytest ...` completion command was not directly runnable in this shell because `pytest` is not on PATH, so the same commands were run through the project environment with `uv run`. Codex review and test-quality review both completed cleanly.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #599 <- src/aptl/backends/aces.py, Issue #599 <- src/aptl/backends/aces_evaluator.py, Issue #599 <- src/aptl/backends/aces_orchestrator.py, Issue #599 <- src/aptl/backends/aces_manifest.py, Issue #599 <- docs/aces/techvault-static-validation-gate.md, Issue #599 <- docs/aces/techvault-live-validation-gate.md, APTL-TM-014 <- src/aptl/backends/aces.py
- TESTS: Issue #599 <- tests/test_aces_backend.py, Issue #599 <- pre-commit run --all-files, Issue #599 <- uv run pytest -n auto -k "not integration", Issue #599 <- uv run pytest -n auto tests/test_techvault_static_gate.py -m integration

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/599.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.