### PR TITLE
feat: cross-platform core — hostenv layer + remove silent sudo (M8)

### DIFF
--- a/src/aptl/core/certs.py
+++ b/src/aptl/core/certs.py
@@ -9,12 +9,16 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from aptl.core import hostenv
 from aptl.utils.logging import get_logger
 
 log = get_logger("certs")
 
 _CERTS_SUBDIR = "config/wazuh_indexer_ssl_certs"
 _CERT_COMPOSE_FILE = "generate-indexer-certs.yml"
+# Reused (already pulled) to chown the bind-mounted certs from inside a
+# container, so ownership is repaired without escalating on the host.
+_CERT_GENERATOR_IMAGE = "wazuh/wazuh-certs-generator:0.0.2"
 
 
 @dataclass
@@ -98,29 +102,69 @@ def ensure_ssl_certs(project_dir: Path) -> CertResult:
             error=error_msg,
         )
 
-    log.info("Fixing certificate permissions...")
+    ownership_error = _fix_cert_ownership(certs_dir, project_dir)
+    if ownership_error is not None:
+        return ownership_error
 
-    # Fix ownership: chown -R $(id -u):$(id -g)
+    log.info("SSL certificates generated successfully at %s", certs_dir)
+    return CertResult(
+        success=True,
+        generated=True,
+        certs_dir=certs_dir,
+    )
+
+
+def _fix_cert_ownership(certs_dir: Path, project_dir: Path) -> CertResult | None:
+    """Repair ownership of container-generated certs without host sudo.
+
+    A native Linux Docker engine writes the bind-mounted certificates as
+    root. Instead of escalating on the host with ``sudo`` (which silently
+    runs under passwordless sudo, breaks on Windows, and is unnecessary on
+    Docker Desktop), chown the files back to the invoking user from *inside*
+    a throwaway container — root within the container, no host privilege.
+
+    Docker Desktop's file-sharing layer already maps ownership to the user,
+    and an unknown/absent engine must not trigger any privileged action, so
+    the fix runs only for a native Linux engine (see
+    :func:`hostenv.needs_host_ownership_fix`).
+
+    Returns ``None`` on success (or when no fix is needed), or a failing
+    :class:`CertResult` describing the problem.
+    """
+    if not hostenv.needs_host_ownership_fix():
+        log.info(
+            "Skipping certificate ownership fix "
+            "(not a native Linux Docker engine)."
+        )
+        return None
+
     uid = os.getuid()
     gid = os.getgid()
+    log.info("Repairing certificate ownership via container (uid=%d gid=%d)...", uid, gid)
     try:
         perm_result = subprocess.run(
-            ["sudo", "-n", "chown", "-R", f"{uid}:{gid}", str(certs_dir)],
+            [
+                "docker", "run", "--rm",
+                "--entrypoint", "chown",
+                "-v", f"{certs_dir}:/certificates",
+                _CERT_GENERATOR_IMAGE,
+                "-R", f"{uid}:{gid}", "/certificates",
+            ],
             capture_output=True,
             text=True,
             cwd=project_dir,
-            timeout=30,
+            timeout=60,
         )
     except subprocess.TimeoutExpired:
-        log.error("Permission fix timed out after 30s")
+        log.error("Ownership repair timed out after 60s")
         return CertResult(
             success=False,
             generated=True,
             certs_dir=certs_dir,
-            error="Permission fix timed out after 30s",
+            error="Certificate ownership repair timed out after 60s",
         )
     except (FileNotFoundError, OSError) as exc:
-        log.error("Failed to fix certificate permissions: %s", exc)
+        log.error("Failed to repair certificate ownership: %s", exc)
         return CertResult(
             success=False,
             generated=True,
@@ -129,16 +173,8 @@ def ensure_ssl_certs(project_dir: Path) -> CertResult:
         )
 
     if perm_result.returncode != 0:
-        stderr = perm_result.stderr.strip()
-        if "a password is required" in stderr or "sudo:" in stderr:
-            error_msg = (
-                f"sudo requires a password — run "
-                f"'sudo chown -R {uid}:{gid} {certs_dir}' manually "
-                f"or configure passwordless sudo for chown"
-            )
-        else:
-            error_msg = stderr or "Permission fix failed"
-        log.error("Failed to fix permissions: %s", error_msg)
+        error_msg = perm_result.stderr.strip() or "Certificate ownership repair failed"
+        log.error("Failed to repair certificate ownership: %s", error_msg)
         return CertResult(
             success=False,
             generated=True,
@@ -146,9 +182,4 @@ def ensure_ssl_certs(project_dir: Path) -> CertResult:
             error=error_msg,
         )
 
-    log.info("SSL certificates generated successfully at %s", certs_dir)
-    return CertResult(
-        success=True,
-        generated=True,
-        certs_dir=certs_dir,
-    )
+    return None

