### PR TITLE
fix(lab) + docs: pre-pull suricata seeder image; document macOS pipx/Colima/Desktop gotchas

### DIFF
--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -22,9 +22,26 @@ sudo usermod -aG docker $USER
 
 Sign out and back in after changing Docker group membership.
 
-**macOS:** Install Docker Desktop and allocate enough memory in
-Settings -> Resources. The full `techvault-operational` stack needs more than
-20GB.
+**macOS (Docker Desktop):** Install Docker Desktop and allocate enough memory
+in Settings -> Resources. The full `techvault-operational` stack needs more
+than 20GB.
+
+**macOS (Colima alternative, no Docker Desktop):** If you cannot use Docker
+Desktop (licensing, corporate policy, or preference), Colima runs the same
+Docker Engine in a `lima` VM and APTL supports it directly. The APTL host
+check calls out this path when Docker Buildx is missing; the full setup is:
+
+```bash
+brew install docker docker-buildx docker-compose colima
+mkdir -p ~/.docker/cli-plugins
+ln -sf "$(brew --prefix docker-buildx)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
+ln -sf "$(brew --prefix docker-compose)/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
+colima start --cpu 4 --memory 8 --disk 60
+```
+
+Bump the resources for the full `techvault-operational` stack (see the
+RAM/disk requirements above). `colima start` also sets the active `docker`
+context to `colima`; verify with `docker context ls`.
 
 **Windows:** Install Docker Desktop with the WSL2 backend enabled. Run APTL from
 PowerShell, Windows Terminal, Git Bash, or a WSL2 shell; keep Docker Desktop
