### PR TITLE
fix: bind mailserver ports to loopback (ADR-034/ADR-039)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -760,10 +760,16 @@ services:
     domainname: techvault.local
     restart: unless-stopped
     ports:
-      - "25:25"
-      - "143:143"
-      - "587:587"
-      - "993:993"
+      # Loopback-only (ADR-039): the mailserver holds fixture credentials
+      # (known lab password), so its SMTP/IMAP ports must not be published on
+      # 0.0.0.0 where an exposed host would become an open, known-cred relay.
+      # In-range traffic (kali phishing -> victims) uses the docker networks
+      # below, not these host publishes; these exist only for operator access
+      # from the host itself.
+      - "127.0.0.1:25:25"
+      - "127.0.0.1:143:143"
+      - "127.0.0.1:587:587"
+      - "127.0.0.1:993:993"
     environment:
       - ENABLE_SPAMASSASSIN=0
       - ENABLE_CLAMAV=0

--- a/tests/test_docker_compose_port_bindings.py
+++ b/tests/test_docker_compose_port_bindings.py
@@ -37,6 +37,15 @@ MANAGEMENT_SURFACES = [
     ("aptl-otel-collector", 4317),
     ("aptl-otel-collector", 4318),
     ("aptl-tempo", 3200),
+    # mailserver holds fixture credentials (a known lab password), so its
+    # SMTP/IMAP host publishes must NOT be reachable on 0.0.0.0 where an
+    # exposed host becomes an open, known-cred relay (issue #668). The in-range
+    # phishing path (kali -> victims) uses the docker networks, not these host
+    # publishes, so loopback binding does not reduce attack realism.
+    ("mailserver", 25),
+    ("mailserver", 143),
+    ("mailserver", 587),
+    ("mailserver", 993),
 ]
 
 # Deliberate victim / attack-surface targets that MUST remain reachable on all


### PR DESCRIPTION
## Summary

The `mailserver` (docker-mailserver, `mail` profile) holds **fixture credentials** — a deliberately-known lab password — but published its SMTP/IMAP host ports on `0.0.0.0`:

```yaml
ports:
  - "25:25"
  - "143:143"
  - "587:587"
  - "993:993"
```

So enabling `mail` on an exposed host stood up an **internet-reachable mail server with a publicly-known credential** — an open-relay / account-takeover liability, and inconsistent with the loopback binding every other credentialed surface uses (ADR-034 Host Exposure Amendment / ADR-039).

## Change

- Bind the four mail ports to `127.0.0.1`.
- Add `mailserver` 25/143/587/993 to `MANAGEMENT_SURFACES` in `tests/test_docker_compose_port_bindings.py`, so the policy test fails if they're ever re-exposed on all interfaces.

The in-range phishing path (kali → victims) uses the docker networks, not these host publishes, so attack realism is unchanged; the host publishes are operator-convenience only.

## Scope / what this is NOT

This is the **security half** of #668. The other half — auto-seeding mailboxes so the profile "just works" — is **held**: doing it ACES-conformantly (mail accounts authored in the SDL and materialized by the realizer, instead of the hardcoded `containers/mailserver/setup.sh`) is blocked on missing ACES capabilities, filed as **Brad-Edwards/aces#708** (no authored provisioning construct; no credential-value on `Account`/`RuntimeMailMailbox`; realizer doesn't materialize account-placements). We chose not to fake conformance by parsing captured inventory or hardcoding a seed. Until aces#708 lands, `mail` stays manual (`docker exec aptl-mailserver bash /tmp/setup.sh`).

## Tests

- `test_docker_compose_port_bindings.py` — 20 passed (mailserver now loopback-enforced).
- `test_mailserver_inventory.py` — 13 passed (asserts container→host_port, unaffected by the host-IP prefix).
- `docker compose config` — valid.

## Note (no action needed here)

The captured mailserver SDL inventory records `published_ports host_ip: ''` (a point-in-time snapshot from when it was all-interfaces). No test cross-checks that against compose, so nothing breaks; it'll reflect `127.0.0.1` on the next mailserver inventory recapture. Not hand-editing captured evidence to avoid fabricating a capture.
