### PR TITLE
fix(compose): suricata memory 1g -> 3g so IDS stays up under full APTL rule set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,7 +224,14 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1g
+          # 1g was too small: the container OOM-killed (exit 137) shortly
+          # after loading the full ~52k signature set (default + local +
+          # MISP + suricata_rules + falco + ad + webapp + database +
+          # samba + postgresql). Colima on macOS reproduced this
+          # consistently with 18 restarts before compose gave up. 3g
+          # leaves headroom for signature reloads and packet buffers
+          # without dominating the 24 GB Colima footprint.
+          memory: 3g
     networks:
       aptl-dmz:
         ipv4_address: 172.20.1.50


### PR DESCRIPTION
Same class of defect as the cortex 2g fix in #724 / issue #723.

## Failure

\`aptl-suricata\` OOM-kills (exit 137) shortly after startup on a fresh macOS + Colima install running \`aptl-labs\` 4.2.2 with \`enterprise+soc+dns+fileshare\` enabled:

\`\`\`
Mem=1073741824 OOMKilled=true RestartCount=18 Exit=137
aptl-suricata   Restarting (137) 25 seconds ago
\`\`\`

## Root cause

Suricata loads the full APTL signature set at startup — local + MISP + \`suricata_rules\` + \`falco\` + \`ad\` + \`webapp\` + \`database\` + \`samba\` + \`postgresql\` — about **52k signatures**. The current \`deploy.resources.limits.memory: 1g\` is not enough for that plus packet buffers, and the container gets kernel-killed before Wazuh's suricata sidecar can consume its eve.json.

## Fix

Raise to \`3g\`. Comment in the diff explains why. This still fits comfortably alongside the rest of the stack on the 24 GB Colima allocation the walkthrough calls for.

## Test plan
- [ ] End-to-end \`aptl lab start\` on Colima with the walkthrough's aptl.json — suricata stays Up, eve.json flows into Wazuh (verify in the ongoing manual walk).