### PR TITLE
fix: preserve LF rendered configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,48 @@
 # `union` concatenates both sides of append-only conflicts instead of
 # producing conflict markers. See `changelog.d/README.md`.
 CHANGELOG.md merge=union
+
+# Linux containers consume these files through bind mounts or Docker/Compose
+# parsers. Keep shipped templates and generated artifact paths LF-normalized
+# even when the checkout happens on a Windows host.
+docker-compose*.yml text eol=lf
+aptl.json text eol=lf
+.env.example text eol=lf
+.mcp.json.example text eol=lf
+
+config/**/*.conf text eol=lf
+config/**/*.env text eol=lf
+config/**/*.list text eol=lf
+config/**/*.py text eol=lf
+config/**/*.rules text eol=lf
+config/**/*.xml text eol=lf
+config/**/*.yaml text eol=lf
+config/**/*.yml text eol=lf
+config/wazuh_cluster/custom-shuffle text eol=lf
+config/wazuh_cluster/etc/lists/active-response-whitelist text eol=lf
+
+containers/**/Dockerfile* text eol=lf
+containers/**/*.conf text eol=lf
+containers/**/*.css text eol=lf
+containers/**/*.html text eol=lf
+containers/**/*.json text eol=lf
+containers/**/*.md text eol=lf
+containers/**/*.ps1 text eol=lf
+containers/**/*.py text eol=lf
+containers/**/*.rules text eol=lf
+containers/**/*.service text eol=lf
+containers/**/*.sh text eol=lf
+containers/**/*.sql text eol=lf
+containers/**/*.template text eol=lf
+containers/**/*.txt text eol=lf
+containers/**/*.yaml text eol=lf
+containers/**/*.yml text eol=lf
+containers/**/*.zone text eol=lf
+containers/dns/zones/172.20.rev text eol=lf
+containers/kali/scripts/* text eol=lf
+containers/keys/* text eol=lf
+
+scripts/**/*.sh text eol=lf
+
+.aptl/config/** text eol=lf
+.aptl/realization/** text eol=lf

--- a/src/aptl/core/credentials.py
+++ b/src/aptl/core/credentials.py
@@ -231,7 +231,7 @@ def _atomic_write_secure(target: Path, content: str) -> None:
             f"Temp render path {tmp} escapes its output directory {parent}"
         )
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as fh:
             fh.write(content)
             fh.flush()
             os.fsync(fh.fileno())
@@ -290,7 +290,7 @@ def _render_secure(
     if not source_path.exists():
         raise FileNotFoundError(f"Config template not found: {source_path}")
 
-    rendered = transform(source_path.read_text())
+    rendered = transform(source_path.read_text(encoding="utf-8"))
 
     # Reject a symlinked generated path *before* we mkdir/chmod through
     # it (a symlink at .aptl/config or the output file could otherwise

--- a/src/aptl/core/deployment/_compose_image_realization.py
+++ b/src/aptl/core/deployment/_compose_image_realization.py
@@ -120,6 +120,7 @@ class ComposeRealizationImageMixin:
         override_path.write_text(
             yaml.safe_dump({"services": services}, sort_keys=True),
             encoding="utf-8",
+            newline="\n",
         )
         return override_path
 

--- a/src/aptl/core/env.py
+++ b/src/aptl/core/env.py
@@ -239,7 +239,7 @@ def _write_dotenv(path: Path, content: str) -> None:
     )
     tmp_path = Path(tmp_name)
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as tmp:
             tmp.write(content)
         os.replace(tmp_path, path)
         if os.name == "posix":

--- a/src/aptl/services/misp_suricata_sync/rule_writer.py
+++ b/src/aptl/services/misp_suricata_sync/rule_writer.py
@@ -33,7 +33,7 @@ def write_if_changed(target: Path, content: str) -> bool:
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp = target.with_suffix(target.suffix + ".tmp")
     try:
-        with open(tmp, "w", encoding="utf-8") as fh:
+        with open(tmp, "w", encoding="utf-8", newline="\n") as fh:
             fh.write(content)
             fh.flush()
             os.fsync(fh.fileno())

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -32,6 +32,20 @@ _skip_no_posix_modes = pytest.mark.skipif(
 )
 
 
+def _patch_windows_default_fdopen(mocker, module_path: str):
+    """Make text writes default to CRLF unless the caller pins newlines."""
+    real_fdopen = os.fdopen
+
+    def fdopen_with_windows_default(fd, mode="r", *args, **kwargs):
+        if "b" not in mode and "newline" not in kwargs:
+            kwargs["newline"] = "\r\n"
+        return real_fdopen(fd, mode, *args, **kwargs)
+
+    return mocker.patch(
+        f"{module_path}.os.fdopen", side_effect=fdopen_with_windows_default
+    )
+
+
 def _layout_dashboard(project_dir: Path, content: str) -> Path:
     target = project_dir / _DASHBOARD_SOURCE_RELPATH
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -178,6 +192,26 @@ class TestSyncDashboardConfig:
         rendered_dir = _rendered_dashboard(tmp_path).parent
         assert not list(rendered_dir.glob("*.tmp"))
 
+    def test_rendered_dashboard_config_is_lf_even_from_crlf_template(
+        self, tmp_path, mocker,
+    ):
+        from aptl.core.credentials import sync_dashboard_config
+
+        source = tmp_path / _DASHBOARD_SOURCE_RELPATH
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(
+            b"hosts:\r\n"
+            b"  - default:\r\n"
+            b'      password: "placeholder"\r\n'
+        )
+        _patch_windows_default_fdopen(mocker, "aptl.core.credentials")
+
+        sync_dashboard_config(tmp_path, "a-real-secret")
+
+        rendered = _rendered_dashboard(tmp_path).read_bytes()
+        assert b"\r\n" not in rendered
+        assert b'password: "a-real-secret"\n' in rendered
+
 
 class TestSyncManagerConfig:
     """Tests for manager (wazuh_manager.conf) cluster key rendering."""
@@ -219,6 +253,28 @@ class TestSyncManagerConfig:
         assert source.read_bytes() == before
         assert "real-cluster-secret" not in source.read_text()
         assert '<key>real-cluster-secret</key>' in _rendered_manager(tmp_path).read_text()
+
+    def test_rendered_manager_config_is_lf_even_from_crlf_template(
+        self, tmp_path, mocker,
+    ):
+        from aptl.core.credentials import sync_manager_config
+
+        source = tmp_path / _MANAGER_SOURCE_RELPATH
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(
+            b"<ossec_config>\r\n"
+            b"  <cluster>\r\n"
+            b"    <key>placeholder_cluster_key</key>\r\n"
+            b"  </cluster>\r\n"
+            b"</ossec_config>\r\n"
+        )
+        _patch_windows_default_fdopen(mocker, "aptl.core.credentials")
+
+        sync_manager_config(tmp_path, "real-cluster-secret")
+
+        rendered = _rendered_manager(tmp_path).read_bytes()
+        assert b"\r\n" not in rendered
+        assert b"<key>real-cluster-secret</key>\n" in rendered
 
     def test_preserves_surrounding_xml_content(self, tmp_path):
         from aptl.core.credentials import sync_manager_config

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -842,6 +842,16 @@ class TestDockerComposeBackend:
             ),
         )
         (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+        real_write_text = Path.write_text
+
+        def write_text_with_windows_default(
+            path, data, encoding=None, errors=None, newline=None,
+        ):
+            if newline is None:
+                newline = "\r\n"
+            return real_write_text(
+                path, data, encoding=encoding, errors=errors, newline=newline,
+            )
 
         def fake_run(cmd, **kwargs):
             del kwargs
@@ -849,7 +859,10 @@ class TestDockerComposeBackend:
                 return MagicMock(returncode=0, stdout="test_aptl-internal\n", stderr="")
             return MagicMock(returncode=0, stdout="", stderr="")
 
-        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+        with (
+            patch.object(Path, "write_text", new=write_text_with_windows_default),
+            patch("subprocess.run", side_effect=fake_run) as mock_run,
+        ):
             result = backend.realize(spec, build=False)
 
         assert result.success is True
@@ -880,6 +893,7 @@ class TestDockerComposeBackend:
         assert "custom:" in override
         assert "image: aptl-custom:local" in override
         assert "build: null" in override
+        assert b"\r\n" not in override_path.read_bytes()
 
     def test_stop_calls_compose_down(self, tmp_path):
         backend = self._make_backend(tmp_path)

--- a/tests/test_env_hydration.py
+++ b/tests/test_env_hydration.py
@@ -4,6 +4,20 @@ import os
 from uuid import uuid4
 
 
+def _patch_windows_default_fdopen(mocker, module_path):
+    """Make text writes default to CRLF unless the caller pins newlines."""
+    real_fdopen = os.fdopen
+
+    def fdopen_with_windows_default(fd, mode="r", *args, **kwargs):
+        if "b" not in mode and "newline" not in kwargs:
+            kwargs["newline"] = "\r\n"
+        return real_fdopen(fd, mode, *args, **kwargs)
+
+    return mocker.patch(
+        f"{module_path}.os.fdopen", side_effect=fdopen_with_windows_default
+    )
+
+
 def _write_wazuh_templates(project_dir):
     """Create minimal Wazuh templates used by dotenv hydration."""
     values = {
@@ -68,6 +82,19 @@ class TestHydrateDotenv:
         assert find_placeholder_env_values(env) == []
         if os.name == "posix":
             assert env_path.stat().st_mode & 0o777 == 0o600
+
+    def test_created_env_uses_lf_when_host_default_is_crlf(self, tmp_path, mocker):
+        from aptl.core.env import hydrate_dotenv
+
+        _write_wazuh_templates(tmp_path)
+        env_path = tmp_path / ".env"
+        _patch_windows_default_fdopen(mocker, "aptl.core.env")
+
+        hydrate_dotenv(env_path)
+
+        raw = env_path.read_bytes()
+        assert b"\r\n" not in raw
+        assert raw.endswith(b"\n")
 
     def test_replaces_placeholders_and_appends_missing_values(self, tmp_path):
         from aptl.core.env import find_placeholder_env_values, hydrate_dotenv, load_dotenv

--- a/tests/test_line_endings.py
+++ b/tests/test_line_endings.py
@@ -1,0 +1,21 @@
+"""Line-ending policy tests for cross-platform lab artifacts."""
+
+from pathlib import Path
+
+
+def test_gitattributes_locks_lab_artifacts_to_lf():
+    attrs = Path(".gitattributes").read_text(encoding="utf-8")
+
+    required_rules = {
+        "docker-compose*.yml text eol=lf",
+        "config/**/*.yml text eol=lf",
+        "config/**/*.xml text eol=lf",
+        "containers/**/*.sh text eol=lf",
+        "containers/**/*.ps1 text eol=lf",
+        "scripts/**/*.sh text eol=lf",
+        ".aptl/config/** text eol=lf",
+        ".aptl/realization/** text eol=lf",
+    }
+
+    missing = sorted(rule for rule in required_rules if rule not in attrs)
+    assert missing == []

