### PR TITLE
fix: narrow evaluator surface to conditions and objectives

### DIFF
--- a/docs/aces/m1-aces-conformance-truth-up-preflight.md
+++ b/docs/aces/m1-aces-conformance-truth-up-preflight.md
@@ -23,9 +23,10 @@ record boundary. This note narrows the guardrails for making APTL's
   live infrastructure or a contract-clean control-plane path. Conformance is a
   verification boundary, not an assertion boundary.
 - Evaluation progression must be truthful. `AptlEvaluator` may publish
-  `PENDING`, `RUNNING`, terminal outcome, and score/progress fields only when
-  those values are driven from real RTE-001 objective/evaluation execution or
-  from an upstream ACES evaluation contract that defines the field.
+  `PENDING`, `RUNNING`, and terminal condition/objective outcomes only when
+  those values are driven from real RTE-001 observations or from an upstream
+  ACES evaluation contract that defines the field. APTL does not declare the
+  deprecated SDL scoring chain as a runtime capability.
 - Participant runtime live actions must be compiled-artifact and realization
   driven. The legacy `DEFAULT_PARTICIPANT_ACTIONS` TechVault probe can remain a
   compatibility fallback, but new live conformance behavior must use
@@ -132,28 +133,28 @@ validated descriptor or typed backend parameter, not editing a TechVault branch,
 forking the manifest generator, adding a new conformance runner, or copying
 ACES schemas into APTL.
 
-## Issue #606 Evaluator Live-Score Addendum
+## Issue #606 Evaluator Surface Addendum
 
 Issue #606 is an evaluator truth-up on the already-declared
 `full-remote-control-plane` surface, not a manifest promotion and not a new
-score schema. `AptlEvaluator` remains the ACES adapter boundary, and the public
-DTOs remain `EvaluationExecutionState` plus `EvaluationHistoryEvent` records
-stored on `RuntimeSnapshot.evaluation_results` and
+score schema. After ACES ADR-073, APTL narrows that surface to conditions and
+objectives: SDL `metrics`, `evaluations`, `tlos`, and `goals` are not declared
+runtime capabilities. `AptlEvaluator` remains the ACES adapter boundary, and the
+public DTOs remain `EvaluationExecutionState` plus `EvaluationHistoryEvent`
+records stored on `RuntimeSnapshot.evaluation_results` and
 `RuntimeSnapshot.evaluation_history`.
 
