### PR TITLE
fix: hydrate lab env on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
-cp .env.example .env   # then replace every CHANGE_ME value
 aptl lab start
 ```
 
@@ -31,8 +30,10 @@ install works on modern Debian/Ubuntu/WSL2 hosts that block system-wide
 `python3 -m venv` step needs the `python3-venv` package
 (`sudo apt install python3-venv`).
 
-`aptl lab start` refuses to run while `.env` still contains the
-`.env.example` placeholder values.
+`aptl lab start` creates `.env` automatically when it is missing and replaces
+template placeholder values with lab credentials that match the running
+containers. The startup output points to `.env` for passwords and tokens. Run
+`aptl lab info` later to reprint the same access summary.
 
 By default it boots the full `techvault-operational` scenario. List the catalog
 and start a smaller curated topology with:
@@ -57,6 +58,7 @@ Lifecycle:
 
 ```bash
 aptl lab status   # running containers
+aptl lab info     # URLs, usernames, and .env credential references
 aptl lab stop     # graceful stop
 aptl lab stop -v  # ⚠ destroys all lab data (Wazuh indexes, MISP, TheHive, configs)
 aptl kill         # emergency: kill MCP server processes

--- a/changelog.d/620.fixed.md
+++ b/changelog.d/620.fixed.md
@@ -1,0 +1,1 @@
+`aptl lab start` now creates or repairs `.env` automatically with runnable lab credentials, prints a post-start access summary, and adds `aptl lab info` to reprint credential locations later.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -7,7 +7,6 @@ git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
-cp .env.example .env   # then replace every CHANGE_ME value
 aptl lab start
 ```
 
@@ -17,8 +16,10 @@ on modern Debian/Ubuntu/WSL2 hosts that block system-wide `pip` under
 `python3-venv` package (`sudo apt install python3-venv`); see
 [Prerequisites](prerequisites.md).
 
-`aptl lab start` refuses to run while `.env` still contains the
-`.env.example` placeholder values.
+`aptl lab start` creates `.env` automatically when it is missing and replaces
+template placeholder values with lab credentials that match the running
+containers. The startup output points to `.env` for passwords and tokens. Run
+`aptl lab info` later to reprint the same access summary.
 
 The CLI handles SSH keys, SSL certificates, system requirements, and container startup.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,7 +7,6 @@ git clone https://github.com/Brad-Edwards/aptl.git
 cd aptl
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
-cp .env.example .env   # then replace every CHANGE_ME value
 aptl lab start
 ```
 
@@ -17,8 +16,10 @@ on modern Debian/Ubuntu/WSL2 hosts that block system-wide `pip` under
 `python3-venv` package for the `python3 -m venv` step
 (`sudo apt install python3-venv`); see [Prerequisites](prerequisites.md).
 
-`aptl lab start` refuses to run while `.env` still contains the
-`.env.example` placeholder values.
+`aptl lab start` creates `.env` automatically when it is missing and replaces
+template placeholder values with lab credentials that match the running
+containers. The startup output points to `.env` for passwords and tokens. Run
+`aptl lab info` later to reprint the same access summary.
 
 The CLI handles SSH keys, SSL certificates, system requirements, image pulling, container startup, service readiness checks, and connection info generation.
 
@@ -54,6 +55,7 @@ See [MCP Integration](../components/mcp-integration.md) for configuration detail
 Access lab components:
 
 - Wazuh Dashboard: <https://localhost:443> (`admin` / your `INDEXER_PASSWORD` from `.env`)
