### PR TITLE
fix: enable full SOC lab in default config so init+start works

### DIFF
--- a/src/aptl/core/config.py
+++ b/src/aptl/core/config.py
@@ -45,15 +45,23 @@ class ContainerSettings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # Defaults match the full DEFAULT_ACES_SCENARIO (techvault-operational) that
+    # `aptl lab start` provisions when no scenario is given, so a plain
+    # `aptl lab init` + `aptl lab start` brings up the complete lab the
+    # walkthrough documents. With soc/enterprise/dns/fileshare off, Compose only
+    # created the wazuh/victim/kali subset while the ACES handoff still tried to
+    # wire the scenario's ad/dns/cortex/db nodes, so start failed with
+    # "No such container". `reverse` and `mail` stay off — they are not part of
+    # that scenario.
     wazuh: bool = True
     victim: bool = True
     kali: bool = True
     reverse: bool = False
-    enterprise: bool = False
-    soc: bool = False
+    enterprise: bool = True
+    soc: bool = True
     mail: bool = False
-    fileshare: bool = False
-    dns: bool = False
+    fileshare: bool = True
+    dns: bool = True
 
     def enabled_profiles(self) -> list[str]:
         """Return docker compose profile names for enabled containers."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,11 +62,11 @@ _EXPECTED_CONTAINER_DEFAULTS = {
     "victim": True,
     "kali": True,
     "reverse": False,
-    "enterprise": False,
-    "soc": False,
+    "enterprise": True,
+    "soc": True,
     "mail": False,
-    "fileshare": False,
-    "dns": False,
+    "fileshare": True,
+    "dns": True,
 }
 
 
@@ -104,7 +104,19 @@ class TestContainerSettings:
         """
         from aptl.core.config import ContainerSettings
 
-        settings = ContainerSettings(wazuh=True, victim=False, kali=True, reverse=False)
+        # Set every field explicitly so this exercises enabled_profiles() itself
+        # rather than the model defaults.
+        settings = ContainerSettings(
+            wazuh=True,
+            victim=False,
+            kali=True,
+            reverse=False,
+            enterprise=False,
+            soc=False,
+            mail=False,
+            fileshare=False,
+            dns=False,
+        )
         assert set(settings.enabled_profiles()) == {"wazuh", "kali"}
 
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -901,7 +901,20 @@ class TestOrchestrateLabStart:
 
         return AptlConfig(
             lab={"name": "test-lab"},
-            containers={"wazuh": True, "victim": True, "kali": True, "reverse": False},
+            # Explicit minimal profile set: these orchestration tests assert
+            # behavior for a wazuh/victim/kali lab, so pin every flag rather
+            # than inheriting the (now SOC-enabled) config defaults.
+            containers={
+                "wazuh": True,
+                "victim": True,
+                "kali": True,
+                "reverse": False,
+                "enterprise": False,
+                "soc": False,
+                "mail": False,
+                "fileshare": False,
+                "dns": False,
+            },
         )
 
     def _patch_all_steps(self, mocker, tmp_path):
@@ -931,11 +944,19 @@ class TestOrchestrateLabStart:
             json.dumps(
                 {
                     "lab": {"name": "test-lab"},
+                    # Pin every profile: these orchestration tests assert the
+                    # outcome/diagnostics of a wazuh/victim/kali lab, so the
+                    # written config must not inherit the SOC-enabled defaults.
                     "containers": {
                         "wazuh": True,
                         "victim": True,
                         "kali": True,
                         "reverse": False,
+                        "enterprise": False,
+                        "soc": False,
+                        "mail": False,
+                        "fileshare": False,
+                        "dns": False,
                     },
                 }
             )
@@ -1923,11 +1944,19 @@ class TestStartupClassificationWiring:
 
         return AptlConfig(
             lab={"name": "test-lab"},
+            # Pin the SOC/enterprise/dns/fileshare flags off: these wiring tests
+            # assert diagnostics for a wazuh/victim/kali lab, so don't inherit
+            # the (now SOC-enabled) config defaults.
             containers={
                 "wazuh": wazuh,
                 "victim": victim,
                 "kali": kali,
                 "reverse": reverse,
+                "enterprise": False,
+                "soc": False,
+                "mail": False,
+                "fileshare": False,
+                "dns": False,
             },
         )
 


### PR DESCRIPTION
## Problem (reproduced on Windows with the real 4.2.1 PyPI release)

`pipx install aptl-labs` → `aptl lab init <dir>` → `aptl lab start` fails out of the box:

```
Lab start failed: ACES runtime handoff failed: aptl.provisioner.backend-start-failed
at runtime.apply.provisioning: Failed to connect aptl-ad to aptl_aptl-internal:
No such container: aptl-ad; Container aptl-cortex was not inspectable for realized
node cortex.; Container aptl-db was not inspectable ...; Failed to connect aptl-dns ...
```

Only ~10 of the ~31 containers are created.

## Root cause (platform-independent)

- Default `aptl lab start` (no `--scenario`) provisions `DEFAULT_ACES_SCENARIO = scenarios/techvault-operational.sdl.yaml` — the full lab (SOC + enterprise AD + DNS + fileshare).
- But the default `aptl.json` that `init` writes (`ContainerSettings` defaults) had `soc/enterprise/dns/fileshare = false`.
- So Compose only brings up the wazuh/victim/kali profiles, while the ACES handoff still tries to wire the scenario's `ad`/`dns`/`cortex`/`db` nodes → "No such container".

This fails identically on Linux/macOS — it's a config↔scenario default mismatch, not OS-specific.

## Fix

Default `soc`, `enterprise`, `dns`, and `fileshare` to `true` so a plain `init` + `start` brings up the complete lab the walkthrough documents. `reverse`/`mail` stay off (not part of `techvault-operational`).

## Tests

Updated `_EXPECTED_CONTAINER_DEFAULTS` and made `test_enabled_profiles_returns_only_enabled` set fields explicitly (so it tests the method, not the defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)