--- a/src/aptl/core/hostenv.py
+++ b/src/aptl/core/hostenv.py
@@ -1,0 +1,113 @@
+"""Host + Docker environment detection.
+
+Cross-platform capability layer for the ``aptl lab`` control plane. aptl runs
+on Linux, macOS, and Windows, and against either a native Linux Docker engine
+or Docker Desktop. Host-touching steps (kernel checks, file-ownership repair,
+key permissions) must branch on *which* OS and *which* Docker mode they are
+running under instead of assuming Linux-native semantics.
+
+Named ``hostenv`` rather than ``platform`` to avoid shadowing the stdlib
+``platform`` module for anyone reading or extending this package.
+"""
+
+import subprocess
+import sys
+
+from aptl.utils.logging import get_logger
+
+log = get_logger("hostenv")
+
+OS_LINUX = "linux"
+OS_MACOS = "macos"
+OS_WINDOWS = "windows"
+OS_UNKNOWN = "unknown"
+
+DOCKER_LINUX_NATIVE = "linux_native"
+DOCKER_DESKTOP = "docker_desktop"
+DOCKER_UNKNOWN = "unknown"
+
+
+def host_os() -> str:
+    """Return the host operating system.
+
+    One of :data:`OS_LINUX`, :data:`OS_MACOS`, :data:`OS_WINDOWS`, or
+    :data:`OS_UNKNOWN`. Derived from ``sys.platform`` (same signal the
+    existing ``kill.py`` process-scan gate uses).
+    """
+    plat = sys.platform
+    if plat.startswith("linux"):
+        return OS_LINUX
+    if plat == "darwin":
+        return OS_MACOS
+    if plat.startswith("win"):
+        return OS_WINDOWS
+    return OS_UNKNOWN
+
+
+def is_linux() -> bool:
+    """Return True when the host OS is Linux."""
+    return host_os() == OS_LINUX
+
+
+def is_macos() -> bool:
+    """Return True when the host OS is macOS."""
+    return host_os() == OS_MACOS
+
+
+def is_windows() -> bool:
+    """Return True when the host OS is Windows."""
+    return host_os() == OS_WINDOWS
+
+
+def docker_mode() -> str:
+    """Return whether Docker is a native Linux engine or Docker Desktop.
+
+    Probes ``docker info`` for its ``OperatingSystem`` field: Docker Desktop
+    reports the literal string ``Docker Desktop`` on every host OS, whereas a
+    native Linux engine reports the distribution (e.g. ``Ubuntu 24.04.4 LTS``).
+
+    Returns one of :data:`DOCKER_LINUX_NATIVE`, :data:`DOCKER_DESKTOP`, or
+    :data:`DOCKER_UNKNOWN`. Detection failures (Docker absent or not running)
+    yield :data:`DOCKER_UNKNOWN` so callers can fail safe.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "info", "--format", "{{.OperatingSystem}}"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        log.warning("Could not probe docker info: %s", exc)
+        return DOCKER_UNKNOWN
+
+    if result.returncode != 0:
+        log.warning(
+            "docker info returned non-zero: %s",
+            result.stderr.strip() or "no stderr",
+        )
+        return DOCKER_UNKNOWN
+
+    operating_system = result.stdout.strip()
+    if not operating_system:
+        return DOCKER_UNKNOWN
+    if operating_system == "Docker Desktop":
+        return DOCKER_DESKTOP
+    return DOCKER_LINUX_NATIVE
+
+
+def is_docker_desktop() -> bool:
+    """Return True when Docker is running as Docker Desktop."""
+    return docker_mode() == DOCKER_DESKTOP
+
+
+def needs_host_ownership_fix() -> bool:
+    """Return True when container-written bind-mount files need host chown.
+
+    Only a native Linux Docker engine bind-mounts files back onto the host as
+    root, requiring an ownership repair. Docker Desktop's file-sharing layer
+    maps ownership to the invoking user, and an unknown/absent engine must not
+    trigger any privileged action. So this is True only for
+    :data:`DOCKER_LINUX_NATIVE`.
+    """
+    return docker_mode() == DOCKER_LINUX_NATIVE

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -954,7 +954,9 @@ def _seed_suricata_volumes_local(ctx: _LabStartContext) -> LabResult | None:
 
     # ctx.backend is narrowed to the local Compose backend by the caller's guard.
     assert ctx.backend is not None
-    ownership = ensure_suricata_config_source_ownership(ctx.project_dir)
+    ownership = ensure_suricata_config_source_ownership(
+        ctx.project_dir, SURICATA_IMAGE
+    )
     if not ownership.success:
         log.error(
             "Suricata config source ownership restore failed: %s",

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -72,6 +72,7 @@ from aptl.core.snapshot import (
     list_container_snapshots,
 )
 from aptl.core.ssh import ensure_pivot_key, ensure_ssh_keys
+from aptl.core import hostenv
 from aptl.core.sysreqs import check_max_map_count
 from aptl.utils.logging import get_logger
 from aptl.utils.redaction import redact
@@ -779,7 +780,21 @@ def _step_ensure_ssh_keys(ctx: _LabStartContext) -> LabResult | None:
 
 
 def _step_check_sysreqs(ctx: _LabStartContext) -> LabResult | None:
-    """Validate host kernel settings required by Wazuh."""
+    """Validate host kernel settings required by Wazuh.
+
+    ``vm.max_map_count`` is a Linux kernel parameter that only applies to a
+    native Linux Docker engine. On Docker Desktop (any host OS) the setting
+    lives inside the Docker VM, which ships an adequate default, and on
+    macOS/Windows the ``sysctl`` OID does not exist at all. Enforcing the
+    check there would abort ``lab start`` for a setting the host cannot own,
+    so it is skipped (not failed) whenever we are not on a native Linux engine.
+    """
+    if hostenv.is_docker_desktop() or not hostenv.is_linux():
+        log.info(
+            "Step 4: Skipping vm.max_map_count check "
+            "(handled by the Docker VM on Docker Desktop / non-Linux hosts)."
+        )
+        return None
     log.info("Step 4: Checking system requirements...")
     sysreq_result = check_max_map_count()
     if sysreq_result.passed:

--- a/src/aptl/core/suricata_seed.py
+++ b/src/aptl/core/suricata_seed.py
@@ -17,6 +17,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from aptl.core import hostenv
 from aptl.core.credentials import (
     PathContainmentError,
     _canonical_generated_path,
@@ -105,30 +106,37 @@ def _chown_direct(paths: list[Path], uid: int, gid: int) -> list[Path]:
     return [p for p in paths if p.stat().st_uid != uid]
 
 
-def _sudo_chown_error(stderr: str, paths_arg: list[str], uid: int, gid: int) -> str:
-    """Build the actionable error message for a failed ``sudo chown``."""
-    stderr = stderr.strip()
-    if "a password is required" in stderr or "sudo:" in stderr:
-        hint = f"sudo chown {uid}:{gid} " + " ".join(paths_arg)
-        return (
-            f"Suricata config sources are not writable — run "
-            f"'{hint}' manually or configure passwordless sudo for chown"
-        )
-    return stderr or "Suricata config ownership restore failed"
-
-
-def _restore_via_sudo(
-    still_foreign: list[Path], uid: int, gid: int, project_dir: Path,
+def _restore_via_container(
+    still_foreign: list[Path],
+    uid: int,
+    gid: int,
+    project_dir: Path,
+    seeder_image: str,
 ) -> SuricataSourceOwnershipResult:
-    """Escalate the ownership repair through passwordless ``sudo chown``."""
-    paths_arg = [str(p) for p in still_foreign]
+    """Chown the still-foreign sources from inside a root container.
+
+    Repairs ownership without escalating on the host: a throwaway container
+    runs as root and chowns the bind-mounted files to the invoking user. No
+    host ``sudo`` — silent under passwordless sudo, absent on Windows, and
+    unnecessary on Docker Desktop. Reuses the Suricata seeder image, which is
+    already present at this step.
+    """
+    rel_targets = [
+        f"/project/{p.relative_to(project_dir).as_posix()}" for p in still_foreign
+    ]
     try:
         perm_result = subprocess.run(
-            ["sudo", "-n", "chown", f"{uid}:{gid}", *paths_arg],
+            [
+                "docker", "run", "--rm",
+                "--entrypoint", "chown",
+                "-v", f"{project_dir}:/project",
+                seeder_image,
+                f"{uid}:{gid}", *rel_targets,
+            ],
             capture_output=True,
             text=True,
             cwd=project_dir,
-            timeout=30,
+            timeout=60,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         return SuricataSourceOwnershipResult(
@@ -142,12 +150,15 @@ def _restore_via_sudo(
     if perm_result.returncode != 0:
         return SuricataSourceOwnershipResult(
             success=False,
-            error=_sudo_chown_error(perm_result.stderr, paths_arg, uid, gid),
+            error=(
+                perm_result.stderr.strip()
+                or "Suricata config ownership restore failed"
+            ),
         )
 
     repaired = tuple(str(p.relative_to(project_dir)) for p in still_foreign)
     log.info(
-        "Restored Suricata config source ownership via sudo: %s",
+        "Restored Suricata config source ownership via container: %s",
         ", ".join(repaired),
     )
     return SuricataSourceOwnershipResult(success=True, repaired=repaired)
@@ -155,6 +166,7 @@ def _restore_via_sudo(
 
 def ensure_suricata_config_source_ownership(
     project_dir: Path,
+    seeder_image: str,
 ) -> SuricataSourceOwnershipResult:
     """Return checked-in Suricata seed sources to the invoking operator's uid/gid.
 
