### PR TITLE
chore(deps): refresh uv.lock so aces-sdl matches pyproject PyPI source (closes #715)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4,8 +4,8 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aces-sdl"
-version = "0.3.0"
-source = { git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev#ce1bc07ab8bb80e7afaf6c304ac69f4a2e5dd8ec" }
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asyncssh" },
     { name = "cryptography" },
@@ -18,6 +18,10 @@ dependencies = [
     { name = "sse-starlette" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/22/d289c7667d271732af8783f4b7d24e47e6506d94e2581ae47804b686fb04/aces_sdl-0.19.1.tar.gz", hash = "sha256:8a8d1a3e0b0717cddf2d342fef70eeeb6d123cbddff592cfa72e421cb8011fa7", size = 1282207, upload-time = "2026-07-06T04:06:03.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/75/f94651cc43cf4696c7cd7bceb2f3c7042ab672a04fb209b29a3ccea0a6f3/aces_sdl-0.19.1-py3-none-any.whl", hash = "sha256:727e10a5eb83cfa3fe8b4bb9abcbabe2b24e6497427d5943decc1d2a4ec1e1cf", size = 1091838, upload-time = "2026-07-06T04:06:02.201Z" },
 ]
 
 [[package]]
@@ -52,8 +56,8 @@ wheels = [
 ]
 
 [[package]]
-name = "aptl"
-version = "0.1.0"
+name = "aptl-labs"
+version = "4.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aces-sdl" },
@@ -95,7 +99,7 @@ web = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aces-sdl", git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev" },
+    { name = "aces-sdl", specifier = ">=0.1.0" },
     { name = "asyncssh", marker = "extra == 'web'", specifier = ">=2.17.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
Closes #715.

## Problem

\`pyproject.toml\` declares \`aces-sdl\` from PyPI (\`0.19.1\`) but the checked-in \`uv.lock\` still pins it to the old \`git\` source at \`0.3.0\`:

\`\`\`
-version = "0.3.0"
-source = { git = "https://github.com/Brad-Edwards/aces.git?subdirectory=implementations%2Fpython&rev=dev#ce1bc07ab8bb80e7afaf6c304ac69f4a2e5dd8ec" }
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
\`\`\`

Every fresh \`uv sync\` on a clean clone produces a dirty working tree, and every non-trivial PR gets \`uv.lock\` churn as noise. Blocks a clean dev→main promotion (#739).

## Fix

\`uv lock\` refresh only. No pyproject or code change, no Python-level behavior change; the wheel resolves from PyPI at \`0.19.1\` which is what pyproject already asked for.

## Test plan

- [x] \`git status\` clean after fresh \`uv sync\`
- [x] Non-code change; test surface not affected