### PR TITLE
fix: make generated cert mounts container-readable

### DIFF
--- a/scripts/seed-prime.sh
+++ b/scripts/seed-prime.sh
@@ -147,7 +147,8 @@ fi
 echo ""
 echo "[3/7] Waiting for Wazuh Indexer to be healthy..."
 
-INDEXER_URL="${INDEXER_URL:-https://localhost:9200}"
+INDEXER_PORT="${APTL_HP_WAZUH_INDEXER_9200:-9200}"
+INDEXER_URL="${INDEXER_URL:-https://localhost:${INDEXER_PORT}}"
 INDEXER_USER="${INDEXER_USERNAME:-admin}"
 INDEXER_PASS="${INDEXER_PASSWORD:-SecretPassword}"
 

--- a/src/aptl/core/certs.py
+++ b/src/aptl/core/certs.py
@@ -56,7 +56,7 @@ def ensure_ssl_certs(project_dir: Path) -> CertResult:
                 certs_dir=certs_dir,
                 error=alias_error,
             )
-        _ensure_user_writable_certs(certs_dir)
+        _ensure_container_readable_certs(certs_dir)
         log.info("SSL certificates already exist at %s", certs_dir)
         return CertResult(
             success=True,
@@ -89,7 +89,7 @@ def _generate_ssl_certs(project_dir: Path, certs_dir: Path) -> CertResult:
                 certs_dir=certs_dir,
                 error=alias_error,
             )
-        _ensure_user_writable_certs(certs_dir)
+        _ensure_container_readable_certs(certs_dir)
         log.info("SSL certificates generated successfully at %s", certs_dir)
         result = CertResult(success=True, generated=True, certs_dir=certs_dir)
     return result
@@ -117,27 +117,28 @@ def _ensure_manager_root_ca_alias(certs_dir: Path) -> str | None:
     return error
 
 
-def _ensure_user_writable_certs(certs_dir: Path) -> None:
-    """Make generated cert files removable by the invoking host user.
+def _ensure_container_readable_certs(certs_dir: Path) -> None:
+    """Make generated cert files readable through non-root bind mounts.
 
