### PR TITLE
fix(lab): use resolved indexer host port in readiness probe (was hardcoded 9200)

### DIFF
--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -1233,7 +1233,21 @@ def _step_wait_for_services(ctx: _LabStartContext) -> LabResult | None:
     if "wazuh" not in ctx.selected_profiles:
         return None
 
-    indexer_url = "https://localhost:9200"
+    # Use the actual published host port for the indexer. If port 9200 was
+    # already in use on the host (Cursor / another OpenSearch / a k8s
+    # port-forward), `_step_resolve_host_ports` remapped the publish; probing
+    # the literal 9200 in that case reaches whatever else is on 9200 and
+    # falsely reports the indexer as unready. `ctx.resolved_ports` carries
+    # the post-remap answer.
+    indexer_port = next(
+        (
+            r.resolved_port
+            for r in ctx.resolved_ports
+            if getattr(r, "service", None) == "wazuh.indexer"
+        ),
+        9200,
+    )
+    indexer_url = f"https://localhost:{indexer_port}"
     indexer_result = wait_for_service(
         check_fn=partial(
             check_indexer_ready,

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -2172,6 +2172,68 @@ class TestStartupClassificationWiring:
         assert "HTTP 403" in indexer_diags[0].message
         assert "aptl lab stop -v" in indexer_diags[0].operator_action
 
+    def test_wait_for_services_probes_the_resolved_indexer_port_not_9200(
+        self, tmp_path, mocker
+    ):
+        """When 9200 is already in use on the host, `_step_resolve_host_ports`
+        remaps the indexer publish; the readiness probe must follow the
+        remap or it hits whatever else is on 9200 and reports the SIEM
+        store as unready even though it is fully healthy on the remapped
+        port."""
+        from aptl.core.host_ports import ResolvedPort
+        from aptl.core.lab import _step_wait_for_services
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path)
+        ctx.resolved_ports = [
+            ResolvedPort(
+                service="wazuh.indexer",
+                env_var="APTL_HP_WAZUH_INDEXER_9200",
+                default_port=9200,
+                resolved_port=20015,
+                protos=("tcp",),
+                host_ip="127.0.0.1",
+                remapped=True,
+            ),
+        ]
+        mock_wait = mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            return_value=ServiceResult(ready=True, elapsed_seconds=1.0),
+        )
+
+        _step_wait_for_services(ctx)
+
+        # First wait_for_service call is the indexer wait; its check_fn is a
+        # partial(check_indexer_ready, url=..., ...) — assert the resolved
+        # port made it through.
+        indexer_call_kwargs = mock_wait.call_args_list[0].kwargs
+        assert indexer_call_kwargs["service_name"] == "Wazuh Indexer"
+        assert indexer_call_kwargs["check_fn"].keywords["url"] == (
+            "https://localhost:20015"
+        )
+
+    def test_wait_for_services_falls_back_to_9200_when_no_remap(
+        self, tmp_path, mocker
+    ):
+        """No entry for wazuh.indexer in `ctx.resolved_ports` (the common
+        case where 9200 was free) keeps the historical URL."""
+        from aptl.core.lab import _step_wait_for_services
+        from aptl.core.services import ServiceResult
+
+        ctx = self._ctx(tmp_path)
+        # resolved_ports left as the default empty list.
+        mock_wait = mocker.patch(
+            "aptl.core.lab.wait_for_service",
+            return_value=ServiceResult(ready=True, elapsed_seconds=1.0),
+        )
+
+        _step_wait_for_services(ctx)
+
+        indexer_call_kwargs = mock_wait.call_args_list[0].kwargs
+        assert indexer_call_kwargs["check_fn"].keywords["url"] == (
+            "https://localhost:9200"
+        )
+
     def test_wait_for_services_manager_timeout_emits_telemetry_warning(
         self, tmp_path, mocker
     ):


### PR DESCRIPTION
Closes #733.

## Failure

Reproduced on macOS + Colima with aptl-labs 4.2.2 while walking through the workshop end-to-end. When any process on the host holds port 9200 (Cursor's remote-tunnel feature happened to be doing it for me — a k8s port-forward, another OpenSearch install, etc. would produce the same thing), the compose port remap correctly moves the indexer publish to a 20xxx port:

\`\`\`
[lab start] Host port 9200 for wazuh.indexer is in use; publishing on 20015 instead.
...
$ docker port aptl-wazuh-indexer
9200/tcp -> 127.0.0.1:20015

$ curl -sk -u admin:\$INDEXER_PASSWORD https://localhost:20015/_cluster/health
{"status":"green", ...} HTTP=200
\`\`\`

But the readiness probe in \`_step_wait_for_services\` kept using a literal \`https://localhost:9200\`. It hit whatever else was on 9200, then reported the SIEM store as unready after the full 300s window:

\`\`\`
[lab start] Readiness: Wazuh Indexer still waiting (285/300s).
Wazuh Indexer timed out after 305.7s
[telemetry|warning] wait_for_services/wazuh_indexer - Wazuh Indexer did not become ready within 305s
Lab is degraded_usable
\`\`\`

A student would then see the "SIEM ingest will not work" diagnostic on an actually-healthy lab and not know whether to trust the SOC.

## Fix

Source the port from \`ctx.resolved_ports\` (the same list the "Host port remaps" summary is printed from). Falls back to 9200 when no entry matches (the common case where 9200 was free).

## Tests

- \`test_wait_for_services_probes_the_resolved_indexer_port_not_9200\` — asserts a wazuh.indexer remap at 20015 flows into the probe URL.
- \`test_wait_for_services_falls_back_to_9200_when_no_remap\` — preserves the historical behavior when no remap entry exists.
- All 11 existing \`wait_for_services\` tests still pass unchanged.

## Follow-on scope not touched here (worth a separate look)

\`aptl lab info\` and the walkthrough dashboard-URL table probably have the same shape of hardcoded URLs (443, 3100, 8443, 9000, 9001, 3001). \`info\` at least already knows about the resolved ports since the start-summary prints them. Filing follow-ups if I find more.