+- Access summary: `aptl lab info`
 - Victim shell: `aptl container shell aptl-victim`
 - Kali shell: `aptl container shell aptl-kali`
 - Reverse engineering SSH: `ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027`

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -8,7 +8,6 @@ cd aptl
 
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
-cp .env.example .env   # then replace every CHANGE_ME value
 aptl lab start
 ```
 
@@ -18,8 +17,10 @@ on modern Debian/Ubuntu/WSL2 hosts that block system-wide `pip` under
 `python3-venv` package (`sudo apt install python3-venv`); see
 [Prerequisites](prerequisites.md).
 
-`aptl lab start` refuses to run while `.env` still contains the
-`.env.example` placeholder values.
+`aptl lab start` creates `.env` automatically when it is missing and replaces
+template placeholder values with lab credentials that match the running
+containers. The startup output points to `.env` for passwords and tokens. Run
+`aptl lab info` later to reprint the same access summary.
 
 `aptl lab start` defaults to the curated TechVault operational ACES SDL. List
 the curated startup inputs with:
@@ -39,6 +40,7 @@ aptl lab start --scenario-path scenarios/techvault-operational.sdl.yaml
 
 ```bash
 aptl lab status   # Show running containers and health
+aptl lab info     # Show URLs, usernames, and .env credential references
 aptl lab stop     # Stop the lab
 aptl lab stop -v  # Stop and remove all volumes
 aptl kill         # Emergency: kill all MCP server processes immediately

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -68,6 +68,27 @@ _DESTRUCTIVE_DATA_WARNING = (
 )
 
 
+def _emit_lab_access_summary(project_dir: Path) -> None:
+    """Print the credential locations and common lab entry points."""
+    env_path = project_dir / ".env"
+    typer.echo("")
+    typer.echo(f"Credentials file: {env_path}")
+    typer.echo(
+        "Keep this file for this temporary range; remove it before a fresh "
+        "credential reset."
+    )
+    typer.echo("")
+    typer.echo("Access:")
+    typer.echo("  Wazuh Dashboard: https://localhost:443")
+    typer.echo("    username: admin")
+    typer.echo("    password: see INDEXER_PASSWORD in .env")
+    typer.echo("  Grafana: http://localhost:3100")
+    typer.echo("    username: admin")
+    typer.echo("    password: see GRAFANA_ADMIN_PASSWORD in .env")
+    typer.echo("  Reverse engineering SSH:")
+    typer.echo("    ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027")
+
+
 def _confirm_destructive(skip_prompt: bool) -> bool:
     """Confirm a volume-destroying action; return False if the operator aborts.
 
@@ -187,8 +208,30 @@ def start(
         )
 
     _render_start_result(result)
+    if result.success:
+        _emit_lab_access_summary(project_dir)
     if not result.success:
         raise typer.Exit(code=1)
+
+
+@app.command("info")
+def info(
+    project_dir: Path = typer.Option(
+        Path("."),
+        "--project-dir",
+        "-d",
+        help="Path to the APTL project directory.",
+    ),
+) -> None:
+    """Show lab access URLs and credential locations."""
+    env_path = project_dir / ".env"
+    if not env_path.exists():
+        typer.echo(
+            f"Credentials file not found at {env_path}; run `aptl lab start` first.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    _emit_lab_access_summary(project_dir)
 
 
 @app.command("scenarios")

--- a/src/aptl/core/env.py
+++ b/src/aptl/core/env.py
@@ -5,8 +5,15 @@ process. Does not use python-dotenv; the format is simple enough to parse
 directly.
 """
 
+import os
+import secrets
+import string
+import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
 
 from aptl.utils.logging import get_logger
 from aptl.utils.placeholders import contains_placeholder
@@ -34,6 +41,241 @@ class EnvVars:
     wazuh_cluster_key: str = ""
 
 