-    The upstream generator emits read-only PEM files. On some Docker VM file
-    sharing layers, notably macOS-backed mounts, that can prevent ordinary
-    cleanup even when the files map back to the host user. This is a
-    best-effort host-side chmod and never escalates privileges.
+    The upstream generator emits owner-only PEM files. Wazuh Indexer and Wazuh
+    Dashboard run as non-root uid 1000 inside the container, which may not match
+    the host uid that ran ``aptl lab start``. Keep the host-side directory
+    private while widening the mounted files so the container processes can read
+    them.
     """
     try:
-        certs_dir.chmod(certs_dir.stat().st_mode | 0o700)
+        certs_dir.chmod(0o700)
     except OSError as exc:
         log.warning(
-            "Could not make generated cert directory writable (%s): %s", certs_dir, exc
+            "Could not make generated cert directory private (%s): %s", certs_dir, exc
         )
     for path in certs_dir.iterdir():
         if not path.is_file():
             continue
         try:
-            path.chmod(path.stat().st_mode | 0o600)
+            path.chmod(0o644)
         except OSError as exc:
-            log.warning("Could not make generated cert writable (%s): %s", path, exc)
+            log.warning("Could not make generated cert readable (%s): %s", path, exc)
 
 
 def _run_cert_generator(project_dir: Path, certs_dir: Path) -> CertResult | None:
@@ -231,8 +232,8 @@ def _cert_ownership_repair_command(certs_dir: Path, user: tuple[int, int]) -> li
     uid, gid = user
     script = (
         f"chown -R {uid}:{gid} /certificates && "
-        "find /certificates -type d -exec chmod u+rwx {} + && "
-        "find /certificates -type f -exec chmod u+rw {} +"
+        "find /certificates -type d -exec chmod 700 {} + && "
+        "find /certificates -type f -exec chmod 644 {} +"
     )
     return [
         "docker",

--- a/src/aptl/core/soc_ca.py
+++ b/src/aptl/core/soc_ca.py
@@ -157,9 +157,9 @@ def ensure_soc_certs(project_dir: Path) -> CertResult:
     returns ``generated=True``.
 
     The CA private key, each service private key, and each PKCS#12
-    passphrase are written with mode ``0o600``. Public certs are ``0o644``
-    so a container process running as a non-root UID can still read them
-    across a bind mount.
+    passphrase are written with mode ``0o600``. Public certs and PKCS#12
+    keystores are ``0o644`` so a container process running as a non-root UID
+    can still read them across a bind mount.
 
     Never logs PEM content, key paths, or passphrases. Failure messages
     cite only the SOC tool name and the affected layer.
@@ -278,14 +278,12 @@ def _generate_all(output_dir: Path) -> None:
       host-side access control. No other local user can traverse in.
     - Public certs (``lab-ca.pem``, ``server.pem``) are ``0o644`` so
       bind-mounts and operator inspection work without root.
-    - Private keys (``lab-ca.key``, ``server.key``), PKCS#12 keystores,
-      and the env_file keystore-password blobs are ``0o600``. The SOC
-      service containers each have been verified live to read the
-      private material at this mode (MISP nginx, TheHive Play, Shuffle
-      nginx all run as the host UID 1000 in the lab images we ship);
-      tightening the mode keeps an unprivileged process *inside* the
-      container — different from the service user — from reading the
-      private material via the bind mount.
+    - Private keys (``lab-ca.key``, ``server.key``) and the env_file
+      keystore-password blobs are ``0o600``.
+    - PKCS#12 keystores are ``0o644`` because TheHive's non-root process reads
+      the bind-mounted file as a container UID that may not match the host user
+      that ran ``aptl lab start``. The owner-only parent directory remains the
+      host-side access control.
 
     Symlink containment (ADR-029 § Secret at rest): each per-service
     subdirectory is verified to be a real directory under ``output_dir``
@@ -407,7 +405,7 @@ def _ensure_service_keystore(
         _invalidate_keystore(svc_dir)
     elif ks_path.is_file() and pw_path.is_file():
         # Reuse-path permission reapply (codex cycle-3 sec).
-        _enforce_mode(ks_path, 0o600, kind="file")
+        _enforce_mode(ks_path, 0o644, kind="file")
         _enforce_mode(pw_path, 0o600, kind="file")
     if not (ks_path.is_file() and pw_path.is_file()):
         password = secrets.token_urlsafe(24)
@@ -420,7 +418,7 @@ def _ensure_service_keystore(
                 password.encode()
             ),
         )
-        _atomic_write(ks_path, ks_bytes, mode=0o600)
+        _atomic_write(ks_path, ks_bytes, mode=0o644)
         # Write the password in Docker Compose ``env_file`` format
         # (``KEY=value``) so the TheHive/Cortex services can
         # consume it via ``env_file:`` rather than baking the

--- a/tests/test_certs.py
+++ b/tests/test_certs.py
@@ -41,6 +41,10 @@ def _successful_generator(mocker, certs_dir):
     return mocker.patch("aptl.core.certs.subprocess.run", side_effect=fake_run)
 
 
+def _mode(path):
+    return path.stat().st_mode & 0o777
+
+
 class TestEnsureSSLCerts:
     """Tests for SSL certificate generation and management."""
 
@@ -60,7 +64,36 @@ class TestEnsureSSLCerts:
         assert result.generated is False
         assert result.certs_dir == certs_dir
         assert (certs_dir / "root-ca-manager.pem").read_text() == "fake-cert"
-        assert (certs_dir / "root-ca-manager.pem").stat().st_mode & 0o200
+        assert _mode(certs_dir) == 0o700
+        assert _mode(certs_dir / "root-ca.pem") == 0o644
+        assert _mode(certs_dir / "root-ca-manager.pem") == 0o644
+        mock_run.assert_not_called()
+
+    def test_existing_certs_are_widened_for_non_root_container_mounts(
+        self, tmp_path, mocker
+    ):
+        """Existing generated certs must be readable by non-root Wazuh images."""
+        from aptl.core.certs import ensure_ssl_certs
+
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
+        certs_dir.mkdir(parents=True)
+        root_ca = certs_dir / "root-ca.pem"
+        root_ca.write_text("fake-cert")
+        dashboard_key = certs_dir / "wazuh.dashboard-key.pem"
+        dashboard_key.write_text("fake-key")
+        root_ca.chmod(0o600)
+        dashboard_key.chmod(0o600)
+        certs_dir.chmod(0o700)
+        mock_run = mocker.patch("aptl.core.certs.subprocess.run")
+
+        result = ensure_ssl_certs(tmp_path)
+
+        assert result.success is True
+        assert result.generated is False
+        assert _mode(certs_dir) == 0o700
+        assert _mode(root_ca) == 0o644
+        assert _mode(dashboard_key) == 0o644
+        assert _mode(certs_dir / "root-ca-manager.pem") == 0o644
         mock_run.assert_not_called()
 
     def test_linux_native_generator_runs_as_root_then_repairs_ownership(
@@ -79,9 +112,9 @@ class TestEnsureSSLCerts:
         assert result.generated is True
         assert result.certs_dir == certs_dir
         assert (certs_dir / "root-ca-manager.pem").read_text() == "fake-cert"
-        assert (certs_dir / "root-ca.pem").stat().st_mode & 0o200
-        assert (certs_dir / "wazuh.manager-key.pem").stat().st_mode & 0o200
-        assert certs_dir.stat().st_mode & 0o200
+        assert _mode(certs_dir / "root-ca.pem") == 0o644
+        assert _mode(certs_dir / "wazuh.manager-key.pem") == 0o644
+        assert _mode(certs_dir) == 0o700
         assert mock_run.call_count == 2
         generator_cmd = mock_run.call_args_list[0][0][0]
         assert generator_cmd == [
@@ -105,6 +138,7 @@ class TestEnsureSSLCerts:
         assert repair_cmd[6] == f"{certs_dir.resolve()}:/certificates"
         assert repair_cmd[7] == "wazuh/wazuh-certs-generator:0.0.2"
         assert "chown -R 1000:1000 /certificates" in repair_cmd[-1]
+        assert "find /certificates -type f -exec chmod 644 {} +" in repair_cmd[-1]
 
     def test_linux_native_precreates_output_dir(self, tmp_path, mocker, linux_native):
         """Precreating the bind mount avoids Docker making a root-owned dir."""
@@ -125,8 +159,8 @@ class TestEnsureSSLCerts:
         assert result.success is True
         assert result.generated is True
         assert (certs_dir / "root-ca-manager.pem").read_text() == "fake-cert"
-        assert (certs_dir / "root-ca.pem").stat().st_mode & 0o200
-        assert certs_dir.stat().st_mode & 0o200
+        assert _mode(certs_dir / "root-ca.pem") == 0o644
+        assert _mode(certs_dir) == 0o700
         generator_cmd = mock_run.call_args_list[0][0][0]
         assert "--user" not in generator_cmd
 
@@ -148,8 +182,8 @@ class TestEnsureSSLCerts:
         assert "--user" not in generator_cmd
         assert generator_cmd[-1] == "generator"
         assert (certs_dir / "root-ca-manager.pem").read_text() == "fake-cert"
-        assert (certs_dir / "root-ca.pem").stat().st_mode & 0o200
-        assert certs_dir.stat().st_mode & 0o200
+        assert _mode(certs_dir / "root-ca.pem") == 0o644
+        assert _mode(certs_dir) == 0o700
         getuid.assert_not_called()
         getgid.assert_not_called()
 
@@ -194,7 +228,7 @@ class TestEnsureSSLCerts:
         assert result.success is True
         assert result.generated is False
         assert (certs_dir / "root-ca-manager.pem").read_text() == "existing-cert"
-        assert (certs_dir / "root-ca-manager.pem").stat().st_mode & 0o200
+        assert _mode(certs_dir / "root-ca-manager.pem") == 0o644
         mock_run.assert_not_called()
 
     def test_missing_generated_root_ca_is_reported(self, tmp_path, mocker):

--- a/tests/test_cortex_integration_config.py
+++ b/tests/test_cortex_integration_config.py
@@ -88,6 +88,8 @@ def test_prime_seed_provisions_and_persists_cortex_key():
     text = SEED_PRIME_SCRIPT.read_text(encoding="utf-8")
 
     assert "aptl-cortex aptl-thehive aptl-misp aptl-shuffle-frontend" in text
+    assert 'INDEXER_PORT="${APTL_HP_WAZUH_INDEXER_9200:-9200}"' in text
+    assert 'INDEXER_URL="${INDEXER_URL:-https://localhost:${INDEXER_PORT}}"' in text
     assert 'CORTEX_API_KEY=$("$SCRIPT_DIR/cortex-apikey.sh"' in text
     assert 'update_env_var CORTEX_API_KEY "$CORTEX_API_KEY"' in text
     assert "sed -i" not in text

--- a/tests/test_soc_ca.py
+++ b/tests/test_soc_ca.py
@@ -173,9 +173,9 @@ class TestPermissions:
 
     - Output dir + per-service subdirs: ``0o700`` (host-side access control).
     - Public certs: ``0o644`` (operator-readable, mounted as RO).
-    - Private keys, PKCS#12 keystores, keystore password files:
-      ``0o600``. Tight by intent — the service inside the container
-      runs as the host UID (verified live) and needs no other reader.
+    - Private keys and keystore password files: ``0o600``.
+    - PKCS#12 keystores: ``0o644`` so non-root Play containers can read the
+      bind-mounted file when their UID differs from the host user.
     """
 
     def test_output_dir_is_owner_traverseable_only(self, tmp_path):
