### PR TITLE
fix(lab): restart wazuh-manager between compose retries if daemons never spawn

### DIFF
--- a/src/aptl/core/deployment/_compose_queries.py
+++ b/src/aptl/core/deployment/_compose_queries.py
@@ -288,6 +288,23 @@ class ComposeQueryMixin(object):
         argv = ["docker", "exec", name, *cmd]
         return self._run(argv, timeout=timeout)
 
+    def container_restart(self, name: str, *, timeout: int | None = None) -> None:
+        """Restart a container by name via ``docker restart``.
+
+        Best-effort: propagates the CalledProcessError-style non-zero
+        return through a log at warning level so the caller can proceed
+        with a retry regardless.
+        """
+        argv = ["docker", "restart", name]
+        result = self._run(argv, timeout=timeout or _HOST_INVENTORY_TIMEOUT)
+        if result.returncode != 0:
+            log.warning(
+                "docker restart %s returned %s: %s",
+                name,
+                result.returncode,
+                (result.stderr or "").strip(),
+            )
+
     def container_exists(self, name: str) -> bool:
         info = self.container_inspect(name)
         if not info:

--- a/src/aptl/core/deployment/backend.py
+++ b/src/aptl/core/deployment/backend.py
@@ -306,6 +306,17 @@ class DeploymentBackend(Protocol):
         """
         ...
 
+    def container_restart(self, name: str, *, timeout: int | None = None) -> None:
+        """Restart a running container (docker restart <name>).
+
+        Used by the wazuh-manager watchdog (#732) between compose retry
+        attempts on hosts (Colima on macOS is the reproducible case) where
+        s6-supervise gets stuck reporting EACCES on executable service
+        `run` scripts and no wazuh daemon ever spawns — a docker-level
+        restart clears the state.
+        """
+        ...
+
     # Host inventory (CLI-004 / ADR-023) ----------------------------------
     #
     # These return parsed host-level information instead of exposing a

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -1166,8 +1166,9 @@ def _restart_wazuh_manager_if_stuck(ctx: _LabStartContext) -> None:
     This helper is best-effort: any failure to inspect or restart is
     logged and ignored (the caller retries the compose up regardless).
     """
-    if ctx.backend is None:
-        return
+    # Caller (`_step_start_containers`) is icontract-guarded so
+    # `ctx.backend is not None` — no defensive check needed here.
+    assert ctx.backend is not None
     try:
         info = ctx.backend.container_inspect(_WAZUH_MANAGER_CONTAINER)
     except Exception:  # noqa: BLE001 — never let diagnostics abort start

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -1151,6 +1151,60 @@ def _step_pull_images(ctx: _LabStartContext) -> LabResult | None:
     return None
 
 
+_WAZUH_MANAGER_CONTAINER = "aptl-wazuh-manager"
+
+
+def _restart_wazuh_manager_if_stuck(ctx: _LabStartContext) -> None:
+    """Restart wazuh-manager if it is Up but its daemons never spawned (#732).
+
+    Colima on macOS reproducibly gets s6-supervise into a state where
+    every attempt to exec the (executable) `run` scripts returns EACCES
+    and the wazuh daemons never spawn. The container itself stays Up
+    because PID 1 (s6-svscan) survives, so docker's own restart policy
+    never fires. A single `docker restart` clears the state cleanly.
+
+    This helper is best-effort: any failure to inspect or restart is
+    logged and ignored (the caller retries the compose up regardless).
+    """
+    if ctx.backend is None:
+        return
+    try:
+        info = ctx.backend.container_inspect(_WAZUH_MANAGER_CONTAINER)
+    except Exception:  # noqa: BLE001 — never let diagnostics abort start
+        return
+    state = info.get("State") or {}
+    if state.get("Status") != "running":
+        return
+    # Ask the container what wazuh daemons are alive. Amazon Linux 2023 in
+    # the manager image ships without `ps`, so we walk /proc directly.
+    probe = ["sh", "-c",
+             "ls /proc/[0-9]*/comm 2>/dev/null | while read f; do "
+             "read n < \"$f\"; case \"$n\" in wazuh-*) echo \"$n\";; esac; "
+             "done | sort -u | wc -l"]
+    try:
+        result = ctx.backend.container_exec(
+            _WAZUH_MANAGER_CONTAINER, probe, timeout=10
+        )
+    except Exception:  # noqa: BLE001
+        return
+    if result.returncode != 0:
+        return
+    try:
+        daemon_count = int((result.stdout or "0").strip())
+    except ValueError:
+        return
+    if daemon_count > 0:
+        return  # daemons are alive; nothing to do
+    log.warning(
+        "wazuh-manager is Up but has 0 wazuh-* daemons; restarting once "
+        "before compose retry (see issue #732)."
+    )
+    try:
+        ctx.backend.container_restart(_WAZUH_MANAGER_CONTAINER)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("wazuh-manager restart attempt failed: %s", exc)
+
+
 @_runtime_require(
     lambda ctx: config_is_loaded(ctx.config),
     description="config_is_loaded(ctx.config)",
@@ -1185,6 +1239,14 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
         import time
 
         time.sleep(60)
+        # Colima on macOS reproducibly leaves the wazuh-manager container
+        # in a state where s6-supervise reports EACCES on the (executable)
+        # `run` scripts and the wazuh daemons never spawn (#732). The
+        # container stays Up so docker's own restart policy never fires,
+        # but no wazuh-* processes exist inside. A single `docker restart`
+        # clears the state; do that before the retry so compose isn't
+        # forced to try running `up` against a broken container instance.
+        _restart_wazuh_manager_if_stuck(ctx)
         outcome = start_aces_scenario(
             ctx.project_dir,
             ctx.config,

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -5,6 +5,7 @@ SSHComposeBackend, config model, and factory function.
 """
 
 import json
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1340,6 +1341,29 @@ class TestDockerComposeBackendContainerInteraction:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             backend.container_exec("aptl-victim", ["true"], timeout=5)
         assert mock_run.call_args[1]["timeout"] == 5
+
+    # container_restart ----------------------------------------------------
+
+    def test_container_restart_issues_docker_restart(self, tmp_path):
+        backend = self._make_backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            backend.container_restart("aptl-wazuh-manager")
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["docker", "restart", "aptl-wazuh-manager"]
+
+    def test_container_restart_logs_warning_on_nonzero_exit(self, tmp_path, caplog):
+        backend = self._make_backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="No such container: whatever"
+            )
+            caplog.set_level(logging.WARNING, logger="aptl")
+            backend.container_restart("aptl-wazuh-manager")
+        # Best-effort — no exception raised, but the failure is logged.
+        assert any(
+            "docker restart" in rec.getMessage() for rec in caplog.records
+        )
 
     # container_inspect ----------------------------------------------------
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -3190,6 +3190,150 @@ class TestLabOrchestrationContracts:
 
         backend.container_restart.assert_not_called()
 
+    def test_start_containers_skips_restart_when_wazuh_manager_not_running(
+        self, mocker, tmp_path
+    ):
+        """State.Status != 'running' means the container is gone / dead /
+        being recreated by compose itself — restarting would race
+        compose. Skip."""
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        backend = MagicMock()
+        backend.container_inspect.return_value = {
+            "State": {"Status": "exited"},
+        }
+        ctx.backend = backend
+
+        mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=[
+                LabResult(success=False, error="compose still starting"),
+                LabResult(success=True, message="ok"),
+            ],
+        )
+        mocker.patch("time.sleep")
+
+        _step_start_containers(ctx)
+
+        backend.container_restart.assert_not_called()
+        backend.container_exec.assert_not_called()
+
+    def test_start_containers_watchdog_swallows_probe_exceptions(
+        self, mocker, tmp_path
+    ):
+        """The watchdog is best-effort: exceptions from container_inspect
+        or container_exec must not abort the retry. Also covers the
+        `int()` ValueError branch when the /proc walk emits garbage."""
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        backend = MagicMock()
+        backend.container_inspect.side_effect = RuntimeError("boom")
+        ctx.backend = backend
+
+        mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=[
+                LabResult(success=False, error="compose still starting"),
+                LabResult(success=True, message="ok"),
+            ],
+        )
+        mocker.patch("time.sleep")
+
+        # Should complete without raising; retry still runs.
+        result = _step_start_containers(ctx)
+        assert result is None
+        backend.container_restart.assert_not_called()
+
+    def test_start_containers_watchdog_swallows_exec_failures(
+        self, mocker, tmp_path
+    ):
+        """A nonzero exec probe (or non-int stdout) blocks the restart —
+        we do not know the process state, so refuse to restart rather
+        than guess wrong."""
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        backend = MagicMock()
+        backend.container_inspect.return_value = {"State": {"Status": "running"}}
+        backend.container_exec.return_value = MagicMock(
+            returncode=1, stdout="", stderr="probe failed"
+        )
+        ctx.backend = backend
+
+        mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=[
+                LabResult(success=False, error="compose still starting"),
+                LabResult(success=True, message="ok"),
+            ],
+        )
+        mocker.patch("time.sleep")
+
+        _step_start_containers(ctx)
+        backend.container_restart.assert_not_called()
+
+    def test_start_containers_watchdog_swallows_restart_failure(
+        self, mocker, tmp_path
+    ):
+        """`container_restart` raising is logged and swallowed — the
+        retry proceeds regardless."""
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        backend = MagicMock()
+        backend.container_inspect.return_value = {"State": {"Status": "running"}}
+        backend.container_exec.return_value = MagicMock(returncode=0, stdout="0\n")
+        backend.container_restart.side_effect = RuntimeError("daemon down")
+        ctx.backend = backend
+
+        mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=[
+                LabResult(success=False, error="compose still starting"),
+                LabResult(success=True, message="ok"),
+            ],
+        )
+        mocker.patch("time.sleep")
+
+        result = _step_start_containers(ctx)
+        assert result is None
+        # We tried, we failed, we did not raise.
+        backend.container_restart.assert_called_once_with("aptl-wazuh-manager")
+
+    def test_start_containers_watchdog_handles_non_numeric_daemon_count(
+        self, mocker, tmp_path
+    ):
+        """If /proc walk returns non-numeric output (e.g. a sh error line),
+        the ValueError branch keeps the retry going with no restart."""
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        backend = MagicMock()
+        backend.container_inspect.return_value = {"State": {"Status": "running"}}
+        backend.container_exec.return_value = MagicMock(
+            returncode=0, stdout="not-a-number\n"
+        )
+        ctx.backend = backend
+
+        mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=[
+                LabResult(success=False, error="compose still starting"),
+                LabResult(success=True, message="ok"),
+            ],
+        )
+        mocker.patch("time.sleep")
+
+        _step_start_containers(ctx)
+        backend.container_restart.assert_not_called()
+
     def test_start_containers_hints_for_stale_realization_networks(
         self, mocker, tmp_path
     ):

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -3126,6 +3126,70 @@ class TestLabOrchestrationContracts:
             selected,
         ]
 
+    def test_start_containers_restarts_wazuh_manager_when_stuck_between_attempts(
+        self, mocker, tmp_path
+    ):
+        """When the first compose up fails and the SOC retry path fires,
+        aptl inspects wazuh-manager. On Colima/macOS it can be Up but
+        with zero wazuh-* daemons alive (#732). One `docker restart`
+        clears the state; do it once, before the retry, so compose is
+        not asked to `up` against a broken container."""
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        backend = MagicMock()
+        backend.container_inspect.return_value = {
+            "State": {"Status": "running"},
+        }
+        # Stub the /proc walk that counts wazuh-* daemons — 0 alive.
+        backend.container_exec.return_value = MagicMock(returncode=0, stdout="0\n")
+        ctx.backend = backend
+
+        mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=[
+                LabResult(success=False, error="compose still starting"),
+                LabResult(success=True, message="ok"),
+            ],
+        )
+        mocker.patch("time.sleep")
+
+        result = _step_start_containers(ctx)
+
+        assert result is None
+        backend.container_restart.assert_called_once_with("aptl-wazuh-manager")
+
+    def test_start_containers_skips_restart_when_wazuh_daemons_alive(
+        self, mocker, tmp_path
+    ):
+        """Daemons alive inside the container: the retry is likely
+        succeeding for a different reason; do NOT restart wazuh-manager."""
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        backend = MagicMock()
+        backend.container_inspect.return_value = {
+            "State": {"Status": "running"},
+        }
+        # 9 wazuh-* processes alive => watchdog stays quiet.
+        backend.container_exec.return_value = MagicMock(returncode=0, stdout="9\n")
+        ctx.backend = backend
+
+        mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=[
+                LabResult(success=False, error="compose still starting"),
+                LabResult(success=True, message="ok"),
+            ],
+        )
+        mocker.patch("time.sleep")
+
+        _step_start_containers(ctx)
+
+        backend.container_restart.assert_not_called()
+
     def test_start_containers_hints_for_stale_realization_networks(
         self, mocker, tmp_path
     ):


### PR DESCRIPTION
Closes #732.

## Failure

Reproduced end-to-end on macOS + Colima with aptl-labs 4.2.2 running the full \`techvault-operational\` scenario. On the initial container start, \`aptl-wazuh-manager\` comes up as \`Up (health: starting)\` but the wazuh daemons never spawn. After the healthcheck's \`start_period\` expires, compose fails the ACES handoff with \`dependency wazuh.manager failed to start: container aptl-wazuh-manager is unhealthy\`. The container itself stays Up because s6-svscan (PID 1) survives, so docker's \`restart: always\` policy never fires.

## Diagnosis (full detail in #732)

Container logs show s6-supervise looping on:

\`\`\`
s6-supervise filebeat: warning: unable to spawn ./run - waiting 10 seconds
s6-supervise (child): fatal: unable to exec run: Permission denied
\`\`\`

even though every relevant script has \`-rwxr-xr-x\` and the shebang resolves (\`docker exec aptl-wazuh-manager /etc/services.d/filebeat/run\` starts filebeat successfully). Live process tree inside the container is only \`s6-svscan\` + a handful of \`s6-supervise\` — no filebeat, no wazuh-analysisd, no python API. Root cause is somewhere in the Wazuh 4.12.0 image / s6-overlay v2 / Colima's overlayfs-under-qemu-emulation interaction; not aptl-fixable.

## Unblock

\`docker restart aptl-wazuh-manager\` clears the state every time. The \`/etc/cont-init.d/\` scripts run to completion (0-wazuh-init, 1-config-filebeat, 2-manager) and the container reaches healthy with all 9 wazuh daemons + the python API alive.

## Fix

Between the first-attempt failure and the existing 60s SOC-retry in \`_step_start_containers\`, aptl now:

1. \`container_inspect\`s aptl-wazuh-manager.
2. Walks \`/proc/[0-9]*/comm\` inside it (\`ps\` is not installed in the image), counts \`wazuh-*\` processes.
3. If the container is Up and the count is 0, issues one \`container_restart\`.

Every step is wrapped in a suppressed exception so the watchdog never aborts start on its own — if the probe fails for any reason, the retry proceeds as it always did. Only \`aptl-wazuh-manager\` is restarted; nothing else in the compose graph is touched.

Adds \`container_restart\` to the DeploymentBackend Protocol and its DockerComposeBackend implementation for the one new subprocess call.

## Tests

- \`test_start_containers_restarts_wazuh_manager_when_stuck_between_attempts\` — 0 daemons → \`container_restart\` called once.
- \`test_start_containers_skips_restart_when_wazuh_daemons_alive\` — 9 daemons → no restart.
- All 18 existing \`start_containers\` / \`wait_for_services\` tests still pass unchanged.

## Verified end-to-end

The manual restart pattern this PR automates was the missing step in the live walkthrough run that produced #713 / #722 / #724 / #726 / #727 / #731 / #733 / #735. With the manual restart in place, the full \`techvault-operational\` stack came up healthy on Colima and every walkthrough section verified (§2 status, §4 Kali, §5 tools, §6 nmap + SMB + SSH brute-force triggering rule 5710 and SQLi triggering rule 302011, §8 all six dashboards).