### PR TITLE
docs(troubleshooting): triage 'Up (unhealthy)' containers — memory-tight vs daemons-crashed

### DIFF
--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -72,7 +72,7 @@ You do not have to free these by hand: `aptl lab start` probes every published
 host port and, if a default is already in use (Windows reserves UDP 5353 for
 mDNS; an editor's automatic port-forwarding may hold others), publishes that
 service on a free port instead and prints the real ports under "Host port
-remaps" in the start summary. Use the reported ports (e.g. the Wazuh Dashboard
+remaps" in the start summary. Use the reported ports (for example, the Wazuh Dashboard
 URL, or `dig @localhost -p <reported-port> techvault.local SOA`). Pin a specific
 port with the matching `APTL_HP_*` / `APTL_DNS_HOST_PORT` variable to override.
 
@@ -86,7 +86,7 @@ block system-wide `pip` under [PEP 668](https://peps.python.org/pep-0668/), so
 
 For released installs on any OS, prefer `pipx install aptl-labs`.
 
-**macOS gotcha — pipx bound to the system Python 3.9.** `aptl-labs` requires
+**macOS gotcha—pipx bound to the system Python 3.9.** `aptl-labs` requires
 Python 3.11+ (declared in `pyproject.toml`). If your `pipx` was installed
 against the Command Line Tools Python (`/usr/bin/python3`, which is 3.9),
 `pipx install aptl-labs` fails with:
@@ -96,7 +96,7 @@ ERROR: Could not find a version that satisfies the requirement aptl-labs (from v
 ```
 
 The real cause is the "Ignored the following versions that require a
-different python version" line further up in pip's output — every published
+different python version" line further up in pip's output—every published
 `aptl-labs` release is filtered out by the Python-version gate. Recover with
 a scoped standalone Python that pipx fetches just for this venv:
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -171,7 +171,7 @@ container aptl-<name> is unhealthy` and `docker ps` shows the container
 as `Up (unhealthy)`, there are two very different failure modes worth
 distinguishing before assuming the tool is broken:
 
-**1. Memory too tight — the service is being kernel-killed during warm-up.**
+**1. Memory too tight—the service is being kernel-killed during warm-up.**
 Check the deploy limit vs the service's needs:
 
 ```bash
@@ -198,10 +198,10 @@ docker exec aptl-<name> sh -c 'ls /proc/[0-9]*/comm | while read f; do read n < 
 ```
 
 Compare the live process list against what the container is supposed to
-run (e.g. wazuh-manager should show `wazuh-analysisd`, `wazuh-modulesd`,
-`wazuh-execd`, and a python API process — not just `s6-supervise` +
+run (for example, wazuh-manager should show `wazuh-analysisd`, `wazuh-modulesd`,
+`wazuh-execd`, and a python API process—not just `s6-supervise` +
 `filebeat`). If the intended daemons are missing, check the service's
-own log directory (e.g. `/var/ossec/logs/ossec.log` for Wazuh) for the
+own log directory (for example, `/var/ossec/logs/ossec.log` for Wazuh) for the
 crash cause. Wazuh-manager silent-crash after startup is tracked in
 [#725](https://github.com/Brad-Edwards/aptl/issues/725).
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -164,6 +164,47 @@ sudo lsof -i :443
 # Disable in System Preferences → Sharing
 ```
 
+### A container is `Up` but reports `unhealthy`, blocking `aptl lab start`
+
+When `aptl lab start` fails with `dependency <name> failed to start:
+container aptl-<name> is unhealthy` and `docker ps` shows the container
+as `Up (unhealthy)`, there are two very different failure modes worth
+distinguishing before assuming the tool is broken:
+
+**1. Memory too tight — the service is being kernel-killed during warm-up.**
+Check the deploy limit vs the service's needs:
+
+```bash
+docker inspect aptl-<name> --format 'Mem={{.HostConfig.Memory}} OOMKilled={{.State.OOMKilled}} RestartCount={{.RestartCount}}'
+docker logs --tail 30 aptl-<name>
+```
+
+Signs: `RestartCount` climbing, entrypoint lines like `Killed  su ... bin/<service>`,
+`OOMKilled` may stay `false` if the JVM/child was killed outside docker's
+tracking. The fix is to raise `deploy.resources.limits.memory` on that
+service in `docker-compose.yml`. Cortex 3.1.8 at 512m was one confirmed
+case ([#723](https://github.com/Brad-Edwards/aptl/issues/723), fixed on
+`dev`); watch for similar behavior on any service whose limit is 128m /
+256m / 512m if its images are non-trivial (JVM, Play, Elasticsearch,
+Cassandra, etc.).
+
+**2. Container is running but the intended daemons have died silently.**
+The container's PID 1 (often `s6` or a shell) survives, so docker still
+reports `Up`, but the workload processes are gone and the healthcheck
+port is closed.
+
+```bash
+docker exec aptl-<name> sh -c 'ls /proc/[0-9]*/comm | while read f; do read n < "$f"; echo "$(basename $(dirname $f)) $n"; done | sort -k2'
+```
+
+Compare the live process list against what the container is supposed to
+run (e.g. wazuh-manager should show `wazuh-analysisd`, `wazuh-modulesd`,
+`wazuh-execd`, and a python API process — not just `s6-supervise` +
+`filebeat`). If the intended daemons are missing, check the service's
+own log directory (e.g. `/var/ossec/logs/ossec.log` for Wazuh) for the
+crash cause. Wazuh-manager silent-crash after startup is tracked in
+[#725](https://github.com/Brad-Edwards/aptl/issues/725).
+
 ### `aptl lab start` fails with "Existing network aptl_aptl-... does not match realized network"
 
 Symptom on a machine that has run an older aptl-labs release before the


### PR DESCRIPTION
Follow-on to #713 and #724 from the same live-fire onboarding walk. Two distinct \"container is Up but unhealthy\" failure modes hit during the \`techvault-operational\` boot:

1. **Memory-tight** — cortex 3.1.8 at 512m was kernel-killed during warm-up. Fix landed in #724.
2. **Daemons crashed inside** — wazuh-manager container stayed \`Up\` but the Wazuh daemons and API python process died silently; only \`s6-supervise\` + \`filebeat\` + \`tail\` remained. Filed as #725.

Both produce the same-looking compose error (\`dependency <name> failed to start: container aptl-<name> is unhealthy\`) but need different responses. This PR adds a troubleshooting entry that gives the reader the two-step triage:
- \`docker inspect ... {{.HostConfig.Memory}} {{.State.OOMKilled}} {{.RestartCount}}\` + log grep for kernel-kill signatures
- \`docker exec\` + \`/proc/[0-9]*/comm\` walk to catch the daemons-dead-inside case (works without \`ps\` in minimal images)

Docs-only. No code change.

Refs #723 #725