### PR TITLE
fix: pin lab status compose project

### DIFF
--- a/changelog.d/622.fixed.md
+++ b/changelog.d/622.fixed.md
@@ -1,0 +1,1 @@
+**Fixed `aptl lab status` for non-`aptl` checkout directories.** Text status now queries the configured Compose project instead of deriving a different project name from the working directory.

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -238,7 +238,8 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
         Returns:
             LabStatus with container information.
         """
-        cmd = ["docker", "compose", "ps", "--format", "json"]
+        cmd = self._build_command("ps", profiles=[])
+        cmd.extend(["--format", "json"])
 
         result = self._run(cmd)
 

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -893,6 +893,23 @@ class TestDockerComposeBackend:
         assert status.running is True
         assert len(status.containers) == 1
 
+    def test_status_uses_configured_project_name(self, tmp_path):
+        backend = self._make_backend(tmp_path / "aptl-workshop-main.h9Jare")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='[{"Name":"aptl-victim","State":"running"}]',
+                stderr="",
+            )
+            status = backend.status()
+
+        assert status.running is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ["docker", "compose", "-p", "test"]
+        assert cmd[-3:] == ["ps", "--format", "json"]
+        assert mock_run.call_args[1]["cwd"] == tmp_path / "aptl-workshop-main.h9Jare"
+
     def test_status_parses_ndjson(self, tmp_path):
         backend = self._make_backend(tmp_path)
         ndjson = (


### PR DESCRIPTION
## Summary

Pins `DockerComposeBackend.status()` to the configured Compose project so text status sees the containers started by `aptl lab start` from checkout directories whose basename is not `aptl`.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #622

## ADR Impact

- ADR-021

## Changes

- Route backend status through the existing Compose command builder so `docker compose ps` includes `-p <project_name>`.
- Add a regression test covering a workshop-style checkout directory with a configured project name.
- Add the issue 622 changelog fragment.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Passed `pre-commit run --all-files`; passed `PATH="$PWD/.venv/bin:$PATH" pytest -n auto -k "not integration" && PATH="$PWD/.venv/bin:$PATH" pytest -n auto tests/test_techvault_static_gate.py -m integration`; passed focused status tests.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #622 <- src/aptl/core/deployment/docker_compose.py
- TESTS: Issue #622 <- tests/test_deployment_backend.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/622.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
