### PR TITLE
feat: auto-remap in-use host ports and report real URLs on lab start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,13 @@ SHUFFLE_API_KEY=31a211c4-ea5c-4a49-b022-5e2434e758a7
 # Grafana (OTel observability stack)
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=CHANGE_ME_grafana_password
+
+# Host-port publishing. Every service's published host port has a
+# `${APTL_HP_<SERVICE>_<PORT>:-default}` (or, for DNS, `APTL_DNS_HOST_PORT`)
+# override. `aptl lab start` probes each default and, if it is already in use
+# on this host (e.g. mDNS on 5353, an editor's port-forwarding, another app),
+# automatically publishes that service on a free port instead and reports the
+# real port in the start summary. Set any of these to pin a specific port; a
+# value you set here is always honored as-is.
+# APTL_DNS_HOST_PORT=5353
+# APTL_HP_WAZUH_DASHBOARD_5601=443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,10 +22,10 @@ services:
       # surfaces bind 127.0.0.1 so they are not reachable from other hosts on
       # the operator's LAN. Container-side ports and the security-net addresses
       # are unchanged; in-cluster agents reach the manager over the Docker net.
-      - "127.0.0.1:1514:1514"
-      - "127.0.0.1:1515:1515"
-      - "127.0.0.1:514:514/udp"
-      - "127.0.0.1:55000:55000"
+      - "127.0.0.1:${APTL_HP_WAZUH_MANAGER_1514:-1514}:1514"
+      - "127.0.0.1:${APTL_HP_WAZUH_MANAGER_1515:-1515}:1515"
+      - "127.0.0.1:${APTL_HP_WAZUH_MANAGER_514:-514}:514/udp"
+      - "127.0.0.1:${APTL_HP_WAZUH_MANAGER_55000:-55000}:55000"
     environment:
       - INDEXER_URL=https://wazuh.indexer:9200
       - INDEXER_USERNAME=${INDEXER_USERNAME}
@@ -98,7 +98,7 @@ services:
     restart: always
     ports:
       # ADR-034 Host Exposure Amendment (issue #416): loopback-only.
-      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:${APTL_HP_WAZUH_INDEXER_9200:-9200}:9200"
     environment:
       - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
     ulimits:
@@ -140,7 +140,7 @@ services:
     restart: always
     ports:
       # ADR-034 Host Exposure Amendment (issue #416): loopback-only.
-      - "127.0.0.1:443:5601"
+      - "127.0.0.1:${APTL_HP_WAZUH_DASHBOARD_5601:-443}:5601"
     environment:
       - INDEXER_USERNAME=${INDEXER_USERNAME}
       - INDEXER_PASSWORD=${INDEXER_PASSWORD}
@@ -246,7 +246,7 @@ services:
     restart: unless-stopped
     ports:
       # ADR-034 Host Exposure Amendment (issue #416): loopback-only.
-      - "127.0.0.1:8443:443"
+      - "127.0.0.1:${APTL_HP_MISP_443:-8443}:443"
     environment:
       - MYSQL_HOST=misp-db
       - MYSQL_DATABASE=misp
@@ -388,7 +388,7 @@ services:
     restart: unless-stopped
     ports:
       # ADR-034 Host Exposure Amendment (issue #416): loopback-only.
-      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:${APTL_HP_THEHIVE_9000:-9000}:9000"
     environment:
       - JVM_OPTS=-Xms512m -Xmx512m
     # SEC-006 / ADR-034: keystore password loaded from the env_file
@@ -553,11 +553,11 @@ services:
       # in-container nginx config overlay terminates TLS using the
       # lab-CA-signed cert. ADR-034 Host Exposure Amendment (issue #416):
       # loopback-only.
-      - "127.0.0.1:3443:443"
+      - "127.0.0.1:${APTL_HP_SHUFFLE_FRONTEND_443:-3443}:443"
       # Host port 3001 → container 80 (HTTP). The in-container nginx
       # listens on 80/443 only; the previous 3001:3001 mapping pointed at
       # a port nothing listens on (issue #405). Loopback-only (issue #416).
-      - "127.0.0.1:3001:80"
+      - "127.0.0.1:${APTL_HP_SHUFFLE_FRONTEND_80:-3001}:80"
     environment:
       - BACKEND_HOSTNAME=shuffle-backend
     volumes:
@@ -661,7 +661,7 @@ services:
       # ADR-034 Host Exposure Amendment (issue #416): Cortex holds the host
       # docker.sock; loopback-binding removes the LAN-reachable management
       # surface. (Socket-proxy hardening is a separate follow-up.)
-      - "127.0.0.1:9001:9001"
+      - "127.0.0.1:${APTL_HP_CORTEX_9001:-9001}:9001"
     environment:
       - job_directory=/opt/cortex/jobs
     volumes:
@@ -706,7 +706,7 @@ services:
     hostname: webapp
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "${APTL_HP_WEBAPP_8080:-8080}:8080"
     environment:
       - DB_HOST=172.20.2.11
       - DB_PORT=5432
@@ -766,10 +766,10 @@ services:
       # In-range traffic (kali phishing -> victims) uses the docker networks
       # below, not these host publishes; these exist only for operator access
       # from the host itself.
-      - "127.0.0.1:25:25"
-      - "127.0.0.1:143:143"
-      - "127.0.0.1:587:587"
-      - "127.0.0.1:993:993"
+      - "127.0.0.1:${APTL_HP_MAILSERVER_25:-25}:25"
+      - "127.0.0.1:${APTL_HP_MAILSERVER_143:-143}:143"
+      - "127.0.0.1:${APTL_HP_MAILSERVER_587:-587}:587"
+      - "127.0.0.1:${APTL_HP_MAILSERVER_993:-993}:993"
     environment:
       - ENABLE_SPAMASSASSIN=0
       - ENABLE_CLAMAV=0
@@ -807,8 +807,8 @@ services:
     hostname: ns1.techvault.local
     restart: unless-stopped
     ports:
-      - "5353:53/tcp"
-      - "5353:53/udp"
+      - "${APTL_DNS_HOST_PORT:-5353}:53/tcp"
+      - "${APTL_DNS_HOST_PORT:-5353}:53/udp"
     environment:
       # In-process Wazuh agent (issue #248) — replaces wazuh-sidecar-dns.
       - WAZUH_MANAGER=wazuh.manager
