### PR TITLE
feat: run MCP build and SOC seed shell steps on native Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -47,5 +47,9 @@ containers/keys/* text eol=lf
 
 scripts/**/*.sh text eol=lf
 
+# `aptl lab start` runs mcp/build-all-mcps.sh through a POSIX shell (Git Bash on
+# Windows), which fails on CRLF-mangled lines, so keep the MCP build scripts LF.
+mcp/**/*.sh text eol=lf
+
 .aptl/config/** text eol=lf
 .aptl/realization/** text eol=lf

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -1696,12 +1696,9 @@ def _step_build_mcps(ctx: _LabStartContext) -> LabResult | None:
         )
         return None
     try:
-        mcp_result = subprocess.run(
-            [str(mcp_script)],
-            capture_output=True,
-            text=True,
-            cwd=ctx.project_dir,
-        )
+        from aptl.utils.shell import run_shell_script
+
+        mcp_result = run_shell_script(mcp_script, cwd=ctx.project_dir)
         if mcp_result.returncode != 0:
             # Raw stderr stays in the log (existing redaction owns it);
             # the structured diagnostic carries only a narrow summary.
@@ -1819,10 +1816,10 @@ def _run_seed_soc_script(ctx: _LabStartContext) -> None:
 def _execute_seed_soc_script(ctx: _LabStartContext, seed_script: Path) -> None:
     """Execute the SOC seed script and emit non-fatal diagnostics."""
     try:
-        seed_result = subprocess.run(
-            [str(seed_script)],
-            capture_output=True,
-            text=True,
+        from aptl.utils.shell import run_shell_script
+
+        seed_result = run_shell_script(
+            seed_script,
             cwd=ctx.project_dir,
             env={**os.environ, **ctx.raw_env},
             timeout=1200,

--- a/src/aptl/utils/shell.py
+++ b/src/aptl/utils/shell.py
@@ -1,0 +1,126 @@
+"""Cross-platform execution of the lab's POSIX shell scripts.
+
+A couple of control-plane steps (MCP build, SOC seed) are bash scripts. On
+Linux and macOS they run directly via their shebang. Windows has no POSIX shell
+on PATH by default, so this locates **Git Bash** — the shell shipped with Git
+for Windows, a native Windows program (MSYS2) — and runs the script through it.
+
+WSL's ``C:\\Windows\\System32\\bash.exe`` is deliberately *not* used: it runs the
+script inside a separate Linux distribution with its own filesystem and
+toolchain (and often no Docker CLI), which is not the intended runtime. We only
+accept a Git-for-Windows bash.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from aptl.utils.logging import get_logger
+
+log = get_logger("shell")
+
+_IS_WINDOWS = sys.platform.startswith("win")
+
+
+def _looks_like_wsl(path: Path) -> bool:
+    """True for the WSL launcher shim under System32 (not a real POSIX shell)."""
+    parts = {p.lower() for p in path.parts}
+    return "system32" in parts or "windowsapps" in parts
+
+
+def _git_bash_from_git() -> Path | None:
+    """Derive Git Bash from the ``git`` executable on PATH.
+
+    Git for Windows lays out ``<root>\\cmd\\git.exe`` alongside
+    ``<root>\\bin\\bash.exe``; that bash is the native MSYS2 shell.
+    """
+    git = shutil.which("git")
+    if not git:
+        return None
+    root = Path(git).resolve().parent.parent  # <root>/cmd/git.exe -> <root>
+    candidate = root / "bin" / "bash.exe"
+    return candidate if candidate.is_file() else None
+
+
+def _git_bash_from_known_locations() -> Path | None:
+    for base in (
+        os.environ.get("ProgramFiles", r"C:\Program Files"),
+        os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+        os.environ.get("LocalAppData", ""),
+    ):
+        if not base:
+            continue
+        candidate = Path(base) / "Git" / "bin" / "bash.exe"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def find_posix_shell() -> Path | None:
+    """Return a POSIX shell for running ``.sh`` scripts, or None to run direct.
+
+    Non-Windows returns None (the script runs via its shebang). On Windows this
+    returns a Git-for-Windows ``bash.exe``, never the WSL launcher. Returns None
+    when no suitable shell is found so callers can degrade gracefully.
+    """
+    if not _IS_WINDOWS:
+        return None
+    shell = _git_bash_from_git() or _git_bash_from_known_locations()
+    if shell is None:
+        # Last resort: a bash on PATH that is not the WSL shim.
+        found = shutil.which("bash")
+        if found and not _looks_like_wsl(Path(found)):
+            shell = Path(found)
+    return shell
+
+
+def _to_shell_arg(script: Path) -> str:
+    """Render *script* for a bash argv, using forward slashes on Windows.
+
+    Git Bash accepts a Windows path with forward slashes (``C:/a/b.sh``);
+    backslashes would be treated as escapes.
+    """
+    text = str(script)
+    return text.replace("\\", "/") if _IS_WINDOWS else text
+
+
+def run_shell_script(
+    script: Path,
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a POSIX shell script, cross-platform.
+
+    On Unix the script is executed directly (shebang). On Windows it is run
+    through Git Bash. Raises :class:`FileNotFoundError` when no POSIX shell is
+    available on Windows — the same exception callers already handle to degrade
+    the step to a non-fatal diagnostic. Output is captured and decoded as UTF-8.
+    """
+    if _IS_WINDOWS:
+        shell = find_posix_shell()
+        if shell is None:
+            raise FileNotFoundError(
+                "no POSIX shell found to run "
+                f"{script.name}; install Git for Windows (provides Git Bash)"
+            )
+        argv = [str(shell), _to_shell_arg(script)]
+        log.debug("Running %s via %s", script.name, shell)
+    else:
+        argv = [str(script)]
+
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(cwd) if cwd is not None else None,
+        env=env,
+        timeout=timeout,
+    )

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,67 @@
+"""Tests for cross-platform POSIX shell-script execution.
+
+Runs a real script through the resolver so Git Bash invocation is validated on
+Windows and direct shebang execution on Unix.
+"""
+
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from aptl.utils import shell
+
+
+def _write_script(tmp_path: Path) -> Path:
+    script = tmp_path / "hello.sh"
+    script.write_text(
+        '#!/bin/bash\necho "hello $1"\ncd "$(dirname "$0")" && pwd\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return script
+
+
+def test_runs_script_and_captures_output(tmp_path):
+    script = _write_script(tmp_path)
+    result = shell.run_shell_script(script, cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "hello" in result.stdout
+
+
+def test_passes_environment(tmp_path):
+    script = tmp_path / "env.sh"
+    script.write_text(
+        '#!/bin/bash\necho "val=$APTL_TEST_VAR"\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    import os
+
+    result = shell.run_shell_script(
+        script, cwd=tmp_path, env={**os.environ, "APTL_TEST_VAR": "xyz"}
+    )
+    assert "val=xyz" in result.stdout
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX-only branch")
+def test_find_posix_shell_none_on_unix():
+    assert shell.find_posix_shell() is None
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows-only branch")
+def test_find_git_bash_on_windows_not_wsl():
+    found = shell.find_posix_shell()
+    assert found is not None, "Git Bash should be discoverable on the Windows CI/dev host"
+    assert not shell._looks_like_wsl(found), f"must not select the WSL shim: {found}"
+    assert found.name.lower() == "bash.exe"
+
+
+def test_looks_like_wsl_flags_system32():
+    assert shell._looks_like_wsl(Path(r"C:\Windows\System32\bash.exe")) is True
+    assert shell._looks_like_wsl(Path(r"C:\Program Files\Git\bin\bash.exe")) is False


### PR DESCRIPTION
## Problem

The two shell-script start steps — MCP build (`mcp/build-all-mcps.sh`) and SOC seed (`scripts/seed-prime.sh`) — invoke their `.sh` files directly (`subprocess.run([str(script)])`). Windows has no POSIX shell on PATH, so those steps **always** degrade to a capability diagnostic there, even when Node/curl are installed. On the real 4.2.1 pipx flow this shows up as:

```
[capability|build_mcps] MCP build could not run
[capability|seed_soc]  SOC seeding could not run
```

## Fix

Add `aptl.utils.shell.run_shell_script`:
- **Unix:** runs the script directly via its shebang (unchanged).
- **Windows:** runs it through **Git Bash** — the native shell shipped with Git for Windows (MSYS2). It deliberately locates Git Bash via `git.exe` (or known install dirs) and **never** uses `System32\bash.exe` (the WSL launcher, which runs in a separate distro with no Docker CLI).
- When no POSIX shell is found it raises `FileNotFoundError`, which `_step_build_mcps` / `_execute_seed_soc_script` already catch to degrade gracefully — so nothing changes on a Windows host without Git Bash.

`seed-prime.sh` needs only `curl`/`awk`/`docker` (no `jq`), all of which Git Bash provides.

Also LF-protects `mcp/**/*.sh` in `.gitattributes` — `build-all-mcps.sh` is bundled into the wheel and run through a POSIX shell, which fails on CRLF-mangled lines.

## Tests

New `tests/test_shell.py` runs a real script through the resolver (validates Git Bash invocation on Windows, shebang on Unix) and asserts the WSL shim is never selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)