### PR TITLE
fix: use exception logging for cert generator

### DIFF
--- a/src/aptl/core/certs.py
+++ b/src/aptl/core/certs.py
@@ -158,7 +158,7 @@ def _run_cert_generator(project_dir: Path, certs_dir: Path) -> CertResult | None
         )
         error_msg = "Certificate generation timed out after 300s"
     except OSError as exc:
-        log.error("Failed to run docker compose: %s", exc)
+        log.exception("Failed to run docker compose")
         error_msg = str(exc)
     else:
         if result.returncode != 0:


### PR DESCRIPTION
## Summary

Fix the Sonar branch-gate finding on `dev` by using `log.exception(...)` in the certificate generator's Docker Compose launch failure path.

## Root cause

The `dev` push run for PR #703 failed Sonar rule `python:S8572` at `src/aptl/core/certs.py:161`; the handler logged the caught `OSError` with `log.error(..., exc)` instead of exception-aware logging.

## Validation

- `.venv/bin/pytest tests/test_certs.py -q`
- `.venv/bin/ruff format --check src/aptl/core/certs.py`
- `.venv/bin/ruff check src/aptl/core/certs.py`
- `pre-commit run --all-files`
