### PR TITLE
fix(release): document release-please title parsing

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,6 +10,8 @@ Nobody runs a script, hand-edits the version, or edits `CHANGELOG.md`.
   Bump rules: `feat:` → minor, `fix:` / `perf:` → patch, `feat!:` or a
   `BREAKING CHANGE:` footer → major (demoted to minor while `0.x`). Other types
   (`docs`, `chore`, `refactor`, `test`, `ci`, `build`) → no release.
+- Use one Conventional Commit type and scope only; compound titles such as
+  `fix(...) + docs:` are not parseable by release-please.
 - **Do not** edit `CHANGELOG.md` or the version; release-please owns both.
   Because feature PRs never touch `CHANGELOG.md`, concurrent PRs never conflict
   on it.


### PR DESCRIPTION
## Summary
- documents that release PR titles must use one Conventional Commit type/scope
- prevents compound titles from being missed by release-please

## Validation
- pre-commit hooks for this docs-only change passed locally, including Vale

## Release note
This is intentionally a valid `fix:` commit so release-please can cut the patch release after the previous unparseable merged title.
