### PR TITLE
fix: add stale network lab start hint

### DIFF
--- a/changelog.d/621.fixed.md
+++ b/changelog.d/621.fixed.md
@@ -1,0 +1,1 @@
+Added a direct `aptl lab stop` / `aptl lab stop -v` recovery hint when lab startup fails on stale APTL network labels.

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -83,6 +83,28 @@ if TYPE_CHECKING:
 
 log = get_logger("lab")
 
+_STALE_NETWORK_RECOVERY_HINT = (
+    "Run `aptl lab stop` and retry, or `aptl lab stop -v` "
+    "if you need a clean lab."
+)
+
+
+def _looks_like_stale_realization_network_error(error: str) -> bool:
+    """Return True when Docker reports old APTL networks with stale labels."""
+
+    return (
+        "Existing network " in error
+        and " does not match realized network " in error
+        and "label org.aptl.realization.network expected 'true'" in error
+    )
+
+
+def _lab_start_failure_error(error: str) -> str:
+    message = f"Lab start failed: {error}"
+    if _looks_like_stale_realization_network_error(error):
+        return f"{message}\n{_STALE_NETWORK_RECOVERY_HINT}"
+    return message
+
 
 def start_aces_scenario(
     project_dir: Path,
@@ -1124,7 +1146,7 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
     log.error("Lab start failed: %s", lab_result.error)
     return LabResult(
         success=False,
-        error=f"Lab start failed: {lab_result.error}",
+        error=_lab_start_failure_error(lab_result.error),
     )
 
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -100,6 +100,8 @@ def _looks_like_stale_realization_network_error(error: str) -> bool:
 
 
 def _lab_start_failure_error(error: str) -> str:
+    """Build the CLI-visible lab-start failure message with recovery hints."""
+
     message = f"Lab start failed: {error}"
     if _looks_like_stale_realization_network_error(error):
         return f"{message}\n{_STALE_NETWORK_RECOVERY_HINT}"

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -2675,6 +2675,33 @@ class TestLabOrchestrationContracts:
             selected,
         ]
 
+    def test_start_containers_hints_for_stale_realization_networks(
+        self, mocker, tmp_path
+    ):
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        stale_error = (
+            "ACES runtime handoff failed: aptl.provisioner.backend-start-failed "
+            "at runtime.apply.provisioning: Existing network aptl_aptl-dmz "
+            "does not match realized network dmz-net: label "
+            "org.aptl.realization.network expected 'true', found ''."
+        )
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config()
+        ctx.backend = MagicMock()
+        mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            return_value=LabResult(success=False, error=stale_error),
+        )
+
+        result = _step_start_containers(ctx)
+
+        assert result is not None
+        assert result.success is False
+        assert "Lab start failed:" in result.error
+        assert "Run `aptl lab stop` and retry" in result.error
+        assert "`aptl lab stop -v`" in result.error
+
     # -- ssh_key_is_ready --------------------------------------------
 
     def test_test_ssh_without_ssh_key_raises_violation(self, tmp_path):


### PR DESCRIPTION
## Summary

Lab startup now recognizes stale APTL realization-network label mismatches and appends a direct recovery hint telling operators to run `aptl lab stop` and retry, or `aptl lab stop -v` for a clean lab.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #621

## ADR Impact

- ADR-021

## Changes

- Added stale realization-network error detection at the lab-start failure wrapper.
- Appended the workshop-friendly `aptl lab stop` / `aptl lab stop -v` recovery hint to matching startup failures.
- Added a regression test for the ACES/backend stale-network error shape.
- Added the issue 621 changelog fragment.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- `uv run pytest -n auto -k "stale_realization_networks or test_start_containers_preserves_scenario_path_on_soc_retry" tests/test_lab.py`
- `pre-commit run --all-files`
- `uv run pytest -n auto -k "not integration"`
- `uv run pytest -n auto tests/test_techvault_static_gate.py -m integration`

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #621 <- src/aptl/core/lab.py
- TESTS: Issue #621 <- tests/test_lab.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/621.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