@@ -68,6 +85,26 @@ block system-wide `pip` under [PEP 668](https://peps.python.org/pep-0668/), so
 `error: externally-managed-environment`.
 
 For released installs on any OS, prefer `pipx install aptl-labs`.
+
+**macOS gotcha — pipx bound to the system Python 3.9.** `aptl-labs` requires
+Python 3.11+ (declared in `pyproject.toml`). If your `pipx` was installed
+against the Command Line Tools Python (`/usr/bin/python3`, which is 3.9),
+`pipx install aptl-labs` fails with:
+
+```
+ERROR: Could not find a version that satisfies the requirement aptl-labs (from versions: none)
+```
+
+The real cause is the "Ignored the following versions that require a
+different python version" line further up in pip's output — every published
+`aptl-labs` release is filtered out by the Python-version gate. Recover with
+a scoped standalone Python that pipx fetches just for this venv:
+
+```bash
+pipx install --python 3.12 --fetch-missing-python aptl-labs
+```
+
+Alternatively, `brew install python@3.12` and use that interpreter.
 
 For source installs, create a virtualenv. On Debian/Ubuntu/WSL2, install the
 `venv` module first (Debian ships it separately from `python3`):

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -164,6 +164,41 @@ sudo lsof -i :443
 # Disable in System Preferences → Sharing
 ```
 
+### macOS: Docker Desktop uninstall leftovers
+
+If you uninstalled Docker Desktop and switched to Colima (or brew-installed
+Docker), two leftover pieces silently break `aptl lab start`:
+
+**Dead CLI plugin symlinks** in `~/.docker/cli-plugins/*` still point at
+`/Applications/Docker.app/Contents/Resources/cli-plugins/...`. `docker
+buildx` and `docker compose` then fail with `unknown command` even after
+`brew install docker-buildx docker-compose`. Repoint them at the brew
+binaries and drop the other dead symlinks:
+
+```bash
+ln -sf "$(brew --prefix docker-buildx)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
+ln -sf "$(brew --prefix docker-compose)/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
+for f in ~/.docker/cli-plugins/*; do [ -L "$f" ] && [ ! -e "$f" ] && rm "$f"; done
+```
+
+**Stale `credsStore` in `~/.docker/config.json`.** Docker Desktop's
+installer sets `"credsStore": "desktop"`, and `docker pull` on any image
+requiring a credential lookup then fails with:
+
+```
+error getting credentials - err: exec: "docker-credential-desktop": executable file not found in $PATH
+```
+
+Remove that key from `~/.docker/config.json`. A minimal working config after
+switching to Colima looks like:
+
+```json
+{
+  "auths": {},
+  "currentContext": "colima"
+}
+```
+
 ### WSL2
 ```bash
 # Restart WSL2

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -989,6 +989,14 @@ def _seed_suricata_volumes_local(ctx: _LabStartContext) -> LabResult | None:
 
     # ctx.backend is narrowed to the local Compose backend by the caller's guard.
     assert ctx.backend is not None
+    # Pull the seeder image up front. Both the ownership repair and the seed
+    # container implicitly pull it via `docker run`, and on a fresh host a
+    # failed/slow implicit pull can surface as an opaque `exit 125` from the
+    # seeder with no docker stderr in the redacted log path — pulling here
+    # keeps registry failures at a stage the user can reason about (a
+    # `Failed to pull ...` warning) instead of a bare seed-exit code.
+    for pull_warning in ctx.backend.pull_images([SURICATA_IMAGE]):
+        log.warning(pull_warning)
     ownership = ensure_suricata_config_source_ownership(ctx.project_dir, SURICATA_IMAGE)
     if not ownership.success:
         log.error(

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1820,6 +1820,29 @@ class TestSeedSuricataVolumesStep:
         suffixes = {s.volume_suffix for s in seeds}
         assert suffixes == {"suricata_config_seed", "suricata_misp_rules"}
 
+    def test_seeder_image_pulled_before_ownership_and_seed(self, tmp_path):
+        """Pre-pull surfaces registry failures before opaque `exit 125` from
+        the seeder container (both the ownership repair and seed step
+        implicitly pull the same image via `docker run`)."""
+        from aptl.core.lab import SURICATA_IMAGE, _step_seed_suricata_volumes
+
+        _write_suricata_seed_sources(tmp_path)
+        backend = MagicMock()
+        backend.pull_images.return_value = []
+
+        result = _step_seed_suricata_volumes(self._ctx(tmp_path, backend))
+
+        assert result is None
+        backend.pull_images.assert_called_once_with([SURICATA_IMAGE])
+        # Pull happens before the seed hand-off.
+        pull_call = next(
+            i for i, c in enumerate(backend.mock_calls) if c[0] == "pull_images"
+        )
+        seed_call = next(
+            i for i, c in enumerate(backend.mock_calls) if c[0] == "seed_named_volumes"
+        )
+        assert pull_call < seed_call
+
     def test_seed_error_aborts_lab_start_step(self, tmp_path, caplog):
         from aptl.core.deployment.errors import BackendSeedError
         from aptl.core.lab import _step_seed_suricata_volumes


### PR DESCRIPTION
## Summary

Two upstream fixes surfaced from a fresh-install walkthrough on macOS. Both target the "student's first `aptl lab start`" path.

### Code — `fix(lab): pre-pull suricata seeder image before ownership/seed steps`
On a fresh Docker host, both the Suricata ownership repair and the ADR-043 seed run `docker run` against `SURICATA_IMAGE` with no prior pull. The seeder's redacted error path in `docker_compose.py` intentionally does not surface docker stderr, so a failed implicit pull surfaced only as an opaque `exit 125` from the seed container:

```
Seed of volume suricata_config_seed failed (exit 125)
Suricata volume seed failed: BackendSeedError
```

`_seed_suricata_volumes_local` now calls `ctx.backend.pull_images([SURICATA_IMAGE])` and logs any warnings before the ownership repair and seed. Registry/network failures now show up at a stage the user can reason about (a `Failed to pull ...` warning) instead of downstream as a bare seed exit code.

New test `test_seeder_image_pulled_before_ownership_and_seed` asserts the pull happens and precedes the seed hand-off.

### Docs — `docs(getting-started)`: three fresh-install pitfalls
- `docs/getting-started/prerequisites.md`: macOS callout for the pipx / Python 3.9 CLT trap (`Could not find a version that satisfies the requirement aptl-labs`), with the `pipx install --python 3.12 --fetch-missing-python` recovery.
- `docs/getting-started/prerequisites.md`: macOS Colima block mirroring the exact commands the APTL host check already recommends when Docker Buildx is missing.
- `docs/troubleshooting/index.md`: entry for Docker Desktop uninstall leftovers (dead `~/.docker/cli-plugins/*` symlinks and stale `credsStore: "desktop"` in `~/.docker/config.json`).

## Out of scope, flagged for follow-up

- `uv.lock` currently drifts against `pyproject.toml` for `aces-sdl` (git dep → PyPI dep). Reverted from this PR; needs a separate `chore(deps)` refresh.
- The redacted seeder error path (`_seed_one_named_volume` in `docker_compose.py`) still surfaces only `exit <code>` with no docker stderr context. The pre-pull addresses the common case; the general "surface a redacted hint" improvement could be a follow-up if operators keep hitting seed failures for reasons other than a missing image.

## Test plan
- [x] `uv run pytest tests/test_lab.py::TestSeedSuricataVolumesStep tests/test_deployment_backend.py::TestSeedNamedVolumes` — 11 passed
- [x] `uv run ruff check tests/test_lab.py src/aptl/core/lab.py` — clean
- [ ] End-to-end: `colima delete && colima start && aptl lab start` on a fresh Docker host to confirm the pre-pull removes the exit-125 surprise (recommended before merge).