### PR TITLE
fix: use exception logging for sysreq parse errors

### DIFF
--- a/src/aptl/core/sysreqs.py
+++ b/src/aptl/core/sysreqs.py
@@ -161,8 +161,8 @@ def _evaluate_sysctl_result(
     stdout = result.stdout.strip()
     try:
         current_value = _parse_sysctl_value(stdout)
-    except ValueError as exc:
-        log.error("Failed to parse sysctl output '%s': %s", stdout, exc)
+    except ValueError:
+        log.exception("Failed to parse sysctl output '%s'", stdout)
         return SysReqResult(
             passed=False,
             current_value=0,


### PR DESCRIPTION
## Summary
- use exception logging for sysctl parse failures so the branch Sonar new-issue gate is satisfied

## Verification
- `.venv/bin/pytest tests/test_sysreqs.py -q`
- `.venv/bin/ruff format --check src/aptl/core/sysreqs.py`
- `.venv/bin/ruff check src/aptl/core/sysreqs.py`
- `pre-commit run --all-files`