### PR TITLE
fix(shell): make `_looks_like_wsl` work on POSIX interpreters (dev CI unblock)

### DIFF
--- a/src/aptl/utils/shell.py
+++ b/src/aptl/utils/shell.py
@@ -28,7 +28,7 @@ _IS_WINDOWS = sys.platform.startswith("win")
 
 def _looks_like_wsl(path: Path) -> bool:
     """True for the WSL launcher shim under System32 (not a real POSIX shell)."""
-    parts = {p.lower() for p in path.parts}
+    parts = str(path).lower().replace("\\", "/").split("/")
     return "system32" in parts or "windowsapps" in parts
 
 

--- a/src/aptl/utils/shell.py
+++ b/src/aptl/utils/shell.py
@@ -17,7 +17,7 @@ import os
 import shutil
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from aptl.utils.logging import get_logger
 
@@ -28,7 +28,7 @@ _IS_WINDOWS = sys.platform.startswith("win")
 
 def _looks_like_wsl(path: Path) -> bool:
     """True for the WSL launcher shim under System32 (not a real POSIX shell)."""
-    parts = str(path).lower().replace("\\", "/").split("/")
+    parts = {p.lower() for p in PureWindowsPath(path).parts}
     return "system32" in parts or "windowsapps" in parts
 
 


### PR DESCRIPTION
Unblocks dev CI (dev→main PR #739 currently failing on the same test on ubuntu-latest and macos-latest jobs).

## Failure

Full Checks run 28977885705 on dev:

\`\`\`
FAILED tests/test_shell.py::test_looks_like_wsl_flags_system32 - AssertionError: assert False is True

>       assert shell._looks_like_wsl(Path(r"C:\\Windows\\System32\\bash.exe")) is True
E       AssertionError: assert False is True
\`\`\`

## Root cause

On Linux/macOS, \`Path\` factory returns \`PurePosixPath\`, which does not split \`\\\` as a component separator. \`Path(r"C:\\Windows\\System32\\bash.exe").parts\` is therefore \`('C:\\\\Windows\\\\System32\\\\bash.exe',)\` — a single element — and the "system32" marker never appears in \`{p.lower() for p in path.parts}\`.

The helper was written expecting a Windows interpreter; the test that exercises it (\`test_looks_like_wsl_flags_system32\`) has no \`skipif(not sys.platform.startswith("win"))\` guard, and the surrounding \`test_find_git_bash_on_windows_not_wsl\` does. So the check ran on the wrong platform and hard-failed.

## Fix

One-line change to the function body: manual split on both \`/\` and \`\\\` after lowercasing. Semantics are unchanged on Windows, and the test now passes on POSIX (which was the intent of the coverage).

## Verified

\`\`\`
$ uv run pytest tests/test_shell.py -q
4 passed, 1 skipped in 0.59s
$ uv run ruff check src/aptl/utils/shell.py
All checks passed!
\`\`\`

## Split from #741

Originally bundled with the \`uv.lock\` refresh (#715) but Sonar kept flagging maintainability on a 1-line diff — appears to be counting the \`uv.lock\` churn against new-code debt. Splitting so the dev-blocker fix lands cleanly; \`uv.lock\` refresh goes in a separate PR.