### PR TITLE
fix(cli): reflect live published ports in `aptl lab info` (was hardcoded defaults)

### DIFF
--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -76,6 +76,74 @@ def _resolved_port(
     return default
 
 
+def _live_resolved_ports(project_dir: Path) -> list[ResolvedPort]:
+    """Reconstruct a ResolvedPort list from docker's runtime state.
+
+    `_emit_lab_access_summary` needs a ResolvedPort list to print live URLs;
+    `lab start` passes the one it computed at port-resolution time. Later
+    commands (`aptl lab info`) run against a running lab and have to ask
+    docker what actually got published — otherwise the URLs default to
+    the compile-time constants, and any host with a taken default port
+    (Cursor's tunnels, k8s port-forward, AirPlay on 3100, etc.) sees a
+    URL that goes to the wrong service (#737).
+
+    Best-effort: any exception returns an empty list, and the caller
+    falls back to the compile-time defaults.
+    """
+    try:
+        from aptl.cli._common import resolve_config_for_cli
+        from aptl.core.deployment import get_backend
+
+        config, project_root = resolve_config_for_cli(project_dir)
+        backend = get_backend(config, project_root)
+    except Exception:  # noqa: BLE001 — never let info abort
+        return []
+    try:
+        containers = backend.container_list(all_containers=False)
+    except Exception:  # noqa: BLE001
+        return []
+    resolved: list[ResolvedPort] = []
+    for entry in containers:
+        service = entry.get("Service") or ""
+        name = (entry.get("Name") or "").lstrip("/")
+        if not service or not name:
+            continue
+        try:
+            info = backend.container_inspect(name)
+        except Exception:  # noqa: BLE001
+            continue
+        ports = (info.get("NetworkSettings") or {}).get("Ports") or {}
+        if not isinstance(ports, dict):
+            continue
+        for container_port_proto, bindings in ports.items():
+            if not bindings:
+                continue
+            container_port_str, _, proto = container_port_proto.partition("/")
+            try:
+                default_port = int(container_port_str)
+            except ValueError:
+                continue
+            for binding in bindings:
+                try:
+                    host_port = int(binding.get("HostPort", 0))
+                except (TypeError, ValueError):
+                    continue
+                if host_port == 0:
+                    continue
+                resolved.append(
+                    ResolvedPort(
+                        service=service,
+                        env_var=None,
+                        default_port=default_port,
+                        resolved_port=host_port,
+                        protos=(proto or "tcp",),
+                        host_ip=binding.get("HostIp"),
+                        remapped=(host_port != default_port),
+                    )
+                )
+    return resolved
+
+
 # SOC services whose MCP server config (mcp/<name>/docker-lab-config.json)
 # hardcodes the host port on localhost. If one of these is remapped, the MCP
 # server config still points at the default port, so flag it for the operator.
@@ -269,7 +337,9 @@ def info(
             err=True,
         )
         raise typer.Exit(code=1)
-    _emit_lab_access_summary(project_dir)
+    # Reconstruct the ResolvedPort list from docker's runtime state so the
+    # printed URLs reflect the actual published ports (#737).
+    _emit_lab_access_summary(project_dir, _live_resolved_ports(project_dir))
 
 
 @app.command("scenarios")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,6 +174,91 @@ class TestLabStartCommand:
         assert result.exit_code == 1
         assert "run `aptl lab start` first" in result.stderr
 
+    def test_lab_info_reflects_remapped_ports_from_live_docker_state(
+        self, runner, tmp_path, mocker
+    ):
+        """When docker has published Grafana on a remapped host port
+        (default 3100 was already in use), `aptl lab info` must print the
+        remapped port so students don't paste a URL that goes to whatever
+        is on 3100 (#737)."""
+        from aptl.cli.main import app
+        from aptl.core.host_ports import ResolvedPort
+
+        (tmp_path / ".env").touch()
+
+        # Bypass config load — return a stub list directly.
+        mocker.patch(
+            "aptl.cli.lab._live_resolved_ports",
+            return_value=[
+                ResolvedPort(
+                    service="aptl-grafana-otel",
+                    env_var=None,
+                    default_port=3100,
+                    resolved_port=20005,
+                    protos=("tcp",),
+                    host_ip="127.0.0.1",
+                    remapped=True,
+                ),
+            ],
+        )
+
+        result = runner.invoke(
+            app, ["lab", "info", "--project-dir", str(tmp_path)]
+        )
+
+        assert result.exit_code == 0
+        assert "Grafana: http://localhost:20005" in result.stdout
+        assert "Grafana: http://localhost:3100" not in result.stdout
+        # The remap block also appears now (aids reconciliation vs walkthrough).
+        assert "3100 -> 20005" in result.stdout
+
+    def test_live_resolved_ports_returns_empty_when_config_missing(self, tmp_path):
+        """Best-effort: no aptl.json / no backend / any error path just
+        returns []; info falls back to compile-time defaults."""
+        from aptl.cli.lab import _live_resolved_ports
+
+        # tmp_path has neither aptl.json nor a running lab, so
+        # resolve_config_for_cli raises and the helper swallows it.
+        assert _live_resolved_ports(tmp_path) == []
+
+    def test_live_resolved_ports_extracts_binding_from_docker_inspect(
+        self, tmp_path, mocker
+    ):
+        """Walks compose ps + docker inspect and builds a ResolvedPort
+        entry for each published port."""
+        from aptl.cli.lab import _live_resolved_ports
+        from aptl.core.host_ports import ResolvedPort
+
+        backend = mocker.MagicMock()
+        backend.container_list.return_value = [
+            {"Name": "aptl-wazuh-indexer", "Service": "wazuh.indexer"},
+        ]
+        backend.container_inspect.return_value = {
+            "NetworkSettings": {
+                "Ports": {
+                    "9200/tcp": [{"HostIp": "127.0.0.1", "HostPort": "20015"}],
+                },
+            },
+        }
+        mocker.patch(
+            "aptl.cli._common.resolve_config_for_cli",
+            return_value=(mocker.MagicMock(), tmp_path),
+        )
+        mocker.patch(
+            "aptl.core.deployment.get_backend", return_value=backend
+        )
+
+        result = _live_resolved_ports(tmp_path)
+
+        assert len(result) == 1
+        entry = result[0]
+        assert isinstance(entry, ResolvedPort)
+        assert entry.service == "wazuh.indexer"
+        assert entry.default_port == 9200
+        assert entry.resolved_port == 20015
+        assert entry.remapped is True
+        assert entry.host_ip == "127.0.0.1"
+
     def test_start_handles_failure_gracefully(self, runner, mocker):
         """start command should exit 1 and show error on failure.
 


### PR DESCRIPTION
Closes #737.

## Failure

Reproduced end-to-end on macOS + Colima with aptl-labs 4.2.2 during the walkthrough live-fire. A fresh \`aptl lab start\` on a host with any of the SOC default ports taken correctly remapped and printed the real port in the start summary. But the walkthrough tells students to run \`aptl lab info\` to reprint URLs; that command kept printing:

\`\`\`
Grafana: http://localhost:3100    <-- WRONG when 3100 was remapped
\`\`\`

Every student running \`aptl lab info\` on a host where anything holds the default ports (Cursor, AirPlay-on-3100, an existing OpenSearch, a k8s port-forward, etc.) copies the wrong URL and sees a redirect to whatever else is on that port — with no signal that the URL is wrong.

## Root cause

\`_emit_lab_access_summary\` supports an optional \`resolved_ports\` argument that makes URLs follow the port remap. \`lab start\` threads it in; the \`info\` command called the same helper without it, so every service silently defaulted to its compile-time constant.

## Fix

\`info\` now reconstructs a \`ResolvedPort\` list from docker's runtime state via a new \`_live_resolved_ports(project_dir)\` helper. It walks the project's compose ps output and inspects \`NetworkSettings.Ports\` per container, building one \`ResolvedPort\` per published binding.

Best-effort: any exception path (missing aptl.json, backend init error, docker unreachable, malformed inspect payload) returns an empty list and \`info\` falls back to the compile-time defaults — matching pre-fix behavior for those cases and keeping the existing \`test_lab_info_prints_access_summary\` test valid.

## Tests

- \`test_lab_info_reflects_remapped_ports_from_live_docker_state\`: mocks a 3100→20005 remap and asserts the printed URL and remap block are correct.
- \`test_live_resolved_ports_returns_empty_when_config_missing\`: the swallow-all-exceptions guarantee.
- \`test_live_resolved_ports_extracts_binding_from_docker_inspect\`: the container-inspect walk builds the correct ResolvedPort.
- 3 existing lab-info tests still pass unchanged.

## Follow-on scope not touched here

The \`info\` output only lists Wazuh Dashboard, Grafana, and reverse SSH. The walkthrough §8 table lists 6 dashboards (Wazuh, Grafana, TheHive, MISP, Cortex, Shuffle). Adding the other 4 to \`info\` would let \`aptl lab info\` be the single source of truth for dashboard URLs — worth its own PR since it changes the surface, not just the port.