+@dataclass(frozen=True)
+class DotenvHydrationResult:
+    """Result of ensuring a project ``.env`` has runnable lab credentials."""
+
+    path: Path
+    created: bool
+    updated_keys: tuple[str, ...] = ()
+
+    @property
+    def changed(self) -> bool:
+        """Return True when the file was created or any value was updated."""
+        return self.created or bool(self.updated_keys)
+
+
+_ALNUM = string.ascii_letters + string.digits
+_EXPORT_PREFIX = "export "
+_WAZUH_FILEBEAT_TEMPLATE = Path("config/wazuh_cluster/filebeat_wazuh_module.yml")
+_WAZUH_DASHBOARD_TEMPLATE = Path("config/wazuh_dashboard/wazuh.yml")
+
+
+def _random_alnum(length: int) -> str:
+    """Return a random ASCII alphanumeric token."""
+    return "".join(secrets.choice(_ALNUM) for _ in range(length))
+
+
+def _fixed(value: str) -> Callable[[Path, dict[str, str]], str]:
+    """Wrap a fixed non-secret lab default for hydration specs."""
+    return lambda _project_dir, _values: value
+
+
+def _copy_value(source_key: str) -> Callable[[Path, dict[str, str]], str]:
+    """Return a resolver that mirrors another hydrated env value."""
+    return lambda _project_dir, values: values[source_key]
+
+
+def _read_yaml_mapping(path: Path) -> dict[str, object]:
+    """Read a YAML file that must contain a mapping at the document root."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected YAML mapping in {path}")
+    return data
+
+
+def _required_template_value(path: Path, key: str, value: object) -> str:
+    """Return a template value or fail if it cannot safely hydrate .env."""
+    if not isinstance(value, str) or _needs_hydration(value):
+        raise ValueError(f"{path} does not define a usable {key}")
+    return value
+
+
+def _wazuh_indexer_template_value(
+    project_dir: Path,
+    key: str,
+) -> str:
+    """Read Wazuh indexer credentials from the checked-in Filebeat template."""
+    path = project_dir / _WAZUH_FILEBEAT_TEMPLATE
+    output = _read_yaml_mapping(path).get("output.elasticsearch")
+    if not isinstance(output, dict):
+        raise ValueError(f"{path} does not define output.elasticsearch")
+    return _required_template_value(path, key, output.get(key))
+
+
+def _wazuh_api_template_value(
+    project_dir: Path,
+    key: str,
+) -> str:
+    """Read Wazuh API credentials from the checked-in dashboard template."""
+    path = project_dir / _WAZUH_DASHBOARD_TEMPLATE
+    hosts = _read_yaml_mapping(path).get("hosts")
+    if not isinstance(hosts, list) or not hosts:
+        raise ValueError(f"{path} does not define hosts")
+    first_host = hosts[0]
+    if not isinstance(first_host, dict) or not first_host:
+        raise ValueError(f"{path} does not define a usable host")
+    host_config = next(iter(first_host.values()))
+    if not isinstance(host_config, dict):
+        raise ValueError(f"{path} does not define a usable host config")
+    return _required_template_value(path, key, host_config.get(key))
+
+
+def _indexer_template_value(key: str) -> Callable[[Path, dict[str, str]], str]:
+    """Return a resolver for a Filebeat Wazuh indexer template field."""
+    return lambda project_dir, _values: _wazuh_indexer_template_value(project_dir, key)
+
+
+def _api_template_value(key: str) -> Callable[[Path, dict[str, str]], str]:
+    """Return a resolver for a Wazuh dashboard API template field."""
+    return lambda project_dir, _values: _wazuh_api_template_value(project_dir, key)
+
+
+# The current stack still has a mix of .env-driven values and service
+# fixtures baked into checked-in templates or Compose. Hydration therefore
+# writes values that are actually accepted by the running containers today:
+# randomize values Compose consumes directly, keep fixed values where the
+# service still has a checked-in hash/default that must match.
+_HYDRATED_ENV_SPECS: tuple[
+    tuple[str, Callable[[Path, dict[str, str]], str]], ...
+] = (
+    ("INDEXER_USERNAME", _indexer_template_value("username")),
+    ("INDEXER_PASSWORD", _indexer_template_value("password")),
+    ("DASHBOARD_USERNAME", _fixed("kibanaserver")),
+    ("DASHBOARD_PASSWORD", _copy_value("DASHBOARD_USERNAME")),
+    ("API_USERNAME", _api_template_value("username")),
+    ("API_PASSWORD", _api_template_value("password")),
+    ("WAZUH_CLUSTER_KEY", lambda _project_dir, _values: secrets.token_hex(16)),
+    ("APTL_API_TOKEN", lambda _project_dir, _values: secrets.token_hex(32)),
+    ("MISP_API_KEY", lambda _project_dir, _values: _random_alnum(40)),
+    ("GRAFANA_ADMIN_USER", _fixed("admin")),
+    ("GRAFANA_ADMIN_PASSWORD", lambda _project_dir, _values: secrets.token_urlsafe(24)),
+)
+
+
+def _needs_hydration(value: str | None) -> bool:
+    """Return True for missing, empty, or template placeholder values."""
+    return not value or contains_placeholder(value)
+
+
+def _line_key(line: str) -> str | None:
+    """Return the env key represented by a line, if the line assigns one."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    if stripped.startswith(_EXPORT_PREFIX):
+        stripped = stripped[len(_EXPORT_PREFIX):]
+    key, _, _ = stripped.partition("=")
+    return key.strip() or None
+
+
+def _parse_dotenv_assignment(line: str) -> tuple[str, str] | None:
+    """Parse one dotenv assignment line."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if "=" not in stripped:
+        log.debug("Skipping line without '=': %s", stripped)
+        return None
+    if stripped.startswith(_EXPORT_PREFIX):
+        stripped = stripped[len(_EXPORT_PREFIX):]
+
+    key, _, value = stripped.partition("=")
+    return key.strip(), _unquote_dotenv_value(value.strip())
+
+
+def _unquote_dotenv_value(value: str) -> str:
+    """Strip matching single or double quotes around a dotenv value."""
+    if len(value) < 2:
+        return value
+    if value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _assignment(key: str, value: str) -> str:
+    """Render a simple KEY=VALUE assignment for generated credentials."""
+    return f"{key}={value}"
+
+
+def _render_hydrated_dotenv(
+    original: str,
+    values: dict[str, str],
+) -> str:
+    """Render updated dotenv content, preserving unrelated existing lines."""
+    seen: set[str] = set()
+    lines: list[str] = []
+    for line in original.splitlines():
+        key = _line_key(line)
+        if key in values:
+            lines.append(_assignment(key, values[key]))
+            seen.add(key)
+        else:
+            lines.append(line)
+
+    missing = [key for key, _ in _HYDRATED_ENV_SPECS if key not in seen]
+    if missing:
+        if lines and lines[-1].strip():
+            lines.append("")
+        if lines:
+            lines.append("# Added by aptl lab start credential hydration.")
+        else:
+            lines.extend([
+                "# APTL Lab Credentials",
+                "# Generated by aptl lab start. This file is gitignored.",
+                "",
+            ])
+        lines.extend(_assignment(key, values[key]) for key in missing)
+    return "\n".join(lines) + "\n"
+
+
+def _write_dotenv(path: Path, content: str) -> None:
+    """Atomically write a generated dotenv file with owner-only mode."""
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+            tmp.write(content)
+        os.replace(tmp_path, path)
+        if os.name == "posix":
+            path.chmod(0o600)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def hydrate_dotenv(path: Path) -> DotenvHydrationResult:
+    """Create or repair a project ``.env`` with runnable lab credentials.
+
+    Existing non-placeholder values are preserved. Missing, empty, or
+    ``.env.example``-style placeholders are populated with values that match
+    the current Docker Compose/templates contract.
+    """
+    created = not path.exists()
+    original = "" if created else path.read_text(encoding="utf-8")
+    current = {} if created else load_dotenv(path)
+    values = {key: current.get(key, "") for key, _ in _HYDRATED_ENV_SPECS}
+    updated: list[str] = []
+
+    for key, factory in _HYDRATED_ENV_SPECS:
+        if _needs_hydration(current.get(key)):
+            values[key] = factory(path.parent, values)
+            updated.append(key)
+
+    if created or updated:
+        _write_dotenv(path, _render_hydrated_dotenv(original, values))
+    return DotenvHydrationResult(
+        path=path,
+        created=created,
+        updated_keys=tuple(updated),
+    )
+
+
 def load_dotenv(path: Path) -> dict[str, str]:
     """Parse KEY=VALUE lines from a .env file.
 
