### PR TITLE
fix: show lab start progress

### DIFF
--- a/changelog.d/624.fixed.md
+++ b/changelog.d/624.fixed.md
@@ -1,0 +1,1 @@
+Show live `aptl lab start` phase and readiness progress during long startup work.

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -89,6 +89,11 @@ def _emit_lab_access_summary(project_dir: Path) -> None:
     typer.echo("    ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027")
 
 
+def _emit_lab_start_progress(message: str) -> None:
+    """Print participant-facing startup progress."""
+    typer.echo(f"[lab start] {message}")
+
+
 def _confirm_destructive(skip_prompt: bool) -> bool:
     """Confirm a volume-destroying action; return False if the operator aborts.
 
@@ -199,12 +204,14 @@ def start(
             remove_volumes=True,
             skip_seed=skip_seed,
             scenario_path=selected_scenario,
+            progress=_emit_lab_start_progress,
         )
     else:
         result = orchestrate_lab_start(
             project_dir,
             skip_seed=skip_seed,
             scenario_path=selected_scenario,
+            progress=_emit_lab_start_progress,
         )
 
     _render_start_result(result)

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -83,6 +83,8 @@ if TYPE_CHECKING:
 
 log = get_logger("lab")
 
+ProgressCallback = Callable[[str], None]
+
 _STALE_NETWORK_RECOVERY_HINT = (
     "Run `aptl lab stop` and retry, or `aptl lab stop -v` "
     "if you need a clean lab."
@@ -367,6 +369,7 @@ def clean_boot_lab(
     skip_seed: bool = False,
     scenario_path: Optional[Path] = None,
     backend: Optional["DeploymentBackend"] = None,
+    progress: ProgressCallback | None = None,
 ) -> LabResult:
     """Boot the lab into a guaranteed clean state (RNG-001).
 
