### PR TITLE
docs: lead quick-start with a virtualenv to survive PEP 668

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,17 @@ One `aptl lab start` brings up: a fictional company's infrastructure (AD, web, D
 ```bash
 git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 cp .env.example .env   # then replace every CHANGE_ME value
 aptl lab start
 ```
+
+The virtualenv keeps the install off the system Python, so the editable
+install works on modern Debian/Ubuntu/WSL2 hosts that block system-wide
+`pip` under [PEP 668](https://peps.python.org/pep-0668/). On those hosts the
+`python3 -m venv` step needs the `python3-venv` package
+(`sudo apt install python3-venv`).
 
 `aptl lab start` refuses to run while `.env` still contains the
 `.env.example` placeholder values.
@@ -136,7 +143,7 @@ Smoke-test the wiring once the lab is up:
 Localhost-only web UI for lab control and scenario runs.
 
 ```bash
-pip install -e ".[web]"
+pip install -e ".[web]"        # in the same .venv from Quick Start
 aptl web serve                 # API server
 cd web && npm install && npm run dev   # frontend (separate terminal)
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,9 +5,15 @@
 ```bash
 git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 aptl lab start
 ```
+
+The virtualenv keeps the editable install off the system Python, so it works
+on modern Debian/Ubuntu/WSL2 hosts that block system-wide `pip` under
+[PEP 668](https://peps.python.org/pep-0668/). Those hosts need the
+`python3-venv` package (`sudo apt install python3-venv`).
 
 **Use the CLI.** Manual deployment is error-prone and takes longer.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -5,10 +5,17 @@
 ```bash
 git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 cp .env.example .env   # then replace every CHANGE_ME value
 aptl lab start
 ```
+
+The virtualenv keeps the editable install off the system Python, so it works
+on modern Debian/Ubuntu/WSL2 hosts that block system-wide `pip` under
+[PEP 668](https://peps.python.org/pep-0668/). Those hosts need the
+`python3-venv` package (`sudo apt install python3-venv`); see
+[Prerequisites](prerequisites.md).
 
 `aptl lab start` refuses to run while `.env` still contains the
 `.env.example` placeholder values.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,10 +5,17 @@
 ```bash
 git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 cp .env.example .env   # then replace every CHANGE_ME value
 aptl lab start
 ```
+
+The virtualenv keeps the editable install off the system Python, so it works
+on modern Debian/Ubuntu/WSL2 hosts that block system-wide `pip` under
+[PEP 668](https://peps.python.org/pep-0668/). Those hosts need the
+`python3-venv` package for the `python3 -m venv` step
+(`sudo apt install python3-venv`); see [Prerequisites](prerequisites.md).
 
 `aptl lab start` refuses to run while `.env` still contains the
 `.env.example` placeholder values.

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -32,6 +32,30 @@ echo 'vm.max_map_count=262144' | sudo tee -a /etc/sysctl.conf
 netstat -tlnp | grep -E "(443|2027|8443|9000|9001|9200|55000)"
 ```
 
+## Python environment
+
+Install the CLI into a virtualenv, not the system Python. Modern
+Debian/Ubuntu/WSL2 hosts mark the system interpreter as externally managed and
+block system-wide `pip` under [PEP 668](https://peps.python.org/pep-0668/), so
+`pip install -e .` against the system Python fails with
+`error: externally-managed-environment`.
+
+**Debian/Ubuntu/WSL2:** install the `venv` module first (Debian ships it
+separately from `python3`):
+
+```bash
+sudo apt install python3-venv   # or python3-full
+```
+
+Then create and activate the virtualenv from the repo root:
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+```
+
+`.venv` is gitignored. Re-run `source .venv/bin/activate` in each new shell
+before using `aptl`.
+
 ## Verify
 
 ```bash

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -6,10 +6,17 @@
 git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
 
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 cp .env.example .env   # then replace every CHANGE_ME value
 aptl lab start
 ```
+
+The virtualenv keeps the editable install off the system Python, so it works
+on modern Debian/Ubuntu/WSL2 hosts that block system-wide `pip` under
+[PEP 668](https://peps.python.org/pep-0668/). Those hosts need the
+`python3-venv` package (`sudo apt install python3-venv`); see
+[Prerequisites](prerequisites.md).
 
 `aptl lab start` refuses to run while `.env` still contains the
 `.env.example` placeholder values.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,16 @@ Docker-based purple team lab: Wazuh SIEM + enterprise infrastructure + Kali + AI
 ```bash
 git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 aptl lab start
 ```
+
+The virtualenv keeps the editable install off the system Python, so it works
+on modern Debian/Ubuntu/WSL2 hosts that block system-wide `pip` under
+[PEP 668](https://peps.python.org/pep-0668/). Those hosts need the
+`python3-venv` package (`sudo apt install python3-venv`); see
+[Prerequisites](getting-started/prerequisites.md).
 
 **Access:**
 


### PR DESCRIPTION
## Summary

The documented `pip install -e .` quick-start fails on modern Debian/Ubuntu/WSL2 hosts, which mark the system interpreter as externally managed and block system-wide pip under PEP-668. Workshop participants hit `error: externally-managed-environment` at the first install step and never reach lab startup. This leads every participant-facing quick-start with a virtualenv activation line and documents the `python3-venv` prerequisite for Debian-family hosts, matching the pattern CONTRIBUTING.md already uses. Requirement-free docs-only change (no `## Requirements` section on the issue).

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #611

## ADR Impact

- No ADR required

## Changes

- Lead the Quick Start in README.md, docs/index.md, docs/deployment.md, and docs/getting-started/{index,installation,quick-start}.md with `python3 -m venv .venv && source .venv/bin/activate` before `pip install -e .`
- Add a short note in each quick-start explaining the venv keeps the editable install off the system Python (PEP-668) and calling out the `python3-venv` package for Debian-family hosts
- Add a 'Python environment' section to docs/getting-started/prerequisites.md documenting the externally-managed-environment failure, the `sudo apt install python3-venv` prerequisite, and venv creation/activation
- Note the optional web UI install (README) runs in the same .venv from Quick Start

## Test Plan

- Docs-only; no executable code touched.
- `pre-commit run` on the changed files passes (Vale prose lint + file hygiene).
- Fast unit suite green (1865 passed, 90 skipped).
- mkdocs --strict and the full completion gate run in CI on the branch.

## Ground Control Checks

- [x] Docs-only change; requirement-free (no `## Requirements` section on the issue)
- [x] Vale prose lint passes on all changed markdown
- [x] Change mirrors the existing venv-first pattern in CONTRIBUTING.md

## Traceability

- IMPLEMENTS: (none — requirement-free maintenance run)
- TESTS: (none — documentation-only run)

## Documentation

Updated: this change is the documentation update itself. See diff.