--- a/tests/test_misp_suricata_sync.py
+++ b/tests/test_misp_suricata_sync.py
@@ -6,6 +6,7 @@ The translator MUST never emit ``drop``/``reject`` regardless of input.
 
 from __future__ import annotations
 
+import builtins
 import json
 import logging
 import socket
@@ -600,13 +601,31 @@ class TestRenderHashListFile:
 class TestWriteIfChanged:
     """Tests for the atomic, idempotent rule-file writer."""
 
-
     def test_creates_file_when_missing(self, tmp_path: Path):
         from aptl.services.misp_suricata_sync.rule_writer import write_if_changed
 
         target = tmp_path / "misp-iocs.rules"
         assert write_if_changed(target, "hello\n") is True
         assert target.read_text() == "hello\n"
+
+    def test_writes_lf_when_host_default_is_crlf(self, tmp_path: Path, mocker):
+        from aptl.services.misp_suricata_sync.rule_writer import write_if_changed
+
+        real_open = builtins.open
+
+        def open_with_windows_default(file, mode="r", *args, **kwargs):
+            if "b" not in mode and "w" in mode and "newline" not in kwargs:
+                kwargs["newline"] = "\r\n"
+            return real_open(file, mode, *args, **kwargs)
+
+        mocker.patch("builtins.open", side_effect=open_with_windows_default)
+        target = tmp_path / "misp-iocs.rules"
+
+        assert write_if_changed(target, "alert\nsecond\n") is True
+
+        raw = target.read_bytes()
+        assert b"\r\n" not in raw
+        assert raw == b"alert\nsecond\n"
 
     def test_returns_false_when_content_identical(self, tmp_path: Path):
         from aptl.services.misp_suricata_sync.rule_writer import write_if_changed


### PR DESCRIPTION
## Summary
- enforce LF checkout policy for shipped lab config, container templates, scripts, and ignored rendered artifact paths
- write credentialized configs, generated .env, Suricata IOC rules, and ACES Compose overrides with explicit LF newlines
- add Windows-default newline simulation tests for rendered files and generated lab artifacts

## Validation
- .venv/bin/python -m pytest tests/test_credentials.py tests/test_env_hydration.py tests/test_misp_suricata_sync.py tests/test_deployment_backend.py tests/test_line_endings.py -q
- rg CR-byte scan over .gitattributes, docker-compose.yml, config/, containers/, scripts/, .env.example, .mcp.json.example, aptl.json
- git check-attr text eol for representative shipped and generated artifact paths
- .venv/bin/pre-commit run --all-files

Closes #684