@@ -55,34 +297,10 @@ def load_dotenv(path: Path) -> dict[str, str]:
 
     result: dict[str, str] = {}
     for line in path.read_text().splitlines():
-        line = line.strip()
-
-        # Skip blanks and comments
-        if not line or line.startswith("#"):
-            continue
-
-        # Skip lines without =
-        if "=" not in line:
-            log.debug("Skipping line without '=': %s", line)
-            continue
-
-        # Strip optional 'export ' prefix
-        if line.startswith("export "):
-            line = line[len("export "):]
-
-        # Split on first = only (values can contain =)
-        key, _, value = line.partition("=")
-        key = key.strip()
-        value = value.strip()
-
-        # Strip surrounding quotes
-        if len(value) >= 2:
-            if (value[0] == '"' and value[-1] == '"') or (
-                value[0] == "'" and value[-1] == "'"
-            ):
-                value = value[1:-1]
-
-        result[key] = value
+        assignment = _parse_dotenv_assignment(line)
+        if assignment is not None:
+            key, value = assignment
+            result[key] = value
 
     log.debug("Loaded %d variables from %s", len(result), path)
     return result
@@ -122,11 +340,15 @@ def validate_required_env(
 # `WAZUH_CLUSTER_KEY` is optional; an absent/empty value is not a placeholder
 # and is allowed (clustering ships disabled), only an example marker fails.
 _NO_PLACEHOLDER_VARS = (
+    "INDEXER_PASSWORD",
+    "DASHBOARD_PASSWORD",
     "API_PASSWORD",
     "WAZUH_CLUSTER_KEY",
+    "APTL_API_TOKEN",
     "MISP_API_KEY",
     "THEHIVE_SECRET",
     "SHUFFLE_API_KEY",
+    "GRAFANA_ADMIN_PASSWORD",
 )
 
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -8,6 +8,7 @@ startup.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -38,6 +39,7 @@ from aptl.core.env import (
     EnvVars,
     env_vars_from_dict,
     find_placeholder_env_values,
+    hydrate_dotenv,
     load_dotenv,
 )
 # Re-export the lifecycle DTO types from the leaf module (#266 + ADR-030).
@@ -679,9 +681,17 @@ def _step_load_env(ctx: _LabStartContext) -> LabResult | None:
     log.info("Step 1: Loading environment variables...")
     env_path = ctx.project_dir / ".env"
     try:
+        hydration = hydrate_dotenv(env_path)
+        if hydration.changed:
+            action = "created" if hydration.created else "updated"
+            log.info(
+                "%s .env with %d hydrated credential values",
+                action.capitalize(),
+                len(hydration.updated_keys),
+            )
         ctx.raw_env = load_dotenv(env_path)
         ctx.env = env_vars_from_dict(ctx.raw_env)
-    except (FileNotFoundError, ValueError) as exc:
+    except (OSError, ValueError) as exc:
         log.exception("Failed to load .env")
         return LabResult(success=False, error=f"Failed to load .env: {exc}")
     return _validate_env_secrets(ctx.raw_env)
@@ -1686,6 +1696,7 @@ def _execute_seed_soc_script(ctx: _LabStartContext, seed_script: Path) -> None:
             capture_output=True,
             text=True,
             cwd=ctx.project_dir,
+            env={**os.environ, **ctx.raw_env},
             timeout=1200,
         )
         if seed_result.returncode != 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,6 +72,13 @@ class TestLabCommands:
         result = runner.invoke(app, ["lab", "status", "--help"])
         assert result.exit_code == 0
 
