### PR TITLE
docs(workshop): generalize rollout capacity example

### DIFF
--- a/docs/workshop/emergency-rollout.md
+++ b/docs/workshop/emergency-rollout.md
@@ -30,8 +30,8 @@ found during a fallback should become a release or docs issue after the event.
 ## Capacity Model
 
 Size the fleet from the instance vCPU count, not the instance count. For
-example, 25 `m7i.2xlarge` hosts consume 200 Standard On-Demand vCPUs because
-each host has 8 vCPUs. Keep quota headroom for canaries and replacement hosts.
+example, `m7i.2xlarge` hosts consume 8 Standard On-Demand vCPUs each. Keep
+quota headroom for canaries and replacement hosts.
 
 Before launch, check:
 


### PR DESCRIPTION
## Summary
- remove the specific host-count example from the emergency rollout runbook
- keep capacity guidance generic by documenting per-host vCPU sizing

## Tests
- pre-commit run --files docs/workshop/emergency-rollout.md
- rg scan for SFU, event dates, headcount, and student-number references in the affected workshop docs