### PR TITLE
refactor: manage __version__ as a release-please literal (#647)

### DIFF
--- a/src/aptl/__init__.py
+++ b/src/aptl/__init__.py
@@ -1,11 +1,6 @@
 """Advanced Purple Team Lab CLI."""
 
-from importlib.metadata import PackageNotFoundError, version as _version
-
-try:
-    # Version lives in pyproject.toml (managed by release-please); read it from
-    # installed metadata so there is one source of truth.
-    __version__ = _version("aptl")
-except PackageNotFoundError:
-    # Running from a source tree without installed package metadata.
-    __version__ = "0.0.0"
+# Version is managed by release-please, which bumps this literal in lockstep
+# with pyproject.toml on every release. A fresh clone therefore shows the last
+# released version.
+__version__ = "3.0.10"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,30 +1,10 @@
-"""Version resolution in aptl/__init__.py."""
+"""Version exposure in aptl/__init__.py."""
 
 from __future__ import annotations
 
-import importlib
-import importlib.metadata as _md
 
-import pytest
-
-
-def test_version_resolves_from_installed_metadata() -> None:
+def test_version_is_populated() -> None:
     import aptl
 
     assert aptl.__version__
-    assert aptl.__version__ != "0.0.0"
-
-
-def test_version_falls_back_when_not_installed() -> None:
-    import aptl
-
-    with pytest.MonkeyPatch.context() as mp:
-        def _raise(name: str) -> str:
-            raise _md.PackageNotFoundError(name)
-
-        mp.setattr(_md, "version", _raise)
-        importlib.reload(aptl)
-        assert aptl.__version__ == "0.0.0"
-
-    # Restore the real version for the rest of the suite.
-    importlib.reload(aptl)
+    assert aptl.__version__[0].isdigit()


### PR DESCRIPTION
release-please's Python updater rewrites version-shaped literals in src/aptl/__init__.py. Our importlib.metadata fallback sentinel ("0.0.0") matched, so a release bump rewrote it and broke the fallback assertion in test_version.py. Use a plain `__version__` literal that release-please maintains in lockstep with pyproject.toml instead; a fresh clone now shows the last released version, and there is no sentinel to clobber.