### PR TITLE
fix: unblock dev CI (`_looks_like_wsl` works on POSIX + refresh uv.lock)

### DIFF
--- a/src/aptl/utils/shell.py
+++ b/src/aptl/utils/shell.py
@@ -27,11 +27,7 @@ _IS_WINDOWS = sys.platform.startswith("win")
 
 
 def _looks_like_wsl(path: Path) -> bool:
-    """True for the WSL launcher shim under System32 (not a real POSIX shell).
-
-    Splits on both ``/`` and ``\\`` so the marker check works on POSIX
-    interpreters too (``PurePosixPath.parts`` does not split ``\\``).
-    """
+    """True for the WSL launcher shim under System32 (not a real POSIX shell)."""
     parts = str(path).lower().replace("\\", "/").split("/")
     return "system32" in parts or "windowsapps" in parts
 

--- a/src/aptl/utils/shell.py
+++ b/src/aptl/utils/shell.py
@@ -27,8 +27,17 @@ _IS_WINDOWS = sys.platform.startswith("win")
 
 
 def _looks_like_wsl(path: Path) -> bool:
-    """True for the WSL launcher shim under System32 (not a real POSIX shell)."""
-    parts = {p.lower() for p in path.parts}
+    """True for the WSL launcher shim under System32 (not a real POSIX shell).
+
+    Robust to both path-separator styles: on POSIX, ``Path(r"C:\\Windows\\...")``
+    keeps the whole thing as one component (Path does not split ``\\`` on
+    non-Windows), so relying on ``path.parts`` misses the marker. Splitting on
+    both ``/`` and ``\\`` after lowercasing makes this work regardless of the
+    running interpreter, which the ``test_looks_like_wsl_flags_system32``
+    coverage exercises on Linux/macOS CI.
+    """
+    text = str(path).lower().replace("\\", "/")
+    parts = set(text.split("/"))
     return "system32" in parts or "windowsapps" in parts
 
 

--- a/src/aptl/utils/shell.py
+++ b/src/aptl/utils/shell.py
@@ -29,15 +29,10 @@ _IS_WINDOWS = sys.platform.startswith("win")
 def _looks_like_wsl(path: Path) -> bool:
     """True for the WSL launcher shim under System32 (not a real POSIX shell).
 
-    Robust to both path-separator styles: on POSIX, ``Path(r"C:\\Windows\\...")``
-    keeps the whole thing as one component (Path does not split ``\\`` on
-    non-Windows), so relying on ``path.parts`` misses the marker. Splitting on
-    both ``/`` and ``\\`` after lowercasing makes this work regardless of the
-    running interpreter, which the ``test_looks_like_wsl_flags_system32``
-    coverage exercises on Linux/macOS CI.
+    Splits on both ``/`` and ``\\`` so the marker check works on POSIX
+    interpreters too (``PurePosixPath.parts`` does not split ``\\``).
     """
-    text = str(path).lower().replace("\\", "/")
-    parts = set(text.split("/"))
+    parts = str(path).lower().replace("\\", "/").split("/")
     return "system32" in parts or "windowsapps" in parts
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,8 +4,8 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aces-sdl"
-version = "0.3.0"
-source = { git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev#ce1bc07ab8bb80e7afaf6c304ac69f4a2e5dd8ec" }
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asyncssh" },
     { name = "cryptography" },
@@ -18,6 +18,10 @@ dependencies = [
     { name = "sse-starlette" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/22/d289c7667d271732af8783f4b7d24e47e6506d94e2581ae47804b686fb04/aces_sdl-0.19.1.tar.gz", hash = "sha256:8a8d1a3e0b0717cddf2d342fef70eeeb6d123cbddff592cfa72e421cb8011fa7", size = 1282207, upload-time = "2026-07-06T04:06:03.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/75/f94651cc43cf4696c7cd7bceb2f3c7042ab672a04fb209b29a3ccea0a6f3/aces_sdl-0.19.1-py3-none-any.whl", hash = "sha256:727e10a5eb83cfa3fe8b4bb9abcbabe2b24e6497427d5943decc1d2a4ec1e1cf", size = 1091838, upload-time = "2026-07-06T04:06:02.201Z" },
 ]
 
 [[package]]
@@ -52,8 +56,8 @@ wheels = [
 ]
 
 [[package]]
-name = "aptl"
-version = "0.1.0"
+name = "aptl-labs"
+version = "4.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aces-sdl" },
@@ -95,7 +99,7 @@ web = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aces-sdl", git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev" },
+    { name = "aces-sdl", specifier = ">=0.1.0" },
     { name = "asyncssh", marker = "extra == 'web'", specifier = ">=2.17.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
Closes #715. Also unblocks the current dev→main promotion PR #739.

## What was failing on dev

The last Checks run on dev (28977885705) hit two orthogonal problems, both bundled here per the issue-tracker ask.

### 1. `tests/test_shell.py::test_looks_like_wsl_flags_system32` — Python tests + coverage (all platforms)

\`\`\`
>       assert shell._looks_like_wsl(Path(r"C:\\Windows\\System32\\bash.exe")) is True
E       AssertionError: assert False is True
\`\`\`

Root cause: on Linux/macOS the standard library's \`Path\` factory returns a \`PurePosixPath\`, which does not split \`\\\` as a separator, so \`Path(r"C:\\Windows\\System32\\bash.exe").parts\` is the single-element tuple \`('C:\\\\Windows\\\\System32\\\\bash.exe',)\`. \`_looks_like_wsl\` iterates \`.parts\`, so it never sees "system32" and returns False. The function was written expecting a Windows interpreter; the test that exercises it is not Windows-guarded.

Fix: split on both \`/\` and \`\\\` after lowercasing so the marker check works regardless of which platform the test runs on. Comment explains why to future readers.

Local repro before the fix:

\`\`\`
$ uv run pytest tests/test_shell.py -q
1 failed, 3 passed, 1 skipped
\`\`\`

Local repro after the fix:

\`\`\`
$ uv run pytest tests/test_shell.py -q
4 passed, 1 skipped
\`\`\`

### 2. \`uv.lock\` drifts from \`pyproject.toml\` (issue #715)

\`aces-sdl\` moved from a git ref to a PyPI release. The checked-in \`uv.lock\` still pinned it at \`0.3.0\` from git, so every fresh \`uv sync\` produced a dirty working tree — noise on every PR and a genuine drift risk on the promotion PR.

\`uv lock\` refresh promotes to the matching PyPI entry (\`0.19.1\`).

## Test plan

- [x] \`uv run pytest tests/test_shell.py -q\` — 4 passed, 1 skipped
- [x] \`uv run ruff check src/aptl/utils/shell.py\` — clean
- [x] \`git status\` after \`uv sync\` — clean

## Follow-on scope worth a look

The \`test_shell.py\` fix uncovered a general "tests that mention Windows paths need to work on POSIX interpreters" hygiene point. There are a few other Windows-path-shaped strings in the codebase (mostly under \`_git_bash_from_known_locations\`) that only run under Windows guards today — worth a follow-up sweep if you want defense in depth against similar cross-platform drift.