### PR TITLE
feat: add host platform detection layer

### DIFF
--- a/src/aptl/core/hostenv.py
+++ b/src/aptl/core/hostenv.py
@@ -1,0 +1,126 @@
+"""Host + Docker environment detection.
+
+Cross-platform capability layer for the ``aptl lab`` control plane. aptl runs
+on Linux, macOS, and Windows, and against either a native Linux Docker engine
+or Docker Desktop. Host-touching steps (kernel checks, file-ownership repair,
+key permissions) must branch on *which* OS and *which* Docker mode they are
+running under instead of assuming Linux-native semantics.
+
+Named ``hostenv`` rather than ``platform`` to avoid shadowing the stdlib
+``platform`` module for anyone reading or extending this package.
+"""
+
+import subprocess
+import sys
+
+from aptl.utils.logging import get_logger
+
+log = get_logger("hostenv")
+
+OS_LINUX = "linux"
+OS_MACOS = "macos"
+OS_WINDOWS = "windows"
+OS_UNKNOWN = "unknown"
+
+DOCKER_LINUX_NATIVE = "linux_native"
+DOCKER_DESKTOP = "docker_desktop"
+DOCKER_UNKNOWN = "unknown"
+
+
+def host_os() -> str:
+    """Return the host operating system.
+
+    One of :data:`OS_LINUX`, :data:`OS_MACOS`, :data:`OS_WINDOWS`, or
+    :data:`OS_UNKNOWN`. Derived from ``sys.platform`` (same signal the
+    existing ``kill.py`` process-scan gate uses).
+    """
+    plat = sys.platform
+    detected = OS_UNKNOWN
+    if plat.startswith("linux"):
+        detected = OS_LINUX
+    elif plat == "darwin":
+        detected = OS_MACOS
+    elif plat.startswith("win"):
+        detected = OS_WINDOWS
+    return detected
+
+
+def is_linux() -> bool:
+    """Return True when the host OS is Linux."""
+    return host_os() == OS_LINUX
+
+
+def is_macos() -> bool:
+    """Return True when the host OS is macOS."""
+    return host_os() == OS_MACOS
+
+
+def is_windows() -> bool:
+    """Return True when the host OS is Windows."""
+    return host_os() == OS_WINDOWS
+
+
+def docker_mode() -> str:
+    """Return whether Docker is a native Linux engine or Docker Desktop.
+
+    Probes ``docker info`` for its ``OperatingSystem`` field: Docker Desktop
+    reports the literal string ``Docker Desktop`` on every host OS, whereas a
+    native Linux engine reports the distribution (e.g. ``Ubuntu 24.04.4 LTS``).
+
+    Returns one of :data:`DOCKER_LINUX_NATIVE`, :data:`DOCKER_DESKTOP`, or
+    :data:`DOCKER_UNKNOWN`. Detection failures (Docker absent or not running)
+    yield :data:`DOCKER_UNKNOWN` so callers can fail safe.
+    """
+    return _docker_mode_from_operating_system(_docker_operating_system())
+
+
+def _docker_operating_system() -> str | None:
+    try:
+        result = _run_docker_info()
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        log.warning("Could not probe docker info: %s", exc)
+        return None
+    if result.returncode != 0:
+        log.warning(
+            "docker info returned non-zero: %s",
+            result.stderr.strip() or "no stderr",
+        )
+        return None
+
+    operating_system = result.stdout.strip()
+    return operating_system or None
+
+
+def _run_docker_info() -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", "info", "--format", "{{.OperatingSystem}}"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def _docker_mode_from_operating_system(operating_system: str | None) -> str:
+    mode = DOCKER_UNKNOWN
+    if operating_system == "Docker Desktop":
+        mode = DOCKER_DESKTOP
+    elif operating_system:
+        mode = DOCKER_LINUX_NATIVE
+    return mode
+
+
+def is_docker_desktop() -> bool:
+    """Return True when Docker is running as Docker Desktop."""
+    return docker_mode() == DOCKER_DESKTOP
+
+
+def needs_host_ownership_fix() -> bool:
+    """Return True when container-written bind-mount files need host chown.
+
+    Only a native Linux Docker engine bind-mounts files back onto the host as
+    root, requiring an ownership repair. Docker Desktop's file-sharing layer
+    maps ownership to the invoking user, and an unknown/absent engine must not
+    trigger any privileged action. So this is True only for
+    :data:`DOCKER_LINUX_NATIVE`.
+    """
+    return docker_mode() == DOCKER_LINUX_NATIVE

--- a/src/aptl/core/hostenv.py
+++ b/src/aptl/core/hostenv.py
@@ -77,7 +77,7 @@ def docker_mode() -> str:
 def _docker_operating_system() -> str | None:
     try:
         result = _run_docker_info()
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+    except (OSError, subprocess.TimeoutExpired) as exc:
         log.warning("Could not probe docker info: %s", exc)
         return None
     if result.returncode != 0:

--- a/src/aptl/core/hostenv.py
+++ b/src/aptl/core/hostenv.py
@@ -75,6 +75,7 @@ def docker_mode() -> str:
 
 
 def _docker_operating_system() -> str | None:
+    """Return Docker's reported operating system, or None when unavailable."""
     try:
         result = _run_docker_info()
     except (OSError, subprocess.TimeoutExpired) as exc:
@@ -92,6 +93,7 @@ def _docker_operating_system() -> str | None:
 
 
 def _run_docker_info() -> subprocess.CompletedProcess[str]:
