### PR TITLE
fix: report the correct aptl --version on released installs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,10 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "package-name": "aptl"
+      "package-name": "aptl",
+      "extra-files": [
+        "src/aptl/__init__.py"
+      ]
     }
   }
 }

--- a/src/aptl/__init__.py
+++ b/src/aptl/__init__.py
@@ -1,6 +1,9 @@
 """Advanced Purple Team Lab CLI."""
 
-# Version is managed by release-please, which bumps this literal in lockstep
-# with pyproject.toml on every release. A fresh clone therefore shows the last
-# released version.
-__version__ = "4.0.0"
+# Version is bumped by release-please in lockstep with pyproject.toml on every
+# release, via the `extra-files` entry in release-please-config.json plus the
+# `x-release-please-version` annotation below (the python updater only rewrites
+# pyproject.toml, not this src-layout __init__.py). Keep the annotation comment
+# on the same line as the literal, and keep the literal equal to pyproject's
+# `version` — test_version_consistency.py enforces the latter.
+__version__ = "4.1.1"  # x-release-please-version

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,28 @@
+"""Guard: ``aptl.__version__`` must equal pyproject.toml's ``[project].version``.
+
+Regression test for the CLI reporting a stale version. release-please's python
+updater rewrites ``pyproject.toml`` but not the src-layout
+``src/aptl/__init__.py``, so the two drifted (pyproject 4.1.1 while
+``__version__`` stayed 4.0.0) and ``aptl --version`` reported the wrong value on
+a real PyPI install. release-please now bumps both (``extra-files`` +
+``x-release-please-version`` annotation); this test fails if they drift again.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import aptl
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_version_matches_pyproject() -> None:
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    assert aptl.__version__ == data["project"]["version"], (
+        f"aptl.__version__={aptl.__version__!r} != pyproject "
+        f"version={data['project']['version']!r}; release-please must bump both "
+        "(release-please-config.json extra-files + the x-release-please-version "
+        "annotation in src/aptl/__init__.py)"
+    )


### PR DESCRIPTION
## Summary

On a real `pipx install aptl-labs` (published **4.1.1**), the CLI reports the wrong version:

```
$ aptl --version
aptl 4.0.0        # but the installed distribution is 4.1.1
```

`release-please`'s `python` updater rewrites `pyproject.toml` but **not** the src-layout `src/aptl/__init__.py` (it looks for `aptl/__init__.py`, not `src/aptl/__init__.py`), so `__version__` stayed pinned at `4.0.0` across the `4.0.1`, `4.1.0`, and `4.1.1` releases while `pyproject.toml` advanced. `aptl.__version__` is what `aptl --version` prints, so every released install misreports its version.

## Fix

- Add `src/aptl/__init__.py` to the `extra-files` list in `release-please-config.json`, with an `# x-release-please-version` annotation on the `__version__` line, so release-please bumps the literal in lockstep with `pyproject.toml`.
- Correct the current literal to `4.1.1` (matching the latest release) so installs report the right version immediately.
- Add `tests/test_version_consistency.py`, which asserts `aptl.__version__ == pyproject [project].version` and fails if they ever drift again.

## How it was found

De-novo clean-box install of the published `4.1.1` wheel from PyPI (follow-up validation to #659 / #664): `pipx install aptl-labs` installed `4.1.1` (confirmed via `pipx list`) but `aptl --version` printed `4.0.0`.

## Note

This corrects reporting only; the `4.1.1` code (DEP-008 bundling + the web-api `--workers` fix) is already correct on PyPI. The next release-please release will bump both files together.
