### PR TITLE
fix: point TheHive references at https (it serves HTTPS on 9000)

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -61,7 +61,7 @@
       "command": "./tools/bin/thehivemcp",
       "args": ["--transport", "stdio"],
       "env": {
-        "THEHIVE_URL": "http://localhost:9000",
+        "THEHIVE_URL": "https://localhost:9000",
         "THEHIVE_API_KEY": "<run scripts/thehive-apikey.sh>",
         "THEHIVE_ORGANISATION": "APTL"
       }

--- a/docs/components/mcp-smoke-test-protocol.md
+++ b/docs/components/mcp-smoke-test-protocol.md
@@ -282,7 +282,7 @@ If SOC stack is enabled:
 | Service | URL | Check |
 |---|---|---|
 | MISP | https://localhost:8443 | Login page loads |
-| TheHive | http://localhost:9000 | Status API returns 200 |
+| TheHive | https://localhost:9000 | Status API returns 200 |
 | Shuffle | http://localhost:3443 | Frontend loads |
 
 ### 5. Network Connectivity

--- a/docs/testing/smoke-test-plan.md
+++ b/docs/testing/smoke-test-plan.md
@@ -143,7 +143,7 @@ Verify every container starts and passes its health check.
 |----|------|----------|-----|
 | SVC-30 | MISP container running | Status: running, HTTPS on 8443 | `curl -ks https://localhost:8443/users/login \| head -5` |
 | SVC-31 | MISP DB healthy | MariaDB running | `docker inspect aptl-misp-db --format '{{.State.Health.Status}}'` |
-| SVC-32 | TheHive running | API responds on port 9000 | `curl -sf http://localhost:9000/api/v1/status` |
+| SVC-32 | TheHive running | API responds on port 9000 | `curl -ksf https://localhost:9000/api/status` |
 | SVC-33 | TheHive Cassandra healthy | Status: healthy | `docker inspect aptl-thehive-cassandra --format '{{.State.Health.Status}}'` |
 | SVC-34 | TheHive ES healthy | Status: healthy | `docker inspect aptl-thehive-es --format '{{.State.Health.Status}}'` |
 | SVC-35 | Shuffle backend running | API responds on 5001 | `curl -sf http://localhost:5001/api/v1/health` |
@@ -424,7 +424,7 @@ Notes:
 - **Startup time**: The full stack (wazuh + enterprise + soc) takes 10-15 minutes for all services to become healthy. TheHive and MISP are the slowest. Don't start testing section 4 until SVC-30 through SVC-38 all pass.
 - **Order matters**: Section 3 (red team) should run before section 4 (blue team) because the blue team tests verify that attacks were detected. The Infrastructure Tester and Red Team Tester should work sequentially, not in parallel, for sections 2-3. Blue Team Tester can start section 4a/4c while red team finishes.
 - **MISP first-run**: MISP takes a long time on first boot (database migration). MCP-01 and MCP-02 may need to be retried after 5-10 minutes.
-- **TheHive first-run**: TheHive requires initial admin setup (create org + user + API key) before the MCP server can authenticate. The tester should create the admin account via the UI at `http://localhost:9000` first, then set `THEHIVE_API_KEY` in the environment.
+- **TheHive first-run**: TheHive requires initial admin setup (create org + user + API key) before the MCP server can authenticate. The tester should create the admin account via the UI at `https://localhost:9000` first, then set `THEHIVE_API_KEY` in the environment.
 - **Shuffle first-run**: Shuffle needs initial login and API key creation at `https://localhost:3443`. Set `SHUFFLE_API_KEY` after initial setup.
 - **Section 5 tests**: These require stopping the lab, changing `aptl.json`, and restarting. Run them last to avoid disrupting other tests.
 - **Kali tool availability**: Some Kali tools (ldapsearch, psql, smbclient) may need to be installed if not in the base image. The Red Team Tester should check and install as needed: `apt-get install -y ldap-utils postgresql-client smbclient`.

--- a/examples/aptl-lab-topology.sdl.yaml
+++ b/examples/aptl-lab-topology.sdl.yaml
@@ -718,7 +718,7 @@ conditions:
     interval: 15
 
   thehive-health:
-    command: "curl -sf http://localhost:9000/api/status || exit 1"
+    command: "curl -ksf https://localhost:9000/api/status || exit 1"
     interval: 30
 
   cassandra-health:

--- a/tests/test_mcp_config_example.py
+++ b/tests/test_mcp_config_example.py
@@ -1,0 +1,37 @@
+"""Guard for the shipped .mcp.json.example template.
+
+TheHive terminates HTTPS in-container on port 9000 (see the docker-compose
+healthcheck ``curl -ksf https://localhost:9000/api/status``), so a client
+pointed at ``http://localhost:9000`` gets a dead connection. The example MCP
+config is copied verbatim by users, so its TheHive URL must use the same
+scheme the service actually serves.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_mcp_example_is_valid_json() -> None:
+    data = json.loads((REPO_ROOT / ".mcp.json.example").read_text(encoding="utf-8"))
+    assert "mcpServers" in data
+
+
+def test_thehive_example_url_matches_served_scheme() -> None:
+    data = json.loads((REPO_ROOT / ".mcp.json.example").read_text(encoding="utf-8"))
+    url = data["mcpServers"]["thehive"]["env"]["THEHIVE_URL"]
+    assert url.startswith("https://"), (
+        f"TheHive serves HTTPS on 9000, so .mcp.json.example THEHIVE_URL must be "
+        f"https:// (got {url!r})"
+    )
+
+    # The compose healthcheck is the source of truth for the served scheme.
+    compose = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    assert re.search(r"curl[^\n]*https://localhost:9000/api/status", compose), (
+        "expected the docker-compose TheHive healthcheck to probe "
+        "https://localhost:9000/api/status"
+    )


### PR DESCRIPTION
## Summary

TheHive terminates HTTPS in-container on port 9000 — the docker-compose healthcheck is `curl -ksf https://localhost:9000/api/status`, and the captured inventory records a "9000 HTTPS listener." So anything pointed at `http://localhost:9000` gets a dead connection.

Several references still used `http://`, most importantly **`.mcp.json.example`**, which users copy verbatim to `.mcp.json` — so the TheHive MCP server (`thehivemcp`) is misconfigured out of the box. Surfaced during the pre-event clean-box walkthrough: an `http://localhost:9000` probe returned nothing while the container was healthy and serving on `https`.

## Change

Point the stale references at `https` (with `-k` for the self-signed lab CA cert):

- `.mcp.json.example` — `THEHIVE_URL` → `https://localhost:9000` (the functional fix).
- `docs/testing/smoke-test-plan.md` — SVC-32 probe → `curl -ksf https://localhost:9000/api/status` (also corrects the path to the served `/api/status`), and the first-run UI URL → `https://`.
- `docs/components/mcp-smoke-test-protocol.md` — TheHive endpoint → `https://`.
- `examples/aptl-lab-topology.sdl.yaml` — example healthcheck → `curl -ksf https://…`.
- Guard test `tests/test_mcp_config_example.py`: `.mcp.json.example`'s TheHive URL must be `https` and match the compose healthcheck scheme, so this can't silently re-drift.

The already-correct https references (mcp-casemgmt config, `core/collectors.py`, `scripts/thehive-apikey.sh`, `tests/helpers.py`) are unchanged. `scenarios/archive/` is left untouched (frozen reference material).

## Tests
`test_mcp_config_example.py` passes; `.mcp.json.example` is valid JSON; Vale clean on the changed docs; no `http://localhost:9000` references remain outside `scenarios/archive/`.