+    """Run the Docker CLI probe used for engine-mode detection."""
     return subprocess.run(
         ["docker", "info", "--format", "{{.OperatingSystem}}"],
         capture_output=True,
@@ -101,6 +103,7 @@ def _run_docker_info() -> subprocess.CompletedProcess[str]:
 
 
 def _docker_mode_from_operating_system(operating_system: str | None) -> str:
+    """Classify a Docker operating-system string into an aptl Docker mode."""
     mode = DOCKER_UNKNOWN
     if operating_system == "Docker Desktop":
         mode = DOCKER_DESKTOP

--- a/tests/test_hostenv.py
+++ b/tests/test_hostenv.py
@@ -1,0 +1,113 @@
+"""Tests for the host + Docker environment detection layer."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+import pytest
+
+from aptl.core import hostenv
+
+
+@dataclass
+class _FakeProc:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# host_os / is_* — driven by sys.platform
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("sys_platform", "expected"),
+    [
+        ("linux", hostenv.OS_LINUX),
+        ("linux2", hostenv.OS_LINUX),
+        ("darwin", hostenv.OS_MACOS),
+        ("win32", hostenv.OS_WINDOWS),
+        ("cygwin", hostenv.OS_UNKNOWN),
+        ("freebsd13", hostenv.OS_UNKNOWN),
+    ],
+)
+def test_host_os_mapping(monkeypatch, sys_platform, expected) -> None:
+    monkeypatch.setattr(hostenv.sys, "platform", sys_platform)
+    assert hostenv.host_os() == expected
+
+
+def test_os_boolean_helpers(monkeypatch) -> None:
+    monkeypatch.setattr(hostenv.sys, "platform", "linux")
+    assert hostenv.is_linux() and not hostenv.is_macos() and not hostenv.is_windows()
+
+    monkeypatch.setattr(hostenv.sys, "platform", "darwin")
+    assert hostenv.is_macos() and not hostenv.is_linux() and not hostenv.is_windows()
+
+    monkeypatch.setattr(hostenv.sys, "platform", "win32")
+    assert hostenv.is_windows() and not hostenv.is_linux() and not hostenv.is_macos()
+
+
+# --------------------------------------------------------------------------- #
+# docker_mode — driven by `docker info` OperatingSystem
+# --------------------------------------------------------------------------- #
+def _patch_docker(monkeypatch, *, returncode=0, stdout="", stderr="", raises=None):
+    def fake_run(cmd, **kwargs):
+        assert cmd[:2] == ["docker", "info"]
+        if raises is not None:
+            raise raises
+        return _FakeProc(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr(hostenv.subprocess, "run", fake_run)
+
+
+def test_docker_mode_desktop(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="Docker Desktop\n")
+    assert hostenv.docker_mode() == hostenv.DOCKER_DESKTOP
+    assert hostenv.is_docker_desktop() is True
+
+
+def test_docker_mode_linux_native(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="Ubuntu 24.04.4 LTS\n")
+    assert hostenv.docker_mode() == hostenv.DOCKER_LINUX_NATIVE
+    assert hostenv.is_docker_desktop() is False
+
+
+def test_docker_mode_unknown_on_nonzero(monkeypatch) -> None:
+    _patch_docker(monkeypatch, returncode=1, stderr="Cannot connect to the Docker daemon")
+    assert hostenv.docker_mode() == hostenv.DOCKER_UNKNOWN
+
+
+def test_docker_mode_unknown_on_empty(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="   \n")
+    assert hostenv.docker_mode() == hostenv.DOCKER_UNKNOWN
+
+
+def test_docker_mode_unknown_when_docker_absent(monkeypatch) -> None:
+    _patch_docker(monkeypatch, raises=FileNotFoundError("docker"))
+    assert hostenv.docker_mode() == hostenv.DOCKER_UNKNOWN
+
+
+def test_docker_mode_unknown_on_timeout(monkeypatch) -> None:
+    _patch_docker(
+        monkeypatch, raises=subprocess.TimeoutExpired(cmd="docker info", timeout=15)
+    )
+    assert hostenv.docker_mode() == hostenv.DOCKER_UNKNOWN
+
+
+# --------------------------------------------------------------------------- #
+# needs_host_ownership_fix — True only for a native Linux engine
+# --------------------------------------------------------------------------- #
+def test_ownership_fix_only_for_linux_native(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="Ubuntu 24.04.4 LTS")
+    assert hostenv.needs_host_ownership_fix() is True
+
+
+def test_ownership_fix_skipped_on_desktop(monkeypatch) -> None:
+    _patch_docker(monkeypatch, stdout="Docker Desktop")
+    assert hostenv.needs_host_ownership_fix() is False
+
+
+def test_ownership_fix_skipped_when_unknown(monkeypatch) -> None:
+    """Fail safe: never trigger a privileged fix when the engine is unknown."""
+    _patch_docker(monkeypatch, raises=FileNotFoundError("docker"))
+    assert hostenv.needs_host_ownership_fix() is False


### PR DESCRIPTION
## What
Add the M8 foundation for cross-platform host and Docker-mode detection.

Closes #676.

## Changes
- Add `src/aptl/core/hostenv.py` with `host_os()`, OS helpers, `docker_mode()`, `is_docker_desktop()`, and `needs_host_ownership_fix()`.
- Detect Linux, macOS, Windows, and unknown hosts from `sys.platform`.
- Detect Docker Desktop vs native Linux Docker with `docker info --format {{.OperatingSystem}}`, returning `unknown` when Docker is unavailable or cannot be probed.
- Treat host ownership repair as needed only for native Linux Docker.
- Cover the OS and Docker branches with unit tests.

## Tests
- `.venv/bin/python -m pytest tests/test_hostenv.py -q`
- `.venv/bin/python -m pytest -n auto -k "not integration"`
- `.venv/bin/pre-commit run --all-files`
- `PATH=/home/atomik/src/aptl/.venv/bin:$PATH .venv/bin/python -m pytest -n auto tests/test_techvault_static_gate.py -m integration`
