### PR TITLE
fix: evaluator live score progression

### DIFF
--- a/changelog.d/606.fixed.md
+++ b/changelog.d/606.fixed.md
@@ -1,0 +1,1 @@
+Evaluator progress and score surfaces now advance from observed ACES runtime state instead of remaining pending-only placeholders.

--- a/docs/aces/m1-aces-conformance-truth-up-preflight.md
+++ b/docs/aces/m1-aces-conformance-truth-up-preflight.md
@@ -132,6 +132,44 @@ validated descriptor or typed backend parameter, not editing a TechVault branch,
 forking the manifest generator, adding a new conformance runner, or copying
 ACES schemas into APTL.
 
+## Issue #606 Evaluator Live-Score Addendum
+
+Issue #606 is an evaluator truth-up on the already-declared
+`full-remote-control-plane` surface, not a manifest promotion and not a new
+score schema. `AptlEvaluator` remains the ACES adapter boundary, and the public
+DTOs remain `EvaluationExecutionState` plus `EvaluationHistoryEvent` records
+stored on `RuntimeSnapshot.evaluation_results` and
+`RuntimeSnapshot.evaluation_history`.
+
+Live score/progress must be derived from observed run state for the current
+evaluation address and run id. Registration state (`PENDING` plus
+`evaluation_started`) is truthful only before observation; it is not progress.
+When observation advances a run, the adapter may emit `RUNNING`, `READY`, or
+`FAILED` only with history events that match the compiled `execution_contract`.
+
+Score and pass/fail fields are controlled by the compiled `result_contract`,
+not by APTL convention. Metric resources may expose `score` only when
+`supports_score` is true, and a terminal ready metric with `fixed_max_score`
+must use that max score. Condition, objective, evaluation, TLO, and goal
+resources may expose `passed` only when `supports_passed` is true. Do not treat
+objective completion count, elapsed time, or workflow step count as a score
+unless the compiled evaluation contract says that resource is score-bearing.
+
+The conformance re-verification path for #606 is the existing one:
+`evaluation_result_contract_diagnostics()`, `run_target_conformance()` for
+`full-remote-control-plane`, the published `aces conformance backend --profile
+full-remote-control-plane`, and the live-gate run archive as evidence that the
+declared evaluator surface was exercised against live behavior. If persisted
+evidence is added, it must be referenced through `evidence_refs` and written via
+`LocalRunStore.write_json()` / `write_jsonl()` / `append_jsonl()`, never by
+embedding raw SOC payloads or backend stderr into result envelopes.
+
+The extensibility parameter for evaluator progression is the tuple
+`(evaluation_address, result_contract, execution_contract, observed_state,
+run_id)`. The next variation should be another metric, objective, scenario, or
+evidence source, not a TechVault branch, a hardcoded score curve, a duplicate
+validator, or a separate live-gate-only score model.
+
 ## Whole-Repo View
 
 - Canonical configs: `.ground-control.yaml`, `.gc/plan-rules.md`,

--- a/docs/aces/techvault-live-validation-gate.md
+++ b/docs/aces/techvault-live-validation-gate.md
@@ -96,8 +96,10 @@ schema `aptl.live-gate.manifest/v1`. It records:
   endpoints).
 - **`evidence`**: the telemetry-path summary (event types and counts, never raw
   payloads).
-- **`evaluator_surfaces_deferred`**: objectives, scoring, and the evaluator
-  run-archive output, each tracked by issue #312.
+- **`evaluator_surfaces`**: the declared `full-remote-control-plane` evaluator
+  profile and ACES evaluation result/history contracts. This is an evidence
+  index, not a score source; live score/progress belongs in ACES
+  `evaluation_results` and `evaluation_history` derived from observed run state.
 
 ## Observable parity
 
@@ -105,10 +107,12 @@ The live gate validates the operational startup contract. The public boot SDL,
 `scenarios/techvault-operational.sdl.yaml`, names the steady-state Compose
 services and networks at range granularity; the deep inventory SDL,
 `scenarios/techvault.sdl.yaml`, remains the detailed asset/parity evidence
-surface proven by the static inventory tests. The evaluator surfaces
-(objectives, scoring, injects, workflows, and the evaluator run-archive output)
-are deferred to issue #312. The run archive is proof of what the operational
-model realized; it does not substitute for SDL encoding.
+surface proven by the static inventory tests. Evaluator contracts are part of
+the declared `full-remote-control-plane` surface; #606 tightens that surface so
+live score progression must come from real evaluation observations and pass the
+same ACES conformance/re-verification path. The run archive is proof of what
+the operational model realized; it does not substitute for SDL encoding or for
+ACES evaluation result/history envelopes.
 
 ## Prerequisites
 

