### PR TITLE
Resolve Sonar security rating findings

### DIFF
--- a/src/aptl/api/routers/scenarios.py
+++ b/src/aptl/api/routers/scenarios.py
@@ -95,5 +95,5 @@ async def get_scenario_detail(
     project_dir: Annotated[Path, Depends(get_project_dir)],
 ) -> ScenarioDetailResponse:
     """Project one curated scenario into a backend-owned workbench detail."""
-    log.info("GET /scenarios/%s", scenario_id)
+    log.info("GET /scenarios/{scenario_id}")
     return await asyncio.to_thread(_load_scenario_detail, project_dir, scenario_id)

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -921,7 +921,7 @@ def _seed_suricata_volumes_local(ctx: _LabStartContext) -> LabResult | None:
     ) as exc:
         # Narrow, redacted failure (ADR-043): name the artifact/exception
         # type, not raw Docker stderr.
-        log.error("Suricata volume seed failed: %s", type(exc).__name__)
+        log.exception("Suricata volume seed failed: %s", type(exc).__name__)
         return LabResult(
             success=False,
             error=f"Suricata runtime volume seeding failed: {exc}",

--- a/tests/test_api_scenarios.py
+++ b/tests/test_api_scenarios.py
@@ -1,6 +1,7 @@
 """Tests for the scenario catalog summary API endpoint (UI-008c)."""
 
 import json
+import logging
 
 import pytest
 
@@ -206,6 +207,15 @@ class TestScenarioDetailEndpoint:
     def test_detail_no_catalog_returns_404(self, api_client):
         response = api_client.get("/api/scenarios/anything")
         assert response.status_code == 404
+
+    def test_detail_does_not_log_user_controlled_id(self, api_client, caplog):
+        caplog.set_level(logging.INFO, logger="aptl.api.scenarios")
+
+        response = api_client.get("/api/scenarios/%0Aforged-entry")
+
+        assert response.status_code == 404
+        assert "GET /scenarios/{scenario_id}" in caplog.text
+        assert "forged-entry" not in caplog.text
 
     def test_detail_omits_internal_path(self, api_client, tmp_path):
         self._catalog_with_minimal(tmp_path)

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -5,6 +5,7 @@ compose command construction, and full orchestration. All subprocess/docker
 calls are mocked.
 """
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -1533,7 +1534,7 @@ class TestSeedSuricataVolumesStep:
         suffixes = {s.volume_suffix for s in seeds}
         assert suffixes == {"suricata_config_seed", "suricata_misp_rules"}
 
-    def test_seed_error_aborts_lab_start_step(self, tmp_path):
+    def test_seed_error_aborts_lab_start_step(self, tmp_path, caplog):
         from aptl.core.deployment.errors import BackendSeedError
         from aptl.core.lab import _step_seed_suricata_volumes
 
@@ -1542,6 +1543,7 @@ class TestSeedSuricataVolumesStep:
         backend.seed_named_volumes.side_effect = BackendSeedError(
             "Seeding named volume 'suricata_config_seed' failed"
         )
+        caplog.set_level(logging.ERROR, logger="aptl.lab")
 
         result = _step_seed_suricata_volumes(self._ctx(tmp_path, backend))
 
@@ -1550,6 +1552,13 @@ class TestSeedSuricataVolumesStep:
         assert "suricata runtime volume seeding failed" in (
             result.error or ""
         ).lower()
+        seed_records = [
+            record
+            for record in caplog.records
+            if record.getMessage() == "Suricata volume seed failed: BackendSeedError"
+        ]
+        assert seed_records
+        assert seed_records[0].exc_info is not None
 
     def test_missing_source_aborts_step(self, tmp_path):
         from aptl.core.lab import _step_seed_suricata_volumes


### PR DESCRIPTION
## Summary
- avoid logging attacker-controlled scenario ids in the scenario detail route
- use exception-aware logging in the Suricata volume seed failure handler
- add regressions for the Sonar-flagged logging paths

## Validation
- uv run pytest tests/test_api_scenarios.py::TestScenarioDetailEndpoint::test_detail_does_not_log_user_controlled_id -q
- uv run pytest tests/test_lab.py::TestSeedSuricataVolumesStep::test_seed_error_aborts_lab_start_step -q
- uv run pytest tests/test_api_scenarios.py -q
- uv run pytest tests/test_lab.py::TestSeedSuricataVolumesStep -q
- uv run pytest tests/ -q -k "not integration"
- uv run --with pre-commit pre-commit run --all-files --show-diff-on-failure

Fixes #619.
Unblocks the SonarCloud quality gate failure currently keeping PR #613 red.