-Live score/progress must be derived from observed run state for the current
-evaluation address and run id. Registration state (`PENDING` plus
+Live evaluator progression must be derived from observed run state for the
+current evaluation address and run id. Registration state (`PENDING` plus
 `evaluation_started`) is truthful only before observation; it is not progress.
-When observation advances a run, the adapter may emit `RUNNING`, `READY`, or
-`FAILED` only with history events that match the compiled `execution_contract`.
+When observation advances a supported condition or objective, the adapter may
+emit `RUNNING`, `READY`, or `FAILED` only with history events that match the
+compiled `execution_contract`.
 
-Score and pass/fail fields are controlled by the compiled `result_contract`,
-not by APTL convention. Metric resources may expose `score` only when
-`supports_score` is true, and a terminal ready metric with `fixed_max_score`
-must use that max score. Condition, objective, evaluation, TLO, and goal
-resources may expose `passed` only when `supports_passed` is true. Do not treat
-objective completion count, elapsed time, or workflow step count as a score
-unless the compiled evaluation contract says that resource is score-bearing.
+Pass/fail fields are controlled by the compiled `result_contract`, not by APTL
+convention. Condition and objective resources may expose `passed` only when
+`supports_passed` is true. Do not treat objective completion count, elapsed
+time, workflow step count, metric totals, or thresholds as an APTL score.
 
 The conformance re-verification path for #606 is the existing one:
 `evaluation_result_contract_diagnostics()`, `run_target_conformance()` for
@@ -166,7 +167,7 @@ embedding raw SOC payloads or backend stderr into result envelopes.
 
 The extensibility parameter for evaluator progression is the tuple
 `(evaluation_address, result_contract, execution_contract, observed_state,
-run_id)`. The next variation should be another metric, objective, scenario, or
+run_id)`. The next variation should be another condition/objective scenario or
 evidence source, not a TechVault branch, a hardcoded score curve, a duplicate
 validator, or a separate live-gate-only score model.
 
@@ -195,7 +196,7 @@ validator, or a separate live-gate-only score model.
   publishes them upstream.
 - Keeping adapter docstrings or docs that still describe APTL as merely
   orchestration-capable without a historical label.
-- Treating evaluator registration as live score progression.
+- Treating evaluator registration as live evaluation progression.
 - Treating participant episode lifecycle calls as lab start/stop operations.
 - Extending `DEFAULT_PARTICIPANT_ACTIONS` as the primary design instead of
   using runtime-derived action bindings.
@@ -218,7 +219,7 @@ validator, or a separate live-gate-only score model.
   Docker Compose topology, startup ordering, generated config, SOC TLS, web
   auth, terminal relay, snapshot registry, or run archive layout.
 - Do not make participant runtime a general shell-execution API.
-- Do not make evaluator scoring a simulated state machine detached from real
-  objective/evaluation observations.
+- Do not make evaluator progression a simulated state machine detached from real
+  condition/objective observations.
 - Do not replace the static/live gates with a new M1-specific gate. Extend the
   existing gate owners and profile parameters when implementation begins.

--- a/docs/aces/paper-scenario-realization.md
+++ b/docs/aces/paper-scenario-realization.md
@@ -34,8 +34,14 @@ contract by resolving service refs from the runtime plan and Compose backend
 mapping, then checks the portal login endpoint from Kali and records negative
 boundary markers for direct database and Wazuh API reachability. Those markers
 are participant-runtime evidence for the boundary; Wazuh evidence remains
-evaluator-only and is registered as pending evaluator/runtime state rather than
-participant-visible task context or a detection-quality claim.
+evaluator-only rather than participant-visible task context or a
+detection-quality claim.
+
+The upstream paper SDL still carries OCR-style `metrics`, `evaluations`, `tlos`,
+and `goals` as source content. APTL does not declare or realize that SDL scoring
+chain after ACES ADR-073; planning records unsupported evaluator-section
+diagnostics for those resources while retaining the condition/objective
+evaluation surface that belongs to the runtime target.
 
 The participant behavior, action-contract, observation-boundary, action-instance,
 and shared-state snapshot entries are emitted from the runtime-selected

--- a/docs/aces/techvault-live-validation-gate.md
+++ b/docs/aces/techvault-live-validation-gate.md
@@ -97,9 +97,10 @@ schema `aptl.live-gate.manifest/v1`. It records:
 - **`evidence`**: the telemetry-path summary (event types and counts, never raw
   payloads).
 - **`evaluator_surfaces`**: the declared `full-remote-control-plane` evaluator
-  profile and ACES evaluation result/history contracts. This is an evidence
-  index, not a score source; live score/progress belongs in ACES
-  `evaluation_results` and `evaluation_history` derived from observed run state.
+  profile and ACES evaluation result/history contracts for conditions and
+  objectives. This is an evidence index, not a score source; live evaluator
+  progression belongs in ACES `evaluation_results` and `evaluation_history`
+  derived from observed run state.
 
 ## Observable parity
 
@@ -108,11 +109,11 @@ The live gate validates the operational startup contract. The public boot SDL,
 services and networks at range granularity; the deep inventory SDL,
 `scenarios/techvault.sdl.yaml`, remains the detailed asset/parity evidence
 surface proven by the static inventory tests. Evaluator contracts are part of
-the declared `full-remote-control-plane` surface; #606 tightens that surface so
-live score progression must come from real evaluation observations and pass the
-same ACES conformance/re-verification path. The run archive is proof of what
-the operational model realized; it does not substitute for SDL encoding or for
-ACES evaluation result/history envelopes.
+the declared `full-remote-control-plane` surface; #606 narrows that surface to
+condition/objective evaluation after ACES ADR-073 moved SDL scoring-chain
+semantics out of scope. The run archive is proof of what the operational model
+realized; it does not substitute for SDL encoding or for ACES evaluation
+result/history envelopes.
 
 ## Prerequisites
 

--- a/docs/aces/techvault-static-validation-gate.md
+++ b/docs/aces/techvault-static-validation-gate.md
@@ -60,10 +60,10 @@ local dataclass approximation is not accepted as conformance evidence.
 The parity inventory records, for each required surface, whether TechVault
 represents it today or marks it as a historical gap with an issue reference.
 Startup, workflow/evaluation contract, and participant runtime surfaces are
-represented through the full remote-control-plane target. Evaluator live-score
-progression remains truth-labeled until it is driven by real execution state. A
-surface that is neither represented with evidence nor explicitly tracked fails
-the gate.
+represented through the full remote-control-plane target. Evaluator progression
+is limited to condition/objective evaluation after ACES ADR-073 moved SDL
+scoring-chain semantics out of the authored runtime surface. A surface that is
+neither represented with evidence nor explicitly tracked fails the gate.
 
 ## Advisory in Phase A, blocking at cutover
 

--- a/src/aptl/backends/_aces_evaluator_engine.py
+++ b/src/aptl/backends/_aces_evaluator_engine.py
@@ -21,8 +21,9 @@ from aptl.backends._aces_evaluator_progress import append_progression
 from aptl.utils.redaction import redact
 
 EVALUATION_ADDRESS = "runtime.apply.evaluation"
-OBSERVABLE_RESOURCE_TYPES = frozenset(
-    {"condition-binding", "evaluation", "goal", "metric", "objective", "tlo"}
+OBSERVABLE_RESOURCE_TYPES = frozenset({"condition-binding", "objective"})
+UNSUPPORTED_SCORING_RESOURCE_TYPES = frozenset(
+    {"evaluation", "goal", "metric", "tlo"}
 )
 _FAILED_ENTRY_STATUSES = frozenset({"error", "failed", "unhealthy"})
 _READY_ENTRY_STATUS = "ready"
@@ -65,16 +66,6 @@ def _ready_passed(passed: bool, detail: str) -> _EvaluationOutcome:
     return _EvaluationOutcome(
         status=EvaluationResultStatus.READY,
         passed=passed,
-        detail=detail,
-    )
-
-
-def _ready_score(score: float | int, max_score: int, detail: str) -> _EvaluationOutcome:
-    """Return a ready score outcome."""
-    return _EvaluationOutcome(
-        status=EvaluationResultStatus.READY,
-        score=score,
-        max_score=max_score,
         detail=detail,
     )
 
@@ -214,30 +205,6 @@ def _string_values(raw: object) -> tuple[str, ...]:
     return tuple(str(value) for value in raw if str(value))
 
 
-def _int_value(raw: object) -> int | None:
-    """Return an integer value while excluding bools."""
-    value = raw if not isinstance(raw, bool) and isinstance(raw, int) else None
-    return value
-
-
-def _number_value(raw: object) -> float | int | None:
-    """Return a numeric value while excluding bools."""
-    value = raw if not isinstance(raw, bool) and isinstance(raw, (int, float)) else None
-    return value
-
-
-def _metric_max_score(
-    contract: EvaluationResultContract,
-    payload: dict[str, object],
-) -> int:
-    """Resolve the compiled max score for a conditional metric."""
-    max_score = contract.fixed_max_score
-    spec = payload.get("spec")
-    if max_score is None and isinstance(spec, dict):
-        max_score = _int_value(spec.get("max_score"))
-    return max_score if max_score is not None else 100
-
-
 def _state_truth_value(state: EvaluationExecutionState | None) -> bool | None:
     """Return True/False for ready/failed dependency states; None means wait."""
     value: bool | None = None
@@ -250,10 +217,6 @@ def _state_truth_value(state: EvaluationExecutionState | None) -> bool | None:
             value = False
         elif state.passed is not None:
             value = state.passed
-        elif state.score is not None and state.max_score is None:
-            value = bool(state.score)
-        elif state.score is not None:
-            value = float(state.score) >= float(state.max_score)
     return value
 
 
@@ -296,68 +259,6 @@ def _condition_outcome(
     return outcome
 
 
-def _metric_outcome(
-    payload: dict[str, object],
-    states: dict[str, EvaluationExecutionState],
-    contract: EvaluationResultContract,
-) -> _EvaluationOutcome:
-    """Resolve a conditional metric score from observed condition states."""
-    dependencies = _string_values(payload.get("condition_addresses"))
-    values = [_state_truth_value(states.get(address)) for address in dependencies]
-    if not dependencies:
-        outcome = _running("metric has no observed condition dependencies")
-    elif any(value is None for value in values):
-        outcome = _running("waiting for metric condition dependencies")
-    else:
-        max_score = _metric_max_score(contract, payload)
-        score = max_score if all(bool(value) for value in values) else 0
-        outcome = _ready_score(score, max_score, "scored from observed condition state")
-    return outcome
-
-
-def _min_score_threshold(payload: dict[str, object], total_max_score: float) -> float:
-    """Resolve the minimum score threshold for an evaluation resource."""
-    spec = payload.get("spec")
-    min_score = spec.get("min_score") if isinstance(spec, dict) else None
-    threshold: float | None = None
-    if isinstance(min_score, dict):
-        absolute = _number_value(min_score.get("absolute"))
-        percentage = _number_value(min_score.get("percentage"))
-        if absolute is not None:
-            threshold = float(absolute)
-        elif percentage is not None:
-            threshold = total_max_score * float(percentage) / 100
-    else:
-        direct = _number_value(min_score)
-        threshold = float(direct) if direct is not None else None
-    return total_max_score if threshold is None else threshold
-
-
-def _evaluation_aggregate_outcome(
-    payload: dict[str, object],
-    states: dict[str, EvaluationExecutionState],
-) -> _EvaluationOutcome:
-    """Resolve an evaluation pass/fail outcome from metric scores."""
-    dependencies = _string_values(payload.get("metric_addresses"))
-    metric_states = [states.get(address) for address in dependencies]
-    waiting = not dependencies or any(
-        state is None
-        or state.status in {EvaluationResultStatus.PENDING, EvaluationResultStatus.RUNNING}
-        for state in metric_states
-    )
-    if waiting:
-        outcome = _running("waiting for evaluation metric dependencies")
-    else:
-        total_score = sum(float(state.score or 0) for state in metric_states if state)
-        total_max = sum(float(state.max_score or 0) for state in metric_states if state)
-        threshold = _min_score_threshold(payload, total_max)
-        outcome = _ready_passed(
-            total_score >= threshold,
-            "evaluated from observed metric scores",
-        )
-    return outcome
-
-
 def _resolve_outcome(
     address: str,
     payload: dict[str, object],
@@ -371,24 +272,6 @@ def _resolve_outcome(
     outcome = _running(f"waiting for observed state for {address}")
     if resource_type == "condition-binding":
         outcome = _condition_outcome(payload, snapshot)
-    elif resource_type == "metric":
-        outcome = _metric_outcome(payload, states, contract)
-    elif resource_type == "evaluation":
-        outcome = _evaluation_aggregate_outcome(payload, states)
-    elif resource_type == "tlo":
-        outcome = _aggregate_dependency_outcome(
-            states,
-            _string_values(payload.get("evaluation_address")),
-            ready_detail="TLO evaluated from observed evaluation state",
-            waiting_detail="waiting for TLO evaluation dependency",
-        )
-    elif resource_type == "goal":
-        outcome = _aggregate_dependency_outcome(
-            states,
-            _string_values(payload.get("tlo_addresses")),
-            ready_detail="goal evaluated from observed TLO state",
-            waiting_detail="waiting for goal TLO dependencies",
-        )
     elif resource_type == "objective":
         outcome = _aggregate_dependency_outcome(
             states,
@@ -399,33 +282,12 @@ def _resolve_outcome(
     return outcome
 
 
-def _contract_score_fields(
-    outcome: _EvaluationOutcome,
-    contract: EvaluationResultContract,
-) -> tuple[float | int | None, int | None]:
-    """Return score fields allowed by the compiled result contract."""
-    score = outcome.score if contract.supports_score else None
-    max_score = outcome.max_score if contract.supports_score else None
-    if contract.supports_score and contract.fixed_max_score is not None:
-        max_score = contract.fixed_max_score
-    if contract.supports_score and score is None and outcome.passed is not None:
-        max_score = max_score if max_score is not None else 100
-        score = max_score if outcome.passed else 0
-    return score, max_score
-
-
 def _contract_passed_field(
     outcome: _EvaluationOutcome,
     contract: EvaluationResultContract,
-    score: float | int | None,
-    max_score: int | None,
 ) -> bool | None:
     """Return the pass/fail field allowed by the compiled result contract."""
-    passed = outcome.passed if contract.supports_passed else None
-    if contract.supports_passed and passed is None and score is not None:
-        threshold = max_score if max_score is not None else score
-        passed = float(score) >= float(threshold)
-    return passed
+    return outcome.passed if contract.supports_passed else None
 
 
 def _contractual_outcome(
@@ -435,18 +297,13 @@ def _contractual_outcome(
     """Strip or derive ready result values according to the compiled contract."""
     adjusted = _EvaluationOutcome(status=outcome.status, detail=outcome.detail)
     if outcome.status == EvaluationResultStatus.READY:
-        score, max_score = _contract_score_fields(outcome, contract)
-        passed = _contract_passed_field(outcome, contract, score, max_score)
-        if contract.supports_score and score is None:
-            adjusted = _running("waiting for contract-compatible score result")
-        elif contract.supports_passed and passed is None:
+        passed = _contract_passed_field(outcome, contract)
+        if contract.supports_passed and passed is None:
             adjusted = _running("waiting for contract-compatible pass/fail result")
         else:
             adjusted = _EvaluationOutcome(
                 status=EvaluationResultStatus.READY,
                 passed=passed,
-                score=score,
-                max_score=max_score,
                 detail=outcome.detail,
             )
     return adjusted

--- a/src/aptl/backends/aces_evaluator.py
+++ b/src/aptl/backends/aces_evaluator.py
@@ -5,19 +5,18 @@ the objective/condition surface introduced by SCN-010 follow-on #312. APTL's
 scenario runtime engine (RTE-001) already evaluates conditions and objectives;
 this adapter exposes that surface through the *portable* ACES contracts
 ``evaluation-result-envelope-v1`` and ``evaluation-history-event-stream-v1``
-rather than APTL-native scoring shapes.
+rather than APTL-native scoring shapes or the deprecated SDL scoring chain.
 
 The adapter is the ACES ``Evaluator`` component published on APTL's
 ``RuntimeTarget``. ``start()`` loads an ACES ``EvaluationPlan`` into runtime
 state: it registers every evaluation resource as an ACES ``SnapshotEntry`` and,
-for each observable evaluation resource, records a truthful
-``EvaluationExecutionState`` and then advances observable resources from the
-runtime snapshot supplied by the ACES control plane. Conditions observe
-provisioning entries, conditional metrics score from those condition results,
-and aggregate resources report pass/fail from their compiled dependency
-addresses. The adapter never invents elapsed-time score curves; result values
-are emitted only when the compiled ACES contract allows them. ``stop()`` clears
-evaluation state.
+for each supported observable evaluation resource, records a truthful
+``EvaluationExecutionState`` and then advances conditions and objectives from
+the runtime snapshot supplied by the ACES control plane. Conditions observe
+provisioning entries, and objectives report pass/fail from their compiled
+condition dependencies. SDL ``metrics``/``evaluations``/``tlos``/``goals`` are
+outside APTL's declared evaluator surface after ACES ADR-073 and fail closed if
+present in an evaluation plan. ``stop()`` clears evaluation state.
 
 This keeps the full remote-control-plane evaluation claim honest: APTL
 publishes the evaluation result/history *contract* surface and the
@@ -29,19 +28,148 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from aces_contracts.diagnostics import Diagnostic
-from aces_contracts.evaluation import EvaluationResultContract
+from aces_contracts.evaluation import EvaluationExecutionState, EvaluationResultContract
 from aces_contracts.planning import ChangeAction, EvaluationPlan, RuntimeDomain
 from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
 
 from aptl.backends._aces_evaluator_engine import (
     EVALUATION_ADDRESS,
     OBSERVABLE_RESOURCE_TYPES,
+    UNSUPPORTED_SCORING_RESOURCE_TYPES,
     drive_evaluations,
     evaluation_diagnostic,
     existing_states,
     register_evaluation,
     utc_now,
 )
+
+
+@dataclass
+class _EvaluationRegistration(object):
+    """Mutable registration state for one evaluator start call."""
+
+    entries: dict[str, SnapshotEntry]
+    states: dict[str, EvaluationExecutionState]
+    history: dict[str, list[dict[str, object]]]
+    contracts: dict[str, EvaluationResultContract] = field(default_factory=dict)
+    operation_payloads: dict[str, dict[str, object]] = field(default_factory=dict)
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+    changed: list[str] = field(default_factory=list)
+    registered_at: str = field(default_factory=utc_now)
+
+
+def _registration_for_snapshot(snapshot: RuntimeSnapshot) -> _EvaluationRegistration:
+    """Build mutable evaluator registration state from the current snapshot."""
+    return _EvaluationRegistration(
+        entries=dict(snapshot.entries),
+        states=existing_states(snapshot),
+        history={
+            address: list(events)
+            for address, events in snapshot.evaluation_history.items()
+        },
+    )
+
+
+def _operation_entry(op: object) -> SnapshotEntry:
+    """Render an evaluation operation as a runtime snapshot entry."""
+    return SnapshotEntry(
+        address=op.address,
+        domain=RuntimeDomain.EVALUATION,
+        resource_type=op.resource_type,
+        payload=op.payload,
+        ordering_dependencies=op.ordering_dependencies,
+        refresh_dependencies=op.refresh_dependencies,
+        status="ready",
+    )
+
+
+def _unsupported_scoring_diagnostic(op: object) -> Diagnostic:
+    """Return the diagnostic for deprecated SDL scoring-chain resources."""
+    return evaluation_diagnostic(
+        "aptl.evaluator.unsupported-scoring-section",
+        op.address,
+        (
+            "APTL evaluator supports conditions and objectives; "
+            f"SDL scoring resource type {op.resource_type!r} is "
+            "outside the declared evaluator surface."
+        ),
+    )
+
+
+def _unsupported_score_contract_diagnostic(address: str) -> Diagnostic:
+    """Return the diagnostic for score-bearing supported-resource contracts."""
+    return evaluation_diagnostic(
+        "aptl.evaluator.unsupported-score-contract",
+        address,
+        (
+            "APTL evaluator does not declare scoring support; "
+            "condition/objective result contracts must not request score fields."
+        ),
+    )
+
+
+def _delete_registered_operation(registration: _EvaluationRegistration, op: object) -> None:
+    """Delete an evaluation operation from mutable registration state."""
+    registration.entries.pop(op.address, None)
+    registration.states.pop(op.address, None)
+    registration.history.pop(op.address, None)
+    registration.changed.append(op.address)
+
+
+def _register_observable_operation(
+    registration: _EvaluationRegistration,
+    op: object,
+) -> None:
+    """Register the result/history contract for a supported observable operation."""
+    contract, diagnostics = register_evaluation(
+        op.address,
+        op.payload,
+        registration.registered_at,
+        registration.states,
+        registration.history,
+    )
+    registration.diagnostics.extend(diagnostics)
+    if contract is None:
+        return
+    if contract.supports_score:
+        registration.diagnostics.append(
+            _unsupported_score_contract_diagnostic(op.address)
+        )
+        return
+    registration.contracts[op.address] = contract
+    registration.operation_payloads[op.address] = dict(op.payload)
+
+
+def _register_supported_operation(
+    registration: _EvaluationRegistration,
+    op: object,
+) -> None:
+    """Register a non-scoring evaluation operation."""
+    registration.entries[op.address] = _operation_entry(op)
+    registration.changed.append(op.address)
+    if op.resource_type in OBSERVABLE_RESOURCE_TYPES:
+        _register_observable_operation(registration, op)
+
+
+def _apply_operation(registration: _EvaluationRegistration, op: object) -> None:
+    """Apply one evaluation operation to mutable registration state."""
+    if op.action == ChangeAction.DELETE:
+        _delete_registered_operation(registration, op)
+    elif op.resource_type in UNSUPPORTED_SCORING_RESOURCE_TYPES:
+        registration.diagnostics.append(_unsupported_scoring_diagnostic(op))
+    else:
+        _register_supported_operation(registration, op)
+
+
+def _apply_plan_operations(
+    plan: EvaluationPlan,
+    snapshot: RuntimeSnapshot,
+) -> _EvaluationRegistration:
+    """Apply the evaluation plan operations without driving outcomes."""
+    registration = _registration_for_snapshot(snapshot)
+    for op in plan.actionable_operations:
+        _apply_operation(registration, op)
+    return registration
 
 
 @dataclass
@@ -67,76 +195,40 @@ class AptlEvaluator(object):
                 ],
             )
 
-        entries = dict(working_snapshot.entries)
-        states = existing_states(working_snapshot)
-        history = {
-            address: list(events)
-            for address, events in working_snapshot.evaluation_history.items()
-        }
-        contracts: dict[str, EvaluationResultContract] = {}
-        operation_payloads: dict[str, dict[str, object]] = {}
-        diagnostics: list[Diagnostic] = []
-        changed: list[str] = []
-        registered_at = utc_now()
+        registration = _apply_plan_operations(plan, working_snapshot)
 
-        for op in plan.actionable_operations:
-            if op.action == ChangeAction.DELETE:
-                entries.pop(op.address, None)
-                states.pop(op.address, None)
-                history.pop(op.address, None)
-                changed.append(op.address)
-                continue
-            entries[op.address] = SnapshotEntry(
-                address=op.address,
-                domain=RuntimeDomain.EVALUATION,
-                resource_type=op.resource_type,
-                payload=op.payload,
-                ordering_dependencies=op.ordering_dependencies,
-                refresh_dependencies=op.refresh_dependencies,
-                status="ready",
-            )
-            changed.append(op.address)
-            if op.resource_type in OBSERVABLE_RESOURCE_TYPES:
-                contract, evaluation_diagnostics = register_evaluation(
-                    op.address,
-                    op.payload,
-                    registered_at,
-                    states,
-                    history,
-                )
-                diagnostics.extend(evaluation_diagnostics)
-                if contract is not None:
-                    contracts[op.address] = contract
-                    operation_payloads[op.address] = dict(op.payload)
-
-        if diagnostics:
+        if registration.diagnostics:
             return ApplyResult(
                 success=False,
                 snapshot=working_snapshot,
-                diagnostics=diagnostics,
+                diagnostics=registration.diagnostics,
             )
 
         drive_evaluations(
             plan,
             working_snapshot,
-            operation_payloads,
-            states,
-            history,
-            contracts,
+            registration.operation_payloads,
+            registration.states,
+            registration.history,
+            registration.contracts,
         )
-        results = {address: state.to_payload() for address, state in states.items()}
+        results = {
+            address: state.to_payload()
+            for address, state in registration.states.items()
+        }
         self._results = {address: dict(result) for address, result in results.items()}
         self._history = {
-            address: [dict(event) for event in events] for address, events in history.items()
+            address: [dict(event) for event in events]
+            for address, events in registration.history.items()
         }
         return ApplyResult(
             success=True,
             snapshot=working_snapshot.with_entries(
-                entries,
+                registration.entries,
                 evaluation_results=results,
-                evaluation_history=history,
+                evaluation_history=registration.history,
             ),
-            changed_addresses=changed,
+            changed_addresses=registration.changed,
         )
 
     def status(self) -> dict[str, object]:

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -18,7 +18,8 @@ condition evaluation through ``evaluation-result-envelope-v1`` and
 ``evaluation-history-event-stream-v1`` (see
 ``aptl.backends.aces_evaluator.AptlEvaluator``), and exposes a narrow red
 participant runtime through the participant episode and behavior-history
-contracts.
+contracts. It does not declare the deprecated SDL scoring chain
+(``metrics``/``evaluations``/``tlos``/``goals``) as an APTL runtime capability.
 """
 
 from __future__ import annotations
@@ -115,16 +116,13 @@ _ORCHESTRATOR = OrchestratorCapabilities(
 
 # Evaluator capability declaration. APTL's RTE-001 runtime evaluates scenario
 # conditions (healthchecks realized during provisioning) and objectives through
-# the portable evaluation result/history contracts. Scoring sections are
-# declared because SCN-007 scoring resources compile into the same evaluation
-# plan surface; live score progression must come from real execution state, not
-# synthetic registration state.
+# the portable evaluation result/history contracts. ACES ADR-073 moves graded
+# scoring out of the authored SDL surface, so the manifest deliberately does not
+# claim support for the OCR scoring chain (`metrics`/`evaluations`/`tlos`/`goals`).
 _EVALUATOR = EvaluatorCapabilities(
     name="aptl-rte-evaluator",
-    supported_sections=frozenset(
-        {"conditions", "evaluations", "goals", "metrics", "objectives", "tlos"}
-    ),
-    supports_scoring=True,
+    supported_sections=frozenset({"conditions", "objectives"}),
+    supports_scoring=False,
     supports_objectives=True,
 )
 

--- a/src/aptl/validation/_live_gate_checks.py
+++ b/src/aptl/validation/_live_gate_checks.py
@@ -391,7 +391,7 @@ def check_run_archive_manifest(
     """Persist scenario identity + ACES provenance + validation evidence.
 
     Writes through ``LocalRunStore``'s redacting boundary (ADR-029).
-    Objective / scoring run surfaces are published through the portable
+    Objective and condition run surfaces are published through the portable
     ACES evaluation contracts at the backend boundary. Live evaluator
     progression is emitted by ``AptlEvaluator`` from observed runtime state.
     """

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -342,6 +342,12 @@ def test_create_aptl_manifest_is_canonical_backend_manifest_v2():
     assert required <= set(payload["supported_contract_versions"])
     assert manifest.has_orchestrator is True
     assert manifest.has_evaluator is True
+    assert manifest.evaluator is not None
+    assert manifest.evaluator.supported_sections == frozenset(
+        {"conditions", "objectives"}
+    )
+    assert manifest.evaluator.supports_scoring is False
+    assert manifest.evaluator.supports_objectives is True
     assert manifest.has_participant_runtime is True
     assert manifest.participant_runtime is not None
     assert manifest.participant_runtime.supported_participant_roles == frozenset(

--- a/tests/test_aces_evaluator.py
+++ b/tests/test_aces_evaluator.py
@@ -13,7 +13,6 @@ from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotE
 from aces_processor.compiler import compile_runtime_model
 from aces_processor.planner import plan
 from aces_runtime.evaluation_result_contracts import evaluation_result_contract_diagnostics
-from aces_sdl import parse_sdl_file
 from aces_sdl.parser import parse_sdl
 
 from aptl.backends.aces_evaluator import AptlEvaluator
@@ -51,65 +50,8 @@ _EVALUATION_SCENARIO = dedent(
     """
 )
 
-_SCORING_SCENARIO = dedent(
-    """
-    name: evaluator-score-test
-    nodes:
-      vm:
-        type: vm
-        os: linux
-        resources: {ram: 1 gib, cpu: 1}
-        conditions: {health: ops}
-        roles: {ops: operator}
-    conditions:
-      health: {command: /bin/true, interval: 15}
-    entities:
-      blue: {role: blue}
-    metrics:
-      uptime:
-        type: conditional
-        max-score: 10
-        condition: health
-    evaluations:
-      overall:
-        metrics: [uptime]
-        min-score: {absolute: 10}
-    tlos:
-      service-live:
-        evaluation: overall
-    goals:
-      verify:
-        tlos: [service-live]
-    objectives:
-      validate:
-        entity: blue
-        success:
-          conditions: [health]
-          metrics: [uptime]
-          evaluations: [overall]
-          tlos: [service-live]
-          goals: [verify]
-    workflows:
-      response:
-        start: run
-        steps:
-          run:
-            type: objective
-            objective: validate
-            on-success: finish
-          finish: {type: end}
-    """
-)
-
-
 def _evaluation_plan():
     scenario = parse_sdl(_EVALUATION_SCENARIO)
-    execution_plan = plan(compile_runtime_model(scenario), create_aptl_manifest())
-    return execution_plan.evaluation
-
-
-def _scoring_plan():
-    scenario = parse_sdl(_SCORING_SCENARIO)
     execution_plan = plan(compile_runtime_model(scenario), create_aptl_manifest())
     return execution_plan.evaluation
 
@@ -157,9 +99,9 @@ def test_start_reports_running_until_observed_state_is_available():
         assert history[-1]["status"] == EvaluationResultStatus.RUNNING.value
 
 
-def test_start_derives_scores_from_observed_condition_state():
+def test_start_derives_condition_and_objective_pass_from_observed_state():
     result = AptlEvaluator().start(
-        _scoring_plan(),
+        _evaluation_plan(),
         _snapshot_with_node_status("ready"),
     )
 
@@ -168,42 +110,42 @@ def test_start_derives_scores_from_observed_condition_state():
     assert diagnostics == [], [d.message for d in diagnostics]
 
     results = result.snapshot.evaluation_results
+    assert sorted(results) == [
+        "evaluation.condition.vm.health",
+        "evaluation.objective.validate",
+    ]
     condition = EvaluationExecutionState.from_payload(
         results["evaluation.condition.vm.health"]
     )
-    metric = EvaluationExecutionState.from_payload(results["evaluation.metric.uptime"])
-    evaluation = EvaluationExecutionState.from_payload(
-        results["evaluation.evaluation.overall"]
-    )
-    tlo = EvaluationExecutionState.from_payload(results["evaluation.tlo.service-live"])
-    goal = EvaluationExecutionState.from_payload(results["evaluation.goal.verify"])
     objective = EvaluationExecutionState.from_payload(
         results["evaluation.objective.validate"]
     )
 
     assert condition.status == EvaluationResultStatus.READY
     assert condition.passed is True
-    assert metric.status == EvaluationResultStatus.READY
-    assert metric.score == 10
-    assert metric.max_score == 10
-    assert evaluation.passed is True
-    assert tlo.passed is True
-    assert goal.passed is True
+    assert condition.score is None
+    assert condition.max_score is None
+    assert objective.status == EvaluationResultStatus.READY
     assert objective.passed is True
+    assert objective.score is None
+    assert objective.max_score is None
 
-    metric_history = result.snapshot.evaluation_history["evaluation.metric.uptime"]
-    assert _event_types(metric_history) == [
+    objective_history = result.snapshot.evaluation_history[
+        "evaluation.objective.validate"
+    ]
+    assert _event_types(objective_history) == [
         EvaluationHistoryEventType.EVALUATION_STARTED.value,
         EvaluationHistoryEventType.EVALUATION_UPDATED.value,
         EvaluationHistoryEventType.EVALUATION_READY.value,
     ]
-    assert metric_history[1]["status"] == EvaluationResultStatus.RUNNING.value
-    assert metric_history[-1]["score"] == 10
-    assert metric_history[-1]["max_score"] == 10
+    assert objective_history[1]["status"] == EvaluationResultStatus.RUNNING.value
+    assert objective_history[-1]["passed"] is True
+    assert objective_history[-1].get("score") is None
+    assert objective_history[-1].get("max_score") is None
 
 
-def test_start_keeps_unobserved_scores_running_without_placeholder_values():
-    result = AptlEvaluator().start(_scoring_plan(), RuntimeSnapshot())
+def test_start_keeps_unobserved_evaluations_running_without_placeholder_values():
+    result = AptlEvaluator().start(_evaluation_plan(), RuntimeSnapshot())
 
     assert result.success is True
     diagnostics = evaluation_result_contract_diagnostics(result.snapshot)
@@ -213,15 +155,19 @@ def test_start_keeps_unobserved_scores_running_without_placeholder_values():
     condition = EvaluationExecutionState.from_payload(
         results["evaluation.condition.vm.health"]
     )
-    metric = EvaluationExecutionState.from_payload(results["evaluation.metric.uptime"])
+    objective = EvaluationExecutionState.from_payload(
+        results["evaluation.objective.validate"]
+    )
 
     assert condition.status == EvaluationResultStatus.RUNNING
     assert condition.passed is None
-    assert metric.status == EvaluationResultStatus.RUNNING
-    assert metric.score is None
-    assert metric.max_score is None
+    assert condition.score is None
+    assert objective.status == EvaluationResultStatus.RUNNING
+    assert objective.passed is None
+    assert objective.score is None
+    assert objective.max_score is None
     assert _event_types(
-        result.snapshot.evaluation_history["evaluation.metric.uptime"]
+        result.snapshot.evaluation_history["evaluation.objective.validate"]
     ) == [
         EvaluationHistoryEventType.EVALUATION_STARTED.value,
         EvaluationHistoryEventType.EVALUATION_UPDATED.value,
@@ -230,20 +176,20 @@ def test_start_keeps_unobserved_scores_running_without_placeholder_values():
 
 def test_start_preserves_existing_run_history_when_observation_advances():
     evaluator = AptlEvaluator()
-    initial = evaluator.start(_scoring_plan(), RuntimeSnapshot())
+    initial = evaluator.start(_evaluation_plan(), RuntimeSnapshot())
     assert initial.success is True
 
-    metric_address = "evaluation.metric.uptime"
-    initial_metric = EvaluationExecutionState.from_payload(
-        initial.snapshot.evaluation_results[metric_address]
+    objective_address = "evaluation.objective.validate"
+    initial_objective = EvaluationExecutionState.from_payload(
+        initial.snapshot.evaluation_results[objective_address]
     )
-    initial_history = list(initial.snapshot.evaluation_history[metric_address])
+    initial_history = list(initial.snapshot.evaluation_history[objective_address])
     ready_node = _snapshot_with_node_status("ready").entries["provision.node.vm"]
     observed_entries = dict(initial.snapshot.entries)
     observed_entries[ready_node.address] = ready_node
 
     advanced = evaluator.start(
-        _scoring_plan(),
+        _evaluation_plan(),
         initial.snapshot.with_entries(
             observed_entries,
             evaluation_results=initial.snapshot.evaluation_results,
@@ -252,11 +198,11 @@ def test_start_preserves_existing_run_history_when_observation_advances():
     )
 
     assert advanced.success is True
-    advanced_metric = EvaluationExecutionState.from_payload(
-        advanced.snapshot.evaluation_results[metric_address]
+    advanced_objective = EvaluationExecutionState.from_payload(
+        advanced.snapshot.evaluation_results[objective_address]
     )
-    advanced_history = advanced.snapshot.evaluation_history[metric_address]
-    assert advanced_metric.run_id == initial_metric.run_id
+    advanced_history = advanced.snapshot.evaluation_history[objective_address]
+    assert advanced_objective.run_id == initial_objective.run_id
     assert advanced_history[: len(initial_history)] == initial_history
     assert _event_types(advanced_history) == [
         EvaluationHistoryEventType.EVALUATION_STARTED.value,
@@ -264,19 +210,19 @@ def test_start_preserves_existing_run_history_when_observation_advances():
         EvaluationHistoryEventType.EVALUATION_READY.value,
     ]
 
-    repeated = evaluator.start(_scoring_plan(), advanced.snapshot)
+    repeated = evaluator.start(_evaluation_plan(), advanced.snapshot)
 
     assert repeated.success is True
-    repeated_metric = EvaluationExecutionState.from_payload(
-        repeated.snapshot.evaluation_results[metric_address]
+    repeated_objective = EvaluationExecutionState.from_payload(
+        repeated.snapshot.evaluation_results[objective_address]
     )
-    assert repeated_metric.run_id == initial_metric.run_id
-    assert repeated.snapshot.evaluation_history[metric_address] == advanced_history
+    assert repeated_objective.run_id == initial_objective.run_id
+    assert repeated.snapshot.evaluation_history[objective_address] == advanced_history
 
 
-def test_start_scores_failed_condition_as_observed_zero():
+def test_start_marks_failed_condition_and_objective_failed():
     result = AptlEvaluator().start(
-        _scoring_plan(),
+        _evaluation_plan(),
         _snapshot_with_node_status("failed"),
     )
 
@@ -288,21 +234,15 @@ def test_start_scores_failed_condition_as_observed_zero():
     condition = EvaluationExecutionState.from_payload(
         results["evaluation.condition.vm.health"]
     )
-    metric = EvaluationExecutionState.from_payload(results["evaluation.metric.uptime"])
-    evaluation = EvaluationExecutionState.from_payload(
-        results["evaluation.evaluation.overall"]
-    )
     objective = EvaluationExecutionState.from_payload(
         results["evaluation.objective.validate"]
     )
 
     assert condition.status == EvaluationResultStatus.READY
     assert condition.passed is False
-    assert metric.status == EvaluationResultStatus.READY
-    assert metric.score == 0
-    assert metric.max_score == 10
-    assert evaluation.passed is False
+    assert condition.score is None
     assert objective.passed is False
+    assert objective.score is None
 
 
 def test_start_output_is_evaluation_contract_clean():
@@ -323,26 +263,6 @@ def test_results_and_status_reflect_registered_evaluations():
     assert evaluator.results()
     assert evaluator.history()
     assert evaluator.status()["registered_evaluations"] == sorted(evaluator.results())
-
-
-def test_start_registers_paper_metric_and_tlo_resources():
-    scenario = parse_sdl_file(PROJECT_ROOT / "scenarios" / "paper-agent-loop.sdl.yaml")
-    evaluation = plan(
-        compile_runtime_model(scenario),
-        create_aptl_manifest(),
-    ).evaluation
-
-    result = AptlEvaluator().start(evaluation, RuntimeSnapshot())
-
-    assert result.success is True
-    assert (
-        "evaluation.metric.participant-evidence-complete"
-        in result.snapshot.evaluation_results
-    )
-    assert (
-        "evaluation.tlo.authored-runtime-handoff"
-        in result.snapshot.evaluation_results
-    )
 
 
 def test_start_preserves_existing_provisioning_entries():
@@ -425,6 +345,67 @@ def test_start_fails_closed_on_invalid_result_contract():
 
     assert result.success is False
     assert any(d.code == "aptl.evaluator.evaluation-contract-invalid" for d in result.diagnostics)
+
+
+def test_start_fails_closed_on_scoring_chain_resource():
+    from aces_contracts.planning import EvaluationPlan
+
+    op = _evaluation_op(
+        "evaluation.metric.uptime",
+        {
+            "name": "uptime",
+            "result_contract": {
+                "state_schema_version": "evaluation-result-state/v1",
+                "resource_type": "metric",
+                "supports_passed": False,
+                "supports_score": True,
+                "fixed_max_score": 10,
+            },
+        },
+        resource_type="metric",
+    )
+
+    result = AptlEvaluator().start(
+        EvaluationPlan(resources={}, operations=[op]),
+        RuntimeSnapshot(),
+    )
+
+    assert result.success is False
+    assert result.snapshot.evaluation_results == {}
+    assert any(
+        d.code == "aptl.evaluator.unsupported-scoring-section"
+        for d in result.diagnostics
+    )
+
+
+def test_start_fails_closed_on_score_bearing_condition_contract():
+    from aces_contracts.planning import EvaluationPlan
+
+    op = _evaluation_op(
+        "evaluation.condition.vm.health",
+        {
+            "name": "health",
+            "result_contract": {
+                "state_schema_version": "evaluation-result-state/v1",
+                "resource_type": "condition-binding",
+                "supports_passed": True,
+                "supports_score": True,
+                "fixed_max_score": 10,
+            },
+        },
+        resource_type="condition-binding",
+    )
+
+    result = AptlEvaluator().start(
+        EvaluationPlan(resources={}, operations=[op]),
+        RuntimeSnapshot(),
+    )
+
+    assert result.success is False
+    assert any(
+        d.code == "aptl.evaluator.unsupported-score-contract"
+        for d in result.diagnostics
+    )
 
 
 def test_start_handles_delete_operation():

--- a/tests/test_paper_scenario_static_gate.py
+++ b/tests/test_paper_scenario_static_gate.py
@@ -31,6 +31,17 @@ def _paper_plan():
     return model, RuntimeManager(target).plan(scenario), config
 
 
+def _assert_paper_scoring_chain_is_not_supported(plan) -> None:
+    diagnostics = {(d.code, d.address) for d in plan.diagnostics}
+    assert diagnostics == {
+        ("evaluator.unsupported-section", "evaluation.metrics"),
+        ("evaluator.unsupported-section", "evaluation.evaluations"),
+        ("evaluator.unsupported-section", "evaluation.tlos"),
+        ("evaluator.unsupported-section", "evaluation.goals"),
+        ("evaluator.scoring-unsupported", "evaluation.scoring"),
+    }
+
+
 def test_paper_scenario_compiles_with_participant_runtime_artifacts():
     model, plan, _config = _paper_plan()
 
@@ -47,14 +58,15 @@ def test_paper_scenario_compiles_with_participant_runtime_artifacts():
         "participant.observation-boundary.paper-agent-view"
         in model.observation_boundaries
     )
-    assert plan.diagnostics == []
+    _assert_paper_scoring_chain_is_not_supported(plan)
     assert not (
         PROJECT_ROOT / "src/aptl/backends/aces_paper_participant_actions.py"
     ).exists()
 
 
-def test_paper_scenario_realizes_declared_topology_and_evaluator_surfaces():
+def test_paper_scenario_realizes_declared_topology_and_supported_evaluator_surface():
     _model, plan, config = _paper_plan()
+    _assert_paper_scoring_chain_is_not_supported(plan)
 
     realization = interpret_provisioning_plan(
         plan=plan.provisioning,
@@ -84,8 +96,8 @@ def test_paper_scenario_realizes_declared_topology_and_evaluator_surfaces():
         ),
     }
     assert set(plan.evaluation.resources) >= {
-        "evaluation.metric.participant-evidence-complete",
-        "evaluation.metric.wazuh-evidence-complete",
-        "evaluation.metric.boundary-evidence-complete",
-        "evaluation.tlo.authored-runtime-handoff",
+        "evaluation.condition.red-workbench.participant-observation-recorded",
+        "evaluation.condition.red-workbench.boundary-checks-recorded",
+        "evaluation.condition.wazuh-manager.wazuh-evidence-recorded",
+        "evaluation.objective.demonstrate-handoff",
     }


### PR DESCRIPTION
## Summary

Narrow APTL's declared ACES evaluator surface after ACES ADR-073 so the runtime target supports condition/objective evaluation, not the deprecated SDL scoring chain.

## Related Issues

Closes #606

## Changes

- Declare evaluator support for `conditions` and `objectives` only, with `supports_scoring=false`.
- Fail closed when evaluation plans contain SDL scoring-chain resources (`metrics`, `evaluations`, `tlos`, `goals`) or score-bearing condition/objective contracts.
- Keep `AptlEvaluator` progression for observed condition/objective state through ACES evaluation result/history contracts.
- Update evaluator, conformance, paper scenario, and live/static gate tests for the narrowed surface.
- Update ACES docs to align #606 with ADR-073 and document the paper scenario's unsupported scoring-chain diagnostics.

## Validation

- `uv run pytest tests/test_aces_evaluator.py`
- `uv run pytest tests/test_aces_backend.py -k 'manifest or orchestration_evaluation or evaluator or conformance'`
- `uv run pytest tests/test_aces_backend.py::test_aptl_target_passes_full_remote_control_plane_conformance`
- `uv run pytest tests/test_techvault_live_gate.py -k 'run_archive_writes_manifest or run_archive_roundtrips'`
- `uv run pytest tests/test_paper_scenario_static_gate.py`
- `uv run pytest -n auto -k "not integration"`
- `uv run pytest -n auto tests/test_techvault_static_gate.py -m integration`
- `pre-commit run --all-files`

## Notes

The bare `pytest` executable is not on PATH in this shell, so the Ground Control completion check was run through the repo's `uv` environment.