@@ -166,7 +178,14 @@ def ensure_suricata_config_source_ownership(
     write (EOF fixer). This is a narrow, idempotent repair — it only
     touches the two canonical seed sources when their owner is not the
     current uid.
+
+    The UID-991 trap only occurs on a native Linux Docker engine; on Docker
+    Desktop and macOS/Windows there are no foreign-owned sources (and
+    ``os.getuid`` does not exist on Windows), so the repair is skipped there.
     """
+    if not hostenv.needs_host_ownership_fix():
+        return SuricataSourceOwnershipResult(success=True)
+
     uid = os.getuid()
     gid = os.getgid()
     try:
@@ -177,7 +196,9 @@ def ensure_suricata_config_source_ownership(
     foreign = _foreign_owned_sources(source_files, uid)
     still_foreign = _chown_direct(foreign, uid, gid) if foreign else []
     if still_foreign:
-        return _restore_via_sudo(still_foreign, uid, gid, project_dir)
+        return _restore_via_container(
+            still_foreign, uid, gid, project_dir, seeder_image
+        )
 
     repaired = tuple(str(p.relative_to(project_dir)) for p in foreign)
     if repaired:

--- a/tests/test_certs.py
+++ b/tests/test_certs.py
@@ -1,13 +1,26 @@
 """Tests for SSL certificate generation.
 
-Tests are written FIRST (TDD). All subprocess calls are mocked.
+All subprocess calls are mocked. The ownership-repair step no longer uses
+host ``sudo`` (#677): on a native Linux engine it chowns the bind-mounted
+certs from inside a throwaway container; on Docker Desktop / non-Linux it is
+skipped entirely. ``hostenv.needs_host_ownership_fix`` and ``os.getuid/getgid``
+are mocked so the suite is deterministic and runs on any OS.
 """
 
 import subprocess
-from pathlib import Path
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
+
+
+@pytest.fixture
+def linux_native(mocker):
+    """Force the native-Linux ownership-repair branch with a fixed uid/gid."""
+    mocker.patch(
+        "aptl.core.certs.hostenv.needs_host_ownership_fix", return_value=True
+    )
+    mocker.patch("aptl.core.certs.os.getuid", return_value=1000)
+    mocker.patch("aptl.core.certs.os.getgid", return_value=1000)
 
 
 class TestEnsureSSLCerts:
@@ -30,14 +43,12 @@ class TestEnsureSSLCerts:
         assert result.certs_dir == certs_dir
         mock_run.assert_not_called()
 
-    def test_calls_docker_compose_when_certs_missing(self, tmp_path, mocker):
+    def test_calls_docker_compose_when_certs_missing(self, tmp_path, mocker, linux_native):
         """Should run docker compose generate-indexer-certs.yml when no certs."""
         from aptl.core.certs import ensure_ssl_certs
 
-        # Do NOT create the certs dir
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-
         certs_dir = config_dir / "wazuh_indexer_ssl_certs"
 
         def fake_compose(cmd, **kwargs):
@@ -56,8 +67,6 @@ class TestEnsureSSLCerts:
         assert result.generated is True
         assert result.certs_dir == certs_dir
 
-        # Verify docker compose was called with the cert generation file
-        assert mock_run.call_count >= 1
         first_call_cmd = mock_run.call_args_list[0][0][0]
         assert "docker" in first_call_cmd
         assert "compose" in first_call_cmd
@@ -67,8 +76,7 @@ class TestEnsureSSLCerts:
         """Should return failure when docker compose fails."""
         from aptl.core.certs import ensure_ssl_certs
 
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
+        (tmp_path / "config").mkdir()
 
         mocker.patch(
             "aptl.core.certs.subprocess.run",
@@ -85,47 +93,83 @@ class TestEnsureSSLCerts:
         assert result.generated is False
         assert "generator" in result.error.lower() or "failed" in result.error.lower()
 
-    def test_handles_permission_fixing_failure(self, tmp_path, mocker):
-        """Should return failure when chown/chmod fails."""
+    def test_ownership_fix_skipped_on_docker_desktop(self, tmp_path, mocker):
+        """#677: no ownership step at all on Docker Desktop / non-Linux."""
         from aptl.core.certs import ensure_ssl_certs
 
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
 
-        certs_dir = config_dir / "wazuh_indexer_ssl_certs"
+        mocker.patch(
+            "aptl.core.certs.hostenv.needs_host_ownership_fix", return_value=False
+        )
 
-        call_count = 0
+        def fake_compose(cmd, **kwargs):
+            certs_dir.mkdir(parents=True, exist_ok=True)
+            return MagicMock(returncode=0, stdout="", stderr="")
 
-        def mock_side_effect(cmd, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                # docker compose succeeds
-                certs_dir.mkdir(parents=True, exist_ok=True)
-                return MagicMock(returncode=0, stdout="", stderr="")
-            else:
-                # chown/chmod fails
-                return MagicMock(
-                    returncode=1,
-                    stdout="",
-                    stderr="Permission denied",
-                )
-
-        mocker.patch("aptl.core.certs.subprocess.run", side_effect=mock_side_effect)
+        mock_run = mocker.patch(
+            "aptl.core.certs.subprocess.run", side_effect=fake_compose
+        )
 
         result = ensure_ssl_certs(tmp_path)
 
-        assert result.success is False
-        assert "permission" in result.error.lower()
+        assert result.success is True
+        assert result.generated is True
+        # Only the generator ran; no ownership-repair call.
+        assert mock_run.call_count == 1
 
-    def test_generated_true_when_compose_succeeds_but_chown_fails(self, tmp_path, mocker):
-        """Should set generated=True when certs were created but chown fails (C3)."""
+    def test_ownership_repair_uses_container_not_sudo(self, tmp_path, mocker, linux_native):
+        """#677: ownership repair chowns via a container, never host sudo."""
         from aptl.core.certs import ensure_ssl_certs
 
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
 
-        certs_dir = config_dir / "wazuh_indexer_ssl_certs"
+        def fake_run(cmd, **kwargs):
+            certs_dir.mkdir(parents=True, exist_ok=True)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run = mocker.patch(
+            "aptl.core.certs.subprocess.run", side_effect=fake_run
+        )
+
+        ensure_ssl_certs(tmp_path)
+
+        assert mock_run.call_count == 2
+        repair_cmd = mock_run.call_args_list[1][0][0]
+        # Container-based chown, no host escalation.
+        assert repair_cmd[0] == "docker"
+        assert "run" in repair_cmd
+        assert "--entrypoint" in repair_cmd and "chown" in repair_cmd
+        assert f"{certs_dir}:/certificates" in repair_cmd
+
+    def test_no_command_ever_uses_sudo(self, tmp_path, mocker, linux_native):
+        """#677 guard: not a single issued command may invoke sudo."""
+        from aptl.core.certs import ensure_ssl_certs
+
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
+
+        def fake_run(cmd, **kwargs):
+            certs_dir.mkdir(parents=True, exist_ok=True)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run = mocker.patch(
+            "aptl.core.certs.subprocess.run", side_effect=fake_run
+        )
+
+        ensure_ssl_certs(tmp_path)
+
+        for issued in mock_run.call_args_list:
+            assert "sudo" not in issued[0][0]
+
+    def test_generated_true_when_ownership_repair_fails(self, tmp_path, mocker, linux_native):
+        """Should set generated=True when certs exist but ownership repair fails."""
+        from aptl.core.certs import ensure_ssl_certs
+
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
 
         call_count = 0
 
@@ -133,43 +177,9 @@ class TestEnsureSSLCerts:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                # docker compose succeeds -- certs were generated
                 certs_dir.mkdir(parents=True, exist_ok=True)
                 return MagicMock(returncode=0, stdout="", stderr="")
-            else:
-                # chown fails
-                return MagicMock(
-                    returncode=1,
-                    stdout="",
-                    stderr="Permission denied",
-                )
-
-        mocker.patch("aptl.core.certs.subprocess.run", side_effect=mock_side_effect)
-
-        result = ensure_ssl_certs(tmp_path)
-
-        assert result.success is False
-        assert result.generated is True  # certs WERE generated, only perms failed
-
-    def test_generated_true_when_compose_succeeds_but_chown_raises(self, tmp_path, mocker):
-        """Should set generated=True when certs were created but chown raises OSError (C3)."""
-        from aptl.core.certs import ensure_ssl_certs
-
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        certs_dir = config_dir / "wazuh_indexer_ssl_certs"
-
-        call_count = 0
-
-        def mock_side_effect(cmd, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                certs_dir.mkdir(parents=True, exist_ok=True)
-                return MagicMock(returncode=0, stdout="", stderr="")
-            else:
-                raise OSError("sudo not found")
+            return MagicMock(returncode=1, stdout="", stderr="Permission denied")
 
         mocker.patch("aptl.core.certs.subprocess.run", side_effect=mock_side_effect)
 
@@ -178,9 +188,58 @@ class TestEnsureSSLCerts:
         assert result.success is False
         assert result.generated is True
 
+    def test_generated_true_when_ownership_repair_raises(self, tmp_path, mocker, linux_native):
+        """Should set generated=True when the repair container raises OSError."""
+        from aptl.core.certs import ensure_ssl_certs
+
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
+
+        call_count = 0
+
+        def mock_side_effect(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                certs_dir.mkdir(parents=True, exist_ok=True)
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise OSError("docker not found")
+
+        mocker.patch("aptl.core.certs.subprocess.run", side_effect=mock_side_effect)
+
+        result = ensure_ssl_certs(tmp_path)
+
+        assert result.success is False
+        assert result.generated is True
+
+    def test_ownership_repair_timeout_returns_generated_true(self, tmp_path, mocker, linux_native):
+        """Should return generated=True when the repair container times out."""
+        from aptl.core.certs import ensure_ssl_certs
+
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
+
+        call_count = 0
+
+        def mock_side_effect(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                certs_dir.mkdir(parents=True, exist_ok=True)
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise subprocess.TimeoutExpired(cmd="docker", timeout=60)
+
+        mocker.patch("aptl.core.certs.subprocess.run", side_effect=mock_side_effect)
+
+        result = ensure_ssl_certs(tmp_path)
+
+        assert result.success is False
+        assert result.generated is True
+        assert "timed out" in result.error.lower()
+
     def test_returns_correct_cert_result_fields(self, tmp_path, mocker):
         """Should return CertResult with all fields properly set."""
-        from aptl.core.certs import ensure_ssl_certs, CertResult
+        from aptl.core.certs import CertResult, ensure_ssl_certs
 
         certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
         certs_dir.mkdir(parents=True)
@@ -194,35 +253,31 @@ class TestEnsureSSLCerts:
         assert result.certs_dir == certs_dir
         assert result.error == ""
 
-    def test_uses_project_dir_as_cwd(self, tmp_path, mocker):
+    def test_uses_project_dir_as_cwd(self, tmp_path, mocker, linux_native):
         """Should pass project_dir as cwd to subprocess calls."""
         from aptl.core.certs import ensure_ssl_certs
 
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-        certs_dir = config_dir / "wazuh_indexer_ssl_certs"
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
 
         def fake_compose(cmd, **kwargs):
             certs_dir.mkdir(parents=True, exist_ok=True)
             return MagicMock(returncode=0, stdout="", stderr="")
 
         mock_run = mocker.patch(
-            "aptl.core.certs.subprocess.run",
-            side_effect=fake_compose,
+            "aptl.core.certs.subprocess.run", side_effect=fake_compose
         )
 
         ensure_ssl_certs(tmp_path)
 
-        # The docker compose call should use project_dir as cwd
-        kwargs = mock_run.call_args_list[0][1]
-        assert kwargs.get("cwd") == tmp_path
+        for issued in mock_run.call_args_list:
+            assert issued[1].get("cwd") == tmp_path
 
     def test_handles_subprocess_exception(self, tmp_path, mocker):
-        """Should handle subprocess raising an exception."""
+        """Should handle the generator subprocess raising an exception."""
         from aptl.core.certs import ensure_ssl_certs
 
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
+        (tmp_path / "config").mkdir()
 
         mocker.patch(
             "aptl.core.certs.subprocess.run",
@@ -238,8 +293,7 @@ class TestEnsureSSLCerts:
         """Should return generated=False when docker compose times out."""
         from aptl.core.certs import ensure_ssl_certs
 
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
+        (tmp_path / "config").mkdir()
 
         mocker.patch(
             "aptl.core.certs.subprocess.run",
@@ -252,113 +306,22 @@ class TestEnsureSSLCerts:
         assert result.generated is False
         assert "timed out" in result.error.lower()
 
-    def test_chown_timeout_returns_generated_true(self, tmp_path, mocker):
-        """Should return generated=True when chown times out after cert gen succeeds."""
+    def test_subprocess_call_timeouts(self, tmp_path, mocker, linux_native):
+        """Generator uses timeout=300; ownership repair uses timeout=60."""
         from aptl.core.certs import ensure_ssl_certs
 
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-        certs_dir = config_dir / "wazuh_indexer_ssl_certs"
-
-        call_count = 0
-
-        def mock_side_effect(cmd, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                certs_dir.mkdir(parents=True, exist_ok=True)
-                return MagicMock(returncode=0, stdout="", stderr="")
-            else:
-                raise subprocess.TimeoutExpired(cmd="sudo", timeout=30)
-
-        mocker.patch("aptl.core.certs.subprocess.run", side_effect=mock_side_effect)
-
-        result = ensure_ssl_certs(tmp_path)
-
-        assert result.success is False
-        assert result.generated is True
-        assert "timed out" in result.error.lower()
-
-    def test_chown_uses_sudo_noninteractive_flag(self, tmp_path, mocker):
-        """Should pass -n flag to sudo so it fails instead of prompting."""
-        from aptl.core.certs import ensure_ssl_certs
-
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-        certs_dir = config_dir / "wazuh_indexer_ssl_certs"
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
 
         def fake_run(cmd, **kwargs):
             certs_dir.mkdir(parents=True, exist_ok=True)
             return MagicMock(returncode=0, stdout="", stderr="")
 
         mock_run = mocker.patch(
-            "aptl.core.certs.subprocess.run",
-            side_effect=fake_run,
+            "aptl.core.certs.subprocess.run", side_effect=fake_run
         )
 
         ensure_ssl_certs(tmp_path)
 
-        # Second call is the chown
-        assert mock_run.call_count == 2
-        chown_cmd = mock_run.call_args_list[1][0][0]
-        assert chown_cmd[0] == "sudo"
-        assert chown_cmd[1] == "-n"
-        assert chown_cmd[2] == "chown"
-
-    def test_docker_compose_called_with_timeout(self, tmp_path, mocker):
-        """Should pass timeout=300 to docker compose subprocess call."""
-        from aptl.core.certs import ensure_ssl_certs
-
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-        certs_dir = config_dir / "wazuh_indexer_ssl_certs"
-
-        def fake_run(cmd, **kwargs):
-            certs_dir.mkdir(parents=True, exist_ok=True)
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        mock_run = mocker.patch(
-            "aptl.core.certs.subprocess.run",
-            side_effect=fake_run,
-        )
-
-        ensure_ssl_certs(tmp_path)
-
-        # First call: docker compose with timeout=300
-        compose_kwargs = mock_run.call_args_list[0][1]
-        assert compose_kwargs["timeout"] == 300
-
-        # Second call: chown with timeout=30
-        chown_kwargs = mock_run.call_args_list[1][1]
-        assert chown_kwargs["timeout"] == 30
-
-    def test_sudo_password_required_gives_actionable_error(self, tmp_path, mocker):
-        """Should give actionable guidance when sudo requires a password."""
-        from aptl.core.certs import ensure_ssl_certs
-
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-        certs_dir = config_dir / "wazuh_indexer_ssl_certs"
-
-        call_count = 0
-
-        def mock_side_effect(cmd, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                certs_dir.mkdir(parents=True, exist_ok=True)
-                return MagicMock(returncode=0, stdout="", stderr="")
-            else:
-                return MagicMock(
-                    returncode=1,
-                    stdout="",
-                    stderr="sudo: a password is required",
-                )
-
-        mocker.patch("aptl.core.certs.subprocess.run", side_effect=mock_side_effect)
-
-        result = ensure_ssl_certs(tmp_path)
-
-        assert result.success is False
-        assert result.generated is True
-        assert "manually" in result.error.lower() or "passwordless" in result.error.lower()
+        assert mock_run.call_args_list[0][1]["timeout"] == 300
+        assert mock_run.call_args_list[1][1]["timeout"] == 60

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -757,17 +757,46 @@ def _write_suricata_sources(project_dir):
 class TestEnsureSuricataConfigSourceOwnership:
     """Legacy pre-ADR-043 bind mounts could leave seed sources unwritable."""
 
-    def test_no_op_when_sources_owned_by_current_user(self, tmp_path):
+    _IMAGE = "jasonish/suricata:7.0"
+
+    def _force_linux_native(self, monkeypatch):
+        """Force the native-Linux branch (#678) so the repair logic runs."""
+        monkeypatch.setattr(
+            "aptl.core.suricata_seed.hostenv.needs_host_ownership_fix",
+            lambda: True,
+        )
+
+    def test_no_op_when_sources_owned_by_current_user(self, tmp_path, monkeypatch):
         from aptl.core.suricata_seed import ensure_suricata_config_source_ownership
 
+        self._force_linux_native(monkeypatch)
         _write_suricata_sources(tmp_path)
-        result = ensure_suricata_config_source_ownership(tmp_path)
+        result = ensure_suricata_config_source_ownership(tmp_path, self._IMAGE)
         assert result.success is True
         assert result.repaired == ()
 
-    def test_restores_foreign_owned_sources_with_sudo(self, tmp_path, monkeypatch):
+    def test_skipped_on_non_linux_engine(self, tmp_path, monkeypatch):
+        """#678: no-op (no os.getuid, no subprocess) off a native Linux engine."""
         from aptl.core.suricata_seed import ensure_suricata_config_source_ownership
 
+        monkeypatch.setattr(
+            "aptl.core.suricata_seed.hostenv.needs_host_ownership_fix",
+            lambda: False,
+        )
+        # os.getuid must never be reached (it does not exist on Windows).
+        monkeypatch.setattr(
+            os,
+            "getuid",
+            lambda: (_ for _ in ()).throw(AssertionError("getuid called")),
+        )
+        result = ensure_suricata_config_source_ownership(tmp_path, self._IMAGE)
+        assert result.success is True
+        assert result.repaired == ()
+
+    def test_restores_foreign_owned_sources_with_container(self, tmp_path, monkeypatch):
+        from aptl.core.suricata_seed import ensure_suricata_config_source_ownership
+
+        self._force_linux_native(monkeypatch)
         _write_suricata_sources(tmp_path)
         yaml_path = tmp_path / "config" / "suricata" / "suricata.yaml"
         rules_path = tmp_path / "config" / "suricata" / "rules" / "local.rules"
@@ -797,17 +826,22 @@ class TestEnsureSuricataConfigSourceOwnership:
         )
         monkeypatch.setattr(subprocess, "run", fake_run)
 
-        result = ensure_suricata_config_source_ownership(tmp_path)
+        result = ensure_suricata_config_source_ownership(tmp_path, self._IMAGE)
         assert result.success is True
         assert set(result.repaired) == {
             "config/suricata/suricata.yaml",
             "config/suricata/rules/local.rules",
         }
-        assert calls[0][:4] == ["sudo", "-n", "chown", f"{os.getuid()}:{os.getgid()}"]
+        # Container-based chown, never host sudo.
+        assert calls[0][0] == "docker"
+        assert "run" in calls[0] and "--entrypoint" in calls[0] and "chown" in calls[0]
+        assert "sudo" not in calls[0]
+        assert self._IMAGE in calls[0]
 
-    def test_reports_actionable_error_when_sudo_unavailable(self, tmp_path, monkeypatch):
+    def test_reports_error_when_container_repair_fails(self, tmp_path, monkeypatch):
         from aptl.core.suricata_seed import ensure_suricata_config_source_ownership
 
+        self._force_linux_native(monkeypatch)
         _write_suricata_sources(tmp_path)
         yaml_path = tmp_path / "config" / "suricata" / "suricata.yaml"
 
@@ -826,15 +860,14 @@ class TestEnsureSuricataConfigSourceOwnership:
         )
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(
-                cmd, 1, "", "sudo: a password is required",
-            )
+            return subprocess.CompletedProcess(cmd, 1, "", "chown: operation not permitted")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
 
-        result = ensure_suricata_config_source_ownership(tmp_path)
+        result = ensure_suricata_config_source_ownership(tmp_path, self._IMAGE)
         assert result.success is False
-        assert "passwordless sudo" in result.error
+        assert "not permitted" in result.error
+        assert "sudo" not in result.error
 
 
 class TestBuildSuricataVolumeSeeds:

--- a/tests/test_hostenv.py
+++ b/tests/test_hostenv.py
@@ -1,0 +1,113 @@
+"""Tests for the host + Docker environment detection layer."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+import pytest
+
+from aptl.core import hostenv
+
+
+@dataclass
+class _FakeProc:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# host_os / is_* — driven by sys.platform
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("sys_platform", "expected"),
+    [
+        ("linux", hostenv.OS_LINUX),
+        ("linux2", hostenv.OS_LINUX),
+        ("darwin", hostenv.OS_MACOS),
+        ("win32", hostenv.OS_WINDOWS),
+        ("cygwin", hostenv.OS_UNKNOWN),
+        ("freebsd13", hostenv.OS_UNKNOWN),
+    ],
+)
+def test_host_os_mapping(monkeypatch, sys_platform, expected) -> None:
+    monkeypatch.setattr(hostenv.sys, "platform", sys_platform)
+    assert hostenv.host_os() == expected
+
+
+def test_os_boolean_helpers(monkeypatch) -> None:
+    monkeypatch.setattr(hostenv.sys, "platform", "linux")
+    assert hostenv.is_linux() and not hostenv.is_macos() and not hostenv.is_windows()
+
+    monkeypatch.setattr(hostenv.sys, "platform", "darwin")
+    assert hostenv.is_macos() and not hostenv.is_linux() and not hostenv.is_windows()
+
+    monkeypatch.setattr(hostenv.sys, "platform", "win32")
+    assert hostenv.is_windows() and not hostenv.is_linux() and not hostenv.is_macos()
+
+
+# --------------------------------------------------------------------------- #
+# docker_mode — driven by `docker info` OperatingSystem
+# --------------------------------------------------------------------------- #
+def _patch_docker(monkeypatch, *, returncode=0, stdout="", stderr="", raises=None):
+    def fake_run(cmd, **kwargs):
+        assert cmd[:2] == ["docker", "info"]
+        if raises is not None:
+            raise raises
+        return _FakeProc(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr(hostenv.subprocess, "run", fake_run)
+
+
+def test_docker_mode_desktop(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="Docker Desktop\n")
+    assert hostenv.docker_mode() == hostenv.DOCKER_DESKTOP
+    assert hostenv.is_docker_desktop() is True
+
+
+def test_docker_mode_linux_native(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="Ubuntu 24.04.4 LTS\n")
+    assert hostenv.docker_mode() == hostenv.DOCKER_LINUX_NATIVE
+    assert hostenv.is_docker_desktop() is False
+
+
+def test_docker_mode_unknown_on_nonzero(monkeypatch) -> None:
+    _patch_docker(monkeypatch, returncode=1, stderr="Cannot connect to the Docker daemon")
+    assert hostenv.docker_mode() == hostenv.DOCKER_UNKNOWN
+
+
+def test_docker_mode_unknown_on_empty(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="   \n")
+    assert hostenv.docker_mode() == hostenv.DOCKER_UNKNOWN
+
+
+def test_docker_mode_unknown_when_docker_absent(monkeypatch) -> None:
+    _patch_docker(monkeypatch, raises=FileNotFoundError("docker"))
+    assert hostenv.docker_mode() == hostenv.DOCKER_UNKNOWN
+
+
+def test_docker_mode_unknown_on_timeout(monkeypatch) -> None:
+    _patch_docker(
+        monkeypatch, raises=subprocess.TimeoutExpired(cmd="docker info", timeout=15)
+    )
+    assert hostenv.docker_mode() == hostenv.DOCKER_UNKNOWN
+
+
+# --------------------------------------------------------------------------- #
+# needs_host_ownership_fix — True only for a native Linux engine
+# --------------------------------------------------------------------------- #
+def test_ownership_fix_only_for_linux_native(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="Ubuntu 24.04.4 LTS")
+    assert hostenv.needs_host_ownership_fix() is True
+
+
+def test_ownership_fix_skipped_on_desktop(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="Docker Desktop")
+    assert hostenv.needs_host_ownership_fix() is False
+
+
+def test_ownership_fix_skipped_when_unknown(monkeypatch) -> None:
+    """Fail safe: never trigger a privileged fix when the engine is unknown."""
+    _patch_docker(monkeypatch, raises=FileNotFoundError("docker"))
+    assert hostenv.needs_host_ownership_fix() is False

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -985,7 +985,16 @@ class TestOrchestrateLabStart:
             ),
         )
 
-        # Mock sysreqs
+        # Mock sysreqs. The sysreqs step is now gated on host/Docker mode
+        # (#680): force a native-Linux engine so the orchestration tests
+        # exercise the check_max_map_count path without shelling out to
+        # `docker info`.
+        mocks["is_docker_desktop"] = mocker.patch(
+            "aptl.core.lab.hostenv.is_docker_desktop", return_value=False
+        )
+        mocks["is_linux"] = mocker.patch(
+            "aptl.core.lab.hostenv.is_linux", return_value=True
+        )
         from aptl.core.sysreqs import SysReqResult
         mocks["sysreqs"] = mocker.patch(
             "aptl.core.lab.check_max_map_count",
@@ -1174,6 +1183,47 @@ class TestOrchestrateLabStart:
         assert "map_count" in result.error.lower() or "sysreq" in result.error.lower()
         # Should not have tried to start lab
         mocks["start"].assert_not_called()
+
+    def test_sysreqs_skipped_on_docker_desktop(self, mocker):
+        """#680: vm.max_map_count is not enforced under Docker Desktop."""
+        from aptl.core.lab import _step_check_sysreqs
+
+        mocker.patch("aptl.core.lab.hostenv.is_docker_desktop", return_value=True)
+        mocker.patch("aptl.core.lab.hostenv.is_linux", return_value=True)
+        check = mocker.patch("aptl.core.lab.check_max_map_count")
+
+        assert _step_check_sysreqs(mocker.Mock()) is None
+        check.assert_not_called()
+
+    def test_sysreqs_skipped_on_non_linux(self, mocker):
+        """#680: vm.max_map_count is not enforced on macOS/Windows hosts."""
+        from aptl.core.lab import _step_check_sysreqs
+
+        mocker.patch("aptl.core.lab.hostenv.is_docker_desktop", return_value=False)
+        mocker.patch("aptl.core.lab.hostenv.is_linux", return_value=False)
+        check = mocker.patch("aptl.core.lab.check_max_map_count")
+
+        assert _step_check_sysreqs(mocker.Mock()) is None
+        check.assert_not_called()
+
+    def test_sysreqs_enforced_on_linux_native(self, mocker):
+        """#680: the check still runs (and can fail) on a native Linux engine."""
+        from aptl.core.lab import _step_check_sysreqs
+        from aptl.core.sysreqs import SysReqResult
+
+        mocker.patch("aptl.core.lab.hostenv.is_docker_desktop", return_value=False)
+        mocker.patch("aptl.core.lab.hostenv.is_linux", return_value=True)
+        check = mocker.patch(
+            "aptl.core.lab.check_max_map_count",
+            return_value=SysReqResult(
+                passed=False, current_value=65530, required_value=262144
+            ),
+        )
+
+        result = _step_check_sysreqs(mocker.Mock())
+
+        assert result is not None and result.success is False
+        check.assert_called_once()
 
     def test_stops_on_ssh_key_generation_failure(self, mocker, tmp_path):
         """Should fail if SSH key generation fails."""

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1016,6 +1016,14 @@ class TestOrchestrateLabStart:
             "aptl.core.deployment.docker_compose."
             "DockerComposeBackend.seed_named_volumes",
         )
+        # The seed step also runs the legacy source-ownership repair, which
+        # now probes hostenv (docker info). Stub it so the orchestration
+        # tests stay hermetic (#678).
+        from aptl.core.suricata_seed import SuricataSourceOwnershipResult
+        mocks["suricata_ownership"] = mocker.patch(
+            "aptl.core.suricata_seed.ensure_suricata_config_source_ownership",
+            return_value=SuricataSourceOwnershipResult(success=True),
+        )
 
         # Mock certs
         from aptl.core.certs import CertResult


### PR DESCRIPTION
## What

M8 cross-platform core: introduce a host/Docker-mode detection layer and remove every Linux-native assumption that either aborts `lab start` off-Linux or silently escalates privileges.

Closes #676, #680, #677, #678 (milestone M8).

## Changes
- **#676** — `core/hostenv.py`: `host_os()`, `is_linux/macos/windows()`, `docker_mode()` (`linux_native` vs `docker_desktop`), `needs_host_ownership_fix()`. Named `hostenv` to avoid shadowing stdlib `platform`. Fully unit-tested (mocked) across all branches.
- **#680** — gate the `vm.max_map_count` check: **skip-not-fail** on Docker Desktop / non-Linux (the setting lives in the Docker VM there; the OID doesn't exist on macOS/Windows). Fixes `lab start` aborting on Mac/Windows. Unchanged (including its actionable failure) on a native Linux engine.
- **#677** — certs: replace the `sudo -n chown` on root-owned bind-mounted certs with a **container-root chown** (throwaway container, no host privilege), gated to native-Linux; skipped on Docker Desktop (FS layer maps ownership). Removes `os.getuid/getgid` from any Windows-reachable path.
- **#678** — Suricata legacy source-ownership repair: gate to native-Linux (no-op elsewhere, so no `os.getuid` crash on Windows) and replace the `sudo -n` fallback with a container-root chown reusing the seeder image.

**Result:** no `sudo` reference remains anywhere in `src/aptl/`.

## Tests
- New `tests/test_hostenv.py` (16); rewrote `test_certs.py` to the no-sudo model incl. a guard asserting no issued command contains `sudo`; updated `test_credentials.py` (Suricata) + `test_lab.py` (sysreq gating + hermetic ownership mock). 238 passing across touched files locally.

## Not yet in this PR (rest of M8)
- #681 Windows-safe uid/gid + SSH key perms · #684 LF-safe configs · #679 no-silent-escalation guard test · #682 cross-platform CI matrix · #683 per-OS docs · #685 end-to-end validation on macOS + Windows (AWS harness).

## Validation note
Changes are unit-validated on Linux. Runtime behaviour of the container-chown paths and the Mac/Windows boot path are proven under #685 (EC2 macOS + Windows). This PR has **not** been through the codex/GRC review chain — flagging so you can decide how to gate the merge.
