### PR TITLE
feat: bundle lab assets so pipx install runs a lab without a clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,35 @@ One `aptl lab start` brings up: a fictional company's infrastructure (AD, web, D
 
 ## Quick Start
 
+Install the released CLI and materialize a lab, no clone required:
+
 ```bash
-git clone https://github.com/Brad-Edwards/aptl.git
-cd aptl
 pipx install aptl-labs          # the released CLI, isolated in its own environment
+aptl lab init my-lab            # materialize the lab assets into ./my-lab
+cd my-lab
 aptl lab start
 ```
 
-You still clone the repo when you install the published package: `aptl lab
-start` reads the lab's Compose topology, scenarios, and config templates from
-the checkout. [pipx](https://pipx.pypa.io/) installs the CLI into its own
-virtualenv, so the system-`pip` block on modern Debian/Ubuntu/WSL2 hosts
+`aptl lab init <dir>` copies the bundled lab assets (the Compose topology,
+scenarios, config templates, and container build contexts) out of the
+installed package into `<dir>`, which becomes your lab project directory. The
+published wheel ships those assets, so a PyPI install alone can run a lab.
+[pipx](https://pipx.pypa.io/) installs the CLI into its own virtualenv, so the
+system-`pip` block on modern Debian/Ubuntu/WSL2 hosts
 ([PEP 668](https://peps.python.org/pep-0668/)) never applies. Install pipx with
 `sudo apt install pipx` if you do not have it.
 
-To run from source instead (for development), replace the `pipx` line with a
+To run from source instead (for development), clone the repo and use a
 virtualenv editable install (the `python3 -m venv` step needs `python3-venv` on
-Debian/Ubuntu):
+Debian/Ubuntu). The checkout is itself the project directory, so no `lab init`
+is needed:
 
 ```bash
+git clone https://github.com/Brad-Edwards/aptl.git
+cd aptl
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
+aptl lab start
 ```
 
 `aptl lab start` creates `.env` automatically when it is missing and replaces
@@ -117,7 +125,7 @@ flowchart TD
     Scenario -.->|logs / telemetry| SOC
 ```
 
-The scenario environment is whatever the SDL scenario defines—the default `techvault-operational` topology (AD, web, DB, file share, DNS, mail, victims) is one shape, and [other scenarios](#scenarios) compose different ones. Component-by-component breakdown: [docs/architecture/index.md](docs/architecture/index.md).
+The scenario environment is whatever the SDL scenario defines. The default `techvault-operational` topology (AD, web, DB, file share, DNS, mail, victims) is one shape, and [other scenarios](#scenarios) compose different ones. Component-by-component breakdown: [docs/architecture/index.md](docs/architecture/index.md).
 
 ## Scenarios
 

--- a/containers/misp-suricata-sync/Dockerfile
+++ b/containers/misp-suricata-sync/Dockerfile
@@ -14,6 +14,11 @@ WORKDIR /app
 
 COPY pyproject.toml /app/
 COPY README.md /app/
+# hatch_build.py is a declared wheel build hook in pyproject.toml, so
+# `pip install .` requires it in the build context (issue #659). It no-ops
+# here because this minimal context has no docker-compose.yml, so no lab
+# assets are bundled into the service image.
+COPY hatch_build.py /app/
 COPY src /app/src
 
 RUN pip install --no-cache-dir . \

--- a/docs/architecture/dep-008-self-contained-lab-assets-preflight.md
+++ b/docs/architecture/dep-008-self-contained-lab-assets-preflight.md
@@ -1,0 +1,172 @@
+# DEP-008 Self-Contained Lab Assets Preflight
+
+This note is the architecture preflight for DEP-008 / issue #659. It is
+guidance, not an implementation plan. Existing ADRs remain binding: ADR-007
+owns the Python CLI control plane, ADR-013/ADR-023/ADR-037 own deployment
+backends, ADR-025 owns `aptl.json`, ADR-028 owns generated runtime config,
+ADR-029 owns secret handling, ADR-030 owns lab result envelopes, ADR-031 owns
+orchestration contracts, ADR-043 owns Suricata runtime seeding, and ADR-046
+owns dynamic ACES realization.
+
+## Architecture Decisions
+
+- Treat packaged lab assets as immutable source inputs and the initialized lab
+  directory as the mutable runtime project. Docker Compose, build contexts,
+  generated config, `.env`, keys, run archives, and `.aptl/` state operate only
+  against the materialized project directory.
+- Add one canonical asset materialization boundary for the wheel-owned source
+  tree. Do not scatter `importlib.resources` lookups across `certs.py`,
+  `env.py`, `credentials.py`, `scenario_catalog.py`, `suricata_seed.py`,
+  `snapshot.py`, ACES adapters, or deployment code.
+- `aptl lab init <dir>` should materialize every tracked source asset required
+  by the public startup path: `aptl.json`, `.env.example`, `docker-compose.yml`,
+  `generate-indexer-certs.yml`, `config/certs.yml`, source `config/`
+  templates/rules, `scenarios/`, `containers/`, and any scripts or MCP build
+  inputs that `docker-compose.yml` or `_LAB_START_STEPS` still reference.
+- Never package local generated state: `.env`, `.aptl/`, `keys/`, `.mcp.json`,
+  run archives, `config/soc_certs/`, `config/lab-ssh/`, or
+  `config/wazuh_indexer_ssl_certs/`. Those remain produced by the existing
+  startup steps.
+- `aptl lab start` continues to run the existing project-rooted startup
+  sequence. It may default to `Path(".")` for operator convenience, but the
+  resolved directory must be a materialized project root, not a repository clone
+  assumption and not an `importlib.resources` traversable pretending to be a
+  Docker build context.
+
+## Cross-Cutting Concerns To Reuse
+
+- CLI and project root: `src/aptl/cli/lab.py`, `resolve_config_for_cli()`,
+  `APTL_PROJECT_DIR`, and the existing `--project-dir` convention.
+- Lab lifecycle: `orchestrate_lab_start()`, `_LabStartContext`,
+  `_LAB_START_STEPS`, `_check_bind_mounts()`, `LabResult`,
+  `StartupOutcome`, and `StartupDiagnostic`.
+- Config and env: `AptlConfig`, `load_config()`, `find_config()`,
+  `load_dotenv()`, `hydrate_dotenv()`, `EnvVars`, `env_vars_from_dict()`,
+  `find_placeholder_env_values()`, and `contains_placeholder()`.
+- Asset consumers: `sync_dashboard_config()`, `sync_manager_config()`,
+  `build_suricata_volume_seeds()`, `ensure_ssl_certs()`,
+  `ensure_soc_certs()`, `resolve_scenario_selection()`,
+  `load_scenario_catalog()`, `load_compose_profile_index()`, and
+  `capture_snapshot()`.
+- Deployment boundary: `DeploymentBackend`, `DockerComposeBackend`,
+  `SSHComposeBackend`, compose-project scoping, backend timeouts, typed seed
+  operations, and argv-list subprocess construction.
+- Packaging/release: Hatch config in `pyproject.toml`, the release workflow's
+  `python -m build`, `.gitignore`, and tracked-source selection via
+  `git ls-files` or an equivalent explicit manifest.
+- Observability/persistence: `get_logger()`, `redact()`,
+  `RangeSnapshot.to_dict()`, `LocalRunStore.write_json()`,
+  `write_jsonl()`, and `append_jsonl()`.
+
+## Security And Validation Layers
+
+- **Package asset gate:** the wheel should include only the explicit source
+  asset set. Build/package tests must prove generated secret-bearing paths and
+  ignored local state are absent from both sdist and wheel.
+- **Materialization path gate:** destination paths must reject absolute paths,
+  `..` components, symlinked output chains, and copy targets outside the chosen
+  project root before any write. Reuse or extract the containment primitives
+  already proven in `aptl.core.credentials` / `_soc_ca_io`.
+- **Overwrite gate:** initialization must not silently overwrite `.env`,
+  `.aptl/`, generated keys/certs, run archives, or user-edited project files.
+  Any replacement policy must be explicit and typed at the CLI boundary.
+- **First-party config shape:** durable knobs stay in `AptlConfig` with
+  `extra="forbid"`. Do not add a second JSON/YAML config schema for asset roots
+  or package manifests unless the canonical config model owns it.
+- **Environment binding:** generated `.env` values and placeholders continue
+  through `hydrate_dotenv()`, `load_dotenv()`, `EnvVars`, and
+  `find_placeholder_env_values()`. Package data must never carry real `.env`
+  secrets.
+- **Scenario gate:** curated scenario IDs and explicit paths continue through
+  `ScenarioCatalog` and the ACES parser. Do not revive a local scenario schema
+  or let UI/API code parse `scenarios/` directly.
+- **Docker/OS boundary:** Docker Compose runs with `cwd` set to the materialized
+  project. Build contexts and bind mounts must be real filesystem paths. Do not
+  call raw Docker from a materializer helper or pass secrets in process argv.
+- **Remote backend boundary:** existing SSH-remote refusals for locally
+  generated artifacts remain valid until the backend grows explicit remote
+  materialization. Do not pretend package resources copied locally are visible
+  to a remote Docker daemon.
+- **Error envelopes:** init/start failures use existing Typer exit and
+  `LabResult` shapes. Messages may name the artifact or validation layer, but
+  not `.env` values, generated config contents, private keys, raw Docker stderr,
+  or raw `icontract` messages.
+- **Persistence boundary:** initialized source assets are not run evidence.
+  Runtime snapshots and run records continue through `RangeSnapshot.to_dict()`
+  and `LocalRunStore` redacting writers.
+
+## Extensibility Seam
+
+The seam is the asset source plus materialized project root, parameterized by
+bundle version and an explicit asset manifest. The next reasonable variations
+should fit there without re-editing every consumer:
+
+- a different packaged asset version;
+- a smaller scenario/profile bundle;
+- a future published-image mode that omits local build contexts;
+- backend-owned remote materialization for SSH Compose;
+- validation of package contents against compose bind mounts and startup-step
+  source references.
+
+The seam is not a new deployment backend, scenario schema, run archive schema,
+or Docker command passthrough.
+
+## Whole-Repo Surface
+
+- `pyproject.toml`, release workflow, built sdist/wheel, and package-data
+  inclusion tests.
+- `docker-compose.yml`, `generate-indexer-certs.yml`, Compose build contexts,
+  bind mounts, named volumes, profiles, and project labels.
+- Source assets under `aptl.json`, `.env.example`, `config/`, `scenarios/`,
+  `containers/`, `scripts/`, and `mcp/` when referenced by startup.
+- Generated/runtime state under `.aptl/`, `.env`, `keys/`,
+  `config/soc_certs/`, `config/lab-ssh/`,
+  `config/wazuh_indexer_ssl_certs/`, Docker named volumes, and run archives.
+- `src/aptl/cli/lab.py`, `src/aptl/core/lab.py`,
+  `src/aptl/core/config.py`, `src/aptl/core/env.py`,
+  `src/aptl/core/credentials.py`, `src/aptl/core/suricata_seed.py`,
+  `src/aptl/core/certs.py`, `src/aptl/core/soc_ca.py`,
+  `src/aptl/core/deployment/`, `src/aptl/core/snapshot.py`,
+  `src/aptl/core/scenario_catalog.py`, and `src/aptl/backends/aces*.py`.
+- Host/runtime layers: local filesystem permissions, symlinks, subprocess
+  argv, Docker daemon cwd, SSH Docker transport, image build cache, and package
+  installer layout.
+- Repo gates: `.gc/plan-rules.md`, `pytest`, `pre-commit run --all-files`, and
+  a clean `aptl lab stop -v && aptl lab start` validation for compose/config
+  changes.
+
+## Gotchas And Anti-Patterns
+
+- Treating package data, materialized source assets, generated runtime state,
+  Docker volumes, and run evidence as one "asset" concept.
+- Running Docker Compose directly from `importlib.resources` or a wheel path
+  instead of a real initialized project directory.
+- Fixing only `docker-compose.yml` packaging while leaving `config/`,
+  `scenarios/`, `containers/`, `generate-indexer-certs.yml`, or startup scripts
+  repo-relative.
+- Copying ignored local secrets or generated certs into the wheel because they
+  exist on one developer machine.
+- Adding cwd fallbacks inside individual consumers instead of resolving one
+  project root and passing it through existing boundaries.
+- Duplicating path containment, env parsing, scenario validation, Docker
+  runners, result DTOs, or exception hierarchies.
+- Weakening `_check_bind_mounts()` because init is expected to have copied
+  files; it is still the startup guard that prevents Docker from creating
+  root-owned directories for missing sources.
+- Assuming raw `docker compose up` is supported on a fresh init directory before
+  `aptl lab start` has generated `.env`, certs, keys, rendered config, and
+  Suricata seed volumes.
+
+## Non-Goals
+
+- Do not implement DEP-008 in this preflight.
+- Do not redesign Docker Compose, ACES SDL, deployment backends, startup
+  readiness, Suricata rule semantics, SOC seeding, or run archive layout.
+- Do not switch to published prebuilt images unless a separate requirement
+  explicitly replaces local build contexts.
+- Do not make the wheel a store for generated runtime secrets, private keys,
+  local `.env`, or prior lab state.
+- Do not solve SSH-remote asset synchronization without a backend-owned remote
+  materialization design.
+- Do not require byte-identical regenerated credentials, certs, keys, Docker
+  object IDs, image layers, timestamps, or run records across initialized labs.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,5 +156,6 @@ The victim and kali containers publish no host ports; use
 
 ## Preflights
 
+- [DEP-008 Self-Contained Lab Assets](dep-008-self-contained-lab-assets-preflight.md)
 - [RNG-001 Ephemeral Environments](rng-001-ephemeral-environments-preflight.md)
 - [DEP-003 Ephemeral Lifecycle Policy](dep-003-ephemeral-lifecycle-preflight.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,25 +3,31 @@
 ## Python CLI (Recommended)
 
 ```bash
-git clone https://github.com/Brad-Edwards/aptl.git
-cd aptl
 pipx install aptl-labs
+aptl lab init my-lab
+cd my-lab
 aptl lab start
 ```
 
-Clone the repo even when you install the published package: `aptl lab start`
-reads the Compose topology, scenarios, and config templates from the checkout.
+The published wheel bundles the lab assets, so a PyPI install alone can run a
+lab, no clone required. `aptl lab init <dir>` copies the Compose topology,
+scenarios, config templates, and container build contexts out of the installed
+package into `<dir>`, which becomes your lab project directory.
 [pipx](https://pipx.pypa.io/) installs the CLI into its own virtualenv, so the
 [PEP 668](https://peps.python.org/pep-0668/) system-`pip` block on modern
 Debian/Ubuntu/WSL2 hosts never applies (`sudo apt install pipx` to get it).
 
-To develop against the source tree, install it editable in a virtualenv
-instead of the `pipx` line (needs `python3-venv` on Debian/Ubuntu; see
-[Prerequisites](prerequisites.md)):
+To develop against the source tree, clone the repo and install it editable in a
+virtualenv (needs `python3-venv` on Debian/Ubuntu; see
+[Prerequisites](prerequisites.md)). The checkout is itself the project
+directory, so no `lab init` is needed:
 
 ```bash
+git clone https://github.com/Brad-Edwards/aptl.git
+cd aptl
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
+aptl lab start
 ```
 
 `aptl lab start` creates `.env` automatically when it is missing and replaces

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -6,8 +6,11 @@
 - 20GB+ disk
 - Docker Engine 20.10+
 - Docker Compose 2.0+
-- Python 3.11+ (for CLI)
-- Git
+- Python 3.11+ (for the CLI)
+- Node.js 18+ and npm (for the MCP servers, the AI-agent control plane that
+  `aptl lab start` builds via `mcp/build-all-mcps.sh`; without them the lab
+  still boots but reports `degraded` with MCP servers unavailable)
+- Git (only for the from-source dev install; `pipx install aptl-labs` needs no clone)
 
 ## Install Docker
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -3,18 +3,20 @@
 ## Start Lab
 
 ```bash
-git clone https://github.com/Brad-Edwards/aptl.git
-cd aptl
 pipx install aptl-labs
+aptl lab init my-lab
+cd my-lab
 aptl lab start
 ```
 
-Clone the repo even with the published package: `aptl lab start` reads the
-Compose topology, scenarios, and config templates from the checkout.
-[pipx](https://pipx.pypa.io/) isolates the CLI in its own virtualenv, so the
-[PEP 668](https://peps.python.org/pep-0668/) system-`pip` block on modern
-Debian/Ubuntu/WSL2 hosts never applies (`sudo apt install pipx` to get it). To
-run from source instead, use a virtualenv editable install
+The published wheel bundles the lab assets, so a PyPI install alone can run a
+lab, no clone required. `aptl lab init <dir>` copies the Compose topology,
+scenarios, and config templates out of the installed package into `<dir>`, your
+lab project directory. [pipx](https://pipx.pypa.io/) isolates the CLI in its own
+virtualenv, so the [PEP 668](https://peps.python.org/pep-0668/) system-`pip`
+block on modern Debian/Ubuntu/WSL2 hosts never applies (`sudo apt install pipx`
+to get it). To run from source instead, clone the repo and use a virtualenv
+editable install
 (`python3 -m venv .venv && source .venv/bin/activate && pip install -e .`; needs
 `python3-venv`). See [Prerequisites](prerequisites.md).
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,118 @@
+"""Hatchling build hook: bundle git-tracked lab assets into the wheel.
+
+Issue #659 / DEP-008. The published ``aptl-labs`` wheel historically
+carried only ``src/aptl`` (the Python control plane), so a PyPI install
+still required a full ``git clone`` to obtain the assets a lab needs to
+build and run. This hook bundles every *git-tracked* asset a lab needs —
+``docker-compose.yml``, the scenario/config/container trees, the web
+frontend, helper scripts, and the Python source that several container
+images build from — into the wheel under ``aptl/_labdata/<relpath>`` so
+that ``pipx install aptl-labs`` + ``aptl lab init <dir>`` +
+``aptl lab start`` works without a clone. ``aptl.core.assets`` resolves
+the bundle via ``importlib.resources``.
+
+Only git-tracked files are bundled. That is the mechanism that keeps
+generated secrets and local state out of the distribution:
+``config/soc_certs``, ``config/lab-ssh``, ``config/wazuh_indexer_ssl_certs``,
+``keys/``, ``.aptl/`` and ``__pycache__`` are all gitignored and therefore
+never shipped. When git is unavailable (a wheel built from an sdist has
+no ``.git``), a walk fallback reproduces the same exclusions; the sdist
+itself only contains tracked files, so walking it yields the same set.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+def _load_manifest() -> Any:
+    """Load the dependency-free asset manifest by file path.
+
+    Loading the single file directly (rather than ``import aptl._asset_manifest``)
+    keeps the build hook working in a build environment that has neither the
+    package on ``sys.path`` nor the runtime dependencies installed, while still
+    sharing one source of truth with ``aptl.core.assets`` (issue #659).
+    """
+    manifest_path = Path(__file__).parent / "src" / "aptl" / "_asset_manifest.py"
+    spec = importlib.util.spec_from_file_location("_aptl_asset_manifest", manifest_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load asset manifest from {manifest_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_MANIFEST = _load_manifest()
+_ASSET_ROOTS: tuple[str, ...] = _MANIFEST.ASSET_ROOTS
+_LABDATA_PREFIX: str = _MANIFEST.LABDATA_PREFIX
+_EXCLUDED_DIR_NAMES: frozenset[str] = _MANIFEST.EXCLUDED_DIR_NAMES
+_EXCLUDED_SUFFIXES: tuple[str, ...] = _MANIFEST.EXCLUDED_SUFFIXES
+_DISTRIBUTION_MARKER: str = _MANIFEST.DISTRIBUTION_MARKER
+
+
+class CustomBuildHook(BuildHookInterface):
+    """Force-include the git-tracked lab-asset tree under ``aptl/_labdata``."""
+
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        root = Path(self.root)
+        # Only bundle when building the full lab distribution. Service
+        # container images (misp-suricata-sync, web API) build with a minimal
+        # context that copies only pyproject.toml/README.md/src/hatch_build.py
+        # and run `pip install .`; they must load this hook but must not pull
+        # the lab bundle into their wheel (issue #659 review).
+        if not (root / _DISTRIBUTION_MARKER).is_file():
+            return
+        force_include: dict[str, str] = build_data.setdefault("force_include", {})
+        for rel in self._iter_asset_files(root):
+            source = root / rel
+            target = f"{_LABDATA_PREFIX}/{rel.as_posix()}"
+            force_include[str(source)] = target
+
+    def _iter_asset_files(self, root: Path) -> Iterator[Path]:
+        tracked = self._git_tracked(root)
+        if tracked is not None:
+            yield from tracked
+            return
+        yield from self._walk(root)
+
+    @staticmethod
+    def _git_tracked(root: Path) -> list[Path] | None:
+        """Return tracked asset files, or ``None`` when git is unavailable."""
+        try:
+            completed = subprocess.run(
+                ["git", "ls-files", "-z", "--", *_ASSET_ROOTS],
+                cwd=root,
+                capture_output=True,
+                check=True,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            return None
+        rels = [Path(p) for p in completed.stdout.decode("utf-8").split("\0") if p]
+        return rels or None
+
+    @staticmethod
+    def _walk(root: Path) -> Iterator[Path]:
+        for entry in _ASSET_ROOTS:
+            base = root / entry
+            if base.is_file():
+                yield Path(entry)
+                continue
+            if not base.is_dir():
+                continue
+            for path in base.rglob("*"):
+                if not path.is_file():
+                    continue
+                rel = path.relative_to(root)
+                if any(part in _EXCLUDED_DIR_NAMES for part in rel.parts):
+                    continue
+                if path.suffix in _EXCLUDED_SUFFIXES:
+                    continue
+                yield rel

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -62,6 +62,15 @@ class CustomBuildHook(BuildHookInterface):
     PLUGIN_NAME = "custom"
 
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        # Editable installs (`pip install -e`) redirect imports to the source
+        # tree via a .pth; they must not materialize the bundle into
+        # site-packages, which would create a partial real `aptl/` package
+        # (only aptl/_labdata, no __init__.py/core) that shadows the editable
+        # redirect and breaks `import aptl.core` (issue #659). Dev/editable
+        # runtime resolves lab assets from the checkout via
+        # aptl.core.assets.checkout_root().
+        if version == "editable":
+            return
         root = Path(self.root)
         # Only bundle when building the full lab distribution. Service
         # container images (misp-suricata-sync, web API) build with a minimal

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -23,7 +23,9 @@ itself only contains tracked files, so walking it yields the same set.
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import subprocess
+import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -61,6 +63,10 @@ class CustomBuildHook(BuildHookInterface):
 
     PLUGIN_NAME = "custom"
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._staging_dir: Path | None = None
+
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
         # Editable installs (`pip install -e`) redirect imports to the source
         # tree via a .pth; they must not materialize the bundle into
@@ -79,11 +85,28 @@ class CustomBuildHook(BuildHookInterface):
         # the lab bundle into their wheel (issue #659 review).
         if not (root / _DISTRIBUTION_MARKER).is_file():
             return
+        # Stage assets into a temp dir so their *source* paths differ from the
+        # package's own files. hatchling dedupes force-include by source path,
+        # so mapping the real src/aptl/** files straight into aptl/_labdata
+        # would shadow the standard packages=["src/aptl"] mapping and drop the
+        # actual `aptl` package from the wheel (issue #659: `pipx install`
+        # produced a wheel with only aptl/_labdata and no aptl.cli/aptl.core).
+        # Staging keeps both mappings alive; finalize() removes the temp dir.
+        staging = Path(tempfile.mkdtemp(prefix="aptl-labdata-"))
+        self._staging_dir = staging
         force_include: dict[str, str] = build_data.setdefault("force_include", {})
         for rel in self._iter_asset_files(root):
-            source = root / rel
-            target = f"{_LABDATA_PREFIX}/{rel.as_posix()}"
-            force_include[str(source)] = target
+            staged = staging / rel
+            staged.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(root / rel, staged)
+            force_include[str(staged)] = f"{_LABDATA_PREFIX}/{rel.as_posix()}"
+
+    def finalize(
+        self, version: str, build_data: dict[str, Any], artifact_path: str
+    ) -> None:
+        if self._staging_dir is not None:
+            shutil.rmtree(self._staging_dir, ignore_errors=True)
+            self._staging_dir = None
 
     def _iter_asset_files(self, root: Path) -> Iterator[Path]:
         tracked = self._git_tracked(root)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - Overview: architecture/index.md
     - Networking: architecture/networking.md
     - Enterprise Infrastructure: architecture/enterprise-infrastructure.md
+    - DEP-008 Self-Contained Lab Assets Preflight: architecture/dep-008-self-contained-lab-assets-preflight.md
     - RNG-001 Ephemeral Environments Preflight: architecture/rng-001-ephemeral-environments-preflight.md
     - DEP-003 Ephemeral Lifecycle Policy Preflight: architecture/dep-003-ephemeral-lifecycle-preflight.md
   - Deployment: deployment.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,15 @@ docs = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/aptl"]
 
+# Bundle the git-tracked lab-asset tree (docker-compose.yml, scenarios/,
+# config/, containers/, web/, scripts/, and the source that container images
+# build from) into the wheel under aptl/_labdata/ so `pipx install aptl-labs`
+# + `aptl lab init` runs a lab without a git clone (issue #659 / DEP-008).
+# The hook ships only git-tracked files, which keeps generated secrets and
+# local state out of the distribution. See hatch_build.py.
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
 [tool.ruff]
 # Lint only the Python control-plane source. Tests, generated files, and
 # the (TypeScript) MCP / web trees are out of scope for this check.

--- a/src/aptl/_asset_manifest.py
+++ b/src/aptl/_asset_manifest.py
@@ -1,0 +1,76 @@
+"""Single source of truth for the bundled lab-asset manifest (DEP-008).
+
+This module is imported by *two* consumers that run in different
+environments, so it must stay dependency-free (standard library only):
+
+* ``aptl.core.assets`` (runtime) — decides what a source checkout
+  materializes into a lab project directory.
+* ``hatch_build.py`` (build time) — decides what the wheel ships under
+  ``aptl/_labdata/``. The build environment only has build backend
+  dependencies, so this module must not import pydantic, typer, or any
+  other runtime dependency.
+
+Keeping the manifest here means the wheel's bundled asset set and a
+checkout's materialized set can never drift.
+"""
+
+from __future__ import annotations
+
+# Top-level asset roots bundled into the wheel and materialized by
+# ``aptl lab init``. Each tracked file maps to the same relative path.
+# Derived from docker-compose.yml build contexts and bind mounts (issue
+# #659): several services build with ``context: .`` and
+# ``COPY pyproject.toml README.md src`` + ``pip install .`` (misp-suricata-sync,
+# web API), ``web/`` is its own build context, and ``scripts/`` is
+# bind-mounted. ``keys/`` and ``.aptl/`` are generated at lab start (zero
+# tracked files) and are intentionally absent.
+ASSET_ROOTS: tuple[str, ...] = (
+    "docker-compose.yml",
+    "generate-indexer-certs.yml",
+    ".env.example",
+    "pyproject.toml",
+    "README.md",
+    "hatch_build.py",
+    "src",
+    "scenarios",
+    "config",
+    "containers",
+    "web",
+    "scripts",
+)
+
+# Presence of this file marks a full lab-distribution build context. Minimal
+# package build contexts — e.g. the service container images that
+# ``COPY pyproject.toml README.md src`` then ``pip install .`` — do not carry
+# it, so the build hook skips asset bundling there (issue #659 review): those
+# images must still load the declared hook (hatch_build.py is copied in), but
+# must not pull the multi-megabyte lab bundle into a service wheel.
+DISTRIBUTION_MARKER = "docker-compose.yml"
+
+# Directory names never bundled even beneath a tracked root. Only consulted
+# by the no-git walk fallback; ``git ls-files`` already omits every one.
+# Mirrors the gitignored secret/state and dev-artifact directories so a
+# fallback selection cannot ship them.
+EXCLUDED_DIR_NAMES: frozenset[str] = frozenset(
+    {
+        "__pycache__",
+        "node_modules",
+        ".venv",
+        "dist",
+        "build",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+        ".hypothesis",
+        ".git",
+        "soc_certs",
+        "lab-ssh",
+        "wazuh_indexer_ssl_certs",
+    }
+)
+
+EXCLUDED_SUFFIXES: tuple[str, ...] = (".pyc", ".pyo")
+
+# Where the bundle lives inside the wheel / installed package.
+LABDATA_DIRNAME = "_labdata"
+LABDATA_PREFIX = f"aptl/{LABDATA_DIRNAME}"

--- a/src/aptl/_asset_manifest.py
+++ b/src/aptl/_asset_manifest.py
@@ -18,16 +18,25 @@ from __future__ import annotations
 
 # Top-level asset roots bundled into the wheel and materialized by
 # ``aptl lab init``. Each tracked file maps to the same relative path.
-# Derived from docker-compose.yml build contexts and bind mounts (issue
-# #659): several services build with ``context: .`` and
-# ``COPY pyproject.toml README.md src`` + ``pip install .`` (misp-suricata-sync,
-# web API), ``web/`` is its own build context, and ``scripts/`` is
-# bind-mounted. ``keys/`` and ``.aptl/`` are generated at lab start (zero
-# tracked files) and are intentionally absent.
+# Derived from docker-compose.yml build contexts and bind mounts plus the
+# host-side steps in ``aptl lab start`` (issue #659):
+#   - several services build with ``context: .`` and
+#     ``COPY pyproject.toml README.md src`` + ``pip install .``
+#     (misp-suricata-sync, web API), so those + ``hatch_build.py`` (a declared
+#     wheel build hook) are needed;
+#   - ``web/`` is its own build context and ``scripts/`` is bind-mounted;
+#   - ``mcp/`` holds ``build-all-mcps.sh`` and the MCP server sources that the
+#     ``build_mcps`` start step compiles (needs node/npm on the host);
+#   - ``.mcp.json.example`` seeds MCP client config; ``.dockerignore`` keeps
+#     build contexts lean.
+# ``keys/`` and ``.aptl/`` are generated at lab start (zero tracked files) and
+# are intentionally absent.
 ASSET_ROOTS: tuple[str, ...] = (
     "docker-compose.yml",
+    ".dockerignore",
     "generate-indexer-certs.yml",
     ".env.example",
+    ".mcp.json.example",
     "pyproject.toml",
     "README.md",
     "hatch_build.py",
@@ -37,6 +46,7 @@ ASSET_ROOTS: tuple[str, ...] = (
     "containers",
     "web",
     "scripts",
+    "mcp",
 )
 
 # Presence of this file marks a full lab-distribution build context. Minimal

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -8,6 +8,7 @@ import typer
 
 from aptl.cli import lifecycle
 from aptl.cli.continuity import continuity_audit
+from aptl.core.assets import AssetError, materialize
 from aptl.core.lab import (
     LabResult,
     clean_boot_lab,
@@ -141,6 +142,44 @@ def _render_start_result(result: LabResult) -> None:
             )
             if diag.operator_action:
                 typer.echo(f"      action: {diag.operator_action}")
+
+
+@app.command()
+def init(
+    directory: Path = typer.Argument(
+        ...,
+        help="Directory to materialize the lab project into (created if missing).",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite existing files in the target directory.",
+    ),
+) -> None:
+    """Materialize a self-contained lab project into DIRECTORY.
+
+    Copies the bundled lab assets (docker-compose.yml, scenarios, config,
+    containers, web, scripts, and the source that container images build
+    from) and writes a default aptl.json, so a `pipx install aptl-labs`
+    can run a lab without cloning the repository (DEP-008). After it
+    finishes, run `aptl lab start` from the initialized directory.
+    """
+    try:
+        result = materialize(directory, force=force)
+    except AssetError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(
+        f"Initialized lab project in {result.target_dir} "
+        f"({result.files_written} files)."
+    )
+    if result.config_created:
+        typer.echo(f"    wrote default {result.target_dir / 'aptl.json'}")
+    typer.echo("\nNext steps:")
+    typer.echo(f"    cd {result.target_dir}")
+    typer.echo("    aptl lab start")
 
 
 @app.command()

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -6,9 +6,8 @@ from typing import Optional
 
 import typer
 
-from aptl.cli import lifecycle
+from aptl.cli import lab_init, lifecycle
 from aptl.cli.continuity import continuity_audit
-from aptl.core.assets import AssetError, materialize
 from aptl.core.lab import (
     LabResult,
     clean_boot_lab,
@@ -31,6 +30,10 @@ app = typer.Typer(help="Lab lifecycle management.")
 # module stays focused on lifecycle commands. Register it under `lab`
 # so the command stays at `aptl lab continuity-audit` (no UX change).
 app.command("continuity-audit")(continuity_audit)
+
+# `init` (DEP-008) lives in aptl.cli.lab_init so this module stays the focused
+# lifecycle facade; registered here so the command remains `aptl lab init`.
+lab_init.register(app)
 
 # Ephemeral lifecycle policy commands (DEP-003) live in aptl.cli.lifecycle so
 # this module stays focused; register them under `lab` (no UX change:
@@ -142,44 +145,6 @@ def _render_start_result(result: LabResult) -> None:
             )
             if diag.operator_action:
                 typer.echo(f"      action: {diag.operator_action}")
-
-
-@app.command()
-def init(
-    directory: Path = typer.Argument(
-        ...,
-        help="Directory to materialize the lab project into (created if missing).",
-    ),
-    force: bool = typer.Option(
-        False,
-        "--force",
-        "-f",
-        help="Overwrite existing files in the target directory.",
-    ),
-) -> None:
-    """Materialize a self-contained lab project into DIRECTORY.
-
-    Copies the bundled lab assets (docker-compose.yml, scenarios, config,
-    containers, web, scripts, and the source that container images build
-    from) and writes a default aptl.json, so a `pipx install aptl-labs`
-    can run a lab without cloning the repository (DEP-008). After it
-    finishes, run `aptl lab start` from the initialized directory.
-    """
-    try:
-        result = materialize(directory, force=force)
-    except AssetError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1) from exc
-
-    typer.echo(
-        f"Initialized lab project in {result.target_dir} "
-        f"({result.files_written} files)."
-    )
-    if result.config_created:
-        typer.echo(f"    wrote default {result.target_dir / 'aptl.json'}")
-    typer.echo("\nNext steps:")
-    typer.echo(f"    cd {result.target_dir}")
-    typer.echo("    aptl lab start")
 
 
 @app.command()

--- a/src/aptl/cli/lab_init.py
+++ b/src/aptl/cli/lab_init.py
@@ -1,0 +1,55 @@
+"""`aptl lab init` command (DEP-008, issue #659).
+
+Kept in its own module so ``aptl/cli/lab.py`` stays the focused lifecycle
+facade (and under the file-size gate). Registered onto the ``lab`` Typer app
+by :func:`register`, so the command remains ``aptl lab init`` with no UX
+change.
+"""
+
+from pathlib import Path
+
+import typer
+
+from aptl.core.assets import AssetError, materialize
+
+
+def init(
+    directory: Path = typer.Argument(
+        ...,
+        help="Directory to materialize the lab project into (created if missing).",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite existing files in the target directory.",
+    ),
+) -> None:
+    """Materialize a self-contained lab project into DIRECTORY.
+
+    Copies the bundled lab assets (docker-compose.yml, scenarios, config,
+    containers, web, scripts, and the source that container images build
+    from) and writes a default aptl.json, so a `pipx install aptl-labs`
+    can run a lab without cloning the repository (DEP-008). After it
+    finishes, run `aptl lab start` from the initialized directory.
+    """
+    try:
+        result = materialize(directory, force=force)
+    except AssetError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(
+        f"Initialized lab project in {result.target_dir} "
+        f"({result.files_written} files)."
+    )
+    if result.config_created:
+        typer.echo(f"    wrote default {result.target_dir / 'aptl.json'}")
+    typer.echo("\nNext steps:")
+    typer.echo(f"    cd {result.target_dir}")
+    typer.echo("    aptl lab start")
+
+
+def register(app: typer.Typer) -> None:
+    """Register the ``init`` command onto the given ``lab`` Typer app."""
+    app.command("init")(init)

--- a/src/aptl/core/assets.py
+++ b/src/aptl/core/assets.py
@@ -1,0 +1,243 @@
+"""Locate and materialize the bundled lab-asset tree (DEP-008, issue #659).
+
+This module is the single canonical boundary between the wheel-owned,
+immutable lab-asset source tree and a mutable, runnable lab *project
+directory*. Every other module keeps resolving assets against a
+``project_dir`` (``project_dir / "docker-compose.yml"`` etc.); this module
+is only responsible for producing such a directory.
+
+Two source layouts are supported transparently:
+
+* **Installed wheel** — the build hook (``hatch_build.py``) stages the
+  git-tracked asset tree under ``aptl/_labdata/`` inside the wheel;
+  :func:`bundled_labdata_dir` finds it via ``importlib.resources``.
+* **Source checkout** — when running from a working tree (editable install
+  or tests) ``_labdata`` does not exist, so the repository root is used as
+  the source and the git-tracked asset set is selected the same way the
+  build hook selects it.
+
+In both cases only git-tracked assets are materialized, so generated
+secrets and local state (``config/soc_certs``, ``config/lab-ssh``,
+``config/wazuh_indexer_ssl_certs``, ``keys/``, ``.aptl/``, ``__pycache__``)
+never leak into a materialized project.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+import shutil
+import subprocess
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from aptl._asset_manifest import (
+    ASSET_ROOTS as _ASSET_ROOTS,
+    EXCLUDED_DIR_NAMES as _EXCLUDED_DIR_NAMES,
+    EXCLUDED_SUFFIXES as _EXCLUDED_SUFFIXES,
+    LABDATA_DIRNAME as _LABDATA_DIRNAME,
+)
+from aptl.core.config import AptlConfig
+from aptl.utils.logging import get_logger
+
+log = get_logger("assets")
+
+_CONFIG_FILENAME = "aptl.json"
+
+
+class AssetError(RuntimeError):
+    """Raised when lab assets cannot be located or materialized."""
+
+
+@dataclass(frozen=True)
+class MaterializeResult:
+    """Outcome of :func:`materialize`."""
+
+    target_dir: Path
+    source_dir: Path
+    from_bundle: bool
+    files_written: int
+    config_created: bool
+
+
+def bundled_labdata_dir() -> Path | None:
+    """Return the wheel-bundled ``_labdata`` directory, or ``None``.
+
+    ``None`` means the package was imported from a source checkout rather
+    than an installed wheel, in which case :func:`checkout_root` supplies
+    the assets instead.
+    """
+    try:
+        resource = importlib.resources.files("aptl").joinpath(_LABDATA_DIRNAME)
+    except (ModuleNotFoundError, TypeError):
+        return None
+    if resource.is_dir():
+        return Path(str(resource))
+    return None
+
+
+def checkout_root(package_dir: Path | None = None) -> Path | None:
+    """Return the repository root when running from a source checkout.
+
+    The package lives at ``<root>/src/aptl/__init__.py`` in a checkout, so
+    the root is two parents above the package directory. It only qualifies
+    as an asset source when it actually carries the lab tree.
+
+    Args:
+        package_dir: The ``src/aptl`` directory; defaults to the location of
+            this module. Injectable so the non-checkout branch is testable.
+    """
+    if package_dir is None:
+        package_dir = Path(__file__).resolve().parent.parent
+    root = package_dir.parent.parent
+    if (root / "docker-compose.yml").is_file() and (root / "scenarios").is_dir():
+        return root
+    return None
+
+
+def resolve_asset_source() -> tuple[Path, bool]:
+    """Return ``(source_dir, from_bundle)`` for the lab-asset tree.
+
+    Prefers the wheel bundle; falls back to the source checkout. Raises
+    :class:`AssetError` when neither is available.
+    """
+    bundled = bundled_labdata_dir()
+    if bundled is not None:
+        return bundled, True
+    root = checkout_root()
+    if root is not None:
+        return root, False
+    raise AssetError(
+        "Lab assets not found: the installed package has no bundled "
+        "_labdata and this is not a source checkout. Reinstall aptl-labs."
+    )
+
+
+def default_config_json() -> str:
+    """Return the default ``aptl.json`` contents for a fresh lab project."""
+    payload = AptlConfig().model_dump(mode="json", exclude_none=True)
+    return json.dumps(payload, indent=4) + "\n"
+
+
+def _git_tracked(root: Path) -> list[Path] | None:
+    """Return tracked asset files under ``root``, or ``None`` without git."""
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "-z", "--", *_ASSET_ROOTS],
+            cwd=root,
+            capture_output=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    rels = [Path(p) for p in completed.stdout.decode("utf-8").split("\0") if p]
+    return rels or None
+
+
+def _walk_checkout(root: Path) -> Iterator[Path]:
+    """Yield asset files under ``root``, applying the exclusion denylist."""
+    for entry in _ASSET_ROOTS:
+        base = root / entry
+        if base.is_file():
+            yield Path(entry)
+            continue
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(root)
+            if any(part in _EXCLUDED_DIR_NAMES for part in rel.parts):
+                continue
+            if path.suffix in _EXCLUDED_SUFFIXES:
+                continue
+            yield rel
+
+
+def _iter_source_files(source: Path, from_bundle: bool) -> Iterator[Path]:
+    """Yield asset file paths (relative to ``source``) to materialize."""
+    if from_bundle:
+        for path in sorted(source.rglob("*")):
+            if path.is_file():
+                yield path.relative_to(source)
+        return
+    tracked = _git_tracked(source)
+    if tracked is not None:
+        yield from tracked
+        return
+    yield from _walk_checkout(source)
+
+
+def _resolve_within(base: Path, relative: Path) -> Path:
+    """Resolve ``base / relative`` and confirm it stays inside ``base``."""
+    resolved = (base / relative).resolve()
+    base_resolved = base.resolve()
+    if not resolved.is_relative_to(base_resolved):
+        raise AssetError(f"Refusing to write outside target directory: {relative}")
+    return resolved
+
+
+def materialize(
+    target_dir: Path,
+    *,
+    force: bool = False,
+    write_config: bool = True,
+) -> MaterializeResult:
+    """Copy the bundled lab assets into ``target_dir`` as a lab project.
+
+    Args:
+        target_dir: Destination directory (created if missing).
+        force: Overwrite pre-existing files. When ``False`` the copy
+            refuses if any destination file already exists, so an
+            accidental ``init`` never clobbers an existing project.
+        write_config: Write a default ``aptl.json`` when one is absent.
+
+    Returns:
+        A :class:`MaterializeResult` describing what was written.
+
+    Raises:
+        AssetError: If assets cannot be located, a path escapes
+            ``target_dir``, or a conflict is found while ``force`` is
+            ``False``.
+    """
+    source, from_bundle = resolve_asset_source()
+    target_dir = target_dir.expanduser()
+    files = list(_iter_source_files(source, from_bundle))
+
+    planned = [(rel, _resolve_within(target_dir, rel)) for rel in files]
+    if not force:
+        conflicts = [str(rel) for rel, dest in planned if dest.exists()]
+        if conflicts:
+            preview = ", ".join(sorted(conflicts)[:5])
+            raise AssetError(
+                f"{target_dir} already contains lab assets "
+                f"({len(conflicts)} conflicting file(s): {preview}...). "
+                "Use --force to overwrite or choose an empty directory."
+            )
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for rel, dest in planned:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source / rel, dest)
+
+    config_created = False
+    if write_config:
+        config_path = _resolve_within(target_dir, Path(_CONFIG_FILENAME))
+        if force or not config_path.exists():
+            config_path.write_text(default_config_json(), encoding="utf-8")
+            config_created = True
+
+    log.info(
+        "Materialized %d lab asset(s) into %s (from %s)",
+        len(planned),
+        target_dir,
+        "wheel bundle" if from_bundle else "source checkout",
+    )
+    return MaterializeResult(
+        target_dir=target_dir,
+        source_dir=source,
+        from_bundle=from_bundle,
+        files_written=len(planned),
+        config_created=config_created,
+    )

--- a/src/aptl/core/assets.py
+++ b/src/aptl/core/assets.py
@@ -158,10 +158,19 @@ def _walk_checkout(root: Path) -> Iterator[Path]:
 
 
 def _iter_bundle_files(source: Path) -> Iterator[Path]:
-    """Yield every file under an already-filtered wheel bundle."""
+    """Yield files under a wheel bundle, skipping post-install artifacts.
+
+    The wheel ships a clean bundle, but pip byte-compiles the installed
+    ``.py`` files, so ``__pycache__``/``*.pyc`` appear next to them in
+    site-packages after install. Re-applying the exclusion denylist keeps a
+    materialized project free of that compiled noise.
+    """
     for path in sorted(source.rglob("*")):
-        if path.is_file():
-            yield path.relative_to(source)
+        if not path.is_file():
+            continue
+        rel = path.relative_to(source)
+        if not _is_excluded(rel):
+            yield rel
 
 
 def _iter_source_files(source: Path, from_bundle: bool) -> Iterator[Path]:

--- a/src/aptl/core/assets.py
+++ b/src/aptl/core/assets.py
@@ -135,6 +135,13 @@ def _git_tracked(root: Path) -> list[Path] | None:
     return rels or None
 
 
+def _is_excluded(rel: Path) -> bool:
+    """Return whether a relative path is a gitignored secret/artifact."""
+    if any(part in _EXCLUDED_DIR_NAMES for part in rel.parts):
+        return True
+    return rel.suffix in _EXCLUDED_SUFFIXES
+
+
 def _walk_checkout(root: Path) -> Iterator[Path]:
     """Yield asset files under ``root``, applying the exclusion denylist."""
     for entry in _ASSET_ROOTS:
@@ -145,28 +152,25 @@ def _walk_checkout(root: Path) -> Iterator[Path]:
         if not base.is_dir():
             continue
         for path in base.rglob("*"):
-            if not path.is_file():
-                continue
             rel = path.relative_to(root)
-            if any(part in _EXCLUDED_DIR_NAMES for part in rel.parts):
-                continue
-            if path.suffix in _EXCLUDED_SUFFIXES:
-                continue
-            yield rel
+            if path.is_file() and not _is_excluded(rel):
+                yield rel
+
+
+def _iter_bundle_files(source: Path) -> Iterator[Path]:
+    """Yield every file under an already-filtered wheel bundle."""
+    for path in sorted(source.rglob("*")):
+        if path.is_file():
+            yield path.relative_to(source)
 
 
 def _iter_source_files(source: Path, from_bundle: bool) -> Iterator[Path]:
     """Yield asset file paths (relative to ``source``) to materialize."""
     if from_bundle:
-        for path in sorted(source.rglob("*")):
-            if path.is_file():
-                yield path.relative_to(source)
+        yield from _iter_bundle_files(source)
         return
     tracked = _git_tracked(source)
-    if tracked is not None:
-        yield from tracked
-        return
-    yield from _walk_checkout(source)
+    yield from (tracked if tracked is not None else _walk_checkout(source))
 
 
 def _resolve_within(base: Path, relative: Path) -> Path:

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -237,6 +237,28 @@ def test_materialize_from_checkout_excludes_secrets(
     assert not list(target.rglob("node_modules"))
 
 
+def test_materialize_from_bundle_skips_pip_compiled_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pip byte-compiles the installed bundle; materialize must not copy .pyc."""
+    bundle = tmp_path / "pkg" / "_labdata"
+    (bundle / "src" / "aptl" / "__pycache__").mkdir(parents=True)
+    (bundle / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    (bundle / "src" / "aptl" / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    (bundle / "src" / "aptl" / "__pycache__" / "mod.cpython-312.pyc").write_text(
+        "", encoding="utf-8"
+    )
+    monkeypatch.setattr(assets, "resolve_asset_source", lambda: (bundle, True))
+
+    target = tmp_path / "lab"
+    materialize(target)
+
+    assert (target / "docker-compose.yml").is_file()
+    assert (target / "src" / "aptl" / "mod.py").is_file()
+    assert not list(target.rglob("*.pyc"))
+    assert not list(target.rglob("__pycache__"))
+
+
 def test_real_repo_git_selection_ships_no_secrets() -> None:
     """The real repository's tracked asset set must never include secrets."""
     tracked = assets._git_tracked(REPO_ROOT)

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,256 @@
+"""Tests for ``aptl.core.assets`` — DEP-008 self-contained lab distribution.
+
+These are fast, hermetic unit tests. Materialization is exercised against
+small synthetic source trees (via monkeypatched ``resolve_asset_source``) so
+the suite never copies the real 31M scenario tree, plus one test that runs
+the real-repo git selection to guarantee no secrets are ever shipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aptl.core import assets
+from aptl.core.assets import AssetError, materialize
+from aptl.core.config import load_config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_fake_bundle(root: Path) -> Path:
+    """Create a small, already-filtered bundle tree (as the wheel ships)."""
+    bundle = root / "_labdata"
+    (bundle / "config").mkdir(parents=True)
+    (bundle / "scenarios").mkdir(parents=True)
+    (bundle / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    (bundle / "config" / "certs.yml").write_text("x: 1\n", encoding="utf-8")
+    (bundle / "scenarios" / "catalog.json").write_text("{}\n", encoding="utf-8")
+    return bundle
+
+
+@pytest.fixture
+def fake_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    bundle = _make_fake_bundle(tmp_path / "pkg")
+    monkeypatch.setattr(assets, "resolve_asset_source", lambda: (bundle, True))
+    return bundle
+
+
+def test_materialize_copies_bundle_and_writes_config(
+    fake_bundle: Path, tmp_path: Path
+) -> None:
+    target = tmp_path / "lab"
+    result = materialize(target)
+
+    assert result.from_bundle is True
+    assert result.config_created is True
+    assert (target / "docker-compose.yml").is_file()
+    assert (target / "config" / "certs.yml").is_file()
+    assert (target / "scenarios" / "catalog.json").is_file()
+    assert (target / "aptl.json").is_file()
+    assert result.files_written == 3
+
+
+def test_materialize_default_config_is_valid(fake_bundle: Path, tmp_path: Path) -> None:
+    target = tmp_path / "lab"
+    materialize(target)
+    config = load_config(target / "aptl.json")
+    assert config.lab.name == "aptl"
+    assert "kali" in config.containers.enabled_profiles()
+
+
+def test_materialize_refuses_conflict_without_force(
+    fake_bundle: Path, tmp_path: Path
+) -> None:
+    target = tmp_path / "lab"
+    materialize(target)
+    with pytest.raises(AssetError, match="already contains lab assets"):
+        materialize(target)
+
+
+def test_materialize_force_overwrites(fake_bundle: Path, tmp_path: Path) -> None:
+    target = tmp_path / "lab"
+    materialize(target)
+    (target / "docker-compose.yml").write_text("stale\n", encoding="utf-8")
+    materialize(target, force=True)
+    assert (target / "docker-compose.yml").read_text(encoding="utf-8") == "services: {}\n"
+
+
+def test_materialize_can_skip_config(fake_bundle: Path, tmp_path: Path) -> None:
+    target = tmp_path / "lab"
+    result = materialize(target, write_config=False)
+    assert result.config_created is False
+    assert not (target / "aptl.json").exists()
+
+
+def test_materialize_creates_missing_target(fake_bundle: Path, tmp_path: Path) -> None:
+    target = tmp_path / "deep" / "nested" / "lab"
+    materialize(target)
+    assert (target / "docker-compose.yml").is_file()
+
+
+def test_default_config_json_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "aptl.json"
+    path.write_text(assets.default_config_json(), encoding="utf-8")
+    config = load_config(path)
+    assert config.deployment.provider == "docker-compose"
+
+
+def test_resolve_within_rejects_escape(tmp_path: Path) -> None:
+    with pytest.raises(AssetError, match="outside target directory"):
+        assets._resolve_within(tmp_path, Path("../escape"))
+
+
+def test_resolve_within_allows_nested(tmp_path: Path) -> None:
+    resolved = assets._resolve_within(tmp_path, Path("a/b/c.txt"))
+    assert resolved == (tmp_path / "a" / "b" / "c.txt").resolve()
+
+
+def test_resolve_asset_source_prefers_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = tmp_path / "_labdata"
+    bundle.mkdir()
+    monkeypatch.setattr(assets, "bundled_labdata_dir", lambda: bundle)
+    source, from_bundle = assets.resolve_asset_source()
+    assert (source, from_bundle) == (bundle, True)
+
+
+def test_resolve_asset_source_checkout_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(assets, "bundled_labdata_dir", lambda: None)
+    monkeypatch.setattr(assets, "checkout_root", lambda: tmp_path)
+    source, from_bundle = assets.resolve_asset_source()
+    assert (source, from_bundle) == (tmp_path, False)
+
+
+def test_resolve_asset_source_errors_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(assets, "bundled_labdata_dir", lambda: None)
+    monkeypatch.setattr(assets, "checkout_root", lambda: None)
+    with pytest.raises(AssetError, match="Lab assets not found"):
+        assets.resolve_asset_source()
+
+
+def test_checkout_root_detects_this_repo() -> None:
+    assert assets.checkout_root() == REPO_ROOT
+
+
+def test_checkout_root_none_when_not_a_repo(tmp_path: Path) -> None:
+    fake_pkg = tmp_path / "src" / "aptl"
+    fake_pkg.mkdir(parents=True)
+    assert assets.checkout_root(package_dir=fake_pkg) is None
+
+
+def test_bundled_labdata_dir_absent_in_checkout() -> None:
+    # Running from the source tree, no _labdata has been staged into the package.
+    assert assets.bundled_labdata_dir() is None
+
+
+def test_bundled_labdata_dir_returns_path_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    labdata = tmp_path / "_labdata"
+    labdata.mkdir()
+
+    class _FakeAnchor:
+        def joinpath(self, _name: str) -> Path:
+            return labdata
+
+    monkeypatch.setattr(assets.importlib.resources, "files", lambda _pkg: _FakeAnchor())
+    assert assets.bundled_labdata_dir() == labdata
+
+
+def test_bundled_labdata_dir_none_on_lookup_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(_pkg: str) -> None:
+        raise ModuleNotFoundError("no package")
+
+    monkeypatch.setattr(assets.importlib.resources, "files", _raise)
+    assert assets.bundled_labdata_dir() is None
+
+
+def test_iter_source_files_checkout_uses_git(tmp_path: Path) -> None:
+    # Against the real repo (a git checkout), the git path is taken.
+    rels = {p.as_posix() for p in assets._iter_source_files(REPO_ROOT, from_bundle=False)}
+    assert "docker-compose.yml" in rels
+    assert not any("soc_certs" in r for r in rels)
+
+
+# --- selection / secret-exclusion -----------------------------------------
+
+
+def _make_fake_checkout(root: Path) -> None:
+    """A checkout-like tree with real assets and gitignored secrets/artifacts."""
+    (root / "config" / "wazuh_cluster").mkdir(parents=True)
+    (root / "config" / "soc_certs").mkdir(parents=True)
+    (root / "config" / "lab-ssh").mkdir(parents=True)
+    (root / "containers" / "kali" / "__pycache__").mkdir(parents=True)
+    (root / "web" / "node_modules").mkdir(parents=True)
+    (root / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    (root / "config" / "wazuh_cluster" / "wazuh.yml").write_text("a: 1\n", encoding="utf-8")
+    (root / "config" / "soc_certs" / "ca.key").write_text("SECRET\n", encoding="utf-8")
+    (root / "config" / "lab-ssh" / "id_rsa").write_text("SECRET\n", encoding="utf-8")
+    (root / "containers" / "kali" / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+    (root / "containers" / "kali" / "__pycache__" / "x.pyc").write_text("", encoding="utf-8")
+    # A stray compiled file directly under a tracked dir (not in __pycache__)
+    # must still be excluded by suffix.
+    (root / "containers" / "kali" / "stale.pyc").write_text("", encoding="utf-8")
+    (root / "web" / "node_modules" / "dep.js").write_text("", encoding="utf-8")
+
+
+def test_walk_checkout_excludes_secrets_and_artifacts(tmp_path: Path) -> None:
+    _make_fake_checkout(tmp_path)
+    selected = {p.as_posix() for p in assets._walk_checkout(tmp_path)}
+
+    assert "docker-compose.yml" in selected
+    assert "config/wazuh_cluster/wazuh.yml" in selected
+    assert "containers/kali/Dockerfile" in selected
+    # Secrets and build artifacts must never be selected.
+    assert not any("soc_certs" in s for s in selected)
+    assert not any("lab-ssh" in s for s in selected)
+    assert not any("__pycache__" in s for s in selected)
+    assert not any("node_modules" in s for s in selected)
+    assert not any(s.endswith(".pyc") for s in selected)
+
+
+def test_materialize_from_checkout_excludes_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    _make_fake_checkout(checkout)
+    monkeypatch.setattr(assets, "resolve_asset_source", lambda: (checkout, False))
+
+    target = tmp_path / "lab"
+    materialize(target)
+
+    assert (target / "docker-compose.yml").is_file()
+    assert (target / "containers" / "kali" / "Dockerfile").is_file()
+    assert not (target / "config" / "soc_certs").exists()
+    assert not (target / "config" / "lab-ssh").exists()
+    assert not list(target.rglob("*.pyc"))
+    assert not list(target.rglob("node_modules"))
+
+
+def test_real_repo_git_selection_ships_no_secrets() -> None:
+    """The real repository's tracked asset set must never include secrets."""
+    tracked = assets._git_tracked(REPO_ROOT)
+    assert tracked is not None, "expected a git checkout"
+    posix = [p.as_posix() for p in tracked]
+
+    assert "docker-compose.yml" in posix
+    assert any(p.startswith("scenarios/") for p in posix)
+    assert any(p.startswith("config/") for p in posix)
+
+    for path in posix:
+        assert "soc_certs" not in path
+        assert "lab-ssh" not in path
+        assert "wazuh_indexer_ssl_certs" not in path
+        assert not path.endswith((".pyc", ".pyo"))
+        # Only public key material lives under a tracked keys/ path.
+        assert not path.endswith("id_rsa")

--- a/tests/test_hatch_build_hook.py
+++ b/tests/test_hatch_build_hook.py
@@ -1,0 +1,128 @@
+"""Tests for the wheel build hook (hatch_build.py, DEP-008 / issue #659).
+
+``hatch_build.py`` runs in the build backend environment, which has neither
+the ``aptl`` package on ``sys.path`` nor ``hatchling`` available at test
+time. We stub ``hatchling`` so the module imports, then exercise its file
+selection and force-include mapping. This guards the wheel's asset set (and
+its exclusion of secrets) in the fast suite without a full wheel build.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _install_hatchling_stub() -> None:
+    if "hatchling.builders.hooks.plugin.interface" in sys.modules:
+        return
+
+    class BuildHookInterface:
+        def __init__(self, root: str = ".", *args: object, **kwargs: object) -> None:
+            self.root = root
+
+    chain = [
+        "hatchling",
+        "hatchling.builders",
+        "hatchling.builders.hooks",
+        "hatchling.builders.hooks.plugin",
+        "hatchling.builders.hooks.plugin.interface",
+    ]
+    for name in chain:
+        sys.modules[name] = ModuleType(name)
+    sys.modules["hatchling.builders.hooks.plugin.interface"].BuildHookInterface = (
+        BuildHookInterface
+    )
+
+
+def _load_hatch_build() -> ModuleType:
+    _install_hatchling_stub()
+    spec = importlib.util.spec_from_file_location(
+        "hatch_build", REPO_ROOT / "hatch_build.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_fake_checkout(root: Path) -> None:
+    (root / "config" / "soc_certs").mkdir(parents=True)
+    (root / "containers" / "kali" / "__pycache__").mkdir(parents=True)
+    (root / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    (root / "config" / "certs.yml").write_text("x: 1\n", encoding="utf-8")
+    (root / "config" / "soc_certs" / "ca.key").write_text("SECRET\n", encoding="utf-8")
+    (root / "containers" / "kali" / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+    (root / "containers" / "kali" / "__pycache__" / "x.pyc").write_text("", encoding="utf-8")
+
+
+def test_hook_uses_shared_manifest() -> None:
+    hatch_build = _load_hatch_build()
+    from aptl import _asset_manifest
+
+    assert hatch_build._ASSET_ROOTS == _asset_manifest.ASSET_ROOTS
+    assert hatch_build._EXCLUDED_DIR_NAMES == _asset_manifest.EXCLUDED_DIR_NAMES
+    assert hatch_build._LABDATA_PREFIX == _asset_manifest.LABDATA_PREFIX
+
+
+def test_walk_excludes_secrets_and_artifacts(tmp_path: Path) -> None:
+    hatch_build = _load_hatch_build()
+    _make_fake_checkout(tmp_path)
+    selected = {p.as_posix() for p in hatch_build.CustomBuildHook._walk(tmp_path)}
+
+    assert "docker-compose.yml" in selected
+    assert "containers/kali/Dockerfile" in selected
+    assert not any("soc_certs" in s for s in selected)
+    assert not any("__pycache__" in s for s in selected)
+    assert not any(s.endswith(".pyc") for s in selected)
+
+
+def test_initialize_maps_assets_under_labdata(tmp_path: Path) -> None:
+    hatch_build = _load_hatch_build()
+    _make_fake_checkout(tmp_path)
+    # Force the walk path (this synthetic tree is not a git repo).
+    hook = hatch_build.CustomBuildHook(str(tmp_path))
+    build_data: dict[str, object] = {}
+    hook.initialize("0", build_data)
+
+    force_include = build_data["force_include"]
+    targets = set(force_include.values())
+    assert "aptl/_labdata/docker-compose.yml" in targets
+    assert "aptl/_labdata/containers/kali/Dockerfile" in targets
+    assert not any("soc_certs" in t for t in targets)
+    assert not any(t.endswith(".pyc") for t in targets)
+    # Sources are absolute paths inside the given root.
+    for source in force_include:
+        assert str(tmp_path) in source
+
+
+def test_initialize_skips_minimal_context(tmp_path: Path) -> None:
+    """A build context without docker-compose.yml (service images) bundles nothing."""
+    hatch_build = _load_hatch_build()
+    # Mimic the misp-suricata-sync / web-api context: no docker-compose.yml.
+    (tmp_path / "src").mkdir()
+    (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    (tmp_path / "src" / "mod.py").write_text("x = 1\n", encoding="utf-8")
+
+    hook = hatch_build.CustomBuildHook(str(tmp_path))
+    build_data: dict[str, object] = {}
+    hook.initialize("0", build_data)
+
+    assert build_data.get("force_include", {}) == {}
+
+
+def test_real_repo_git_selection_is_clean() -> None:
+    hatch_build = _load_hatch_build()
+    tracked = hatch_build.CustomBuildHook._git_tracked(REPO_ROOT)
+    assert tracked is not None
+    posix = [p.as_posix() for p in tracked]
+    assert "docker-compose.yml" in posix
+    for path in posix:
+        assert "soc_certs" not in path
+        assert "lab-ssh" not in path
+        assert "wazuh_indexer_ssl_certs" not in path

--- a/tests/test_hatch_build_hook.py
+++ b/tests/test_hatch_build_hook.py
@@ -10,10 +10,12 @@ its exclusion of secrets) in the fast suite without a full wheel build.
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import sys
-import types
 from pathlib import Path
 from types import ModuleType
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -96,9 +98,23 @@ def test_initialize_maps_assets_under_labdata(tmp_path: Path) -> None:
     assert "aptl/_labdata/containers/kali/Dockerfile" in targets
     assert not any("soc_certs" in t for t in targets)
     assert not any(t.endswith(".pyc") for t in targets)
-    # Sources are absolute paths inside the given root.
+    # Every target lives under aptl/_labdata/: none may collide with a real
+    # package path (e.g. aptl/cli/main.py), which would shadow the standard
+    # packages mapping and drop the package from the wheel (issue #659).
+    assert all(t.startswith("aptl/_labdata/") for t in targets)
+    # Sources are staged copies outside the project root (so hatchling does not
+    # dedupe them against the package's own src/aptl files by source path).
+    staging_dir = hook._staging_dir
+    assert staging_dir is not None
     for source in force_include:
-        assert str(tmp_path) in source
+        assert Path(source).is_file()
+        assert str(tmp_path) not in source
+        assert str(staging_dir) in source
+
+    # finalize() removes the staging directory.
+    hook.finalize("0", build_data, "unused.whl")
+    assert not staging_dir.exists()
+    assert hook._staging_dir is None
 
 
 def test_initialize_skips_minimal_context(tmp_path: Path) -> None:
@@ -136,3 +152,56 @@ def test_real_repo_git_selection_is_clean() -> None:
         assert "soc_certs" not in path
         assert "lab-ssh" not in path
         assert "wazuh_indexer_ssl_certs" not in path
+
+
+def _find_build_tool() -> list[str] | None:
+    """Return an argv prefix that builds a wheel, or None if unavailable."""
+    if shutil.which("uv"):
+        return ["uv", "build", "--wheel", "--out-dir"]
+    try:
+        import build  # noqa: F401
+    except ImportError:
+        return None
+    return [sys.executable, "-m", "build", "--wheel", "--outdir"]
+
+
+@pytest.mark.integration
+def test_built_wheel_has_both_package_and_bundle(tmp_path: Path) -> None:
+    """A real wheel build must ship the aptl package AND the lab bundle.
+
+    Regression guard for issue #659: force-including src/aptl into
+    aptl/_labdata shadowed the packages=["src/aptl"] mapping (hatchling
+    dedupes by source path), producing a wheel with only aptl/_labdata and
+    no importable aptl package. Only a real build catches this.
+    """
+    import subprocess
+    import zipfile
+
+    tool = _find_build_tool()
+    if tool is None:
+        pytest.skip("no wheel build tool (uv/build) available")
+
+    outdir = tmp_path / "dist"
+    subprocess.run(
+        [*tool, str(outdir)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    wheels = list(outdir.glob("*.whl"))
+    assert wheels, "no wheel produced"
+    names = zipfile.ZipFile(wheels[0]).namelist()
+
+    # Real, importable package.
+    assert "aptl/__init__.py" in names
+    assert "aptl/cli/main.py" in names
+    assert "aptl/core/assets.py" in names
+    # Lab bundle, secret-free.
+    assert "aptl/_labdata/docker-compose.yml" in names
+    assert any(n.startswith("aptl/_labdata/scenarios/") for n in names)
+    assert not any(
+        s in n
+        for n in names
+        for s in ("soc_certs", "lab-ssh", "wazuh_indexer_ssl_certs")
+    )
+    assert not any(n.endswith(".pyc") for n in names)

--- a/tests/test_hatch_build_hook.py
+++ b/tests/test_hatch_build_hook.py
@@ -116,6 +116,16 @@ def test_initialize_skips_minimal_context(tmp_path: Path) -> None:
     assert build_data.get("force_include", {}) == {}
 
 
+def test_initialize_skips_editable_build(tmp_path: Path) -> None:
+    """Editable installs must not materialize the bundle into site-packages."""
+    hatch_build = _load_hatch_build()
+    _make_fake_checkout(tmp_path)  # has docker-compose.yml, would otherwise bundle
+    hook = hatch_build.CustomBuildHook(str(tmp_path))
+    build_data: dict[str, object] = {}
+    hook.initialize("editable", build_data)
+    assert build_data.get("force_include", {}) == {}
+
+
 def test_real_repo_git_selection_is_clean() -> None:
     hatch_build = _load_hatch_build()
     tracked = hatch_build.CustomBuildHook._git_tracked(REPO_ROOT)

--- a/tests/test_lab_init_cli.py
+++ b/tests/test_lab_init_cli.py
@@ -1,0 +1,56 @@
+"""CLI tests for ``aptl lab init`` (DEP-008, issue #659).
+
+Materialization is redirected at a small synthetic bundle so the command is
+exercised end-to-end without copying the real scenario tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from aptl.cli.main import app
+from aptl.core import assets
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def fake_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    bundle = tmp_path / "pkg" / "_labdata"
+    (bundle / "config").mkdir(parents=True)
+    (bundle / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    (bundle / "config" / "certs.yml").write_text("x: 1\n", encoding="utf-8")
+    monkeypatch.setattr(assets, "resolve_asset_source", lambda: (bundle, True))
+    return bundle
+
+
+def test_lab_init_success(fake_bundle: Path, tmp_path: Path) -> None:
+    target = tmp_path / "lab"
+    result = runner.invoke(app, ["lab", "init", str(target)])
+
+    assert result.exit_code == 0, result.output
+    assert "Initialized lab project" in result.output
+    assert "aptl lab start" in result.output
+    assert (target / "docker-compose.yml").is_file()
+    assert (target / "aptl.json").is_file()
+
+
+def test_lab_init_conflict_without_force(fake_bundle: Path, tmp_path: Path) -> None:
+    target = tmp_path / "lab"
+    runner.invoke(app, ["lab", "init", str(target)])
+    result = runner.invoke(app, ["lab", "init", str(target)])
+
+    assert result.exit_code == 1
+    assert "already contains lab assets" in result.output
+
+
+def test_lab_init_force_overwrites(fake_bundle: Path, tmp_path: Path) -> None:
+    target = tmp_path / "lab"
+    runner.invoke(app, ["lab", "init", str(target)])
+    result = runner.invoke(app, ["lab", "init", str(target), "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert (target / "docker-compose.yml").is_file()

--- a/web/Dockerfile.api
+++ b/web/Dockerfile.api
@@ -18,6 +18,11 @@ RUN apt-get update && \
 # Install Python deps
 COPY pyproject.toml .
 COPY README.md .
+# hatch_build.py is a declared wheel build hook in pyproject.toml, so
+# `pip install .` requires it in the build context (issue #659). It no-ops
+# here (no docker-compose.yml in this context), so no lab assets are bundled
+# into the API image.
+COPY hatch_build.py .
 COPY src/ src/
 RUN pip install --no-cache-dir ".[web]" && \
     apt-get purge -y git && \


### PR DESCRIPTION
## Summary

The published `aptl-labs` wheel shipped only `src/aptl`, so a PyPI install still required a full `git clone` to obtain the Compose file, scenarios, config, and container build contexts a lab needs. This bundles the git-tracked lab-asset tree into the wheel and adds `aptl lab init <dir>` so `pipx install aptl-labs` can run a lab without a clone (DEP-008).

Key finding while scoping: the runtime already resolves every asset against a `project_dir` (`project_dir / "docker-compose.yml"`, `config/`, `scenarios/`, `containers/`), so the real gap was **packaging + materialization**, not path resolution.

## What changed

- **`hatch_build.py`** — a Hatchling wheel build hook stages the git-tracked lab assets into the wheel under `aptl/_labdata/`. Only tracked files ship, so generated secrets (`config/soc_certs`, `config/lab-ssh`, `config/wazuh_indexer_ssl_certs`, `keys/`, `.aptl/`) and `__pycache__` never leak into the distribution. Git-driven selection with a walk fallback for sdist→wheel builds.
- **`src/aptl/core/assets.py`** — one canonical asset-location + materialization boundary. Resolves the wheel bundle via `importlib.resources` with a source-checkout fallback (so `lab init` and tests work from a checkout), copies with path-containment + overwrite safety, and writes a default `aptl.json`.
- **`aptl lab init <dir>`** — thin CLI command that materializes the bundle into a working project directory.
- **`src/aptl/_asset_manifest.py`** — a dependency-free manifest shared by the build hook (build time) and the runtime (`lab init`), so the wheel's bundled set and a checkout's materialized set cannot drift.
- **Service-image fix** — declaring the hook in `pyproject.toml` makes `hatch_build.py` a required input for every `pip install .`. The two service images that install the package (`misp-suricata-sync`, web API) now copy it, and the hook no-ops in minimal build contexts (no `docker-compose.yml`), so those images build without pulling the lab bundle into their wheels.

## Requirement

Implements **DEP-008** — Self-Contained Distribution of Lab Assets from Installed Package.

**Traceability**
- IMPLEMENTS DEP-008: `hatch_build.py`, `src/aptl/_asset_manifest.py`, `src/aptl/core/assets.py`, `src/aptl/cli/lab.py`
- TESTS DEP-008: `tests/test_assets.py`, `tests/test_lab_init_cli.py`, `tests/test_hatch_build_hook.py`

## Testing

- Fast unit tests: materialization, default-config validity, containment, idempotency/`--force`, source resolution, secret exclusion — 100% coverage on `assets.py` + `_asset_manifest.py`. A real-repo git-selection test asserts no secrets are ever selected.
- Build hook exercised via a hatchling stub (selection, force-include mapping, minimal-context no-op).
- Verified end-to-end: built the wheel (410 asset files present, 0 secrets), ran `aptl lab init` into a temp dir (valid `project_dir`), and simulated a service build context (builds successfully, bundles zero `_labdata`).
- Full fast suite green (`pytest -n auto -k "not integration"`), pre-commit lint + Vale + `mkdocs build --strict` pass.

## Review

Pre-push test-quality review: clean. Codex review flagged one real blocker — the newly-declared build hook was absent from the service images' `pip install .` contexts — which is fixed here (copy `hatch_build.py` + minimal-context no-op guard) and verified by simulating the service build.

Closes #659