@@ -204,10 +204,9 @@ class TestPermissions:
 
     def test_service_private_keys_are_owner_read_only(self, tmp_path):
         """Server keys at 0600 — tight by intent per codex security
-        finding. The service process inside each SOC container runs
-        as the host UID 1000 (verified live during SEC-006 bring-up)
-        so 0600 is readable to the service and unreadable to anything
-        else inside the container."""
+        finding. Services that need host-generated private key material through
+        a non-root bind mount should consume the container-readable PKCS#12
+        keystore path instead of widening raw PEM private keys."""
         from aptl.core.soc_ca import LAB_CA_RELDIR, SOC_SERVICE_REGISTRY, ensure_soc_certs
 
         ensure_soc_certs(tmp_path)
@@ -217,10 +216,10 @@ class TestPermissions:
             mode = stat.S_IMODE(key_path.stat().st_mode)
             assert mode == 0o600, f"{svc.name} key mode {oct(mode)} != 0o600"
 
-    def test_keystore_and_password_files_are_owner_read_only(self, tmp_path):
-        """env_file is consumed by Compose on the host (as the host user),
-        and the keystore is consumed by the Play process inside the
-        container (as the host UID per above). Both stay 0600."""
+    def test_keystore_is_container_readable_and_password_file_is_owner_read_only(
+        self, tmp_path
+    ):
+        """Keystore crosses a bind mount; password stays host-side env_file only."""
         from aptl.core.soc_ca import LAB_CA_RELDIR, SOC_SERVICE_REGISTRY, ensure_soc_certs
 
         ensure_soc_certs(tmp_path)
@@ -228,10 +227,16 @@ class TestPermissions:
         for svc in SOC_SERVICE_REGISTRY:
             if not svc.needs_keystore:
                 continue
-            for name in ("keystore.p12", "keystore.p12.password"):
-                p = ca_dir / svc.name / name
-                mode = stat.S_IMODE(p.stat().st_mode)
-                assert mode == 0o600, f"{svc.name} {name} mode {oct(mode)} != 0o600"
+            keystore = ca_dir / svc.name / "keystore.p12"
+            password = ca_dir / svc.name / "keystore.p12.password"
+            keystore_mode = stat.S_IMODE(keystore.stat().st_mode)
+            password_mode = stat.S_IMODE(password.stat().st_mode)
+            assert keystore_mode == 0o644, (
+                f"{svc.name} keystore.p12 mode {oct(keystore_mode)} != 0o644"
+            )
+            assert password_mode == 0o600, (
+                f"{svc.name} keystore.p12.password mode {oct(password_mode)} != 0o600"
+            )
 
 
 class TestSymlinkContainmentPerService:


### PR DESCRIPTION
## Summary
- widen generated Wazuh cert bind-mount files to 0644 while keeping the host-side directory private
- make generated SOC PKCS#12 keystores container-readable while keeping private keys and password env files owner-only
- teach seed-prime.sh to use the remapped Wazuh Indexer host port from APTL_HP_WAZUH_INDEXER_9200

## Validation
- .venv/bin/python -m pytest tests/test_certs.py tests/test_soc_ca.py tests/test_cortex_integration_config.py
- .venv/bin/pre-commit run --all-files
- AWS proof/us-east-2 emergency fleet: SSM full-start command e6feef9a-6472-409b-9917-006cf9da830d succeeded on 26 hosts; sample host i-00b639f276e93e409 reported aptl 4.2.1 and all 31 APTL containers healthy/running