@@ -397,11 +400,14 @@ def clean_boot_lab(
         scenario_path: Optional selected ACES SDL scenario path.
         backend: Optional pre-created deployment backend, forwarded to the
             teardown so callers that already resolved one avoid a re-create.
+        progress: Optional callback for participant-facing startup updates.
 
     Returns:
         LabResult — the boot outcome on success, or a fatal ``FAILED``
         result carrying the redacted cleanup error when teardown fails.
     """
+    if progress is not None:
+        progress("Stopping the existing lab before clean boot.")
     stop_result = stop_lab(
         remove_volumes=remove_volumes,
         project_dir=project_dir,
@@ -421,6 +427,7 @@ def clean_boot_lab(
         project_dir,
         skip_seed=skip_seed,
         scenario_path=scenario_path,
+        progress=progress,
     )
 
 
@@ -580,6 +587,7 @@ class _LabStartContext(object):
     project_dir: Path
     skip_seed: bool
     scenario_path: Path | None = None
+    progress: ProgressCallback | None = None
     raw_env: dict[str, str] = field(default_factory=dict)
     env: "EnvVars | None" = None
     config: "AptlConfig | None" = None
@@ -1180,6 +1188,7 @@ def _step_wait_for_services(ctx: _LabStartContext) -> LabResult | None:
         timeout=300,
         interval=10,
         service_name="Wazuh Indexer",
+        progress=ctx.progress,
     )
     if not indexer_result.ready:
         # Indexer is the SIEM store — without it, detections never land.
@@ -1208,6 +1217,7 @@ def _step_wait_for_services(ctx: _LabStartContext) -> LabResult | None:
         timeout=120,
         interval=5,
         service_name="Wazuh Manager API",
+        progress=ctx.progress,
     )
     if not manager_result.ready:
         _emit_diagnostic(
@@ -1288,6 +1298,7 @@ def _step_test_ssh(ctx: _LabStartContext) -> LabResult | None:
             timeout=60,
             interval=5,
             service_name=f"SSH ({name})",
+            progress=ctx.progress,
         )
         if ssh_wait.ready:
             log.info("SSH to %s is ready", name)
@@ -1816,11 +1827,43 @@ _LAB_START_STEPS = (
     _step_sync_mcp_config,
 )
 
+_LAB_START_PROGRESS_MESSAGES = {
+    "_step_load_env": "Preparing environment and credentials.",
+    "_step_load_config": "Loading lab configuration.",
+    "_step_ensure_ssh_keys": "Preparing SSH keys.",
+    "_step_check_sysreqs": "Checking host requirements.",
+    "_step_sync_credentials": "Rendering service configuration.",
+    "_step_seed_suricata_volumes": "Preparing Suricata runtime volumes.",
+    "_step_generate_certs": "Preparing Wazuh Indexer certificates.",
+    "_step_generate_soc_certs": "Preparing SOC TLS certificates.",
+    "_step_check_bind_mounts": "Checking bind-mount sources.",
+    "_step_pull_images": "Pre-pulling high-latency SOC images.",
+    "_step_start_containers": (
+        "Starting containers with Docker Compose. First startup can take "
+        "several minutes while images build."
+    ),
+    "_step_wait_for_services": "Waiting for Wazuh services to become ready.",
+    "_step_test_ssh": "Testing SSH reachability.",
+    "_step_capture_snapshot": "Capturing a range snapshot.",
+    "_step_write_run_record": "Writing the run reproducibility record.",
+    "_step_pin_terminal_host_keys": "Pinning terminal SSH host keys.",
+    "_step_build_mcps": "Building local MCP server artifacts.",
+    "_step_seed_soc": "Seeding SOC tools.",
+    "_step_sync_mcp_config": "Refreshing MCP client configuration.",
+}
+
+
+def _emit_progress(ctx: _LabStartContext, message: str) -> None:
+    """Emit a participant-facing progress update when a caller opted in."""
+    if ctx.progress is not None:
+        ctx.progress(message)
+
 
 def orchestrate_lab_start(
     project_dir: Path,
     skip_seed: bool = False,
     scenario_path: Path | None = None,
+    progress: ProgressCallback | None = None,
 ) -> LabResult:
     """Orchestrate the complete lab startup process.
 
@@ -1834,6 +1877,7 @@ def orchestrate_lab_start(
         project_dir: Root directory of the APTL project.
         skip_seed: If True, skip SOC tool seeding (Step 13).
         scenario_path: Optional selected ACES SDL scenario path.
+        progress: Optional callback for participant-facing startup updates.
 
     Returns:
         LabResult indicating overall success or failure.
@@ -1843,9 +1887,13 @@ def orchestrate_lab_start(
         project_dir=project_dir,
         skip_seed=skip_seed,
         scenario_path=scenario_path,
+        progress=progress,
     )
 
     for step in _LAB_START_STEPS:
+        progress_message = _LAB_START_PROGRESS_MESSAGES.get(step.__name__)
+        if progress_message:
+            _emit_progress(ctx, progress_message)
         try:
             result = step(ctx)
         except icontract.ViolationError:

--- a/src/aptl/core/services.py
+++ b/src/aptl/core/services.py
@@ -14,6 +14,8 @@ from aptl.utils.logging import get_logger
 
 log = get_logger("services")
 
+ProgressCallback = Callable[[str], None]
+
 
 @dataclass
 class ServiceResult:
@@ -32,6 +34,8 @@ def wait_for_service(
     *,
     time_source: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
+    progress: ProgressCallback | None = None,
+    progress_interval: int = 30,
 ) -> ServiceResult:
     """Poll a service until it becomes ready or timeout is exceeded.
 
@@ -44,6 +48,8 @@ def wait_for_service(
         time_source: Monotonic clock, injectable so tests drive the deadline
             with an explicit value sequence instead of patching the module.
         sleep: Sleep function, injectable so tests don't actually block.
+        progress: Optional callback for participant-facing progress updates.
+        progress_interval: Minimum seconds between progress messages.
 
     Returns:
         ServiceResult indicating whether the service became ready and
@@ -51,6 +57,8 @@ def wait_for_service(
     """
     start = time_source()
     deadline = start + timeout
+    next_progress_elapsed = 0.0
+    bounded_progress_interval = max(progress_interval, interval)
 
     log.info("Waiting for %s (timeout=%ds, interval=%ds)", service_name, timeout, interval)
 
@@ -64,8 +72,14 @@ def wait_for_service(
             log.debug("%s check raised %s: %s", service_name, type(exc).__name__, exc)
 
         now = time_source()
+        elapsed = max(0.0, now - start)
+        if progress is not None and elapsed >= next_progress_elapsed:
+            progress(
+                f"Readiness: {service_name} still waiting "
+                f"({int(elapsed)}/{timeout}s)."
+            )
+            next_progress_elapsed = elapsed + bounded_progress_interval
         if now >= deadline:
-            elapsed = now - start
             log.warning("%s timed out after %.1fs", service_name, elapsed)
             return ServiceResult(
                 ready=False,

--- a/src/aptl/core/services.py
+++ b/src/aptl/core/services.py
@@ -15,6 +15,7 @@ from aptl.utils.logging import get_logger
 log = get_logger("services")
 
 ProgressCallback = Callable[[str], None]
+_PROGRESS_INTERVAL_SECONDS = 30
 
 
 @dataclass
@@ -35,7 +36,6 @@ def wait_for_service(
     time_source: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
     progress: ProgressCallback | None = None,
-    progress_interval: int = 30,
 ) -> ServiceResult:
     """Poll a service until it becomes ready or timeout is exceeded.
 
@@ -49,7 +49,6 @@ def wait_for_service(
             with an explicit value sequence instead of patching the module.
         sleep: Sleep function, injectable so tests don't actually block.
         progress: Optional callback for participant-facing progress updates.
-        progress_interval: Minimum seconds between progress messages.
 
     Returns:
         ServiceResult indicating whether the service became ready and
@@ -58,7 +57,7 @@ def wait_for_service(
     start = time_source()
     deadline = start + timeout
     next_progress_elapsed = 0.0
-    bounded_progress_interval = max(progress_interval, interval)
+    bounded_progress_interval = max(_PROGRESS_INTERVAL_SECONDS, interval)
 
     log.info("Waiting for %s (timeout=%ds, interval=%ds)", service_name, timeout, interval)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ We test our CLI wiring, not typer internals.
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 from typer.testing import CliRunner
@@ -214,6 +214,7 @@ class TestLabStartCommand:
             tmp_path,
             skip_seed=False,
             scenario_path=None,
+            progress=ANY,
         )
 
     def test_start_accepts_catalog_scenario_id(self, runner, mocker, tmp_path):
@@ -246,6 +247,7 @@ class TestLabStartCommand:
             tmp_path,
             skip_seed=False,
             scenario_path=selected,
+            progress=ANY,
         )
 
     def test_start_accepts_explicit_scenario_path(self, runner, mocker, tmp_path):
@@ -285,7 +287,28 @@ class TestLabStartCommand:
             tmp_path,
             skip_seed=False,
             scenario_path=selected,
+            progress=ANY,
         )
+
+    def test_start_prints_progress_updates(self, runner, mocker):
+        """The CLI should surface progress emitted by the startup path."""
+        from aptl.cli.main import app
+        from aptl.core.lab import LabResult
+        from aptl.core.lab_types import StartupOutcome
+
+        def fake_orchestrate(_project_dir, **kwargs):
+            kwargs["progress"]("Starting containers with Docker Compose.")
+            return LabResult(success=True, outcome=StartupOutcome.READY)
+
+        mocker.patch(
+            "aptl.cli.lab.orchestrate_lab_start",
+            side_effect=fake_orchestrate,
+        )
+
+        result = runner.invoke(app, ["lab", "start"])
+
+        assert result.exit_code == 0
+        assert "[lab start] Starting containers with Docker Compose." in result.stdout
 
     def test_start_rejects_both_scenario_selectors(self, runner, mocker, tmp_path):
         """Catalog id and explicit path selectors are mutually exclusive."""
@@ -335,6 +358,7 @@ class TestLabStartCommand:
             remove_volumes=True,
             skip_seed=False,
             scenario_path=None,
+            progress=ANY,
         )
 
     def test_start_clean_aborts_without_confirmation(self, runner, mocker, tmp_path):

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -369,9 +369,16 @@ class TestCleanBootLab:
 
         monkeypatch.setattr(lab, "stop_lab", lambda **k: LabResult(success=True))
 
-        def fake_start(project_dir, *, skip_seed=False, scenario_path=None):
+        def fake_start(
+            project_dir,
+            *,
+            skip_seed=False,
+            scenario_path=None,
+            progress=None,
+        ):
             captured["skip_seed"] = skip_seed
             captured["scenario_path"] = scenario_path
+            captured["progress"] = progress
             return LabResult(success=True, outcome=StartupOutcome.READY)
 
         monkeypatch.setattr(lab, "orchestrate_lab_start", fake_start)
@@ -379,7 +386,33 @@ class TestCleanBootLab:
         scenario = tmp_path / "scenario.yaml"
         clean_boot_lab(tmp_path, skip_seed=True, scenario_path=scenario)
 
-        assert captured == {"skip_seed": True, "scenario_path": scenario}
+        assert captured == {
+            "skip_seed": True,
+            "scenario_path": scenario,
+            "progress": None,
+        }
+
+    def test_clean_boot_forwards_progress_to_start(self, monkeypatch, tmp_path):
+        """Clean boot should let CLI callers keep the same progress stream."""
+        from aptl.core import lab
+        from aptl.core.lab import clean_boot_lab
+        from aptl.core.lab_types import LabResult, StartupOutcome
+
+        progress = MagicMock()
+        captured = {}
+
+        monkeypatch.setattr(lab, "stop_lab", lambda **k: LabResult(success=True))
+
+        def fake_start(project_dir, **kwargs):
+            captured["progress"] = kwargs["progress"]
+            return LabResult(success=True, outcome=StartupOutcome.READY)
+
+        monkeypatch.setattr(lab, "orchestrate_lab_start", fake_start)
+
+        clean_boot_lab(tmp_path, progress=progress)
+
+        assert captured["progress"] is progress
+        progress.assert_any_call("Stopping the existing lab before clean boot.")
 
     def test_clean_boot_remove_volumes_false_honored(self, monkeypatch, tmp_path):
         """The cleanup policy is a knob: remove_volumes=False is forwarded."""
@@ -1040,6 +1073,23 @@ class TestOrchestrateLabStart:
         mocks["certs"].assert_called_once()
         mocks["start"].assert_called_once()
         mocks["capture_snapshot"].assert_called_once()
+
+    def test_orchestrate_emits_progress_when_requested(self, mocker, tmp_path):
+        """A supplied progress callback should receive user-facing startup phases."""
+        from aptl.core.lab import orchestrate_lab_start
+
+        self._patch_all_steps(mocker, tmp_path)
+        progress = MagicMock()
+
+        result = orchestrate_lab_start(tmp_path, progress=progress)
+
+        assert result.success is True
+        progress.assert_any_call("Loading lab configuration.")
+        progress.assert_any_call(
+            "Starting containers with Docker Compose. First startup can take "
+            "several minutes while images build."
+        )
+        progress.assert_any_call("Waiting for Wazuh services to become ready.")
 
     def test_orchestrates_selected_scenario_path(self, mocker, tmp_path):
         """Selected ACES SDL paths should reach the startup handoff."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,7 +6,7 @@ module, so a drift in the clock-call count fails loudly via StopIteration.
 """
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -149,6 +149,47 @@ class TestWaitForService:
         assert result.ready is False
         # Should have checked at most once before timing out
         assert check_fn.call_count <= 1
+
+    def test_emits_progress_on_bounded_cadence_when_requested(self):
+        """Optional progress reports should name the service and elapsed timeout."""
+        from aptl.core.services import wait_for_service
+
+        check_fn = MagicMock(side_effect=[False, False, False, True])
+        progress = MagicMock()
+
+        result = wait_for_service(
+            check_fn=check_fn,
+            timeout=120,
+            interval=10,
+            service_name="Wazuh Indexer",
+            time_source=iter([0.0, 5.0, 20.0, 35.0, 45.0]).__next__,
+            sleep=lambda _seconds: None,
+            progress=progress,
+            progress_interval=30,
+        )
+
+        assert result.ready is True
+        assert progress.call_args_list == [
+            call("Readiness: Wazuh Indexer still waiting (5/120s)."),
+            call("Readiness: Wazuh Indexer still waiting (35/120s)."),
+        ]
+
+    def test_progress_is_silent_by_default(self):
+        """The progress hook is opt-in for programmatic callers."""
+        from aptl.core.services import wait_for_service
+
+        check_fn = MagicMock(side_effect=[False, True])
+
+        result = wait_for_service(
+            check_fn=check_fn,
+            timeout=60,
+            interval=5,
+            service_name="test-service",
+            time_source=iter([0.0, 5.0, 10.0]).__next__,
+            sleep=lambda _seconds: None,
+        )
+
+        assert result.ready is True
 
 
 class TestCheckIndexerReady:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -165,7 +165,6 @@ class TestWaitForService:
             time_source=iter([0.0, 5.0, 20.0, 35.0, 45.0]).__next__,
             sleep=lambda _seconds: None,
             progress=progress,
-            progress_interval=30,
         )
 
         assert result.ready is True


### PR DESCRIPTION
## Summary

Adds participant-facing progress output for `aptl lab start` so long Compose startup and readiness polling no longer appear hung during first-run workshop setup.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #624

## ADR Impact

- ADR-021

## Changes

- Wire the lab CLI to print startup progress messages through an optional core progress callback.
- Emit high-level orchestration phases before each lab-start step, including a first-start notice before Docker Compose work begins.
- Add bounded readiness polling updates that include service name and elapsed timeout for Wazuh and SSH waits.
- Cover CLI progress output, clean-boot progress forwarding, orchestrator phase messages, and service polling cadence in tests.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused tests: `uv run pytest tests/test_services.py tests/test_cli.py::TestLabStartCommand tests/test_lab.py::TestCleanBootLab tests/test_lab.py::TestOrchestrateLabStart -q` (65 passed). Full gates: `pre-commit run --all-files` passed; `.venv/bin/pytest -n auto -k "not integration"` passed (1884 passed, 90 skipped); `PATH=/home/atomik/src/aptl3/.venv/bin:$PATH .venv/bin/pytest -n auto tests/test_techvault_static_gate.py -m integration` passed (4 passed).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #624 <- src/aptl/cli/lab.py, Issue #624 <- src/aptl/core/lab.py, Issue #624 <- src/aptl/core/services.py
- TESTS: Issue #624 <- tests/test_cli.py, Issue #624 <- tests/test_lab.py, Issue #624 <- tests/test_services.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/624.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
