### PR TITLE
fix: drop removed --workers flag from web-api container CMD

### DIFF
--- a/tests/test_web_dockerfile_cmd.py
+++ b/tests/test_web_dockerfile_cmd.py
@@ -13,7 +13,7 @@ import json
 import re
 from pathlib import Path
 
-from typer.testing import CliRunner
+from typer.main import get_command
 
 from aptl.cli.web import app
 
@@ -30,9 +30,17 @@ def _dockerfile_cmd_flags() -> list[str]:
 
 
 def _valid_serve_flags() -> set[str]:
-    result = CliRunner().invoke(app, ["serve", "--help"])
-    assert result.exit_code == 0, result.output
-    return set(re.findall(r"--[a-z0-9][a-z0-9-]+", result.output))
+    # Introspect the Click command the CLI actually builds, rather than scraping
+    # --help text (whose rich rendering varies by terminal/env). This is the
+    # authoritative option surface of `aptl web serve`.
+    command = get_command(app)
+    serve = getattr(command, "commands", {}).get("serve", command)
+    return {
+        opt
+        for param in serve.params
+        for opt in param.opts
+        if opt.startswith("--")
+    }
 
 
 def test_web_api_dockerfile_cmd_uses_only_valid_serve_flags() -> None:

--- a/tests/test_web_dockerfile_cmd.py
+++ b/tests/test_web_dockerfile_cmd.py
@@ -1,0 +1,46 @@
+"""Guard: web/Dockerfile.api CMD may only pass flags `aptl web serve` accepts.
+
+Regression test for the crash loop where the CLI dropped `--workers` but the
+container CMD kept passing `--workers 1`, so `aptl-web-api` exited with a
+"No such option: --workers" usage error on every start. A real wheel/Trivy
+build does not catch this (the image builds fine; it only fails at runtime), so
+this pins the Dockerfile CMD to the actual CLI option surface.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from aptl.cli.web import app
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _dockerfile_cmd_flags() -> list[str]:
+    text = (REPO_ROOT / "web" / "Dockerfile.api").read_text(encoding="utf-8")
+    match = re.search(r"^CMD\s+(\[.*\])\s*$", text, re.MULTILINE)
+    assert match, "web/Dockerfile.api has no single-line JSON CMD array"
+    argv = json.loads(match.group(1))
+    assert argv[:3] == ["aptl", "web", "serve"], argv
+    return [arg for arg in argv[3:] if arg.startswith("--")]
+
+
+def _valid_serve_flags() -> set[str]:
+    result = CliRunner().invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0, result.output
+    return set(re.findall(r"--[a-z0-9][a-z0-9-]+", result.output))
+
+
+def test_web_api_dockerfile_cmd_uses_only_valid_serve_flags() -> None:
+    valid = _valid_serve_flags()
+    flags = _dockerfile_cmd_flags()
+    assert flags, "expected at least one flag in the web-api CMD"
+    for flag in flags:
+        assert flag in valid, (
+            f"web/Dockerfile.api CMD passes {flag}, which `aptl web serve` does "
+            f"not accept (valid: {sorted(valid)})"
+        )

--- a/web/Dockerfile.api
+++ b/web/Dockerfile.api
@@ -34,8 +34,9 @@ EXPOSE 8400
 # Use the `aptl web serve` entrypoint (not raw uvicorn) so the container mints
 # the per-process browser-session secrets and logs the one-time login URL/token
 # (UI-008a / ADR-039). Grab the launch token from the container logs to bootstrap
-# a browser session through the UI origin. A SINGLE worker is required: the
-# launch-token (one-time), session, and terminal-ticket stores are in-process and
-# not shared across workers. --api-only is deliberate: this container serves only
-# the JSON API; the sibling aptl-web-ui (Caddy) container serves the built GUI.
-CMD ["aptl", "web", "serve", "--host", "0.0.0.0", "--port", "8400", "--workers", "1", "--api-only"]
+# a browser session through the UI origin. `aptl web serve` is always
+# single-worker by design (the launch-token, session, and terminal-ticket stores
+# are in-process); it exposes no --workers flag, so passing one crash-loops the
+# container. --api-only is deliberate: this container serves only the JSON API;
+# the sibling aptl-web-ui (Caddy) container serves the built GUI.
+CMD ["aptl", "web", "serve", "--host", "0.0.0.0", "--port", "8400", "--api-only"]


### PR DESCRIPTION
## Summary

The `aptl-web-api` container (`web` compose profile) crash-loops on every start:

```
$ docker logs aptl-web-api
Usage: aptl web serve [OPTIONS]
╭─ Error ─────────────────────────────────────────────╮
│ No such option: --workers                           │
╰─────────────────────────────────────────────────────╯
```

`web/Dockerfile.api` CMD passes `--workers 1`, but `aptl web serve` is single-worker by design and exposes **no** `--workers` option (see `src/aptl/cli/web.py`: "Always single-worker … There is deliberately no --workers flag"). The flag was removed from the CLI but the container CMD was never updated. A wheel/Trivy image build doesn't catch it — the image builds fine and only fails at runtime.

## Fix

- Drop `--workers 1` from the `web/Dockerfile.api` CMD (kept `--api-only`, which is correct for the split API/UI delivery).
- Add `tests/test_web_dockerfile_cmd.py` — a guard that parses the Dockerfile CMD and asserts every flag is a valid `aptl web serve` option, so the Dockerfile CMD can't drift from the CLI again.

## How it was found

Exercising the `web` and `mail` profiles on a fresh clean-box standalone install (follow-up to #659). During that run: `aptl-web-ui` served the SPA (HTTP 200), `aptl-mailserver` came up and served SMTP once seeded, but `aptl-web-api` crash-looped on `--workers`.

## Validation

On a fresh EC2 Ubuntu 24.04 box, running the web-api image with the corrected CMD starts cleanly:

```
Starting APTL web API on 0.0.0.0:8400
INFO:     Started server process [1]
INFO:     Waiting for application startup.
```

Guard test passes; it also confirms `--workers` is not among the valid `aptl web serve` options.