@@ -1275,7 +1275,11 @@ services:
       - APTL_PROXY_TARGET_HOST=172.20.4.30
       - APTL_PROXY_TARGET_PORT=22
     ports:
-      - "127.0.0.1:2023:2023"
+      # Default host port 2023 matches the MCP red config's pinned ssh_port
+      # (mcp/mcp-red/docker-lab-config.json). `aptl lab start` may remap it if
+      # 2023 is in use; the start summary then flags that the MCP client needs
+      # the reported port. The default parity is enforced by test_consistency.
+      - "127.0.0.1:${APTL_HP_KALI_SSH_PROXY_2023:-2023}:2023"
     networks:
       aptl-control:
       aptl-redteam:
@@ -1367,7 +1371,7 @@ services:
       aptl-security:
         ipv4_address: 172.20.0.27
     ports:
-      - "2027:22"    # SSH access
+      - "${APTL_HP_REVERSE_22:-2027}:22"    # SSH access
     environment:
       - SIEM_IP=172.20.0.10  # wazuh.manager
       - LABADMIN_SSH_KEY_FILE=/keys/aptl_lab_key.pub
@@ -1413,7 +1417,7 @@ services:
     restart: unless-stopped
     ports:
       # Loopback-only: only the operator's machine can reach this port (ADR-039).
-      - "127.0.0.1:8400:8400"
+      - "127.0.0.1:${APTL_HP_APTL_WEB_API_8400:-8400}:8400"
     environment:
       - APTL_PROJECT_DIR=/project
       # Validated by the API at runtime. Do not use `${VAR:?}` here: Compose
@@ -1444,7 +1448,7 @@ services:
     restart: unless-stopped
     ports:
       # Loopback-only: only the operator's machine can reach the UI (ADR-039).
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:${APTL_HP_APTL_WEB_UI_3000:-3000}:3000"
     # UI-008a: serves the built static SPA and reverse-proxies /api/* (incl. the
     # terminal WebSocket) to aptl-web-api, which owns the entire auth/CSRF
     # boundary (the FastAPI BFF). The control-plane token is NOT present in this
@@ -1470,8 +1474,8 @@ services:
     image: otel/opentelemetry-collector-contrib:0.123.0
     restart: unless-stopped
     ports:
-      - "127.0.0.1:4317:4317"
-      - "127.0.0.1:4318:4318"
+      - "127.0.0.1:${APTL_HP_APTL_OTEL_COLLECTOR_4317:-4317}:4317"
+      - "127.0.0.1:${APTL_HP_APTL_OTEL_COLLECTOR_4318:-4318}:4318"
     volumes:
       - ./config/otel/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
     healthcheck:
@@ -1495,7 +1499,7 @@ services:
     restart: unless-stopped
     command: ["-config.file=/etc/tempo/tempo.yaml"]
     ports:
-      - "127.0.0.1:3200:3200"
+      - "127.0.0.1:${APTL_HP_APTL_TEMPO_3200:-3200}:3200"
     volumes:
       - ./config/otel/tempo-config.yaml:/etc/tempo/tempo.yaml:ro
       - tempo_data:/var/tempo
@@ -1513,7 +1517,7 @@ services:
     image: grafana/grafana:11.6.0
     restart: unless-stopped
     ports:
