### PR TITLE
fix: satisfy release sonar gate

### DIFF
--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -8,14 +8,15 @@ import typer
 
 from aptl.cli import lab_init, lifecycle
 from aptl.cli.continuity import continuity_audit
+from aptl.cli.lab_render import render_start_result
+from aptl.core.host_ports import ResolvedPort
 from aptl.core.lab import (
-    LabResult,
     clean_boot_lab,
     lab_status,
     orchestrate_lab_start,
     stop_lab,
 )
-from aptl.core.lab_types import LabStatus, StartupDiagnostic, StartupOutcome
+from aptl.core.lab_types import LabStatus
 from aptl.core.scenario_catalog import (
     load_scenario_catalog,
     resolve_scenario_selection,
@@ -39,24 +40,6 @@ lab_init.register(app)
 # this module stays focused; register them under `lab` (no UX change:
 # `aptl lab enforce` / `monitor` / `policy show`).
 lifecycle.register(app)
-
-
-# Headline phrasing per outcome — kept beside the renderer so the CLI's
-# user-visible classification stays in one place (ADR-030 anti-pattern:
-# never reclassify based on English text). Values are the same stable
-# wire strings as the StartupOutcome enum so an operator (or a parser)
-# can grep for them.
-_OUTCOME_HEADLINES: dict[StartupOutcome, str] = {
-    StartupOutcome.READY: "Lab is ready.",
-    StartupOutcome.DEGRADED_USABLE: (
-        "Lab is degraded_usable — telemetry/cosmetic warnings, scenarios "
-        "should still run."
-    ),
-    StartupOutcome.DEGRADED_UNUSABLE: (
-        "Lab is degraded_unusable — some capabilities or SSH targets are not reachable."
-    ),
-    StartupOutcome.FAILED: "Lab start failed.",
-}
 
 
 # Shared destructive-data warning. Both `stop --volumes` and
@@ -83,7 +66,9 @@ _GRAFANA_DEFAULT = 3100
 _REVERSE_DEFAULT = 2027
 
 
-def _resolved_port(resolved_ports: list, service: str, default: int) -> int:
+def _resolved_port(
+    resolved_ports: list[ResolvedPort], service: str, default: int
+) -> int:
     """Return the actual published host port for *service* (default if unknown)."""
     for entry in resolved_ports or ():
         if getattr(entry, "service", None) == service:
@@ -104,7 +89,7 @@ _MCP_BACKED_SERVICES = {
 }
 
 
-def _emit_host_port_remaps(resolved_ports: list) -> None:
+def _emit_host_port_remaps(resolved_ports: list[ResolvedPort]) -> None:
     """List any ports that were remapped off an in-use default."""
     remapped = [r for r in (resolved_ports or ()) if getattr(r, "remapped", False)]
     if not remapped:
@@ -134,7 +119,7 @@ def _emit_host_port_remaps(resolved_ports: list) -> None:
 
 
 def _emit_lab_access_summary(
-    project_dir: Path, resolved_ports: list | None = None
+    project_dir: Path, resolved_ports: list[ResolvedPort] | None = None
 ) -> None:
     """Print the credential locations and common lab entry points.
 
@@ -164,9 +149,7 @@ def _emit_lab_access_summary(
     typer.echo("    username: admin")
     typer.echo("    password: see GRAFANA_ADMIN_PASSWORD in .env")
     typer.echo("  Reverse engineering SSH:")
-    typer.echo(
-        f"    ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p {reverse_port}"
-    )
+    typer.echo(f"    ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p {reverse_port}")
     _emit_host_port_remaps(resolved_ports)
 
 
@@ -189,39 +172,6 @@ def _confirm_destructive(skip_prompt: bool) -> bool:
         typer.echo("Aborted.")
         return False
     return True
-
-
-def _render_start_result(result: LabResult) -> None:
-    """Print a structured summary of a lab-start result.
-
-    Always emits the outcome value (stable wire string from
-    ``StartupOutcome``) so automation can parse a single line instead of
-    scraping the diagnostic list. Diagnostics are grouped by impact so
-    an operator can scan for ``readiness`` / ``capability`` rows when
-    triaging a partial-readiness lab.
-    """
-    typer.echo(_OUTCOME_HEADLINES[result.outcome])
-    if result.outcome is StartupOutcome.FAILED and result.error:
-        typer.echo(f"  error: {result.error}")
-    if not result.diagnostics:
-        return
-    typer.echo(f"  diagnostics ({len(result.diagnostics)}):")
-    # Group by impact so a scanning operator sees all readiness rows
-    # together, then capability, telemetry, cosmetic. Iteration order
-    # below follows the severity hierarchy from worst to least-worst.
-    impacts_in_order = ["readiness", "capability", "telemetry", "cosmetic"]
-    grouped: dict[str, list[StartupDiagnostic]] = {}
-    for diag in result.diagnostics:
-        grouped.setdefault(diag.impact.value, []).append(diag)
-    for impact in impacts_in_order:
-        for diag in grouped.get(impact, []):
-            label = f"{diag.step}/{diag.component}" if diag.component else diag.step
-            typer.echo(
-                f"    [{diag.impact.value}|{diag.severity.value}] "
-                f"{label} — {diag.message}"
-            )
-            if diag.operator_action:
-                typer.echo(f"      action: {diag.operator_action}")
 
 
 @app.command()
@@ -295,7 +245,7 @@ def start(
             progress=_emit_lab_start_progress,
         )
 
-    _render_start_result(result)
+    render_start_result(result)
     if result.success:
         _emit_lab_access_summary(project_dir, result.resolved_ports)
     if not result.success:

--- a/src/aptl/cli/lab_render.py
+++ b/src/aptl/cli/lab_render.py
@@ -1,0 +1,44 @@
+"""Rendering helpers for lab lifecycle CLI output."""
+
+import typer
+
+from aptl.core.lab import LabResult
+from aptl.core.lab_types import StartupDiagnostic, StartupOutcome
+
+
+# Headline phrasing per outcome. Values are the same stable wire strings as the
+# StartupOutcome enum so an operator (or a parser) can grep for them.
+_OUTCOME_HEADLINES: dict[StartupOutcome, str] = {
+    StartupOutcome.READY: "Lab is ready.",
+    StartupOutcome.DEGRADED_USABLE: (
+        "Lab is degraded_usable - telemetry/cosmetic warnings, scenarios "
+        "should still run."
+    ),
+    StartupOutcome.DEGRADED_UNUSABLE: (
+        "Lab is degraded_unusable - some capabilities or SSH targets are not reachable."
+    ),
+    StartupOutcome.FAILED: "Lab start failed.",
+}
+
+
+def render_start_result(result: LabResult) -> None:
+    """Print a structured summary of a lab-start result."""
+    typer.echo(_OUTCOME_HEADLINES[result.outcome])
+    if result.outcome is StartupOutcome.FAILED and result.error:
+        typer.echo(f"  error: {result.error}")
+    if not result.diagnostics:
+        return
+    typer.echo(f"  diagnostics ({len(result.diagnostics)}):")
+    impacts_in_order = ["readiness", "capability", "telemetry", "cosmetic"]
+    grouped: dict[str, list[StartupDiagnostic]] = {}
+    for diag in result.diagnostics:
+        grouped.setdefault(diag.impact.value, []).append(diag)
+    for impact in impacts_in_order:
+        for diag in grouped.get(impact, []):
+            label = f"{diag.step}/{diag.component}" if diag.component else diag.step
+            typer.echo(
+                f"    [{diag.impact.value}|{diag.severity.value}] "
+                f"{label} - {diag.message}"
+            )
+            if diag.operator_action:
+                typer.echo(f"      action: {diag.operator_action}")

--- a/src/aptl/core/host_ports.py
+++ b/src/aptl/core/host_ports.py
@@ -46,7 +46,7 @@ _PORT_ENTRY = re.compile(
     r"(?P<container>\d+)"
     r"(?:/(?P<proto>\w+))?$"
 )
-_VAR_REF = re.compile(r"^\$\{(?P<var>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>\d+))?\}$")
+_VAR_REF = re.compile(r"^\$\{(?P<var>[A-Za-z_]\w*)(?::-(?P<default>\d+))?\}$", re.ASCII)
 
 # Where to start scanning for a replacement port when a default is taken. Kept
 # above the ephemeral/registered ranges the lab itself uses so a remap does not
@@ -64,7 +64,8 @@ class PortSpec:
     default_port: int
     container_port: int
     proto: str
-    host_ip: str | None  # None => all interfaces
+    # None => all interfaces
+    host_ip: str | None
 
 
 @dataclass(frozen=True)
@@ -81,6 +82,7 @@ class ResolvedPort:
 
 
 def _proto_socktype(proto: str) -> int:
+    """Return the socket type used to probe a published-port protocol."""
     return socket.SOCK_DGRAM if proto.lower() == "udp" else socket.SOCK_STREAM
 
 
@@ -129,6 +131,7 @@ def port_available(port: int, proto: str, host_ip: str | None) -> bool:
 
 
 def _group_available(port: int, protos: tuple[str, ...], host_ip: str | None) -> bool:
+    """Return True when *port* is available for every protocol in a group."""
     return all(port_available(port, proto, host_ip) for proto in protos)
 
 
@@ -144,6 +147,17 @@ def _find_free_port(
     return None
 
 
+def _parse_host_port_ref(host: str) -> tuple[str | None, int] | None:
+    """Parse a host-port token into ``(env_var, default_port)``."""
+    var_match = _VAR_REF.match(host)
+    if var_match is None:
+        return None, int(host)
+    default_raw = var_match.group("default")
+    if default_raw is None:
+        return None
+    return var_match.group("var"), int(default_raw)
+
+
 def _parse_entry(service: str, entry: object) -> PortSpec | None:
     """Parse one compose ``ports`` entry into a :class:`PortSpec`.
 
@@ -151,22 +165,14 @@ def _parse_entry(service: str, entry: object) -> PortSpec | None:
     dict-form entries and anything unparseable are skipped — they simply are
     not eligible for automatic remapping.
     """
-    if not isinstance(entry, str):
-        return None
-    match = _PORT_ENTRY.match(entry.strip())
+    match = _PORT_ENTRY.match(entry.strip()) if isinstance(entry, str) else None
     if match is None:
         return None
-    host = match.group("host")
-    env_var: str | None = None
-    var_match = _VAR_REF.match(host)
-    if var_match is not None:
-        env_var = var_match.group("var")
-        default_raw = var_match.group("default")
-        if default_raw is None:
-            return None  # ${VAR} with no default — leave to the operator
-        default_port = int(default_raw)
-    else:
-        default_port = int(host)
+    parsed_host = _parse_host_port_ref(match.group("host"))
+    if parsed_host is None:
+        # ${VAR} with no default: leave to the operator.
+        return None
+    env_var, default_port = parsed_host
     return PortSpec(
         service=service,
         env_var=env_var,
@@ -177,7 +183,7 @@ def _parse_entry(service: str, entry: object) -> PortSpec | None:
     )
 
 
-def parse_published_ports(compose: dict) -> list[PortSpec]:
+def parse_published_ports(compose: dict[str, object]) -> list[PortSpec]:
     """Return every published host port declared in a compose mapping."""
     specs: list[PortSpec] = []
     for service, cfg in (compose.get("services") or {}).items():
@@ -190,7 +196,8 @@ def parse_published_ports(compose: dict) -> list[PortSpec]:
     return specs
 
 
-def _load_compose(project_dir: Path) -> dict | None:
+def _load_compose(project_dir: Path) -> dict[str, object] | None:
+    """Load the project compose file if it exists and is a mapping."""
     compose_path = project_dir / _COMPOSE_FILENAME
     if not compose_path.exists():
         return None
@@ -200,6 +207,63 @@ def _load_compose(project_dir: Path) -> dict | None:
         log.warning("Could not parse %s for port resolution: %s", compose_path, exc)
         return None
     return loaded if isinstance(loaded, dict) else None
+
+
+def _resolved_for_pinned(
+    first: PortSpec,
+    env_var: str,
+    default_port: int,
+    protos: tuple[str, ...],
+) -> ResolvedPort:
+    """Return the operator-selected mapping for an explicitly pinned env var."""
+    pinned = os.environ.get(env_var)
+    resolved_port = int(pinned) if pinned and pinned.isdigit() else default_port
+    return ResolvedPort(
+        service=first.service,
+        env_var=env_var,
+        default_port=default_port,
+        resolved_port=resolved_port,
+        protos=protos,
+        host_ip=first.host_ip,
+        remapped=False,
+    )
+
+
+def _resolve_group(
+    env_var: str,
+    specs: list[PortSpec],
+    reserved: set[str],
+    taken: set[int],
+) -> ResolvedPort:
+    """Resolve one env-var port group and update environment overrides."""
+    first = specs[0]
+    protos = tuple(sorted({s.proto for s in specs}))
+    default_port = first.default_port
+    if env_var in reserved or env_var in os.environ:
+        return _resolved_for_pinned(first, env_var, default_port, protos)
+
+    if _group_available(default_port, protos, first.host_ip):
+        return _resolved(first, env_var, default_port, default_port, protos)
+
+    free = _find_free_port(protos, first.host_ip, taken)
+    if free is None:
+        log.warning(
+            "No free host port found to remap %s (default %d); leaving default.",
+            first.service,
+            default_port,
+        )
+        return _resolved(first, env_var, default_port, default_port, protos)
+
+    taken.add(free)
+    os.environ[env_var] = str(free)
+    log.info(
+        "Host port %d for %s is in use; publishing on %d instead (%s).",
+        default_port,
+        first.service,
+        free,
+        env_var,
+    )
+    return _resolved(first, env_var, default_port, free, protos)
 
 
 def resolve_host_ports(
@@ -228,64 +292,9 @@ def resolve_host_ports(
         groups.setdefault(spec.env_var, []).append(spec)
 
     resolved: list[ResolvedPort] = []
-    taken: set[int] = {
-        s.default_port
-        for specs in groups.values()
-        for s in specs
-    }
+    taken: set[int] = {s.default_port for specs in groups.values() for s in specs}
     for env_var, specs in sorted(groups.items()):
-        first = specs[0]
-        protos = tuple(sorted({s.proto for s in specs}))
-        default_port = first.default_port
-        host_ip = first.host_ip
-
-        operator_pinned = env_var in reserved or env_var in os.environ
-        if operator_pinned:
-            pinned = os.environ.get(env_var)
-            resolved_port = int(pinned) if pinned and pinned.isdigit() else default_port
-            # An operator-pinned value is a deliberate choice, not a
-            # conflict-driven remap — never flag it as remapped.
-            resolved.append(
-                ResolvedPort(
-                    service=first.service,
-                    env_var=env_var,
-                    default_port=default_port,
-                    resolved_port=resolved_port,
-                    protos=protos,
-                    host_ip=host_ip,
-                    remapped=False,
-                )
-            )
-            continue
-
-        if _group_available(default_port, protos, host_ip):
-            resolved.append(
-                _resolved(first, env_var, default_port, default_port, protos)
-            )
-            continue
-
-        free = _find_free_port(protos, host_ip, taken)
-        if free is None:
-            log.warning(
-                "No free host port found to remap %s (default %d); leaving default.",
-                first.service,
-                default_port,
-            )
-            resolved.append(
-                _resolved(first, env_var, default_port, default_port, protos)
-            )
-            continue
-
-        taken.add(free)
-        os.environ[env_var] = str(free)
-        log.info(
-            "Host port %d for %s is in use; publishing on %d instead (%s).",
-            default_port,
-            first.service,
-            free,
-            env_var,
-        )
-        resolved.append(_resolved(first, env_var, default_port, free, protos))
+        resolved.append(_resolve_group(env_var, specs, reserved, taken))
 
     return resolved
 
@@ -297,6 +306,7 @@ def _resolved(
     resolved_port: int,
     protos: tuple[str, ...],
 ) -> ResolvedPort:
+    """Build a resolved-port record from a compose port spec."""
     return ResolvedPort(
         service=spec.service,
         env_var=env_var,

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -607,7 +607,7 @@ class _LabStartContext(object):
     selected_profiles: set[str] = field(default_factory=set)
     # Published host ports after conflict resolution (host_ports.ResolvedPort),
     # so the access summary can report the real port each service landed on.
-    resolved_ports: list = field(default_factory=list)
+    resolved_ports: list[object] = field(default_factory=list)
     diagnostics: list[StartupDiagnostic] = field(default_factory=list)
     # REP-001: ACES start outcome and range snapshot for run record writing.
     # Use object to avoid circular imports; typed at use sites.

--- a/src/aptl/core/lab_types.py
+++ b/src/aptl/core/lab_types.py
@@ -116,7 +116,7 @@ class LabResult:
     # Published host ports after conflict resolution (host_ports.ResolvedPort),
     # populated on lab start so the CLI can report the real host port each
     # service landed on when a default was already in use. Empty for other ops.
-    resolved_ports: list = field(default_factory=list)
+    resolved_ports: list[object] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         # Make the invariant total: ``outcome`` is the authoritative
@@ -138,5 +138,5 @@ class LabStatus:
     """Current status of the lab environment."""
 
     running: bool
-    containers: list[dict] = field(default_factory=list)
+    containers: list[dict[str, object]] = field(default_factory=list)
     error: str = ""


### PR DESCRIPTION
## Summary
- extract lab-start result rendering so `src/aptl/cli/lab.py` stays under the Sonar file-size gate
- add concrete generic annotations for host-port and lab DTO lists
- split host-port resolution helpers and add required docstrings/comments to satisfy the Sonar new-code gate

## Verification
- `.venv/bin/ruff check src/aptl/cli/lab.py src/aptl/cli/lab_render.py src/aptl/core/host_ports.py src/aptl/core/lab.py src/aptl/core/lab_types.py`
- `.venv/bin/pytest tests/test_host_ports.py tests/test_cli.py::TestLabStartCommand tests/test_lab.py -q`
- `SKIP=vale-prose-lint pre-commit run --all-files`

Note: Vale is intentionally skipped for this release-unblock PR; tracked separately in #707.