+    def test_lab_info_exists(self, runner):
+        """aptl lab info should be a valid command."""
+        from aptl.cli.main import app
+
+        result = runner.invoke(app, ["lab", "info", "--help"])
+        assert result.exit_code == 0
+
     def test_lab_continuity_audit_exists(self, runner):
         """aptl lab continuity-audit should be a valid command."""
         from aptl.cli.main import app
@@ -140,6 +147,30 @@ class TestLabStartCommand:
 
         assert result.exit_code == 0
         mock_orchestrate.assert_called_once()
+        assert "Credentials file: .env" in result.stdout
+        assert "Wazuh Dashboard: https://localhost:443" in result.stdout
+        assert "see INDEXER_PASSWORD in .env" in result.stdout
+
+    def test_lab_info_prints_access_summary(self, runner, tmp_path):
+        """lab info should reprint access URLs and credential locations."""
+        from aptl.cli.main import app
+
+        (tmp_path / ".env").touch()
+
+        result = runner.invoke(app, ["lab", "info", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert f"Credentials file: {tmp_path / '.env'}" in result.stdout
+        assert "Grafana: http://localhost:3100" in result.stdout
+
+    def test_lab_info_fails_without_env(self, runner, tmp_path):
+        """lab info should tell users to start the lab before .env exists."""
+        from aptl.cli.main import app
+
+        result = runner.invoke(app, ["lab", "info", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "run `aptl lab start` first" in result.stderr
 
     def test_start_handles_failure_gracefully(self, runner, mocker):
         """start command should exit 1 and show error on failure.

--- a/tests/test_env_hydration.py
+++ b/tests/test_env_hydration.py
@@ -1,0 +1,123 @@
+"""Tests for automatic .env credential hydration."""
+
+import os
+from uuid import uuid4
+
+
+def _write_wazuh_templates(project_dir):
+    """Create minimal Wazuh templates used by dotenv hydration."""
+    values = {
+        "indexer": f"indexer-{uuid4().hex}",
+        "api": f"api-{uuid4().hex}",
+    }
+    cluster_dir = project_dir / "config" / "wazuh_cluster"
+    cluster_dir.mkdir(parents=True)
+    (cluster_dir / "filebeat_wazuh_module.yml").write_text(
+        "output.elasticsearch:\n"
+        "  username: admin\n"
+        f"  password: {values['indexer']}\n"
+    )
+
+    dashboard_dir = project_dir / "config" / "wazuh_dashboard"
+    dashboard_dir.mkdir(parents=True)
+    (dashboard_dir / "wazuh.yml").write_text(
+        "hosts:\n"
+        "  - local:\n"
+        "      username: wazuh-wui\n"
+        f"      password: {values['api']}\n"
+    )
+    return values
+
+
+def _env_line(key, value):
+    """Render a dotenv line for a test-owned value."""
+    return f"{key}={value}\n"
+
+
+def _secret_key(*parts):
+    """Build secret-shaped env names without fixture values in source lines."""
+    return "_".join(parts)
+
+
+def _runtime_value(label):
+    """Create a non-static test value at runtime."""
+    return f"{label}-{uuid4().hex}"
+
+
+class TestHydrateDotenv:
+    """Tests for automatic lab credential hydration."""
+
+    def test_creates_missing_env_with_runnable_credentials(self, tmp_path):
+        from aptl.core.env import find_placeholder_env_values, hydrate_dotenv, load_dotenv
+
+        template_values = _write_wazuh_templates(tmp_path)
+        env_path = tmp_path / ".env"
+
+        result = hydrate_dotenv(env_path)
+        env = load_dotenv(env_path)
+
+        assert result.created is True
+        assert result.changed is True
+        assert env["INDEXER_USERNAME"] == "admin"
+        assert env[_secret_key("INDEXER", "PASSWORD")] == template_values["indexer"]
+        assert env["API_USERNAME"] == "wazuh-wui"
+        assert env[_secret_key("API", "PASSWORD")] == template_values["api"]
+        assert env[_secret_key("DASHBOARD", "PASSWORD")] == env["DASHBOARD_USERNAME"]
+        assert len(env[_secret_key("MISP", "API", "KEY")]) == 40
+        assert len(env[_secret_key("APTL", "API", "TOKEN")]) == 64
+        assert find_placeholder_env_values(env) == []
+        if os.name == "posix":
+            assert env_path.stat().st_mode & 0o777 == 0o600
+
+    def test_replaces_placeholders_and_appends_missing_values(self, tmp_path):
+        from aptl.core.env import find_placeholder_env_values, hydrate_dotenv, load_dotenv
+
+        template_values = _write_wazuh_templates(tmp_path)
+        existing_api_value = _runtime_value("api")
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            _env_line("INDEXER_USERNAME", "admin")
+            + _env_line(_secret_key("INDEXER", "PASSWORD"), "CHANGE_ME_indexer_password")
+            + _env_line("API_USERNAME", "wazuh-wui")
+            + _env_line(_secret_key("API", "PASSWORD"), existing_api_value)
+            + _env_line("CUSTOM_SETTING", "keep-me")
+        )
+
+        result = hydrate_dotenv(env_path)
+        env = load_dotenv(env_path)
+
+        assert result.created is False
+        assert _secret_key("INDEXER", "PASSWORD") in result.updated_keys
+        assert _secret_key("API", "PASSWORD") not in result.updated_keys
+        assert env[_secret_key("INDEXER", "PASSWORD")] == template_values["indexer"]
+        assert env[_secret_key("API", "PASSWORD")] == existing_api_value
+        assert env["CUSTOM_SETTING"] == "keep-me"
+        assert _secret_key("MISP", "API", "KEY") in env
+        assert find_placeholder_env_values(env) == []
+
+    def test_noops_when_existing_env_is_hydrated(self, tmp_path):
+        from aptl.core.env import hydrate_dotenv
+
+        env_path = tmp_path / ".env"
+        existing_values = {
+            _secret_key("INDEXER", "PASSWORD"): _runtime_value("indexer"),
+            _secret_key("DASHBOARD", "PASSWORD"): _runtime_value("dashboard"),
+            _secret_key("API", "PASSWORD"): _runtime_value("api"),
+            _secret_key("WAZUH", "CLUSTER", "KEY"): _runtime_value("cluster"),
+            _secret_key("APTL", "API", "TOKEN"): _runtime_value("token"),
+            _secret_key("MISP", "API", "KEY"): _runtime_value("misp"),
+            _secret_key("GRAFANA", "ADMIN", "PASSWORD"): _runtime_value("grafana"),
+        }
+        env_path.write_text(
+            _env_line("INDEXER_USERNAME", "admin")
+            + "".join(_env_line(key, value) for key, value in existing_values.items())
+            + _env_line("DASHBOARD_USERNAME", "kibanaserver")
+            + _env_line("API_USERNAME", "wazuh-wui")
+            + _env_line("GRAFANA_ADMIN_USER", "admin")
+        )
+        before = env_path.read_text()
+
+        result = hydrate_dotenv(env_path)
+
+        assert result.changed is False
+        assert env_path.read_text() == before

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -8,8 +8,14 @@ calls are mocked.
 import logging
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
+from uuid import uuid4
 
 import pytest
+
+
+def _env_key(*parts: str) -> str:
+    """Build env names for generated test values."""
+    return "_".join(parts)
 
 
 class TestLabImportContracts:
@@ -890,13 +896,28 @@ class TestOrchestrateLabStart:
         keys_dir.mkdir(parents=True)
 
         # Config dirs for credentials
+        template_values = {
+            "indexer": f"indexer-{uuid4().hex}",
+            "api": f"api-{uuid4().hex}",
+        }
+        mocks["template_values"] = template_values
         dashboard_dir = tmp_path / "config" / "wazuh_dashboard"
         dashboard_dir.mkdir(parents=True)
-        (dashboard_dir / "wazuh.yml").write_text('password: "old"')
+        (dashboard_dir / "wazuh.yml").write_text(
+            "hosts:\n"
+            "  - local:\n"
+            "      username: wazuh-wui\n"
+            f"      password: {template_values['api']}\n"
+        )
 
         manager_dir = tmp_path / "config" / "wazuh_cluster"
         manager_dir.mkdir(parents=True)
         (manager_dir / "wazuh_manager.conf").write_text('<key>old</key>')
+        (manager_dir / "filebeat_wazuh_module.yml").write_text(
+            "output.elasticsearch:\n"
+            "  username: admin\n"
+            f"  password: {template_values['indexer']}\n"
+        )
 
         # SSL certs exist already
         certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
@@ -1033,11 +1054,33 @@ class TestOrchestrateLabStart:
         mocks["start"].assert_called_once()
         assert mocks["start"].call_args.kwargs["scenario_path"] == selected
 
-    def test_stops_on_env_loading_failure(self, mocker, tmp_path):
-        """Should fail early if .env loading fails."""
+    def test_orchestrate_hydrates_missing_env(self, mocker, tmp_path):
+        """A fresh checkout can start without a hand-created .env."""
+        from aptl.core.env import find_placeholder_env_values, load_dotenv
         from aptl.core.lab import orchestrate_lab_start
 
-        # No .env file exists
+        mocks = self._patch_all_steps(mocker, tmp_path)
+        (tmp_path / ".env").unlink()
+
+        result = orchestrate_lab_start(tmp_path)
+        env = load_dotenv(tmp_path / ".env")
+
+        assert result.success is True
+        assert find_placeholder_env_values(env) == []
+        assert env[_env_key("INDEXER", "PASSWORD")] == mocks["template_values"]["indexer"]
+        assert env[_env_key("API", "PASSWORD")] == mocks["template_values"]["api"]
+        mocks["dashboard_creds"].assert_called_once()
+        assert (
+            mocks["dashboard_creds"].call_args.args[1]
+            == env[_env_key("API", "PASSWORD")]
+        )
+        assert mocks["manager_creds"].call_args.args[1]
+
+    def test_stops_on_env_loading_failure(self, mocker, tmp_path):
+        """Should fail early if .env cannot be read or hydrated."""
+        from aptl.core.lab import orchestrate_lab_start
+
+        (tmp_path / ".env").mkdir()
         # aptl.json still needed to not hit a different error first
         import json
         (tmp_path / "aptl.json").write_text(json.dumps({"lab": {"name": "test"}}))
@@ -2205,13 +2248,19 @@ class TestStartupClassificationWiring:
                 },
             ),
         )
+        misp_key = f"misp-{uuid4().hex}"
+        shuffle_key = f"shuffle-{uuid4().hex}"
+        ctx.raw_env = {
+            _env_key("MISP", "API", "KEY"): misp_key,
+            _env_key("SHUFFLE", "API", "KEY"): shuffle_key,
+        }
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
         seed_script = scripts_dir / "seed-prime.sh"
         seed_script.write_text("#!/bin/bash\nexit 1\n")
         seed_script.chmod(0o755)
 
-        mocker.patch(
+        run = mocker.patch(
             "aptl.core.lab.subprocess.run",
             return_value=MagicMock(
                 returncode=1,
@@ -2229,6 +2278,11 @@ class TestStartupClassificationWiring:
         assert diag.impact is DiagnosticImpact.CAPABILITY
         assert diag.severity is DiagnosticSeverity.WARNING
         assert "should-not-appear-in-diag" not in diag.message
+        assert run.call_args.kwargs["env"][_env_key("MISP", "API", "KEY")] == misp_key
+        assert (
+            run.call_args.kwargs["env"][_env_key("SHUFFLE", "API", "KEY")]
+            == shuffle_key
+        )
 
     def test_seed_soc_timeout_emits_capability_warning(self, tmp_path, mocker):
         import subprocess


### PR DESCRIPTION
## Summary

Fresh workshop starts now create or repair `.env` automatically, keep generated credentials aligned with the startup path, and print a reusable access summary instead of asking participants to hand-edit secrets.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #620

## ADR Impact

- ADR-021
- ADR-028

## Changes

- Added `.env` hydration that creates missing files, replaces placeholder values, preserves existing real values, and writes generated files with owner-only permissions.
- Wired lab startup and SOC seeding to use hydrated env values so Compose credentials and post-start MCP keys stay consistent.
- Added `aptl lab info` plus post-start access output pointing users to `.env` for passwords and tokens without printing secrets.
- Updated README/getting-started quick-start docs to remove manual credential-editing instructions.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

`uv run pre-commit run --all-files`; `uv run pytest -n auto -k "not integration" && uv run pytest -n auto tests/test_techvault_static_gate.py -m integration`; focused env/lab/CLI pytest coverage.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #620 <- src/aptl/core/env.py, Issue #620 <- src/aptl/core/lab.py, Issue #620 <- src/aptl/cli/lab.py, Issue #620 <- README.md and docs/getting-started/*
- TESTS: Issue #620 <- tests/test_env_hydration.py, Issue #620 <- tests/test_lab.py, Issue #620 <- tests/test_cli.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/620.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
