### PR TITLE
fix(release): document release-please title parsing

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,6 +10,8 @@ Nobody runs a script, hand-edits the version, or edits `CHANGELOG.md`.
   Bump rules: `feat:` → minor, `fix:` / `perf:` → patch, `feat!:` or a
   `BREAKING CHANGE:` footer → major (demoted to minor while `0.x`). Other types
   (`docs`, `chore`, `refactor`, `test`, `ci`, `build`) → no release.
+- Use one Conventional Commit type and scope only; compound titles such as
+  `fix(...) + docs:` are not parseable by release-please.
 - **Do not** edit `CHANGELOG.md` or the version; release-please owns both.
   Because feature PRs never touch `CHANGELOG.md`, concurrent PRs never conflict
   on it.


### PR DESCRIPTION
## Summary
- promotes the release-please title parsing fix from dev to main
- gives release-please a valid `fix:` commit on main so it can cut the patch release

## Validation
- PR title lint passed on #717
- local pre-commit passed on #717, including Vale

## Release path
After this lands on main, release-please should open the patch release PR. Merge that release PR to publish to PyPI.