-      - "127.0.0.1:3100:3000"
+      - "127.0.0.1:${APTL_HP_APTL_GRAFANA_OTEL_3000:-3100}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -51,6 +51,14 @@ echo 'vm.max_map_count=262144' | sudo tee -a /etc/sysctl.conf
 netstat -tlnp | grep -E "(443|2027|8443|9000|9001|9200|55000)"
 ```
 
+You do not have to free these by hand: `aptl lab start` probes every published
+host port and, if a default is already in use (Windows reserves UDP 5353 for
+mDNS; an editor's automatic port-forwarding may hold others), publishes that
+service on a free port instead and prints the real ports under "Host port
+remaps" in the start summary. Use the reported ports (e.g. the Wazuh Dashboard
+URL, or `dig @localhost -p <reported-port> techvault.local SOA`). Pin a specific
+port with the matching `APTL_HP_*` / `APTL_DNS_HOST_PORT` variable to override.
+
 ## Python environment
 
 Install the CLI into a virtualenv, not the system Python. Modern

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -72,9 +72,83 @@ _DESTRUCTIVE_DATA_WARNING = (
 )
 
 
-def _emit_lab_access_summary(project_dir: Path) -> None:
-    """Print the credential locations and common lab entry points."""
+# Service (compose name) -> its default host port. Used to look up the actual
+# published port from a lab-start resolution so the access summary always shows
+# where a service really is, even after an in-use default was remapped.
+_WAZUH_DASHBOARD_SVC = "wazuh.dashboard"
+_GRAFANA_SVC = "aptl-grafana-otel"
+_REVERSE_SVC = "reverse"
+_WAZUH_DASHBOARD_DEFAULT = 443
+_GRAFANA_DEFAULT = 3100
+_REVERSE_DEFAULT = 2027
+
+
+def _resolved_port(resolved_ports: list, service: str, default: int) -> int:
+    """Return the actual published host port for *service* (default if unknown)."""
+    for entry in resolved_ports or ():
+        if getattr(entry, "service", None) == service:
+            return getattr(entry, "resolved_port", default)
+    return default
+
+
+# SOC services whose MCP server config (mcp/<name>/docker-lab-config.json)
+# hardcodes the host port on localhost. If one of these is remapped, the MCP
+# server config still points at the default port, so flag it for the operator.
+_MCP_BACKED_SERVICES = {
+    "wazuh.indexer",
+    "wazuh.manager",
+    "thehive",
+    "misp",
+    "shuffle-frontend",
+    "kali-ssh-proxy",
+}
+
+
+def _emit_host_port_remaps(resolved_ports: list) -> None:
+    """List any ports that were remapped off an in-use default."""
+    remapped = [r for r in (resolved_ports or ()) if getattr(r, "remapped", False)]
+    if not remapped:
+        return
+    typer.echo("")
+    typer.echo(
+        "Host port remaps (a default was already in use on this host, so the "
+        "service is published on a free port instead):"
+    )
+    mcp_affected = []
+    for entry in sorted(remapped, key=lambda r: r.service):
+        protos = "/".join(entry.protos)
+        typer.echo(
+            f"  {entry.service}: {entry.default_port} -> "
+            f"{entry.resolved_port} ({protos})"
+        )
+        if entry.service in _MCP_BACKED_SERVICES:
+            mcp_affected.append(entry)
+    if mcp_affected:
+        typer.echo("")
+        typer.echo(
+            "  Note: these services are consumed by MCP servers that pin the "
+            "default host port in mcp/<name>/docker-lab-config.json. If you "
+            "use those MCP servers, point them at the remapped port above (or "
+            "free the default port and restart)."
+        )
+
+
+def _emit_lab_access_summary(
+    project_dir: Path, resolved_ports: list | None = None
+) -> None:
+    """Print the credential locations and common lab entry points.
+
+    ``resolved_ports`` (host_ports.ResolvedPort list from a lab-start run) makes
+    the printed URLs reflect the real published ports — important on hosts where
+    a default port was in use and the service was remapped to a free one.
+    """
+    resolved_ports = resolved_ports or []
     env_path = project_dir / ".env"
+    dashboard_port = _resolved_port(
+        resolved_ports, _WAZUH_DASHBOARD_SVC, _WAZUH_DASHBOARD_DEFAULT
+    )
+    grafana_port = _resolved_port(resolved_ports, _GRAFANA_SVC, _GRAFANA_DEFAULT)
+    reverse_port = _resolved_port(resolved_ports, _REVERSE_SVC, _REVERSE_DEFAULT)
     typer.echo("")
     typer.echo(f"Credentials file: {env_path}")
     typer.echo(
@@ -83,14 +157,17 @@ def _emit_lab_access_summary(project_dir: Path) -> None:
     )
     typer.echo("")
     typer.echo("Access:")
-    typer.echo("  Wazuh Dashboard: https://localhost:443")
+    typer.echo(f"  Wazuh Dashboard: https://localhost:{dashboard_port}")
     typer.echo("    username: admin")
     typer.echo("    password: see INDEXER_PASSWORD in .env")
-    typer.echo("  Grafana: http://localhost:3100")
+    typer.echo(f"  Grafana: http://localhost:{grafana_port}")
     typer.echo("    username: admin")
     typer.echo("    password: see GRAFANA_ADMIN_PASSWORD in .env")
     typer.echo("  Reverse engineering SSH:")
-    typer.echo("    ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027")
+    typer.echo(
+        f"    ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p {reverse_port}"
+    )
+    _emit_host_port_remaps(resolved_ports)
 
 
 def _emit_lab_start_progress(message: str) -> None:
@@ -220,7 +297,7 @@ def start(
 
     _render_start_result(result)
     if result.success:
-        _emit_lab_access_summary(project_dir)
+        _emit_lab_access_summary(project_dir, result.resolved_ports)
     if not result.success:
         raise typer.Exit(code=1)
 

--- a/src/aptl/core/certs.py
+++ b/src/aptl/core/certs.py
@@ -148,6 +148,11 @@ def _run_cert_generator(project_dir: Path, certs_dir: Path) -> CertResult | None
             _cert_generator_command(certs_dir),
             capture_output=True,
             text=True,
+            # Decode as UTF-8 (not the host locale codec) so Docker's image
+            # pull/build glyphs don't raise UnicodeDecodeError on Windows,
+            # where `text=True` would otherwise decode as cp1252.
+            encoding="utf-8",
+            errors="replace",
             cwd=project_dir,
             timeout=300,
         )
@@ -208,6 +213,8 @@ def _repair_native_linux_cert_ownership(certs_dir: Path) -> str | None:
         _cert_ownership_repair_command(certs_dir, user),
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=120,
     )
     if result.returncode == 0:

--- a/src/aptl/core/collectors.py
+++ b/src/aptl/core/collectors.py
@@ -80,7 +80,12 @@ def _run_cmd(
     """Run a command, returning None on failure."""
     try:
         return subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
         )
     except (subprocess.TimeoutExpired, OSError) as e:
         log.warning("Command failed: %s: %s", " ".join(cmd[:3]), e)

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -129,6 +129,16 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
         else:
             kwargs["capture_output"] = True
             kwargs["text"] = True
+            # Decode captured docker/compose output as UTF-8 explicitly.
+            # Without this, `text=True` decodes with the host's locale
+            # codec, which on Windows is cp1252 and cannot decode the
+            # non-ASCII bytes BuildKit emits (progress glyphs, box-drawing) —
+            # the reader thread raises UnicodeDecodeError mid-build, the
+            # compose call is seen as failed, and the 60s retry then
+            # collides with the containers the first attempt already started.
+            # `errors="replace"` keeps a stray byte from ever aborting a read.
+            kwargs["encoding"] = "utf-8"
+            kwargs["errors"] = "replace"
         if timeout is not None:
             kwargs["timeout"] = timeout
         return kwargs

--- a/src/aptl/core/host_ports.py
+++ b/src/aptl/core/host_ports.py
@@ -1,0 +1,308 @@
+"""Host port publishing: conflict detection, remap, and reporting.
+
+Docker Compose aborts an entire ``up`` if it cannot bind a requested host
+port, and on Windows/macOS other software routinely holds ports the lab wants
+— mDNS on UDP 5353, an editor's automatic port-forwarding, another service on
+3100, and so on. On Windows a held IPv6 ``::1:PORT`` even blocks Docker's IPv4
+``127.0.0.1:PORT`` publish, so the clash is easy to hit and fails the whole
+start.
+
+To keep ``aptl lab start`` robust, the published host ports in
+``docker-compose.yml`` are written through a ``${VAR:-default}`` indirection.
+Before Compose runs, :func:`resolve_host_ports` parses those ports, probes each
+one, and for any that are already in use picks a free port and exports the
+override through the process environment (which Compose reads for variable
+substitution on every code path, with no change to how the compose command is
+built). The resolved mapping is returned so the CLI can report the real URL of
+every service — no matter what it was remapped to.
+
+Nothing here changes lab internals: containers reach each other over the
+Docker networks, never the host publishes. Remapping only affects how the
+operator's host reaches a service's web UI / SSH.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import re
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from aptl.utils.logging import get_logger
+
+log = get_logger("host_ports")
+
+_COMPOSE_FILENAME = "docker-compose.yml"
+
+# A published-port short-syntax entry: ``[ip:]host:container[/proto]`` where the
+# host part may be a literal number or a ``${VAR:-default}`` reference.
+_PORT_ENTRY = re.compile(
+    r"^(?:(?P<ip>\d{1,3}(?:\.\d{1,3}){3}|\[[^\]]+\]):)?"
+    r"(?P<host>\$\{[^}]+\}|\d+):"
+    r"(?P<container>\d+)"
+    r"(?:/(?P<proto>\w+))?$"
+)
+_VAR_REF = re.compile(r"^\$\{(?P<var>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>\d+))?\}$")
+
+# Where to start scanning for a replacement port when a default is taken. Kept
+# above the ephemeral/registered ranges the lab itself uses so a remap does not
+# land on another lab default.
+_REMAP_SCAN_START = 20000
+_REMAP_SCAN_END = 60000
+
+
+@dataclass(frozen=True)
+class PortSpec:
+    """One published host port parsed from the compose file."""
+
+    service: str
+    env_var: str | None
+    default_port: int
+    container_port: int
+    proto: str
+    host_ip: str | None  # None => all interfaces
+
+
+@dataclass(frozen=True)
+class ResolvedPort:
+    """A published host port after conflict resolution."""
+
+    service: str
+    env_var: str | None
+    default_port: int
+    resolved_port: int
+    protos: tuple[str, ...]
+    host_ip: str | None
+    remapped: bool
+
+
+def _proto_socktype(proto: str) -> int:
+    return socket.SOCK_DGRAM if proto.lower() == "udp" else socket.SOCK_STREAM
+
+
+def port_available(port: int, proto: str, host_ip: str | None) -> bool:
+    """Return True if *port* looks free to publish for *proto*.
+
+    Probes both IPv4 and IPv6 loopback (and the wildcard when the publish has
+    no host-IP) because on Windows a process holding ``::1:PORT`` blocks
+    Docker's ``127.0.0.1:PORT`` publish; an *address-in-use* failure on either
+    family is the same conflict Docker would hit.
+
+    Only ``EADDRINUSE`` counts as occupied. A privileged-port ``EACCES`` (ports
+    below 1024 on Linux/macOS cannot be bound by an unprivileged probe, but the
+    Docker daemon binds them as root) must NOT be read as a conflict — otherwise
+    the probe would falsely remap 443/514/etc. and change the published ports on
+    Linux/macOS. Any other bind error is likewise treated as "leave it alone".
+    """
+    socktype = _proto_socktype(proto)
+    targets: list[tuple[int, str]] = []
+    if host_ip and ":" not in host_ip:
+        targets.append((socket.AF_INET, host_ip))
+    else:
+        # Loopback-only publish is probed on both stacks; an all-interfaces
+        # publish (no host_ip) is probed on the wildcards.
+        if host_ip is None:
+            targets.append((socket.AF_INET, "0.0.0.0"))
+            targets.append((socket.AF_INET6, "::"))
+        targets.append((socket.AF_INET, "127.0.0.1"))
+        targets.append((socket.AF_INET6, "::1"))
+
+    for family, addr in targets:
+        sock = socket.socket(family, socktype)
+        try:
+            if family == socket.AF_INET6:
+                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+            sock.bind((addr, port))
+        except OSError as exc:
+            if exc.errno == errno.EADDRINUSE:
+                return False
+            # EACCES (privileged port) or any other error: not a demonstrable
+            # conflict — do not remap.
+            continue
+        finally:
+            sock.close()
+    return True
+
+
+def _group_available(port: int, protos: tuple[str, ...], host_ip: str | None) -> bool:
+    return all(port_available(port, proto, host_ip) for proto in protos)
+
+
+def _find_free_port(
+    protos: tuple[str, ...], host_ip: str | None, avoid: set[int]
+) -> int | None:
+    """Find a port free for every protocol in the group, skipping *avoid*."""
+    for candidate in range(_REMAP_SCAN_START, _REMAP_SCAN_END):
+        if candidate in avoid:
+            continue
+        if _group_available(candidate, protos, host_ip):
+            return candidate
+    return None
+
+
+def _parse_entry(service: str, entry: object) -> PortSpec | None:
+    """Parse one compose ``ports`` entry into a :class:`PortSpec`.
+
+    Only short-string syntax is handled (what this compose file uses). Long
+    dict-form entries and anything unparseable are skipped — they simply are
+    not eligible for automatic remapping.
+    """
+    if not isinstance(entry, str):
+        return None
+    match = _PORT_ENTRY.match(entry.strip())
+    if match is None:
+        return None
+    host = match.group("host")
+    env_var: str | None = None
+    var_match = _VAR_REF.match(host)
+    if var_match is not None:
+        env_var = var_match.group("var")
+        default_raw = var_match.group("default")
+        if default_raw is None:
+            return None  # ${VAR} with no default — leave to the operator
+        default_port = int(default_raw)
+    else:
+        default_port = int(host)
+    return PortSpec(
+        service=service,
+        env_var=env_var,
+        default_port=default_port,
+        container_port=int(match.group("container")),
+        proto=(match.group("proto") or "tcp").lower(),
+        host_ip=match.group("ip"),
+    )
+
+
+def parse_published_ports(compose: dict) -> list[PortSpec]:
+    """Return every published host port declared in a compose mapping."""
+    specs: list[PortSpec] = []
+    for service, cfg in (compose.get("services") or {}).items():
+        if not isinstance(cfg, dict):
+            continue
+        for entry in cfg.get("ports") or []:
+            spec = _parse_entry(service, entry)
+            if spec is not None:
+                specs.append(spec)
+    return specs
+
+
+def _load_compose(project_dir: Path) -> dict | None:
+    compose_path = project_dir / _COMPOSE_FILENAME
+    if not compose_path.exists():
+        return None
+    try:
+        loaded = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        log.warning("Could not parse %s for port resolution: %s", compose_path, exc)
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def resolve_host_ports(
+    project_dir: Path, reserved_env: set[str] | None = None
+) -> list[ResolvedPort]:
+    """Detect occupied published host ports, remap them, and export overrides.
+
+    For each ``${VAR:-default}`` published port, probe the default; if it is
+    already in use, choose a free port and set ``os.environ[VAR]`` so Compose
+    publishes there instead. Ports the operator pinned explicitly (present in
+    *reserved_env* or already in ``os.environ``) are honoured as-is. Returns
+    the resolved mapping for every parameterized port so callers can report the
+    real host port of each service.
+    """
+    reserved = set(reserved_env or set())
+    compose = _load_compose(project_dir)
+    if compose is None:
+        return []
+
+    # Group entries that share an env var (e.g. DNS tcp+udp on one host port)
+    # so they move together and land on a port free for every protocol.
+    groups: dict[str, list[PortSpec]] = {}
+    for spec in parse_published_ports(compose):
+        if spec.env_var is None:
+            continue
+        groups.setdefault(spec.env_var, []).append(spec)
+
+    resolved: list[ResolvedPort] = []
+    taken: set[int] = {
+        s.default_port
+        for specs in groups.values()
+        for s in specs
+    }
+    for env_var, specs in sorted(groups.items()):
+        first = specs[0]
+        protos = tuple(sorted({s.proto for s in specs}))
+        default_port = first.default_port
+        host_ip = first.host_ip
+
+        operator_pinned = env_var in reserved or env_var in os.environ
+        if operator_pinned:
+            pinned = os.environ.get(env_var)
+            resolved_port = int(pinned) if pinned and pinned.isdigit() else default_port
+            # An operator-pinned value is a deliberate choice, not a
+            # conflict-driven remap — never flag it as remapped.
+            resolved.append(
+                ResolvedPort(
+                    service=first.service,
+                    env_var=env_var,
+                    default_port=default_port,
+                    resolved_port=resolved_port,
+                    protos=protos,
+                    host_ip=host_ip,
+                    remapped=False,
+                )
+            )
+            continue
+
+        if _group_available(default_port, protos, host_ip):
+            resolved.append(
+                _resolved(first, env_var, default_port, default_port, protos)
+            )
+            continue
+
+        free = _find_free_port(protos, host_ip, taken)
+        if free is None:
+            log.warning(
+                "No free host port found to remap %s (default %d); leaving default.",
+                first.service,
+                default_port,
+            )
+            resolved.append(
+                _resolved(first, env_var, default_port, default_port, protos)
+            )
+            continue
+
+        taken.add(free)
+        os.environ[env_var] = str(free)
+        log.info(
+            "Host port %d for %s is in use; publishing on %d instead (%s).",
+            default_port,
+            first.service,
+            free,
+            env_var,
+        )
+        resolved.append(_resolved(first, env_var, default_port, free, protos))
+
+    return resolved
+
+
+def _resolved(
+    spec: PortSpec,
+    env_var: str,
+    default_port: int,
+    resolved_port: int,
+    protos: tuple[str, ...],
+) -> ResolvedPort:
+    return ResolvedPort(
+        service=spec.service,
+        env_var=env_var,
+        default_port=default_port,
+        resolved_port=resolved_port,
+        protos=protos,
+        host_ip=spec.host_ip,
+        remapped=resolved_port != default_port,
+    )

--- a/src/aptl/core/hostenv.py
+++ b/src/aptl/core/hostenv.py
@@ -102,6 +102,8 @@ def _run_docker_info() -> subprocess.CompletedProcess[str]:
         ["docker", "info", "--format", "{{.OperatingSystem}}"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=15,
     )
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -605,6 +605,9 @@ class _LabStartContext(object):
     backend: "DeploymentBackend | None" = None
     ssh_key_path: Path | None = None
     selected_profiles: set[str] = field(default_factory=set)
+    # Published host ports after conflict resolution (host_ports.ResolvedPort),
+    # so the access summary can report the real port each service landed on.
+    resolved_ports: list = field(default_factory=list)
     diagnostics: list[StartupDiagnostic] = field(default_factory=list)
     # REP-001: ACES start outcome and range snapshot for run record writing.
     # Use object to avoid circular imports; typed at use sites.
@@ -736,6 +739,33 @@ def _step_load_env(ctx: _LabStartContext) -> LabResult | None:
         log.exception("Failed to load .env")
         return LabResult(success=False, error=f"Failed to load .env: {exc}")
     return _validate_env_secrets(ctx.raw_env)
+
+
+def _step_resolve_host_ports(ctx: _LabStartContext) -> LabResult | None:
+    """Remap any published host port that is already in use before Compose runs.
+
+    Docker Compose aborts the whole ``up`` if it cannot bind a requested host
+    port, and on Windows/macOS other software routinely holds ports the lab
+    wants (mDNS on 5353, an editor's port-forwarding, etc.). This probes each
+    published port and, for any that are taken, exports a free alternate through
+    the ``${VAR:-default}`` indirection Compose reads from the environment — so
+    startup succeeds and the access summary can report the real port. Ports the
+    operator pinned in ``.env`` / the environment are honoured as-is; Linux
+    hosts with nothing on the defaults see no change.
+    """
+    from aptl.core import host_ports
+
+    ctx.resolved_ports = host_ports.resolve_host_ports(
+        ctx.project_dir, reserved_env=set(ctx.raw_env)
+    )
+    for resolved in ctx.resolved_ports:
+        if resolved.remapped:
+            _emit_progress(
+                ctx,
+                f"Host port {resolved.default_port} for {resolved.service} is "
+                f"in use; publishing on {resolved.resolved_port} instead.",
+            )
+    return None
 
 
 def _step_load_config(ctx: _LabStartContext) -> LabResult | None:
@@ -1859,6 +1889,7 @@ def _step_sync_mcp_config(ctx: _LabStartContext) -> LabResult | None:
 # stay aligned.
 _LAB_START_STEPS = (
     _step_load_env,
+    _step_resolve_host_ports,
     _step_load_config,
     _step_ensure_ssh_keys,
     _step_check_sysreqs,
@@ -1881,6 +1912,7 @@ _LAB_START_STEPS = (
 
 _LAB_START_PROGRESS_MESSAGES = {
     "_step_load_env": "Preparing environment and credentials.",
+    "_step_resolve_host_ports": "Checking host port availability.",
     "_step_load_config": "Loading lab configuration.",
     "_step_ensure_ssh_keys": "Preparing SSH keys.",
     "_step_check_sysreqs": "Checking host requirements.",
@@ -1990,6 +2022,7 @@ def orchestrate_lab_start(
         message=message,
         outcome=outcome,
         diagnostics=list(ctx.diagnostics),
+        resolved_ports=list(ctx.resolved_ports),
     )
 
 

--- a/src/aptl/core/lab_types.py
+++ b/src/aptl/core/lab_types.py
@@ -113,6 +113,10 @@ class LabResult:
     error: str = ""
     outcome: "StartupOutcome" = StartupOutcome.READY
     diagnostics: list[StartupDiagnostic] = field(default_factory=list)
+    # Published host ports after conflict resolution (host_ports.ResolvedPort),
+    # populated on lab start so the CLI can report the real host port each
+    # service landed on when a default was already in use. Empty for other ops.
+    resolved_ports: list = field(default_factory=list)
 
     def __post_init__(self) -> None:
         # Make the invariant total: ``outcome`` is the authoritative

--- a/src/aptl/core/services.py
+++ b/src/aptl/core/services.py
@@ -153,6 +153,8 @@ def check_manager_api_ready(container_name: str) -> bool:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=15,
         )
         # Any HTTP response means the API is listening
@@ -191,6 +193,8 @@ def test_ssh_connection(
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         return result.returncode == 0

--- a/src/aptl/utils/curl_safe.py
+++ b/src/aptl/utils/curl_safe.py
@@ -104,7 +104,12 @@ def curl_json(
         # without a separate return per branch.
         try:
             result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=timeout
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
             )
             if result.returncode != 0:
                 log.warning(
@@ -171,7 +176,12 @@ def curl_status(
 
         try:
             result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=timeout
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
             log.warning("curl_safe: subprocess failed: %s", exc.__class__.__name__)
@@ -194,7 +204,14 @@ def _write_temp_0600(prefix: str, content: str) -> str:
     """Write *content* to a 0600 temp file and return its path."""
     fd, path = tempfile.mkstemp(prefix=prefix, text=True)
     try:
-        os.fchmod(fd, 0o600)
+        # Restrict to owner before writing the sensitive header. os.fchmod
+        # is POSIX-only; on Windows fall back to a path-based chmod (mkstemp
+        # already creates the file in the user's private temp dir with an
+        # owner-scoped ACL), so this never breaks the control plane there.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        else:
+            os.chmod(path, 0o600)
         with os.fdopen(fd, "w") as fh:
             fh.write(content)
     except Exception:

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -12,6 +12,15 @@ import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+# Published host ports are parameterized (`${VAR:-default}`) so `aptl lab start`
+# can remap an in-use default to a free port. Resolve to the default so these
+# static checks compare against the value the stack publishes out of the box.
+_COMPOSE_VAR = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*(?::-([^}]*))?\}")
+
+
+def _resolve_compose_vars(text: str) -> str:
+    return _COMPOSE_VAR.sub(lambda m: m.group(1) or "", text)
+
 
 @pytest.fixture
 def compose_config():
@@ -220,9 +229,12 @@ class TestKaliContainerLifecycle:
 
         proxy = services["kali-ssh-proxy"]
         assert proxy["container_name"] == "aptl-kali-ssh-proxy"
-        assert "127.0.0.1:2023:2023" in proxy.get("ports", []), (
-            "kali-ssh-proxy must publish 127.0.0.1:2023 so host-run MCP "
-            "clients work on Docker Desktop, Colima, and WSL2"
+        resolved_ports = [
+            _resolve_compose_vars(str(p)) for p in proxy.get("ports", [])
+        ]
+        assert "127.0.0.1:2023:2023" in resolved_ports, (
+            "kali-ssh-proxy must publish 127.0.0.1:2023 by default so host-run "
+            "MCP clients work on Docker Desktop, Colima, and WSL2"
         )
         assert set(proxy.get("networks", {})) == {
             "aptl-control",

--- a/tests/test_docker_compose_port_bindings.py
+++ b/tests/test_docker_compose_port_bindings.py
@@ -12,10 +12,23 @@ so a future edit cannot silently re-expose a SOC management port nor
 accidentally loopback-bind a victim target.
 """
 
+import re
 from pathlib import Path
 
 import pytest
 import yaml
+
+# Compose variable references (``${VAR}`` / ``${VAR:-default}``) can appear in a
+# port mapping — published host ports are parameterized so `aptl lab start` can
+# remap an in-use default to a free port. Resolve to the default (the binding
+# used when the operator sets no override) so the policy below is checked
+# against the value the stack publishes out of the box.
+_COMPOSE_VAR = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+
+
+def _resolve_compose_vars(text: str) -> str:
+    return _COMPOSE_VAR.sub(lambda m: m.group(2) or "", text)
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 COMPOSE_PATH = PROJECT_ROOT / "docker-compose.yml"
@@ -74,6 +87,7 @@ def _parse_port(entry) -> tuple[str | None, int | None, str]:
     proto = "tcp"
     if "/" in text:
         text, proto = text.rsplit("/", 1)
+    text = _resolve_compose_vars(text)
     parts = text.split(":")
     if len(parts) == 3:
         host_ip, host_port, _container = parts

--- a/tests/test_host_ports.py
+++ b/tests/test_host_ports.py
@@ -1,0 +1,211 @@
+"""Tests for published host-port conflict detection, remap, and reporting.
+
+The probe is exercised against real sockets; the resolver is driven with a
+stubbed ``port_available`` so the remap/grouping/operator-override logic is
+tested deterministically without depending on which host ports happen to be
+free on the test machine.
+"""
+
+from __future__ import annotations
+
+import errno
+import socket
+
+import pytest
+
+from aptl.core import host_ports
+
+
+# --------------------------------------------------------------------------- #
+# _parse_entry — short-syntax port mappings, with and without ${VAR:-default}
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("entry", "expect"),
+    [
+        (
+            "127.0.0.1:${APTL_HP_WAZUH_DASHBOARD_5601:-443}:5601",
+            ("wazuh.dashboard", "APTL_HP_WAZUH_DASHBOARD_5601", 443, 5601, "tcp", "127.0.0.1"),
+        ),
+        (
+            "${APTL_DNS_HOST_PORT:-5353}:53/udp",
+            ("dns", "APTL_DNS_HOST_PORT", 5353, 53, "udp", None),
+        ),
+        (
+            "${APTL_HP_WEBAPP_8080:-8080}:8080",
+            ("webapp", "APTL_HP_WEBAPP_8080", 8080, 8080, "tcp", None),
+        ),
+        (
+            "127.0.0.1:9200:9200",  # unparameterized literal: no env var
+            ("svc", None, 9200, 9200, "tcp", "127.0.0.1"),
+        ),
+    ],
+)
+def test_parse_entry(entry, expect):
+    service = expect[0]
+    spec = host_ports._parse_entry(service, entry)
+    assert spec is not None
+    assert (
+        spec.service,
+        spec.env_var,
+        spec.default_port,
+        spec.container_port,
+        spec.proto,
+        spec.host_ip,
+    ) == expect
+
+
+def test_parse_entry_skips_varref_without_default():
+    assert host_ports._parse_entry("svc", "${APTL_HP_X}:80") is None
+
+
+def test_parse_entry_skips_non_string():
+    assert host_ports._parse_entry("svc", {"target": 80, "published": 8080}) is None
+
+
+def test_parse_published_ports_reads_all_services():
+    compose = {
+        "services": {
+            "a": {"ports": ["127.0.0.1:${APTL_HP_A_1:-1000}:1"]},
+            "b": {"ports": ["${APTL_HP_B_2:-2000}:2/udp", "3000:3"]},
+            "c": {"image": "x"},  # no ports
+        }
+    }
+    specs = host_ports.parse_published_ports(compose)
+    assert {s.service for s in specs} == {"a", "b"}
+    assert len(specs) == 3
+
+
+# --------------------------------------------------------------------------- #
+# port_available — only EADDRINUSE counts as occupied (Linux/macOS safety)
+# --------------------------------------------------------------------------- #
+def test_port_available_true_for_free_high_port():
+    # Bind a socket to grab a free port, release it, then probe it.
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    free_port = s.getsockname()[1]
+    s.close()
+    assert host_ports.port_available(free_port, "tcp", "127.0.0.1") is True
+
+
+def test_port_available_false_when_in_use():
+    holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    holder.bind(("127.0.0.1", 0))
+    port = holder.getsockname()[1]
+    holder.listen(1)
+    try:
+        assert host_ports.port_available(port, "tcp", "127.0.0.1") is False
+    finally:
+        holder.close()
+
+
+def test_port_available_true_on_eacces(mocker):
+    """A privileged-port EACCES must read as available, not occupied.
+
+    Otherwise an unprivileged probe on Linux/macOS would falsely remap 443,
+    514, 25, etc. and move the published ports off their documented defaults.
+    """
+
+    def fake_bind(self, addr):
+        raise OSError(errno.EACCES, "permission denied")
+
+    mocker.patch.object(socket.socket, "bind", fake_bind)
+    assert host_ports.port_available(443, "tcp", "127.0.0.1") is True
+
+
+# --------------------------------------------------------------------------- #
+# resolve_host_ports — remap only conflicts, group shared vars, honor operator
+# --------------------------------------------------------------------------- #
+def _compose():
+    return {
+        "services": {
+            "wazuh.dashboard": {
+                "ports": ["127.0.0.1:${APTL_HP_WAZUH_DASHBOARD_5601:-443}:5601"]
+            },
+            "dns": {
+                "ports": [
+                    "${APTL_DNS_HOST_PORT:-5353}:53/tcp",
+                    "${APTL_DNS_HOST_PORT:-5353}:53/udp",
+                ]
+            },
+            "cortex": {"ports": ["127.0.0.1:${APTL_HP_CORTEX_9001:-9001}:9001"]},
+        }
+    }
+
+
+@pytest.fixture
+def _clean_env(monkeypatch):
+    for var in (
+        "APTL_HP_WAZUH_DASHBOARD_5601",
+        "APTL_DNS_HOST_PORT",
+        "APTL_HP_CORTEX_9001",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_no_remap_when_all_free(mocker, tmp_path, _clean_env):
+    mocker.patch("aptl.core.host_ports._load_compose", return_value=_compose())
+    mocker.patch("aptl.core.host_ports.port_available", return_value=True)
+
+    resolved = host_ports.resolve_host_ports(tmp_path)
+
+    assert all(not r.remapped for r in resolved)
+    assert "APTL_HP_WAZUH_DASHBOARD_5601" not in __import__("os").environ
+
+
+def test_remaps_only_the_occupied_port(mocker, tmp_path, _clean_env):
+    import os
+
+    mocker.patch("aptl.core.host_ports._load_compose", return_value=_compose())
+
+    # 443 occupied, everything else free.
+    def available(port, proto, host_ip):
+        return port != 443
+
+    mocker.patch("aptl.core.host_ports.port_available", side_effect=available)
+
+    resolved = host_ports.resolve_host_ports(tmp_path)
+    by_service = {r.service: r for r in resolved}
+
+    assert by_service["wazuh.dashboard"].remapped is True
+    assert by_service["wazuh.dashboard"].resolved_port != 443
+    assert os.environ["APTL_HP_WAZUH_DASHBOARD_5601"] == str(
+        by_service["wazuh.dashboard"].resolved_port
+    )
+    assert by_service["cortex"].remapped is False
+    assert "APTL_HP_CORTEX_9001" not in os.environ
+
+
+def test_dns_tcp_and_udp_remap_together(mocker, tmp_path, _clean_env):
+    import os
+
+    mocker.patch("aptl.core.host_ports._load_compose", return_value=_compose())
+
+    # Only UDP 5353 is held (mDNS); the shared host port must still move as one.
+    def available(port, proto, host_ip):
+        return not (port == 5353 and proto == "udp")
+
+    mocker.patch("aptl.core.host_ports.port_available", side_effect=available)
+
+    resolved = host_ports.resolve_host_ports(tmp_path)
+    dns = next(r for r in resolved if r.service == "dns")
+
+    assert dns.remapped is True
+    assert set(dns.protos) == {"tcp", "udp"}
+    assert os.environ["APTL_DNS_HOST_PORT"] == str(dns.resolved_port)
+
+
+def test_operator_pinned_value_is_honored(mocker, tmp_path, monkeypatch):
+    monkeypatch.setenv("APTL_DNS_HOST_PORT", "15353")
+    mocker.patch("aptl.core.host_ports._load_compose", return_value=_compose())
+    # Even if the resolver were to probe, a reserved var must be left as-is.
+    probe = mocker.patch("aptl.core.host_ports.port_available", return_value=False)
+
+    resolved = host_ports.resolve_host_ports(
+        tmp_path, reserved_env={"APTL_DNS_HOST_PORT"}
+    )
+    dns = next(r for r in resolved if r.service == "dns")
+
+    assert dns.resolved_port == 15353
+    assert not dns.remapped
+    # The pinned port must not be probed/remapped.
+    assert all(call.args[0] != 5353 for call in probe.call_args_list)

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1020,6 +1020,11 @@ class TestOrchestrateLabStart:
             ),
         )
 
+        # Keep the host-port resolution step inert so orchestration tests do
+        # not probe/remap real host ports (its behaviour is covered by
+        # TestResolveHostPortsStep and the host_ports unit tests).
+        mocker.patch("aptl.core.host_ports.resolve_host_ports", return_value=[])
+
         # Mock credentials sync
         mocks["dashboard_creds"] = mocker.patch("aptl.core.lab.sync_dashboard_config")
         mocks["manager_creds"] = mocker.patch("aptl.core.lab.sync_manager_config")
@@ -1699,6 +1704,79 @@ def _write_suricata_seed_sources(tmp_path):
     ):
         (config_dir / "rules" / "misp" / name).write_text(f"# {name}\n")
     return config_dir
+
+
+class TestResolveHostPortsStep:
+    """`_step_resolve_host_ports` remaps in-use published ports before Compose.
+
+    The step delegates probing/remap to ``host_ports.resolve_host_ports`` and
+    stashes the result on the context so the access summary can report where
+    each service landed. The resolver's own probing logic is covered by the
+    host_ports unit tests; here we pin the wiring: it passes the loaded .env as
+    reserved keys, records the resolution, and announces remaps via progress.
+    """
+
+    def _ctx(self, tmp_path, raw_env=None, progress=None):
+        from aptl.core.lab import _LabStartContext
+
+        return _LabStartContext(
+            project_dir=tmp_path,
+            skip_seed=False,
+            raw_env=raw_env or {},
+            progress=progress,
+        )
+
+    def test_stores_resolution_and_passes_reserved_env(self, mocker, tmp_path):
+        from aptl.core.host_ports import ResolvedPort
+        from aptl.core.lab import _step_resolve_host_ports
+
+        resolution = [
+            ResolvedPort(
+                service="cortex",
+                env_var="APTL_HP_CORTEX_9001",
+                default_port=9001,
+                resolved_port=9001,
+                protos=("tcp",),
+                host_ip="127.0.0.1",
+                remapped=False,
+            )
+        ]
+        resolve = mocker.patch(
+            "aptl.core.host_ports.resolve_host_ports", return_value=resolution
+        )
+        ctx = self._ctx(tmp_path, raw_env={"APTL_DNS_HOST_PORT": "9"})
+
+        result = _step_resolve_host_ports(ctx)
+
+        assert result is None
+        assert ctx.resolved_ports is resolution
+        resolve.assert_called_once_with(
+            tmp_path, reserved_env={"APTL_DNS_HOST_PORT"}
+        )
+
+    def test_announces_remaps_via_progress(self, mocker, tmp_path):
+        from aptl.core.host_ports import ResolvedPort
+        from aptl.core.lab import _step_resolve_host_ports
+
+        remapped = ResolvedPort(
+            service="wazuh.dashboard",
+            env_var="APTL_HP_WAZUH_DASHBOARD_5601",
+            default_port=443,
+            resolved_port=20009,
+            protos=("tcp",),
+            host_ip="127.0.0.1",
+            remapped=True,
+        )
+        mocker.patch(
+            "aptl.core.host_ports.resolve_host_ports", return_value=[remapped]
+        )
+        progress = MagicMock()
+
+        _step_resolve_host_ports(self._ctx(tmp_path, progress=progress))
+
+        notes = " ".join(c.args[0] for c in progress.call_args_list)
+        assert "wazuh.dashboard" in notes
+        assert "443" in notes and "20009" in notes
 
 
 class TestSeedSuricataVolumesStep:


### PR DESCRIPTION
## What & why

Two Windows/Docker-Desktop blockers for `aptl lab start` that remain after the
recent cross-platform work on `dev` (#697–#702):

### 1. Auto-remap in-use host ports, and report the real URLs

Docker Compose aborts the entire `up` on the first published host port it cannot
bind. On Windows/macOS that happens constantly: mDNS reserves UDP 5353, and an
editor's automatic port-forwarding (or any other app) holds the SOC/UI ports.
On Windows a held IPv6 `::1:PORT` even blocks Docker's IPv4 `127.0.0.1:PORT`
publish, so a single clash fails the whole start.

`aptl lab start` now probes every published host port before Compose runs and,
for any already in use, publishes that service on a free port via a
`${VAR:-default}` indirection Compose reads from the process environment (no
change to how the compose command is built, so it works on the standard and
ACES paths alike). The start summary reports the real host port of each service
and flags every remap — including the MCP-backed services whose configs pin the
default port, so the operator knows to reconcile them.

**Linux/macOS are untouched:** only `EADDRINUSE` counts as occupied. An
unprivileged probe of a privileged port (443/514/…) on Linux/macOS returns
`EACCES`, which is deliberately *not* treated as a conflict, so those defaults
never move. A host with nothing on the defaults produces zero remaps and byte-
identical published ports. Operator-pinned ports (`.env` / environment) are
always honored as-is.

### 2. Decode captured docker/compose output as UTF-8

`text=True` decodes with the host locale codec, which on Windows is cp1252 and
cannot decode the non-ASCII bytes BuildKit emits (progress glyphs, box-drawing).
The subprocess reader thread raised `UnicodeDecodeError` mid-build, the compose
call was seen as failed, and the 60s retry then collided with the containers the
first attempt had already started. All capture calls now pass
`encoding="utf-8", errors="replace"`. Also guards the `curl_safe` temp-file
`os.fchmod` (POSIX-only) behind a `hasattr` check.

## Testing

- New `tests/test_host_ports.py`: parsing, `EADDRINUSE`-only detection (incl. an
  `EACCES`-is-available test that pins the Linux/macOS safety), remap, DNS
  tcp+udp grouping, and operator-pin honoring.
- New wiring/report tests in `test_lab.py`, `test_docker_compose_port_bindings.py`,
  `test_consistency.py`.
- Verified end-to-end on Windows + Docker Desktop with an editor holding 8 lab
  ports: all conflicts remapped to free ports, the full stack came up, and the
  summary reported the real URLs.
- `docker compose config` with no overrides resolves to the original default
  ports (the Linux/macOS behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
