### PR TITLE
fix(lab): cross-platform lab-start fixes (indexer wait, WSL detection, Sonar smells)

### DIFF
--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -1318,7 +1318,10 @@ def _step_wait_for_services(ctx: _LabStartContext) -> LabResult | None:
             username=ctx.env.indexer_username,
             password=ctx.env.indexer_password,
         ),
-        timeout=300,
+        # Generous cold-boot headroom: OpenSearch's first-boot init (cluster
+        # formation + security index) can run long when the whole SOC stack and
+        # MCP builds start at once.
+        timeout=600,
         interval=10,
         service_name="Wazuh Indexer",
         progress=ctx.progress,

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -1154,6 +1154,38 @@ def _step_pull_images(ctx: _LabStartContext) -> LabResult | None:
 _WAZUH_MANAGER_CONTAINER = "aptl-wazuh-manager"
 
 
+def _wazuh_manager_daemon_count(ctx: _LabStartContext) -> int | None:
+    """Return the number of live ``wazuh-*`` daemons in the manager container.
+
+    Returns ``None`` when the count can't be determined — the container is not
+    running, or the inspect/exec probe failed. Best-effort: it swallows every
+    inspect/exec failure so a diagnostics probe can never abort lab start.
+    """
+    assert ctx.backend is not None
+    # Amazon Linux 2023 in the manager image ships without `ps`, so walk
+    # /proc directly to count the live wazuh-* daemons.
+    probe = ["sh", "-c",
+             "ls /proc/[0-9]*/comm 2>/dev/null | while read f; do "
+             "read n < \"$f\"; case \"$n\" in wazuh-*) echo \"$n\";; esac; "
+             "done | sort -u | wc -l"]
+    try:
+        info = ctx.backend.container_inspect(_WAZUH_MANAGER_CONTAINER)
+        if (info.get("State") or {}).get("Status") != "running":
+            return None
+        result = ctx.backend.container_exec(
+            _WAZUH_MANAGER_CONTAINER, probe, timeout=10
+        )
+        return (
+            int((result.stdout or "0").strip())
+            if result.returncode == 0
+            else None
+        )
+    except Exception:
+        # Deliberately broad: this watchdog must never let an inspect/exec
+        # failure abort lab start (covered by the swallow-exceptions tests).
+        return None
+
+
 def _restart_wazuh_manager_if_stuck(ctx: _LabStartContext) -> None:
     """Restart wazuh-manager if it is Up but its daemons never spawned (#732).
 
@@ -1169,40 +1201,18 @@ def _restart_wazuh_manager_if_stuck(ctx: _LabStartContext) -> None:
     # Caller (`_step_start_containers`) is icontract-guarded so
     # `ctx.backend is not None` — no defensive check needed here.
     assert ctx.backend is not None
-    try:
-        info = ctx.backend.container_inspect(_WAZUH_MANAGER_CONTAINER)
-    except Exception:  # noqa: BLE001 — never let diagnostics abort start
+    count = _wazuh_manager_daemon_count(ctx)
+    # Daemons are alive, or their state could not be determined: nothing to do.
+    if count is None or count > 0:
         return
-    state = info.get("State") or {}
-    if state.get("Status") != "running":
-        return
-    # Ask the container what wazuh daemons are alive. Amazon Linux 2023 in
-    # the manager image ships without `ps`, so we walk /proc directly.
-    probe = ["sh", "-c",
-             "ls /proc/[0-9]*/comm 2>/dev/null | while read f; do "
-             "read n < \"$f\"; case \"$n\" in wazuh-*) echo \"$n\";; esac; "
-             "done | sort -u | wc -l"]
-    try:
-        result = ctx.backend.container_exec(
-            _WAZUH_MANAGER_CONTAINER, probe, timeout=10
-        )
-    except Exception:  # noqa: BLE001
-        return
-    if result.returncode != 0:
-        return
-    try:
-        daemon_count = int((result.stdout or "0").strip())
-    except ValueError:
-        return
-    if daemon_count > 0:
-        return  # daemons are alive; nothing to do
     log.warning(
         "wazuh-manager is Up but has 0 wazuh-* daemons; restarting once "
         "before compose retry (see issue #732)."
     )
     try:
         ctx.backend.container_restart(_WAZUH_MANAGER_CONTAINER)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
+        # Deliberately broad: a failed restart attempt must not abort start.
         log.warning("wazuh-manager restart attempt failed: %s", exc)
 
 

--- a/src/aptl/utils/shell.py
+++ b/src/aptl/utils/shell.py
@@ -47,12 +47,14 @@ def _git_bash_from_git() -> Path | None:
     git = shutil.which("git")
     if not git:
         return None
-    root = Path(git).resolve().parent.parent  # <root>/cmd/git.exe -> <root>
+    # <root>/cmd/git.exe -> <root>
+    root = Path(git).resolve().parent.parent
     candidate = root / "bin" / "bash.exe"
     return candidate if candidate.is_file() else None
 
 
 def _git_bash_from_known_locations() -> Path | None:
+    """Return Git Bash from a default Git-for-Windows install dir, or None."""
     for base in (
         os.environ.get("ProgramFiles", r"C:\Program Files"),
         os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),

--- a/src/aptl/utils/shell.py
+++ b/src/aptl/utils/shell.py
@@ -27,9 +27,15 @@ _IS_WINDOWS = sys.platform.startswith("win")
 
 
 def _looks_like_wsl(path: Path) -> bool:
-    """True for the WSL launcher shim under System32 (not a real POSIX shell)."""
-    parts = {p.lower() for p in path.parts}
-    return "system32" in parts or "windowsapps" in parts
+    """True for the WSL launcher shim under System32 / WindowsApps.
+
+    Matches on the normalized path string rather than ``path.parts`` so the
+    classification is independent of which OS's path flavour is parsing it: on
+    a non-Windows host ``Path`` does not split a ``C:\\...\\bash.exe`` string
+    into components, which would otherwise miss the ``System32`` segment.
+    """
+    text = str(path).replace("\\", "/").lower()
+    return "/system32/" in text or "/windowsapps/" in text
 
 
 def _git_bash_from_git() -> Path | None:


### PR DESCRIPTION
Cross-platform robustness fixes for `aptl lab start`, self-contained (single PR — supersedes #743).

## 1. Indexer cold-boot readiness timeout 300s → 600s
OpenSearch's first-boot init (cluster formation + security index) can run several minutes while the whole SOC stack and MCP builds start together; 300s tripped a spurious "indexer not ready" telemetry warning even though the container was healthy. (#735 already fixed probing the *resolved* host port after a remap.)

## 2. Cross-platform `_looks_like_wsl`
Matched on `path.parts`, which on a non-Windows host doesn't split a `C:\...\bash.exe` string into components — so `tests/test_shell.py::test_looks_like_wsl_flags_system32` failed on ubuntu/macos CI (a gap in the #729 shell runner). Now matches on the normalized path string; Windows runtime unchanged.

## 3. Clear SonarCloud new-code maintainability smells
The "Maintainability Rating on New Code" gate was failing on smells accumulated since the last release (#729/#736):
- `_restart_wazuh_manager_if_stuck`: extract `_wazuh_manager_daemon_count` (each function ≤3 returns); drop the `# noqa: BLE001` comments Sonar flagged — ruff only enforces C901, so the deliberate broad `except Exception` (required by the swallow-all watchdog tests) is lint-clean without them; drop a trailing comment.
- `shell.py`: add the missing docstring; move a trailing comment onto its own line.

ruff + the manager-watchdog / shell / indexer-wait tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)