--- a/src/aptl/backends/_aces_evaluator_engine.py
+++ b/src/aptl/backends/_aces_evaluator_engine.py
@@ -241,19 +241,19 @@ def _metric_max_score(
 def _state_truth_value(state: EvaluationExecutionState | None) -> bool | None:
     """Return True/False for ready/failed dependency states; None means wait."""
     value: bool | None = None
-    if state is None or state.status in {
+    waiting_statuses = {
         EvaluationResultStatus.PENDING,
         EvaluationResultStatus.RUNNING,
-    }:
-        pass
-    elif state.status == EvaluationResultStatus.FAILED:
-        value = False
-    elif state.passed is not None:
-        value = state.passed
-    elif state.score is not None and state.max_score is None:
-        value = bool(state.score)
-    elif state.score is not None:
-        value = float(state.score) >= float(state.max_score)
+    }
+    if state is not None and state.status not in waiting_statuses:
+        if state.status == EvaluationResultStatus.FAILED:
+            value = False
+        elif state.passed is not None:
+            value = state.passed
+        elif state.score is not None and state.max_score is None:
+            value = bool(state.score)
+        elif state.score is not None:
+            value = float(state.score) >= float(state.max_score)
     return value
 
 

--- a/src/aptl/backends/_aces_evaluator_engine.py
+++ b/src/aptl/backends/_aces_evaluator_engine.py
@@ -1,0 +1,476 @@
+"""Outcome resolution helpers for the APTL ACES evaluator adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.evaluation import (
+    EvaluationExecutionState,
+    EvaluationHistoryEvent,
+    EvaluationHistoryEventType,
+    EvaluationResultContract,
+    EvaluationResultStatus,
+)
+from aces_contracts.planning import EvaluationPlan, RuntimeDomain
+from aces_contracts.runtime_state import RuntimeSnapshot
+
+from aptl.backends._aces_evaluator_progress import append_progression
+from aptl.utils.redaction import redact
+
+EVALUATION_ADDRESS = "runtime.apply.evaluation"
+OBSERVABLE_RESOURCE_TYPES = frozenset(
+    {"condition-binding", "evaluation", "goal", "metric", "objective", "tlo"}
+)
+_FAILED_ENTRY_STATUSES = frozenset({"error", "failed", "unhealthy"})
+_READY_ENTRY_STATUS = "ready"
+
+
+@dataclass(frozen=True)
+class _EvaluationOutcome(object):
+    """Resolved evaluator state before it is rendered as ACES DTO payloads."""
+
+    status: EvaluationResultStatus
+    passed: bool | None = None
+    score: float | int | None = None
+    max_score: int | None = None
+    detail: str | None = None
+
+
+def evaluation_diagnostic(code: str, address: str, message: str) -> Diagnostic:
+    """Build a redacted evaluation-domain ACES error diagnostic."""
+    return Diagnostic(
+        code=code,
+        domain=RuntimeDomain.EVALUATION.value,
+        address=address,
+        message=redact(message),
+        severity=Severity.ERROR,
+    )
+
+
+def utc_now() -> str:
+    """Return the current UTC instant as an ISO-8601 ``...Z`` string."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _running(detail: str) -> _EvaluationOutcome:
+    """Return a running outcome with an operator-facing wait reason."""
+    return _EvaluationOutcome(status=EvaluationResultStatus.RUNNING, detail=detail)
+
+
+def _ready_passed(passed: bool, detail: str) -> _EvaluationOutcome:
+    """Return a ready pass/fail outcome."""
+    return _EvaluationOutcome(
+        status=EvaluationResultStatus.READY,
+        passed=passed,
+        detail=detail,
+    )
+
+
+def _ready_score(score: float | int, max_score: int, detail: str) -> _EvaluationOutcome:
+    """Return a ready score outcome."""
+    return _EvaluationOutcome(
+        status=EvaluationResultStatus.READY,
+        score=score,
+        max_score=max_score,
+        detail=detail,
+    )
+
+
+def _state_matches_contract(
+    state: EvaluationExecutionState,
+    contract: EvaluationResultContract,
+) -> bool:
+    """Return whether a prior state can continue under the compiled contract."""
+    return (
+        state.state_schema_version == contract.state_schema_version
+        and state.resource_type == contract.resource_type
+    )
+
+
+def _load_result_contract(
+    evaluation_address: str,
+    payload: dict[str, object],
+) -> tuple[EvaluationResultContract | None, list[Diagnostic]]:
+    """Load a compiled result contract and return diagnostics on failure."""
+    diagnostics: list[Diagnostic] = []
+    result_contract: EvaluationResultContract | None = None
+    result_contract_payload = payload.get("result_contract")
+    if not isinstance(result_contract_payload, dict):
+        diagnostics = [
+            evaluation_diagnostic(
+                "aptl.evaluator.evaluation-contract-missing",
+                evaluation_address,
+                "ACES evaluation resource is missing its compiled result_contract.",
+            )
+        ]
+    else:
+        try:
+            result_contract = EvaluationResultContract.from_mapping(
+                result_contract_payload
+            )
+        except (TypeError, ValueError) as exc:
+            diagnostics = [
+                evaluation_diagnostic(
+                    "aptl.evaluator.evaluation-contract-invalid",
+                    evaluation_address,
+                    f"ACES evaluation result_contract is invalid: {exc}",
+                )
+            ]
+    return result_contract, diagnostics
+
+
+def _initialize_state(
+    evaluation_address: str,
+    registered_at: str,
+    result_contract: EvaluationResultContract,
+    states: dict[str, EvaluationExecutionState],
+    history: dict[str, list[dict[str, object]]],
+) -> None:
+    """Initialize a new pending run and started event."""
+    states[evaluation_address] = EvaluationExecutionState(
+        state_schema_version=result_contract.state_schema_version,
+        resource_type=result_contract.resource_type,
+        run_id=uuid4().hex,
+        status=EvaluationResultStatus.PENDING,
+        observed_at=registered_at,
+        updated_at=registered_at,
+    )
+    history[evaluation_address] = [
+        EvaluationHistoryEvent(
+            event_type=EvaluationHistoryEventType.EVALUATION_STARTED,
+            timestamp=registered_at,
+            status=EvaluationResultStatus.PENDING,
+        ).to_payload()
+    ]
+
+
+def register_evaluation(
+    evaluation_address: str,
+    payload: dict[str, object],
+    registered_at: str,
+    states: dict[str, EvaluationExecutionState],
+    history: dict[str, list[dict[str, object]]],
+) -> tuple[EvaluationResultContract | None, list[Diagnostic]]:
+    """Record a pending portable state only when the run is not already present."""
+    result_contract, diagnostics = _load_result_contract(evaluation_address, payload)
+    if result_contract is None:
+        return None, diagnostics
+
+    existing_state = states.get(evaluation_address)
+    if existing_state is not None and _state_matches_contract(
+        existing_state,
+        result_contract,
+    ):
+        history.setdefault(evaluation_address, [])
+        return result_contract, []
+
+    _initialize_state(
+        evaluation_address,
+        registered_at,
+        result_contract,
+        states,
+        history,
+    )
+    return result_contract, []
+
+
+def existing_states(snapshot: RuntimeSnapshot) -> dict[str, EvaluationExecutionState]:
+    """Load valid pre-existing evaluation results for untouched plan entries."""
+    states: dict[str, EvaluationExecutionState] = {}
+    for address, payload in snapshot.evaluation_results.items():
+        if not isinstance(payload, dict):
+            continue
+        try:
+            states[address] = EvaluationExecutionState.from_payload(payload)
+        except (TypeError, ValueError):
+            continue
+    return states
+
+
+def _evaluation_order(
+    plan: EvaluationPlan,
+    operation_payloads: dict[str, dict[str, object]],
+) -> list[str]:
+    """Return plan order with startup-order addresses first when available."""
+    ordered: list[str] = []
+    for address in plan.startup_order:
+        if address in operation_payloads and address not in ordered:
+            ordered.append(address)
+    for address in operation_payloads:
+        if address not in ordered:
+            ordered.append(address)
+    return ordered
+
+
+def _string_values(raw: object) -> tuple[str, ...]:
+    """Normalize compiled dependency fields into a tuple of non-empty strings."""
+    if isinstance(raw, str):
+        return (raw,) if raw else ()
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        return ()
+    return tuple(str(value) for value in raw if str(value))
+
+
+def _int_value(raw: object) -> int | None:
+    """Return an integer value while excluding bools."""
+    value = raw if not isinstance(raw, bool) and isinstance(raw, int) else None
+    return value
+
+
+def _number_value(raw: object) -> float | int | None:
+    """Return a numeric value while excluding bools."""
+    value = raw if not isinstance(raw, bool) and isinstance(raw, (int, float)) else None
+    return value
+
+
+def _metric_max_score(
+    contract: EvaluationResultContract,
+    payload: dict[str, object],
+) -> int:
+    """Resolve the compiled max score for a conditional metric."""
+    max_score = contract.fixed_max_score
+    spec = payload.get("spec")
+    if max_score is None and isinstance(spec, dict):
+        max_score = _int_value(spec.get("max_score"))
+    return max_score if max_score is not None else 100
+
+
+def _state_truth_value(state: EvaluationExecutionState | None) -> bool | None:
+    """Return True/False for ready/failed dependency states; None means wait."""
+    value: bool | None = None
+    if state is None or state.status in {
+        EvaluationResultStatus.PENDING,
+        EvaluationResultStatus.RUNNING,
+    }:
+        pass
+    elif state.status == EvaluationResultStatus.FAILED:
+        value = False
+    elif state.passed is not None:
+        value = state.passed
+    elif state.score is not None and state.max_score is None:
+        value = bool(state.score)
+    elif state.score is not None:
+        value = float(state.score) >= float(state.max_score)
+    return value
+
+
+def _aggregate_dependency_outcome(
+    states: dict[str, EvaluationExecutionState],
+    dependencies: tuple[str, ...],
+    *,
+    ready_detail: str,
+    waiting_detail: str,
+) -> _EvaluationOutcome:
+    """Aggregate dependency truth values into a running or pass/fail outcome."""
+    values = [_state_truth_value(states.get(address)) for address in dependencies]
+    waiting = not dependencies or any(value is None for value in values)
+    outcome = (
+        _running(waiting_detail)
+        if waiting
+        else _ready_passed(all(bool(value) for value in values), ready_detail)
+    )
+    return outcome
+
+
+def _condition_outcome(
+    payload: dict[str, object],
+    snapshot: RuntimeSnapshot,
+) -> _EvaluationOutcome:
+    """Resolve a condition outcome from its observed provisioning node state."""
+    node_address = str(payload.get("node_address") or "")
+    node_entry = snapshot.entries.get(node_address) if node_address else None
+    status = str(node_entry.status).lower() if node_entry is not None else ""
+    if not node_address:
+        outcome = _running("condition has no compiled node address")
+    elif node_entry is None:
+        outcome = _running(f"waiting for observed node state: {node_address}")
+    elif status == _READY_ENTRY_STATUS:
+        outcome = _ready_passed(True, f"observed ready node state: {node_address}")
+    elif status in _FAILED_ENTRY_STATUSES:
+        outcome = _ready_passed(False, f"observed failed node state: {node_address}")
+    else:
+        outcome = _running(f"waiting for ready node state: {node_address}")
+    return outcome
+
+
+def _metric_outcome(
+    payload: dict[str, object],
+    states: dict[str, EvaluationExecutionState],
+    contract: EvaluationResultContract,
+) -> _EvaluationOutcome:
+    """Resolve a conditional metric score from observed condition states."""
+    dependencies = _string_values(payload.get("condition_addresses"))
+    values = [_state_truth_value(states.get(address)) for address in dependencies]
+    if not dependencies:
+        outcome = _running("metric has no observed condition dependencies")
+    elif any(value is None for value in values):
+        outcome = _running("waiting for metric condition dependencies")
+    else:
+        max_score = _metric_max_score(contract, payload)
+        score = max_score if all(bool(value) for value in values) else 0
+        outcome = _ready_score(score, max_score, "scored from observed condition state")
+    return outcome
+
+
+def _min_score_threshold(payload: dict[str, object], total_max_score: float) -> float:
+    """Resolve the minimum score threshold for an evaluation resource."""
+    spec = payload.get("spec")
+    min_score = spec.get("min_score") if isinstance(spec, dict) else None
+    threshold: float | None = None
+    if isinstance(min_score, dict):
+        absolute = _number_value(min_score.get("absolute"))
+        percentage = _number_value(min_score.get("percentage"))
+        if absolute is not None:
+            threshold = float(absolute)
+        elif percentage is not None:
+            threshold = total_max_score * float(percentage) / 100
+    else:
+        direct = _number_value(min_score)
+        threshold = float(direct) if direct is not None else None
+    return total_max_score if threshold is None else threshold
+
+
+def _evaluation_aggregate_outcome(
+    payload: dict[str, object],
+    states: dict[str, EvaluationExecutionState],
+) -> _EvaluationOutcome:
+    """Resolve an evaluation pass/fail outcome from metric scores."""
+    dependencies = _string_values(payload.get("metric_addresses"))
+    metric_states = [states.get(address) for address in dependencies]
+    waiting = not dependencies or any(
+        state is None
+        or state.status in {EvaluationResultStatus.PENDING, EvaluationResultStatus.RUNNING}
+        for state in metric_states
+    )
+    if waiting:
+        outcome = _running("waiting for evaluation metric dependencies")
+    else:
+        total_score = sum(float(state.score or 0) for state in metric_states if state)
+        total_max = sum(float(state.max_score or 0) for state in metric_states if state)
+        threshold = _min_score_threshold(payload, total_max)
+        outcome = _ready_passed(
+            total_score >= threshold,
+            "evaluated from observed metric scores",
+        )
+    return outcome
+
+
+def _resolve_outcome(
+    address: str,
+    payload: dict[str, object],
+    snapshot: RuntimeSnapshot,
+    states: dict[str, EvaluationExecutionState],
+    contracts: dict[str, EvaluationResultContract],
+) -> _EvaluationOutcome:
+    """Resolve an operation outcome according to its ACES resource type."""
+    contract = contracts[address]
+    resource_type = contract.resource_type
+    outcome = _running(f"waiting for observed state for {address}")
+    if resource_type == "condition-binding":
+        outcome = _condition_outcome(payload, snapshot)
+    elif resource_type == "metric":
+        outcome = _metric_outcome(payload, states, contract)
+    elif resource_type == "evaluation":
+        outcome = _evaluation_aggregate_outcome(payload, states)
+    elif resource_type == "tlo":
+        outcome = _aggregate_dependency_outcome(
+            states,
+            _string_values(payload.get("evaluation_address")),
+            ready_detail="TLO evaluated from observed evaluation state",
+            waiting_detail="waiting for TLO evaluation dependency",
+        )
+    elif resource_type == "goal":
+        outcome = _aggregate_dependency_outcome(
+            states,
+            _string_values(payload.get("tlo_addresses")),
+            ready_detail="goal evaluated from observed TLO state",
+            waiting_detail="waiting for goal TLO dependencies",
+        )
+    elif resource_type == "objective":
+        outcome = _aggregate_dependency_outcome(
+            states,
+            _string_values(payload.get("success_addresses")),
+            ready_detail="objective evaluated from observed success dependencies",
+            waiting_detail="waiting for objective success dependencies",
+        )
+    return outcome
+
+
+def _contract_score_fields(
+    outcome: _EvaluationOutcome,
+    contract: EvaluationResultContract,
+) -> tuple[float | int | None, int | None]:
+    """Return score fields allowed by the compiled result contract."""
+    score = outcome.score if contract.supports_score else None
+    max_score = outcome.max_score if contract.supports_score else None
+    if contract.supports_score and contract.fixed_max_score is not None:
+        max_score = contract.fixed_max_score
+    if contract.supports_score and score is None and outcome.passed is not None:
+        max_score = max_score if max_score is not None else 100
+        score = max_score if outcome.passed else 0
+    return score, max_score
+
+
+def _contract_passed_field(
+    outcome: _EvaluationOutcome,
+    contract: EvaluationResultContract,
+    score: float | int | None,
+    max_score: int | None,
+) -> bool | None:
+    """Return the pass/fail field allowed by the compiled result contract."""
+    passed = outcome.passed if contract.supports_passed else None
+    if contract.supports_passed and passed is None and score is not None:
+        threshold = max_score if max_score is not None else score
+        passed = float(score) >= float(threshold)
+    return passed
+
+
+def _contractual_outcome(
+    outcome: _EvaluationOutcome,
+    contract: EvaluationResultContract,
+) -> _EvaluationOutcome:
+    """Strip or derive ready result values according to the compiled contract."""
+    adjusted = _EvaluationOutcome(status=outcome.status, detail=outcome.detail)
+    if outcome.status == EvaluationResultStatus.READY:
+        score, max_score = _contract_score_fields(outcome, contract)
+        passed = _contract_passed_field(outcome, contract, score, max_score)
+        if contract.supports_score and score is None:
+            adjusted = _running("waiting for contract-compatible score result")
+        elif contract.supports_passed and passed is None:
+            adjusted = _running("waiting for contract-compatible pass/fail result")
+        else:
+            adjusted = _EvaluationOutcome(
+                status=EvaluationResultStatus.READY,
+                passed=passed,
+                score=score,
+                max_score=max_score,
+                detail=outcome.detail,
+            )
+    return adjusted
+
+
+def drive_evaluations(
+    plan: EvaluationPlan,
+    snapshot: RuntimeSnapshot,
+    operation_payloads: dict[str, dict[str, object]],
+    states: dict[str, EvaluationExecutionState],
+    history: dict[str, list[dict[str, object]]],
+    contracts: dict[str, EvaluationResultContract],
+) -> None:
+    """Advance observable evaluation resources from current snapshot state."""
+    for address in _evaluation_order(plan, operation_payloads):
+        outcome = _resolve_outcome(
+            address,
+            operation_payloads[address],
+            snapshot,
+            states,
+            contracts,
+        )
+        states[address] = append_progression(
+            states[address],
+            _contractual_outcome(outcome, contracts[address]),
+            history[address],
+        )

--- a/src/aptl/backends/_aces_evaluator_progress.py
+++ b/src/aptl/backends/_aces_evaluator_progress.py
@@ -144,28 +144,27 @@ def append_progression(
         EvaluationResultStatus.PENDING,
         EvaluationResultStatus.RUNNING,
     }
-    if _should_keep_terminal_state(state, outcome):
-        pass
-    elif can_run and outcome.status == EvaluationResultStatus.RUNNING:
-        result = _append_running_state(
-            state,
-            events,
-            _next_timestamp(last_timestamp),
-            outcome.detail,
-        )
-    else:
-        if state.status == EvaluationResultStatus.PENDING:
+    if not _should_keep_terminal_state(state, outcome):
+        if can_run and outcome.status == EvaluationResultStatus.RUNNING:
             result = _append_running_state(
                 state,
                 events,
                 _next_timestamp(last_timestamp),
-                None,
+                outcome.detail,
             )
-            last_timestamp = result.updated_at
-        result = _append_terminal_state(
-            state,
-            outcome,
-            events,
-            _next_timestamp(last_timestamp),
-        )
+        else:
+            if state.status == EvaluationResultStatus.PENDING:
+                result = _append_running_state(
+                    state,
+                    events,
+                    _next_timestamp(last_timestamp),
+                    None,
+                )
+                last_timestamp = result.updated_at
+            result = _append_terminal_state(
+                state,
+                outcome,
+                events,
+                _next_timestamp(last_timestamp),
+            )
     return result

--- a/src/aptl/backends/_aces_evaluator_progress.py
+++ b/src/aptl/backends/_aces_evaluator_progress.py
@@ -1,0 +1,171 @@
+"""History progression helpers for ACES evaluator result streams."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Protocol
+
+from aces_contracts.evaluation import (
+    EvaluationExecutionState,
+    EvaluationHistoryEvent,
+    EvaluationHistoryEventType,
+    EvaluationResultStatus,
+)
+
+_ISO_UTC_OFFSET = "+00:00"
+_TERMINAL_RESULT_STATUSES = frozenset(
+    {EvaluationResultStatus.FAILED, EvaluationResultStatus.READY}
+)
+
+
+class _OutcomeLike(Protocol):
+    """Subset of outcome fields needed to append evaluator history."""
+
+    status: EvaluationResultStatus
+    passed: bool | None
+    score: float | int | None
+    max_score: int | None
+    detail: str | None
+
+
+def _next_timestamp(previous: str, *, offset_ms: int = 1) -> str:
+    """Return an ISO timestamp strictly after ``previous``."""
+    parsed = datetime.fromisoformat(previous.replace("Z", _ISO_UTC_OFFSET))
+    return (parsed + timedelta(milliseconds=offset_ms)).isoformat().replace(
+        _ISO_UTC_OFFSET,
+        "Z",
+    )
+
+
+def _terminal_event(status: EvaluationResultStatus) -> EvaluationHistoryEventType:
+    """Map a terminal result status to the portable history event type."""
+    event_type = EvaluationHistoryEventType.EVALUATION_UPDATED
+    if status == EvaluationResultStatus.READY:
+        event_type = EvaluationHistoryEventType.EVALUATION_READY
+    elif status == EvaluationResultStatus.FAILED:
+        event_type = EvaluationHistoryEventType.EVALUATION_FAILED
+    return event_type
+
+
+def _state_matches_outcome(
+    state: EvaluationExecutionState,
+    outcome: _OutcomeLike,
+) -> bool:
+    """Return whether a terminal state already represents the resolved outcome."""
+    return (
+        state.status == outcome.status
+        and state.passed == outcome.passed
+        and state.score == outcome.score
+        and state.max_score == outcome.max_score
+        and state.detail == outcome.detail
+    )
+
+
+def _append_running_state(
+    state: EvaluationExecutionState,
+    events: list[dict[str, object]],
+    timestamp: str,
+    detail: str | None,
+) -> EvaluationExecutionState:
+    """Append a running event and return the corresponding state."""
+    running_state = EvaluationExecutionState(
+        state_schema_version=state.state_schema_version,
+        resource_type=state.resource_type,
+        run_id=state.run_id,
+        status=EvaluationResultStatus.RUNNING,
+        observed_at=state.observed_at,
+        updated_at=timestamp,
+        detail=detail,
+    )
+    events.append(
+        EvaluationHistoryEvent(
+            event_type=EvaluationHistoryEventType.EVALUATION_UPDATED,
+            timestamp=timestamp,
+            status=EvaluationResultStatus.RUNNING,
+            detail=detail,
+        ).to_payload()
+    )
+    return running_state
+
+
+def _append_terminal_state(
+    state: EvaluationExecutionState,
+    outcome: _OutcomeLike,
+    events: list[dict[str, object]],
+    timestamp: str,
+) -> EvaluationExecutionState:
+    """Append a terminal event and return the corresponding final state."""
+    final_state = EvaluationExecutionState(
+        state_schema_version=state.state_schema_version,
+        resource_type=state.resource_type,
+        run_id=state.run_id,
+        status=outcome.status,
+        observed_at=state.observed_at,
+        updated_at=timestamp,
+        passed=outcome.passed,
+        score=outcome.score,
+        max_score=outcome.max_score,
+        detail=outcome.detail,
+    )
+    events.append(
+        EvaluationHistoryEvent(
+            event_type=_terminal_event(outcome.status),
+            timestamp=timestamp,
+            status=outcome.status,
+            passed=outcome.passed,
+            score=outcome.score,
+            max_score=outcome.max_score,
+            detail=outcome.detail,
+        ).to_payload()
+    )
+    return final_state
+
+
+def _should_keep_terminal_state(
+    state: EvaluationExecutionState,
+    outcome: _OutcomeLike,
+) -> bool:
+    """Return whether a terminal run should remain unchanged for this observation."""
+    return state.status in _TERMINAL_RESULT_STATUSES and (
+        outcome.status == EvaluationResultStatus.RUNNING
+        or _state_matches_outcome(state, outcome)
+    )
+
+
+def append_progression(
+    state: EvaluationExecutionState,
+    outcome: _OutcomeLike,
+    events: list[dict[str, object]],
+) -> EvaluationExecutionState:
+    """Append running/terminal events and return the final result state."""
+    result = state
+    last_timestamp = str(events[-1]["timestamp"]) if events else state.updated_at
+    can_run = state.status in {
+        EvaluationResultStatus.PENDING,
+        EvaluationResultStatus.RUNNING,
+    }
+    if _should_keep_terminal_state(state, outcome):
+        pass
+    elif can_run and outcome.status == EvaluationResultStatus.RUNNING:
+        result = _append_running_state(
+            state,
+            events,
+            _next_timestamp(last_timestamp),
+            outcome.detail,
+        )
+    else:
+        if state.status == EvaluationResultStatus.PENDING:
+            result = _append_running_state(
+                state,
+                events,
+                _next_timestamp(last_timestamp),
+                None,
+            )
+            last_timestamp = result.updated_at
+        result = _append_terminal_state(
+            state,
+            outcome,
+            events,
+            _next_timestamp(last_timestamp),
+        )
+    return result

--- a/src/aptl/backends/aces_evaluator.py
+++ b/src/aptl/backends/aces_evaluator.py
@@ -27,537 +27,21 @@ observed run state behind it, not synthetic in-memory progress.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
-from uuid import uuid4
 
-from aces_contracts.diagnostics import Diagnostic, Severity
-from aces_contracts.evaluation import (
-    EvaluationExecutionState,
-    EvaluationHistoryEvent,
-    EvaluationHistoryEventType,
-    EvaluationResultContract,
-    EvaluationResultStatus,
-)
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.evaluation import EvaluationResultContract
 from aces_contracts.planning import ChangeAction, EvaluationPlan, RuntimeDomain
 from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
 
-from aptl.utils.redaction import redact
-
-EVALUATION_ADDRESS = "runtime.apply.evaluation"
-_ISO_UTC_OFFSET = "+00:00"
-_OBSERVABLE_RESOURCE_TYPES = frozenset(
-    {"condition-binding", "evaluation", "goal", "metric", "objective", "tlo"}
+from aptl.backends._aces_evaluator_engine import (
+    EVALUATION_ADDRESS,
+    OBSERVABLE_RESOURCE_TYPES,
+    drive_evaluations,
+    evaluation_diagnostic,
+    existing_states,
+    register_evaluation,
+    utc_now,
 )
-_FAILED_ENTRY_STATUSES = frozenset({"error", "failed", "unhealthy"})
-_READY_ENTRY_STATUS = "ready"
-_TERMINAL_RESULT_STATUSES = frozenset(
-    {EvaluationResultStatus.FAILED, EvaluationResultStatus.READY}
-)
-
-
-def _evaluation_diagnostic(code: str, address: str, message: str) -> Diagnostic:
-    """Build a redacted evaluation-domain ACES error diagnostic."""
-    return Diagnostic(
-        code=code,
-        domain=RuntimeDomain.EVALUATION.value,
-        address=address,
-        message=redact(message),
-        severity=Severity.ERROR,
-    )
-
-
-def _utc_now() -> str:
-    """Return the current UTC instant as an ISO-8601 ``...Z`` string."""
-    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
-
-
-def _next_timestamp(previous: str, *, offset_ms: int = 1) -> str:
-    """Return an ISO timestamp strictly after ``previous``."""
-    parsed = datetime.fromisoformat(previous.replace("Z", _ISO_UTC_OFFSET))
-    return (parsed + timedelta(milliseconds=offset_ms)).isoformat().replace(
-        _ISO_UTC_OFFSET,
-        "Z",
-    )
-
-
-@dataclass(frozen=True)
-class _EvaluationOutcome(object):
-    """Resolved evaluator state before it is rendered as ACES DTO payloads."""
-
-    status: EvaluationResultStatus
-    passed: bool | None = None
-    score: float | int | None = None
-    max_score: int | None = None
-    detail: str | None = None
-
-
-def _running(detail: str) -> _EvaluationOutcome:
-    return _EvaluationOutcome(status=EvaluationResultStatus.RUNNING, detail=detail)
-
-
-def _ready_passed(passed: bool, detail: str) -> _EvaluationOutcome:
-    return _EvaluationOutcome(
-        status=EvaluationResultStatus.READY,
-        passed=passed,
-        detail=detail,
-    )
-
-
-def _ready_score(score: float | int, max_score: int, detail: str) -> _EvaluationOutcome:
-    return _EvaluationOutcome(
-        status=EvaluationResultStatus.READY,
-        score=score,
-        max_score=max_score,
-        detail=detail,
-    )
-
-
-def _state_matches_contract(
-    state: EvaluationExecutionState,
-    contract: EvaluationResultContract,
-) -> bool:
-    return (
-        state.state_schema_version == contract.state_schema_version
-        and state.resource_type == contract.resource_type
-    )
-
-
-def _register_evaluation(
-    evaluation_address: str,
-    payload: dict[str, object],
-    registered_at: str,
-    states: dict[str, EvaluationExecutionState],
-    history: dict[str, list[dict[str, object]]],
-) -> tuple[EvaluationResultContract | None, list[Diagnostic]]:
-    """Record the truthful initial (``PENDING``) portable state for a run."""
-    result_contract_payload = payload.get("result_contract")
-    if not isinstance(result_contract_payload, dict):
-        return None, [
-            _evaluation_diagnostic(
-                "aptl.evaluator.evaluation-contract-missing",
-                evaluation_address,
-                "ACES evaluation resource is missing its compiled result_contract.",
-            )
-        ]
-    try:
-        result_contract = EvaluationResultContract.from_mapping(result_contract_payload)
-    except (TypeError, ValueError) as exc:
-        return None, [
-            _evaluation_diagnostic(
-                "aptl.evaluator.evaluation-contract-invalid",
-                evaluation_address,
-                f"ACES evaluation result_contract is invalid: {exc}",
-            )
-        ]
-
-    existing_state = states.get(evaluation_address)
-    if existing_state is not None and _state_matches_contract(
-        existing_state,
-        result_contract,
-    ):
-        history.setdefault(evaluation_address, [])
-        return result_contract, []
-
-    state = EvaluationExecutionState(
-        state_schema_version=result_contract.state_schema_version,
-        resource_type=result_contract.resource_type,
-        run_id=uuid4().hex,
-        status=EvaluationResultStatus.PENDING,
-        observed_at=registered_at,
-        updated_at=registered_at,
-    )
-    states[evaluation_address] = state
-    history[evaluation_address] = [
-        EvaluationHistoryEvent(
-            event_type=EvaluationHistoryEventType.EVALUATION_STARTED,
-            timestamp=registered_at,
-            status=EvaluationResultStatus.PENDING,
-        ).to_payload()
-    ]
-    return result_contract, []
-
-
-def _existing_states(snapshot: RuntimeSnapshot) -> dict[str, EvaluationExecutionState]:
-    """Load valid pre-existing evaluation results for untouched plan entries."""
-    states: dict[str, EvaluationExecutionState] = {}
-    for address, payload in snapshot.evaluation_results.items():
-        if not isinstance(payload, dict):
-            continue
-        try:
-            states[address] = EvaluationExecutionState.from_payload(payload)
-        except (TypeError, ValueError):
-            continue
-    return states
-
-
-def _evaluation_order(
-    plan: EvaluationPlan,
-    operation_payloads: dict[str, dict[str, object]],
-) -> list[str]:
-    """Return plan order with startup-order addresses first when available."""
-    ordered: list[str] = []
-    for address in plan.startup_order:
-        if address in operation_payloads and address not in ordered:
-            ordered.append(address)
-    for address in operation_payloads:
-        if address not in ordered:
-            ordered.append(address)
-    return ordered
-
-
-def _string_values(raw: object) -> tuple[str, ...]:
-    """Normalize compiled dependency fields into a tuple of non-empty strings."""
-    if isinstance(raw, str):
-        return (raw,) if raw else ()
-    if not isinstance(raw, (list, tuple, set, frozenset)):
-        return ()
-    return tuple(str(value) for value in raw if str(value))
-
-
-def _int_value(raw: object) -> int | None:
-    if isinstance(raw, bool) or not isinstance(raw, int):
-        return None
-    return raw
-
-
-def _number_value(raw: object) -> float | int | None:
-    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
-        return None
-    return raw
-
-
-def _metric_max_score(
-    contract: EvaluationResultContract,
-    payload: dict[str, object],
-) -> int:
-    if contract.fixed_max_score is not None:
-        return contract.fixed_max_score
-    spec = payload.get("spec")
-    if isinstance(spec, dict):
-        spec_max = _int_value(spec.get("max_score"))
-        if spec_max is not None:
-            return spec_max
-    return 100
-
-
-def _state_truth_value(state: EvaluationExecutionState | None) -> bool | None:
-    """Return True/False for ready/failed dependency states; None means wait."""
-    if state is None:
-        return None
-    if state.status in {EvaluationResultStatus.PENDING, EvaluationResultStatus.RUNNING}:
-        return None
-    if state.status == EvaluationResultStatus.FAILED:
-        return False
-    if state.passed is not None:
-        return state.passed
-    if state.score is None:
-        return None
-    if state.max_score is None:
-        return bool(state.score)
-    return float(state.score) >= float(state.max_score)
-
-
-def _aggregate_dependency_outcome(
-    states: dict[str, EvaluationExecutionState],
-    dependencies: tuple[str, ...],
-    *,
-    ready_detail: str,
-    waiting_detail: str,
-) -> _EvaluationOutcome:
-    if not dependencies:
-        return _running(waiting_detail)
-    values = [_state_truth_value(states.get(address)) for address in dependencies]
-    if any(value is None for value in values):
-        return _running(waiting_detail)
-    return _ready_passed(all(bool(value) for value in values), ready_detail)
-
-
-def _condition_outcome(
-    payload: dict[str, object],
-    snapshot: RuntimeSnapshot,
-) -> _EvaluationOutcome:
-    node_address = str(payload.get("node_address") or "")
-    if not node_address:
-        return _running("condition has no compiled node address")
-    node_entry = snapshot.entries.get(node_address)
-    if node_entry is None:
-        return _running(f"waiting for observed node state: {node_address}")
-    status = str(node_entry.status).lower()
-    if status == _READY_ENTRY_STATUS:
-        return _ready_passed(True, f"observed ready node state: {node_address}")
-    if status in _FAILED_ENTRY_STATUSES:
-        return _ready_passed(False, f"observed failed node state: {node_address}")
-    return _running(f"waiting for ready node state: {node_address}")
-
-
-def _metric_outcome(
-    payload: dict[str, object],
-    states: dict[str, EvaluationExecutionState],
-    contract: EvaluationResultContract,
-) -> _EvaluationOutcome:
-    dependencies = _string_values(payload.get("condition_addresses"))
-    if not dependencies:
-        return _running("metric has no observed condition dependencies")
-    values = [_state_truth_value(states.get(address)) for address in dependencies]
-    if any(value is None for value in values):
-        return _running("waiting for metric condition dependencies")
-    max_score = _metric_max_score(contract, payload)
-    score = max_score if all(bool(value) for value in values) else 0
-    return _ready_score(score, max_score, "scored from observed condition state")
-
-
-def _min_score_threshold(payload: dict[str, object], total_max_score: float) -> float:
-    spec = payload.get("spec")
-    min_score = spec.get("min_score") if isinstance(spec, dict) else None
-    if isinstance(min_score, dict):
-        absolute = _number_value(min_score.get("absolute"))
-        if absolute is not None:
-            return float(absolute)
-        percentage = _number_value(min_score.get("percentage"))
-        if percentage is not None:
-            return total_max_score * float(percentage) / 100
-    direct = _number_value(min_score)
-    if direct is not None:
-        return float(direct)
-    return total_max_score
-
-
-def _evaluation_aggregate_outcome(
-    payload: dict[str, object],
-    states: dict[str, EvaluationExecutionState],
-) -> _EvaluationOutcome:
-    dependencies = _string_values(payload.get("metric_addresses"))
-    if not dependencies:
-        return _running("evaluation has no observed metric dependencies")
-    metric_states = [states.get(address) for address in dependencies]
-    if any(
-        state is None or state.status == EvaluationResultStatus.RUNNING
-        for state in metric_states
-    ):
-        return _running("waiting for evaluation metric dependencies")
-    if any(
-        state.status == EvaluationResultStatus.PENDING
-        for state in metric_states
-        if state
-    ):
-        return _running("waiting for evaluation metric dependencies")
-    total_score = sum(float(state.score or 0) for state in metric_states if state)
-    total_max = sum(float(state.max_score or 0) for state in metric_states if state)
-    threshold = _min_score_threshold(payload, total_max)
-    return _ready_passed(
-        total_score >= threshold,
-        "evaluated from observed metric scores",
-    )
-
-
-def _resolve_outcome(
-    address: str,
-    payload: dict[str, object],
-    snapshot: RuntimeSnapshot,
-    states: dict[str, EvaluationExecutionState],
-    contracts: dict[str, EvaluationResultContract],
-) -> _EvaluationOutcome:
-    contract = contracts[address]
-    resource_type = contract.resource_type
-    if resource_type == "condition-binding":
-        return _condition_outcome(payload, snapshot)
-    if resource_type == "metric":
-        return _metric_outcome(payload, states, contract)
-    if resource_type == "evaluation":
-        return _evaluation_aggregate_outcome(payload, states)
-    if resource_type == "tlo":
-        return _aggregate_dependency_outcome(
-            states,
-            _string_values(payload.get("evaluation_address")),
-            ready_detail="TLO evaluated from observed evaluation state",
-            waiting_detail="waiting for TLO evaluation dependency",
-        )
-    if resource_type == "goal":
-        return _aggregate_dependency_outcome(
-            states,
-            _string_values(payload.get("tlo_addresses")),
-            ready_detail="goal evaluated from observed TLO state",
-            waiting_detail="waiting for goal TLO dependencies",
-        )
-    if resource_type == "objective":
-        return _aggregate_dependency_outcome(
-            states,
-            _string_values(payload.get("success_addresses")),
-            ready_detail="objective evaluated from observed success dependencies",
-            waiting_detail="waiting for objective success dependencies",
-        )
-    return _running(f"waiting for observed state for {address}")
-
-
-def _terminal_event(status: EvaluationResultStatus) -> EvaluationHistoryEventType:
-    if status == EvaluationResultStatus.READY:
-        return EvaluationHistoryEventType.EVALUATION_READY
-    if status == EvaluationResultStatus.FAILED:
-        return EvaluationHistoryEventType.EVALUATION_FAILED
-    return EvaluationHistoryEventType.EVALUATION_UPDATED
-
-
-def _state_matches_outcome(
-    state: EvaluationExecutionState,
-    outcome: _EvaluationOutcome,
-) -> bool:
-    return (
-        state.status == outcome.status
-        and state.passed == outcome.passed
-        and state.score == outcome.score
-        and state.max_score == outcome.max_score
-        and state.detail == outcome.detail
-    )
-
-
-def _contractual_outcome(
-    outcome: _EvaluationOutcome,
-    contract: EvaluationResultContract,
-) -> _EvaluationOutcome:
-    """Strip or derive ready result values according to the compiled contract."""
-    if outcome.status != EvaluationResultStatus.READY:
-        return _EvaluationOutcome(status=outcome.status, detail=outcome.detail)
-
-    source_passed = outcome.passed
-    passed = outcome.passed if contract.supports_passed else None
-    score = outcome.score if contract.supports_score else None
-    max_score = outcome.max_score if contract.supports_score else None
-
-    if contract.supports_score:
-        if contract.fixed_max_score is not None and score is not None:
-            max_score = contract.fixed_max_score
-        if score is None and source_passed is not None:
-            max_score = (
-                contract.fixed_max_score
-                if contract.fixed_max_score is not None
-                else 100
-            )
-            score = max_score if source_passed else 0
-        if score is None:
-            return _running("waiting for contract-compatible score result")
-
-    if contract.supports_passed and passed is None and score is not None:
-        threshold = max_score if max_score is not None else score
-        passed = float(score) >= float(threshold)
-    if contract.supports_passed and passed is None:
-        return _running("waiting for contract-compatible pass/fail result")
-
-    return _EvaluationOutcome(
-        status=EvaluationResultStatus.READY,
-        passed=passed,
-        score=score,
-        max_score=max_score,
-        detail=outcome.detail,
-    )
-
-
-def _append_progression(
-    state: EvaluationExecutionState,
-    outcome: _EvaluationOutcome,
-    events: list[dict[str, object]],
-) -> EvaluationExecutionState:
-    """Append running/terminal events and return the final result state."""
-    last_timestamp = str(events[-1]["timestamp"]) if events else state.updated_at
-
-    if state.status in _TERMINAL_RESULT_STATUSES:
-        if outcome.status == EvaluationResultStatus.RUNNING:
-            return state
-        if _state_matches_outcome(state, outcome):
-            return state
-
-    if state.status in {
-        EvaluationResultStatus.PENDING,
-        EvaluationResultStatus.RUNNING,
-    } and outcome.status == EvaluationResultStatus.RUNNING:
-        running_at = _next_timestamp(last_timestamp)
-        running_state = EvaluationExecutionState(
-            state_schema_version=state.state_schema_version,
-            resource_type=state.resource_type,
-            run_id=state.run_id,
-            status=EvaluationResultStatus.RUNNING,
-            observed_at=state.observed_at,
-            updated_at=running_at,
-            detail=outcome.detail,
-        )
-        events.append(
-            EvaluationHistoryEvent(
-                event_type=EvaluationHistoryEventType.EVALUATION_UPDATED,
-                timestamp=running_at,
-                status=EvaluationResultStatus.RUNNING,
-                detail=running_state.detail,
-            ).to_payload()
-        )
-        return running_state
-
-    if state.status == EvaluationResultStatus.PENDING:
-        running_at = _next_timestamp(last_timestamp)
-        running_state = EvaluationExecutionState(
-            state_schema_version=state.state_schema_version,
-            resource_type=state.resource_type,
-            run_id=state.run_id,
-            status=EvaluationResultStatus.RUNNING,
-            observed_at=state.observed_at,
-            updated_at=running_at,
-        )
-        events.append(
-            EvaluationHistoryEvent(
-                event_type=EvaluationHistoryEventType.EVALUATION_UPDATED,
-                timestamp=running_at,
-                status=EvaluationResultStatus.RUNNING,
-            ).to_payload()
-        )
-        last_timestamp = running_state.updated_at
-
-    terminal_at = _next_timestamp(last_timestamp)
-    final_state = EvaluationExecutionState(
-        state_schema_version=state.state_schema_version,
-        resource_type=state.resource_type,
-        run_id=state.run_id,
-        status=outcome.status,
-        observed_at=state.observed_at,
-        updated_at=terminal_at,
-        passed=outcome.passed,
-        score=outcome.score,
-        max_score=outcome.max_score,
-        detail=outcome.detail,
-    )
-    events.append(
-        EvaluationHistoryEvent(
-            event_type=_terminal_event(outcome.status),
-            timestamp=terminal_at,
-            status=outcome.status,
-            passed=outcome.passed,
-            score=outcome.score,
-            max_score=outcome.max_score,
-            detail=outcome.detail,
-        ).to_payload()
-    )
-    return final_state
-
-
-def _drive_evaluations(
-    plan: EvaluationPlan,
-    snapshot: RuntimeSnapshot,
-    operation_payloads: dict[str, dict[str, object]],
-    states: dict[str, EvaluationExecutionState],
-    history: dict[str, list[dict[str, object]]],
-    contracts: dict[str, EvaluationResultContract],
-) -> None:
-    """Advance observable evaluation resources from current snapshot state."""
-    for address in _evaluation_order(plan, operation_payloads):
-        outcome = _resolve_outcome(
-            address,
-            operation_payloads[address],
-            snapshot,
-            states,
-            contracts,
-        )
-        outcome = _contractual_outcome(outcome, contracts[address])
-        states[address] = _append_progression(
-            states[address],
-            outcome,
-            history[address],
-        )
 
 
 @dataclass
@@ -575,7 +59,7 @@ class AptlEvaluator(object):
                 success=False,
                 snapshot=working_snapshot,
                 diagnostics=[
-                    _evaluation_diagnostic(
+                    evaluation_diagnostic(
                         "aptl.evaluator.invalid-plan",
                         EVALUATION_ADDRESS,
                         "APTL evaluator expected an ACES EvaluationPlan.",
@@ -584,7 +68,7 @@ class AptlEvaluator(object):
             )
 
         entries = dict(working_snapshot.entries)
-        states = _existing_states(working_snapshot)
+        states = existing_states(working_snapshot)
         history = {
             address: list(events)
             for address, events in working_snapshot.evaluation_history.items()
@@ -593,7 +77,7 @@ class AptlEvaluator(object):
         operation_payloads: dict[str, dict[str, object]] = {}
         diagnostics: list[Diagnostic] = []
         changed: list[str] = []
-        registered_at = _utc_now()
+        registered_at = utc_now()
 
         for op in plan.actionable_operations:
             if op.action == ChangeAction.DELETE:
@@ -612,8 +96,8 @@ class AptlEvaluator(object):
                 status="ready",
             )
             changed.append(op.address)
-            if op.resource_type in _OBSERVABLE_RESOURCE_TYPES:
-                contract, evaluation_diagnostics = _register_evaluation(
+            if op.resource_type in OBSERVABLE_RESOURCE_TYPES:
+                contract, evaluation_diagnostics = register_evaluation(
                     op.address,
                     op.payload,
                     registered_at,
@@ -632,7 +116,7 @@ class AptlEvaluator(object):
                 diagnostics=diagnostics,
             )
 
-        _drive_evaluations(
+        drive_evaluations(
             plan,
             working_snapshot,
             operation_payloads,

--- a/src/aptl/backends/aces_evaluator.py
+++ b/src/aptl/backends/aces_evaluator.py
@@ -11,25 +11,23 @@ The adapter is the ACES ``Evaluator`` component published on APTL's
 ``RuntimeTarget``. ``start()`` loads an ACES ``EvaluationPlan`` into runtime
 state: it registers every evaluation resource as an ACES ``SnapshotEntry`` and,
 for each observable evaluation resource, records a truthful
-``EvaluationExecutionState`` — the run is ``PENDING`` (registered and awaiting
-execution) with a single ``evaluation_started`` history event, because no
-objective or condition outcome has been observed yet. The adapter never reports
-``READY``/``FAILED`` outcomes or invents scores. Outcome progression is driven
-out-of-band by RTE-001; when that execution-state integration lands (tracked
-by #514), the same ``results()`` / ``history()`` surface will report the real
-``RUNNING`` → terminal transitions and ``EvaluationHistoryEvent`` streams.
-``stop()`` clears evaluation state.
+``EvaluationExecutionState`` and then advances observable resources from the
+runtime snapshot supplied by the ACES control plane. Conditions observe
+provisioning entries, conditional metrics score from those condition results,
+and aggregate resources report pass/fail from their compiled dependency
+addresses. The adapter never invents elapsed-time score curves; result values
+are emitted only when the compiled ACES contract allows them. ``stop()`` clears
+evaluation state.
 
 This keeps the full remote-control-plane evaluation claim honest: APTL
 publishes the evaluation result/history *contract* surface and the
-loaded/registered run state, not a synthetic in-memory result that never
-progresses.
+observed run state behind it, not synthetic in-memory progress.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 from aces_contracts.diagnostics import Diagnostic, Severity
@@ -46,8 +44,14 @@ from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotE
 from aptl.utils.redaction import redact
 
 EVALUATION_ADDRESS = "runtime.apply.evaluation"
+_ISO_UTC_OFFSET = "+00:00"
 _OBSERVABLE_RESOURCE_TYPES = frozenset(
     {"condition-binding", "evaluation", "goal", "metric", "objective", "tlo"}
+)
+_FAILED_ENTRY_STATUSES = frozenset({"error", "failed", "unhealthy"})
+_READY_ENTRY_STATUS = "ready"
+_TERMINAL_RESULT_STATUSES = frozenset(
+    {EvaluationResultStatus.FAILED, EvaluationResultStatus.READY}
 )
 
 
@@ -67,17 +71,68 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+def _next_timestamp(previous: str, *, offset_ms: int = 1) -> str:
+    """Return an ISO timestamp strictly after ``previous``."""
+    parsed = datetime.fromisoformat(previous.replace("Z", _ISO_UTC_OFFSET))
+    return (parsed + timedelta(milliseconds=offset_ms)).isoformat().replace(
+        _ISO_UTC_OFFSET,
+        "Z",
+    )
+
+
+@dataclass(frozen=True)
+class _EvaluationOutcome(object):
+    """Resolved evaluator state before it is rendered as ACES DTO payloads."""
+
+    status: EvaluationResultStatus
+    passed: bool | None = None
+    score: float | int | None = None
+    max_score: int | None = None
+    detail: str | None = None
+
+
+def _running(detail: str) -> _EvaluationOutcome:
+    return _EvaluationOutcome(status=EvaluationResultStatus.RUNNING, detail=detail)
+
+
+def _ready_passed(passed: bool, detail: str) -> _EvaluationOutcome:
+    return _EvaluationOutcome(
+        status=EvaluationResultStatus.READY,
+        passed=passed,
+        detail=detail,
+    )
+
+
+def _ready_score(score: float | int, max_score: int, detail: str) -> _EvaluationOutcome:
+    return _EvaluationOutcome(
+        status=EvaluationResultStatus.READY,
+        score=score,
+        max_score=max_score,
+        detail=detail,
+    )
+
+
+def _state_matches_contract(
+    state: EvaluationExecutionState,
+    contract: EvaluationResultContract,
+) -> bool:
+    return (
+        state.state_schema_version == contract.state_schema_version
+        and state.resource_type == contract.resource_type
+    )
+
+
 def _register_evaluation(
     evaluation_address: str,
     payload: dict[str, object],
     registered_at: str,
-    results: dict[str, dict[str, object]],
+    states: dict[str, EvaluationExecutionState],
     history: dict[str, list[dict[str, object]]],
-) -> list[Diagnostic]:
+) -> tuple[EvaluationResultContract | None, list[Diagnostic]]:
     """Record the truthful initial (``PENDING``) portable state for a run."""
     result_contract_payload = payload.get("result_contract")
     if not isinstance(result_contract_payload, dict):
-        return [
+        return None, [
             _evaluation_diagnostic(
                 "aptl.evaluator.evaluation-contract-missing",
                 evaluation_address,
@@ -87,13 +142,21 @@ def _register_evaluation(
     try:
         result_contract = EvaluationResultContract.from_mapping(result_contract_payload)
     except (TypeError, ValueError) as exc:
-        return [
+        return None, [
             _evaluation_diagnostic(
                 "aptl.evaluator.evaluation-contract-invalid",
                 evaluation_address,
                 f"ACES evaluation result_contract is invalid: {exc}",
             )
         ]
+
+    existing_state = states.get(evaluation_address)
+    if existing_state is not None and _state_matches_contract(
+        existing_state,
+        result_contract,
+    ):
+        history.setdefault(evaluation_address, [])
+        return result_contract, []
 
     state = EvaluationExecutionState(
         state_schema_version=result_contract.state_schema_version,
@@ -103,7 +166,7 @@ def _register_evaluation(
         observed_at=registered_at,
         updated_at=registered_at,
     )
-    results[evaluation_address] = state.to_payload()
+    states[evaluation_address] = state
     history[evaluation_address] = [
         EvaluationHistoryEvent(
             event_type=EvaluationHistoryEventType.EVALUATION_STARTED,
@@ -111,7 +174,390 @@ def _register_evaluation(
             status=EvaluationResultStatus.PENDING,
         ).to_payload()
     ]
-    return []
+    return result_contract, []
+
+
+def _existing_states(snapshot: RuntimeSnapshot) -> dict[str, EvaluationExecutionState]:
+    """Load valid pre-existing evaluation results for untouched plan entries."""
+    states: dict[str, EvaluationExecutionState] = {}
+    for address, payload in snapshot.evaluation_results.items():
+        if not isinstance(payload, dict):
+            continue
+        try:
+            states[address] = EvaluationExecutionState.from_payload(payload)
+        except (TypeError, ValueError):
+            continue
+    return states
+
+
+def _evaluation_order(
+    plan: EvaluationPlan,
+    operation_payloads: dict[str, dict[str, object]],
+) -> list[str]:
+    """Return plan order with startup-order addresses first when available."""
+    ordered: list[str] = []
+    for address in plan.startup_order:
+        if address in operation_payloads and address not in ordered:
+            ordered.append(address)
+    for address in operation_payloads:
+        if address not in ordered:
+            ordered.append(address)
+    return ordered
+
+
+def _string_values(raw: object) -> tuple[str, ...]:
+    """Normalize compiled dependency fields into a tuple of non-empty strings."""
+    if isinstance(raw, str):
+        return (raw,) if raw else ()
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        return ()
+    return tuple(str(value) for value in raw if str(value))
+
+
+def _int_value(raw: object) -> int | None:
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        return None
+    return raw
+
+
+def _number_value(raw: object) -> float | int | None:
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return None
+    return raw
+
+
+def _metric_max_score(
+    contract: EvaluationResultContract,
+    payload: dict[str, object],
+) -> int:
+    if contract.fixed_max_score is not None:
+        return contract.fixed_max_score
+    spec = payload.get("spec")
+    if isinstance(spec, dict):
+        spec_max = _int_value(spec.get("max_score"))
+        if spec_max is not None:
+            return spec_max
+    return 100
+
+
+def _state_truth_value(state: EvaluationExecutionState | None) -> bool | None:
+    """Return True/False for ready/failed dependency states; None means wait."""
+    if state is None:
+        return None
+    if state.status in {EvaluationResultStatus.PENDING, EvaluationResultStatus.RUNNING}:
+        return None
+    if state.status == EvaluationResultStatus.FAILED:
+        return False
+    if state.passed is not None:
+        return state.passed
+    if state.score is None:
+        return None
+    if state.max_score is None:
+        return bool(state.score)
+    return float(state.score) >= float(state.max_score)
+
+
+def _aggregate_dependency_outcome(
+    states: dict[str, EvaluationExecutionState],
+    dependencies: tuple[str, ...],
+    *,
+    ready_detail: str,
+    waiting_detail: str,
+) -> _EvaluationOutcome:
+    if not dependencies:
+        return _running(waiting_detail)
+    values = [_state_truth_value(states.get(address)) for address in dependencies]
+    if any(value is None for value in values):
+        return _running(waiting_detail)
+    return _ready_passed(all(bool(value) for value in values), ready_detail)
+
+
+def _condition_outcome(
+    payload: dict[str, object],
+    snapshot: RuntimeSnapshot,
+) -> _EvaluationOutcome:
+    node_address = str(payload.get("node_address") or "")
+    if not node_address:
+        return _running("condition has no compiled node address")
+    node_entry = snapshot.entries.get(node_address)
+    if node_entry is None:
+        return _running(f"waiting for observed node state: {node_address}")
+    status = str(node_entry.status).lower()
+    if status == _READY_ENTRY_STATUS:
+        return _ready_passed(True, f"observed ready node state: {node_address}")
+    if status in _FAILED_ENTRY_STATUSES:
+        return _ready_passed(False, f"observed failed node state: {node_address}")
+    return _running(f"waiting for ready node state: {node_address}")
+
+
+def _metric_outcome(
+    payload: dict[str, object],
+    states: dict[str, EvaluationExecutionState],
+    contract: EvaluationResultContract,
+) -> _EvaluationOutcome:
+    dependencies = _string_values(payload.get("condition_addresses"))
+    if not dependencies:
+        return _running("metric has no observed condition dependencies")
+    values = [_state_truth_value(states.get(address)) for address in dependencies]
+    if any(value is None for value in values):
+        return _running("waiting for metric condition dependencies")
+    max_score = _metric_max_score(contract, payload)
+    score = max_score if all(bool(value) for value in values) else 0
+    return _ready_score(score, max_score, "scored from observed condition state")
+
+
+def _min_score_threshold(payload: dict[str, object], total_max_score: float) -> float:
+    spec = payload.get("spec")
+    min_score = spec.get("min_score") if isinstance(spec, dict) else None
+    if isinstance(min_score, dict):
+        absolute = _number_value(min_score.get("absolute"))
+        if absolute is not None:
+            return float(absolute)
+        percentage = _number_value(min_score.get("percentage"))
+        if percentage is not None:
+            return total_max_score * float(percentage) / 100
+    direct = _number_value(min_score)
+    if direct is not None:
+        return float(direct)
+    return total_max_score
+
+
+def _evaluation_aggregate_outcome(
+    payload: dict[str, object],
+    states: dict[str, EvaluationExecutionState],
+) -> _EvaluationOutcome:
+    dependencies = _string_values(payload.get("metric_addresses"))
+    if not dependencies:
+        return _running("evaluation has no observed metric dependencies")
+    metric_states = [states.get(address) for address in dependencies]
+    if any(
+        state is None or state.status == EvaluationResultStatus.RUNNING
+        for state in metric_states
+    ):
+        return _running("waiting for evaluation metric dependencies")
+    if any(
+        state.status == EvaluationResultStatus.PENDING
+        for state in metric_states
+        if state
+    ):
+        return _running("waiting for evaluation metric dependencies")
+    total_score = sum(float(state.score or 0) for state in metric_states if state)
+    total_max = sum(float(state.max_score or 0) for state in metric_states if state)
+    threshold = _min_score_threshold(payload, total_max)
+    return _ready_passed(
+        total_score >= threshold,
+        "evaluated from observed metric scores",
+    )
+
+
+def _resolve_outcome(
+    address: str,
+    payload: dict[str, object],
+    snapshot: RuntimeSnapshot,
+    states: dict[str, EvaluationExecutionState],
+    contracts: dict[str, EvaluationResultContract],
+) -> _EvaluationOutcome:
+    contract = contracts[address]
+    resource_type = contract.resource_type
+    if resource_type == "condition-binding":
+        return _condition_outcome(payload, snapshot)
+    if resource_type == "metric":
+        return _metric_outcome(payload, states, contract)
+    if resource_type == "evaluation":
+        return _evaluation_aggregate_outcome(payload, states)
+    if resource_type == "tlo":
+        return _aggregate_dependency_outcome(
+            states,
+            _string_values(payload.get("evaluation_address")),
+            ready_detail="TLO evaluated from observed evaluation state",
+            waiting_detail="waiting for TLO evaluation dependency",
+        )
+    if resource_type == "goal":
+        return _aggregate_dependency_outcome(
+            states,
+            _string_values(payload.get("tlo_addresses")),
+            ready_detail="goal evaluated from observed TLO state",
+            waiting_detail="waiting for goal TLO dependencies",
+        )
+    if resource_type == "objective":
+        return _aggregate_dependency_outcome(
+            states,
+            _string_values(payload.get("success_addresses")),
+            ready_detail="objective evaluated from observed success dependencies",
+            waiting_detail="waiting for objective success dependencies",
+        )
+    return _running(f"waiting for observed state for {address}")
+
+
+def _terminal_event(status: EvaluationResultStatus) -> EvaluationHistoryEventType:
+    if status == EvaluationResultStatus.READY:
+        return EvaluationHistoryEventType.EVALUATION_READY
+    if status == EvaluationResultStatus.FAILED:
+        return EvaluationHistoryEventType.EVALUATION_FAILED
+    return EvaluationHistoryEventType.EVALUATION_UPDATED
+
+
+def _state_matches_outcome(
+    state: EvaluationExecutionState,
+    outcome: _EvaluationOutcome,
+) -> bool:
+    return (
+        state.status == outcome.status
+        and state.passed == outcome.passed
+        and state.score == outcome.score
+        and state.max_score == outcome.max_score
+        and state.detail == outcome.detail
+    )
+
+
+def _contractual_outcome(
+    outcome: _EvaluationOutcome,
+    contract: EvaluationResultContract,
+) -> _EvaluationOutcome:
+    """Strip or derive ready result values according to the compiled contract."""
+    if outcome.status != EvaluationResultStatus.READY:
+        return _EvaluationOutcome(status=outcome.status, detail=outcome.detail)
+
+    source_passed = outcome.passed
+    passed = outcome.passed if contract.supports_passed else None
+    score = outcome.score if contract.supports_score else None
+    max_score = outcome.max_score if contract.supports_score else None
+
+    if contract.supports_score:
+        if contract.fixed_max_score is not None and score is not None:
+            max_score = contract.fixed_max_score
+        if score is None and source_passed is not None:
+            max_score = (
+                contract.fixed_max_score
+                if contract.fixed_max_score is not None
+                else 100
+            )
+            score = max_score if source_passed else 0
+        if score is None:
+            return _running("waiting for contract-compatible score result")
+
+    if contract.supports_passed and passed is None and score is not None:
+        threshold = max_score if max_score is not None else score
+        passed = float(score) >= float(threshold)
+    if contract.supports_passed and passed is None:
+        return _running("waiting for contract-compatible pass/fail result")
+
+    return _EvaluationOutcome(
+        status=EvaluationResultStatus.READY,
+        passed=passed,
+        score=score,
+        max_score=max_score,
+        detail=outcome.detail,
+    )
+
+
+def _append_progression(
+    state: EvaluationExecutionState,
+    outcome: _EvaluationOutcome,
+    events: list[dict[str, object]],
+) -> EvaluationExecutionState:
+    """Append running/terminal events and return the final result state."""
+    last_timestamp = str(events[-1]["timestamp"]) if events else state.updated_at
+
+    if state.status in _TERMINAL_RESULT_STATUSES:
+        if outcome.status == EvaluationResultStatus.RUNNING:
+            return state
+        if _state_matches_outcome(state, outcome):
+            return state
+
+    if state.status in {
+        EvaluationResultStatus.PENDING,
+        EvaluationResultStatus.RUNNING,
+    } and outcome.status == EvaluationResultStatus.RUNNING:
+        running_at = _next_timestamp(last_timestamp)
+        running_state = EvaluationExecutionState(
+            state_schema_version=state.state_schema_version,
+            resource_type=state.resource_type,
+            run_id=state.run_id,
+            status=EvaluationResultStatus.RUNNING,
+            observed_at=state.observed_at,
+            updated_at=running_at,
+            detail=outcome.detail,
+        )
+        events.append(
+            EvaluationHistoryEvent(
+                event_type=EvaluationHistoryEventType.EVALUATION_UPDATED,
+                timestamp=running_at,
+                status=EvaluationResultStatus.RUNNING,
+                detail=running_state.detail,
+            ).to_payload()
+        )
+        return running_state
+
+    if state.status == EvaluationResultStatus.PENDING:
+        running_at = _next_timestamp(last_timestamp)
+        running_state = EvaluationExecutionState(
+            state_schema_version=state.state_schema_version,
+            resource_type=state.resource_type,
+            run_id=state.run_id,
+            status=EvaluationResultStatus.RUNNING,
+            observed_at=state.observed_at,
+            updated_at=running_at,
+        )
+        events.append(
+            EvaluationHistoryEvent(
+                event_type=EvaluationHistoryEventType.EVALUATION_UPDATED,
+                timestamp=running_at,
+                status=EvaluationResultStatus.RUNNING,
+            ).to_payload()
+        )
+        last_timestamp = running_state.updated_at
+
+    terminal_at = _next_timestamp(last_timestamp)
+    final_state = EvaluationExecutionState(
+        state_schema_version=state.state_schema_version,
+        resource_type=state.resource_type,
+        run_id=state.run_id,
+        status=outcome.status,
+        observed_at=state.observed_at,
+        updated_at=terminal_at,
+        passed=outcome.passed,
+        score=outcome.score,
+        max_score=outcome.max_score,
+        detail=outcome.detail,
+    )
+    events.append(
+        EvaluationHistoryEvent(
+            event_type=_terminal_event(outcome.status),
+            timestamp=terminal_at,
+            status=outcome.status,
+            passed=outcome.passed,
+            score=outcome.score,
+            max_score=outcome.max_score,
+            detail=outcome.detail,
+        ).to_payload()
+    )
+    return final_state
+
+
+def _drive_evaluations(
+    plan: EvaluationPlan,
+    snapshot: RuntimeSnapshot,
+    operation_payloads: dict[str, dict[str, object]],
+    states: dict[str, EvaluationExecutionState],
+    history: dict[str, list[dict[str, object]]],
+    contracts: dict[str, EvaluationResultContract],
+) -> None:
+    """Advance observable evaluation resources from current snapshot state."""
+    for address in _evaluation_order(plan, operation_payloads):
+        outcome = _resolve_outcome(
+            address,
+            operation_payloads[address],
+            snapshot,
+            states,
+            contracts,
+        )
+        outcome = _contractual_outcome(outcome, contracts[address])
+        states[address] = _append_progression(
+            states[address],
+            outcome,
+            history[address],
+        )
 
 
 @dataclass
@@ -138,11 +584,13 @@ class AptlEvaluator(object):
             )
 
         entries = dict(working_snapshot.entries)
-        results = dict(working_snapshot.evaluation_results)
+        states = _existing_states(working_snapshot)
         history = {
             address: list(events)
             for address, events in working_snapshot.evaluation_history.items()
         }
+        contracts: dict[str, EvaluationResultContract] = {}
+        operation_payloads: dict[str, dict[str, object]] = {}
         diagnostics: list[Diagnostic] = []
         changed: list[str] = []
         registered_at = _utc_now()
@@ -150,7 +598,7 @@ class AptlEvaluator(object):
         for op in plan.actionable_operations:
             if op.action == ChangeAction.DELETE:
                 entries.pop(op.address, None)
-                results.pop(op.address, None)
+                states.pop(op.address, None)
                 history.pop(op.address, None)
                 changed.append(op.address)
                 continue
@@ -165,14 +613,17 @@ class AptlEvaluator(object):
             )
             changed.append(op.address)
             if op.resource_type in _OBSERVABLE_RESOURCE_TYPES:
-                evaluation_diagnostics = _register_evaluation(
+                contract, evaluation_diagnostics = _register_evaluation(
                     op.address,
                     op.payload,
                     registered_at,
-                    results,
+                    states,
                     history,
                 )
                 diagnostics.extend(evaluation_diagnostics)
+                if contract is not None:
+                    contracts[op.address] = contract
+                    operation_payloads[op.address] = dict(op.payload)
 
         if diagnostics:
             return ApplyResult(
@@ -181,6 +632,15 @@ class AptlEvaluator(object):
                 diagnostics=diagnostics,
             )
 
+        _drive_evaluations(
+            plan,
+            working_snapshot,
+            operation_payloads,
+            states,
+            history,
+            contracts,
+        )
+        results = {address: state.to_payload() for address, state in states.items()}
         self._results = {address: dict(result) for address, result in results.items()}
         self._history = {
             address: [dict(event) for event in events] for address, events in history.items()
@@ -196,7 +656,7 @@ class AptlEvaluator(object):
         )
 
     def status(self) -> dict[str, object]:
-        """Return current evaluation status (registered, pending-execution runs)."""
+        """Return current evaluation status."""
         return {
             "backend": "aptl",
             "registered_evaluations": sorted(self._results),

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -392,8 +392,8 @@ def check_run_archive_manifest(
 
     Writes through ``LocalRunStore``'s redacting boundary (ADR-029).
     Objective / scoring run surfaces are published through the portable
-    ACES evaluation contracts at the backend boundary; live outcome
-    progression from RTE-001 remains follow-on work tracked by #514.
+    ACES evaluation contracts at the backend boundary. Live evaluator
+    progression is emitted by ``AptlEvaluator`` from observed runtime state.
     """
     realization = state.realization_details or {}
     manifest = {
@@ -423,7 +423,9 @@ def check_run_archive_manifest(
                 "evaluation-result-envelope-v1",
                 "evaluation-history-event-stream-v1",
             ],
-            "execution_state_integration": "#514",
+            "execution_state_integration": (
+                "aptl.backends.aces_evaluator.AptlEvaluator"
+            ),
         },
         "orchestrator_surfaces": {
             "profile": "orchestration-evaluation",

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -423,9 +423,7 @@ def check_run_archive_manifest(
                 "evaluation-result-envelope-v1",
                 "evaluation-history-event-stream-v1",
             ],
-            "execution_state_integration": (
-                "aptl.backends.aces_evaluator.AptlEvaluator"
-            ),
+            "execution_state_integration": "aptl.backends.aces_evaluator.AptlEvaluator",
         },
         "orchestrator_surfaces": {
             "profile": "orchestration-evaluation",

--- a/tests/test_aces_evaluator.py
+++ b/tests/test_aces_evaluator.py
@@ -3,8 +3,13 @@
 from pathlib import Path
 from textwrap import dedent
 
-from aces_contracts.evaluation import EvaluationExecutionState, EvaluationResultStatus
-from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
+from aces_contracts.evaluation import (
+    EvaluationExecutionState,
+    EvaluationHistoryEventType,
+    EvaluationResultStatus,
+)
+from aces_contracts.planning import RuntimeDomain
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
 from aces_processor.compiler import compile_runtime_model
 from aces_processor.planner import plan
 from aces_runtime.evaluation_result_contracts import evaluation_result_contract_diagnostics
@@ -46,6 +51,56 @@ _EVALUATION_SCENARIO = dedent(
     """
 )
 
+_SCORING_SCENARIO = dedent(
+    """
+    name: evaluator-score-test
+    nodes:
+      vm:
+        type: vm
+        os: linux
+        resources: {ram: 1 gib, cpu: 1}
+        conditions: {health: ops}
+        roles: {ops: operator}
+    conditions:
+      health: {command: /bin/true, interval: 15}
+    entities:
+      blue: {role: blue}
+    metrics:
+      uptime:
+        type: conditional
+        max-score: 10
+        condition: health
+    evaluations:
+      overall:
+        metrics: [uptime]
+        min-score: {absolute: 10}
+    tlos:
+      service-live:
+        evaluation: overall
+    goals:
+      verify:
+        tlos: [service-live]
+    objectives:
+      validate:
+        entity: blue
+        success:
+          conditions: [health]
+          metrics: [uptime]
+          evaluations: [overall]
+          tlos: [service-live]
+          goals: [verify]
+    workflows:
+      response:
+        start: run
+        steps:
+          run:
+            type: objective
+            objective: validate
+            on-success: finish
+          finish: {type: end}
+    """
+)
+
 
 def _evaluation_plan():
     scenario = parse_sdl(_EVALUATION_SCENARIO)
@@ -53,20 +108,201 @@ def _evaluation_plan():
     return execution_plan.evaluation
 
 
-def test_start_registers_evaluations_as_pending_with_started_history():
+def _scoring_plan():
+    scenario = parse_sdl(_SCORING_SCENARIO)
+    execution_plan = plan(compile_runtime_model(scenario), create_aptl_manifest())
+    return execution_plan.evaluation
+
+
+def _snapshot_with_node_status(status: str) -> RuntimeSnapshot:
+    return RuntimeSnapshot(
+        entries={
+            "provision.node.vm": SnapshotEntry(
+                address="provision.node.vm",
+                domain=RuntimeDomain.PROVISIONING,
+                resource_type="node",
+                payload={"name": "vm"},
+                status=status,
+            )
+        }
+    )
+
+
+def _event_types(events: list[dict[str, object]]) -> list[str]:
+    return [str(event["event_type"]) for event in events]
+
+
+def test_start_reports_running_until_observed_state_is_available():
     evaluator = AptlEvaluator()
     result = evaluator.start(_evaluation_plan(), RuntimeSnapshot())
 
     assert isinstance(result, ApplyResult)
     assert result.success is True
-    assert result.snapshot.evaluation_results, "expected at least one evaluation run recorded"
+    assert result.snapshot.evaluation_results, (
+        "expected at least one evaluation run recorded"
+    )
 
     for address, payload in result.snapshot.evaluation_results.items():
         state = EvaluationExecutionState.from_payload(payload)
-        assert state.status == EvaluationResultStatus.PENDING
+        assert state.status == EvaluationResultStatus.RUNNING
+        assert state.passed is None
+        assert state.score is None
         assert state.run_id
         history = result.snapshot.evaluation_history[address]
-        assert history[0]["event_type"] == "evaluation_started"
+        assert _event_types(history) == [
+            EvaluationHistoryEventType.EVALUATION_STARTED.value,
+            EvaluationHistoryEventType.EVALUATION_UPDATED.value,
+        ]
+        assert history[0]["status"] == EvaluationResultStatus.PENDING.value
+        assert history[-1]["status"] == EvaluationResultStatus.RUNNING.value
+
+
+def test_start_derives_scores_from_observed_condition_state():
+    result = AptlEvaluator().start(
+        _scoring_plan(),
+        _snapshot_with_node_status("ready"),
+    )
+
+    assert result.success is True
+    diagnostics = evaluation_result_contract_diagnostics(result.snapshot)
+    assert diagnostics == [], [d.message for d in diagnostics]
+
+    results = result.snapshot.evaluation_results
+    condition = EvaluationExecutionState.from_payload(
+        results["evaluation.condition.vm.health"]
+    )
+    metric = EvaluationExecutionState.from_payload(results["evaluation.metric.uptime"])
+    evaluation = EvaluationExecutionState.from_payload(
+        results["evaluation.evaluation.overall"]
+    )
+    tlo = EvaluationExecutionState.from_payload(results["evaluation.tlo.service-live"])
+    goal = EvaluationExecutionState.from_payload(results["evaluation.goal.verify"])
+    objective = EvaluationExecutionState.from_payload(
+        results["evaluation.objective.validate"]
+    )
+
+    assert condition.status == EvaluationResultStatus.READY
+    assert condition.passed is True
+    assert metric.status == EvaluationResultStatus.READY
+    assert metric.score == 10
+    assert metric.max_score == 10
+    assert evaluation.passed is True
+    assert tlo.passed is True
+    assert goal.passed is True
+    assert objective.passed is True
+
+    metric_history = result.snapshot.evaluation_history["evaluation.metric.uptime"]
+    assert _event_types(metric_history) == [
+        EvaluationHistoryEventType.EVALUATION_STARTED.value,
+        EvaluationHistoryEventType.EVALUATION_UPDATED.value,
+        EvaluationHistoryEventType.EVALUATION_READY.value,
+    ]
+    assert metric_history[1]["status"] == EvaluationResultStatus.RUNNING.value
+    assert metric_history[-1]["score"] == 10
+    assert metric_history[-1]["max_score"] == 10
+
+
+def test_start_keeps_unobserved_scores_running_without_placeholder_values():
+    result = AptlEvaluator().start(_scoring_plan(), RuntimeSnapshot())
+
+    assert result.success is True
+    diagnostics = evaluation_result_contract_diagnostics(result.snapshot)
+    assert diagnostics == [], [d.message for d in diagnostics]
+
+    results = result.snapshot.evaluation_results
+    condition = EvaluationExecutionState.from_payload(
+        results["evaluation.condition.vm.health"]
+    )
+    metric = EvaluationExecutionState.from_payload(results["evaluation.metric.uptime"])
+
+    assert condition.status == EvaluationResultStatus.RUNNING
+    assert condition.passed is None
+    assert metric.status == EvaluationResultStatus.RUNNING
+    assert metric.score is None
+    assert metric.max_score is None
+    assert _event_types(
+        result.snapshot.evaluation_history["evaluation.metric.uptime"]
+    ) == [
+        EvaluationHistoryEventType.EVALUATION_STARTED.value,
+        EvaluationHistoryEventType.EVALUATION_UPDATED.value,
+    ]
+
+
+def test_start_preserves_existing_run_history_when_observation_advances():
+    evaluator = AptlEvaluator()
+    initial = evaluator.start(_scoring_plan(), RuntimeSnapshot())
+    assert initial.success is True
+
+    metric_address = "evaluation.metric.uptime"
+    initial_metric = EvaluationExecutionState.from_payload(
+        initial.snapshot.evaluation_results[metric_address]
+    )
+    initial_history = list(initial.snapshot.evaluation_history[metric_address])
+    ready_node = _snapshot_with_node_status("ready").entries["provision.node.vm"]
+    observed_entries = dict(initial.snapshot.entries)
+    observed_entries[ready_node.address] = ready_node
+
+    advanced = evaluator.start(
+        _scoring_plan(),
+        initial.snapshot.with_entries(
+            observed_entries,
+            evaluation_results=initial.snapshot.evaluation_results,
+            evaluation_history=initial.snapshot.evaluation_history,
+        ),
+    )
+
+    assert advanced.success is True
+    advanced_metric = EvaluationExecutionState.from_payload(
+        advanced.snapshot.evaluation_results[metric_address]
+    )
+    advanced_history = advanced.snapshot.evaluation_history[metric_address]
+    assert advanced_metric.run_id == initial_metric.run_id
+    assert advanced_history[: len(initial_history)] == initial_history
+    assert _event_types(advanced_history) == [
+        EvaluationHistoryEventType.EVALUATION_STARTED.value,
+        EvaluationHistoryEventType.EVALUATION_UPDATED.value,
+        EvaluationHistoryEventType.EVALUATION_READY.value,
+    ]
+
+    repeated = evaluator.start(_scoring_plan(), advanced.snapshot)
+
+    assert repeated.success is True
+    repeated_metric = EvaluationExecutionState.from_payload(
+        repeated.snapshot.evaluation_results[metric_address]
+    )
+    assert repeated_metric.run_id == initial_metric.run_id
+    assert repeated.snapshot.evaluation_history[metric_address] == advanced_history
+
+
+def test_start_scores_failed_condition_as_observed_zero():
+    result = AptlEvaluator().start(
+        _scoring_plan(),
+        _snapshot_with_node_status("failed"),
+    )
+
+    assert result.success is True
+    diagnostics = evaluation_result_contract_diagnostics(result.snapshot)
+    assert diagnostics == [], [d.message for d in diagnostics]
+
+    results = result.snapshot.evaluation_results
+    condition = EvaluationExecutionState.from_payload(
+        results["evaluation.condition.vm.health"]
+    )
+    metric = EvaluationExecutionState.from_payload(results["evaluation.metric.uptime"])
+    evaluation = EvaluationExecutionState.from_payload(
+        results["evaluation.evaluation.overall"]
+    )
+    objective = EvaluationExecutionState.from_payload(
+        results["evaluation.objective.validate"]
+    )
+
+    assert condition.status == EvaluationResultStatus.READY
+    assert condition.passed is False
+    assert metric.status == EvaluationResultStatus.READY
+    assert metric.score == 0
+    assert metric.max_score == 10
+    assert evaluation.passed is False
+    assert objective.passed is False
 
 
 def test_start_output_is_evaluation_contract_clean():

--- a/tests/test_techvault_live_gate.py
+++ b/tests/test_techvault_live_gate.py
@@ -918,6 +918,10 @@ def test_run_archive_writes_manifest_through_redacting_boundary():
     assert manifest["aces_provenance"]["realization"]["nodes"]
     assert manifest["aces_provenance"]["selected_profiles"] == ["dmz", "soc"]
     assert manifest["evaluator_surfaces"]["profile"] == "full-remote-control-plane"
+    assert (
+        manifest["evaluator_surfaces"]["execution_state_integration"]
+        == "aptl.backends.aces_evaluator.AptlEvaluator"
+    )
     assert manifest["participant_runtime_surfaces"]["contracts"] == [
         "participant-episode-state-envelope-v1",
         "participant-episode-history-event-stream-v1",


### PR DESCRIPTION
## Summary

Implement live evaluator score/progression on APTL's declared ACES evaluation surface from observed runtime state instead of placeholder progression.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #606

## ADR Impact

- ADR-021
- ADR-029
- ADR-035
- ADR-044

## Changes

- Advance AptlEvaluator results from pending to running/ready based on observed RuntimeSnapshot entries and compiled evaluation dependencies.
- Preserve existing evaluator run IDs and history when a later observation advances the same run.
- Gate pass/fail and score fields through EvaluationResultContract support flags and fixed max scores.
- Keep evaluator outcome resolution and history progression in private backend helper modules that satisfy the Sonar new-issue gate.
- Update live-gate evaluator evidence wording and add a changelog fragment.
- Add evaluator tests for observed ready scores, unobserved running state, failed-condition zero score, lifecycle history preservation, and live-gate manifest integration.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

uv run pytest tests/test_aces_evaluator.py; uv run pytest tests/test_aces_backend.py -k 'full_remote_control_plane or evaluator or conformance'; uv run pytest tests/test_techvault_live_gate.py -k 'run_archive_writes_manifest or run_archive_roundtrips'; uv run pytest -n auto -k "not integration"; uv run pytest -n auto tests/test_techvault_static_gate.py -m integration; pre-commit run --all-files

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: issue #606 ← src/aptl/backends/aces_evaluator.py, issue #606 ← src/aptl/backends/_aces_evaluator_engine.py, issue #606 ← src/aptl/backends/_aces_evaluator_progress.py, issue #606 ← src/aptl/validation/_live_gate_checks.py, issue #606 ← docs/aces/techvault-live-validation-gate.md, issue #606 ← docs/aces/m1-aces-conformance-truth-up-preflight.md
- TESTS: issue #606 ← tests/test_aces_evaluator.py, issue #606 ← tests/test_aces_backend.py, issue #606 ← tests/test_techvault_live_gate.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/606.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
