### PR TITLE
feat(aces): realize TechVault content and account placements or fail closed

### DIFF
--- a/changelog.d/+git-env-isolation.fixed.md
+++ b/changelog.d/+git-env-isolation.fixed.md
@@ -1,0 +1,1 @@
+Lab asset selection (`aptl init` materialization and the wheel build hook) now strips inherited git *location* environment variables (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, …) before running `git ls-files`, so running inside a git hook (e.g. pre-commit) can no longer make asset selection resolve to the ambient repository instead of the checkout being processed.

--- a/changelog.d/689.added.md
+++ b/changelog.d/689.added.md
@@ -1,0 +1,1 @@
+TechVault `content-placement` and `account-placement` ACES resources now lower into typed backend realization (a project-scoped named-volume seed for content, service-owned AD provisioner evidence for accounts) or fail closed with a redacted diagnostic before `aptl lab start` side effects, and the operational SDL gains a representative realizable content and account set.

--- a/docs/adrs/adr-046-dynamic-aces-scenario-realization.md
+++ b/docs/adrs/adr-046-dynamic-aces-scenario-realization.md
@@ -261,6 +261,61 @@ static IP, selected backend, and non-secret provenance rule. Persist it through
 rendered Compose overrides containing unrelated config, `.env` values, or
 secret-bearing service configuration.
 
+## TechVault Operational Standup Addendum
+
+Issue #689 makes `scenarios/techvault-operational.sdl.yaml` the honest dynamic
+TechVault startup contract. The operational SDL is the public `aptl lab start`
+target listed in `scenarios/catalog.json`; the deep captured TechVault
+inventory is review evidence, not a runtime source. The operational SDL must
+not import or depend on captured `runtime-observed:` content,
+`datasets-in-services`, inventory-only filesystem manifests, logs, database
+dumps, screenshots, or runtime state that APTL cannot recreate from source on a
+clean machine.
+
+The acceptance bar is compose-guaranteed fidelity from authored ACES resources
+through APTL's interpret-then-driver path. Nodes, images, networks,
+attachments, content placements, and account placements must compile through
+ACES, enter `interpret_provisioning_plan`, appear in typed realization details,
+and be either realized by `DeploymentRealizationSpec` / `DeploymentBackend` or
+explicitly rejected by an ACES diagnostic before side effects. A placement that
+is merely counted in `AptlRealization.details()` is not dynamic realization.
+
+Content in the honest operational SDL is limited to realizable content:
+
+- file content provided as bounded inline text;
+- file content sourced from a project-contained, checked-in path;
+- directories whose materialized contents are sourced from project-contained,
+  checked-in paths or explicit empty-directory declarations.
+
+Do not encode runtime-observed files, generated service config, mutable volume
+state, database rows, index contents, captured package manifests, or arbitrary
+container filesystem trees as operational content. If #576's content
+realization seam is present, `AptlRealization` should lower those ACES
+placements into its canonical typed backend input and the Compose backend
+should reuse existing containment and named-volume/container-copy precedents,
+including `NamedVolumeSeed`, project-scoped volumes, argv-list commands,
+redacted `LabResult` failures, and `BackendSeedError` / `BackendTimeoutError`
+behavior where applicable. If that seam is absent, #689 is blocked or must add
+a narrow typed placement operation to `DeploymentBackend`; it must not add raw
+Docker calls, a second content schema, or a scenario-name special case.
+
+Account declarations must be equally honest. Lab fixture accounts may be
+declared only when the clean startup path actually creates or preserves them
+through an existing service-owned provisioning path or a new typed backend
+account-placement operation. They must not rely on post-capture drift. Designed
+weak target credentials are scenario fixture data; operator/control-plane
+secrets remain under `EnvVars`, `.env`, rendered config, and ADR-029 redaction.
+Do not serialize Wazuh, MISP, TheHive, Shuffle, registry, SSH private key,
+cookie, token, hash, or generated enrollment material into the SDL, run
+evidence, diagnostics, or snapshots.
+
+The manifest honesty rule is strict: APTL may claim `file`, `directory`,
+`dataset`, account, image, or network support only to the extent that the ACES
+planner gate, interpreter, typed backend spec, deployment backend, static tests,
+and live clean-start gate prove that support for the authored TechVault
+surface. A broad `ProvisionerCapabilities` value is not a waiver for a
+no-op interpreter branch.
+
 ## Security Layers
 
 | Layer | Requirement |
@@ -270,8 +325,11 @@ secret-bearing service configuration.
 | Deployment boundary gate | The curated compatibility path may still drive `DeploymentBackend.start_lab` with profiles. The paper scenario drives typed `DeploymentBackend` realization methods. No ACES adapter code calls raw Docker, `docker compose`, or parses compose output directly (ADR-037). |
 | Image trust gate | Node image pull/build decisions are made from ACES `Source` / `source.build` payloads and pass an APTL image policy before backend side effects. Untrusted or insufficient image inputs fail closed through ACES diagnostics without echoing raw image refs, build args, credentials, Dockerfile text, or backend stderr. |
 | Network topology gate | Network creation, IPAM, `internal` egress policy, and per-node attachments come from typed realization specs. Backend validation parses CIDR/gateway/static IP values, preserves project scoping, labels backend-created networks, and fails closed before side effects when authored exact/constrained values cannot be honored. |
+| Content placement gate | Operational TechVault content must be bounded inline text, project-contained checked-in file source, or project-contained checked-in directory source lowered into typed backend placement input. Path containment, safe relative-path validation, project-scoped volumes/copies, and redacted backend failures reuse existing deployment and seed precedents; captured runtime content is rejected. |
+| Account placement gate | Account declarations are allowed only for clean-start-realized lab fixtures or typed backend account placements. Operator secrets, generated credentials, token material, private keys, cookies, and hashes remain outside the SDL and outside realization evidence. |
 | Config and env binding | Non-secret realization knobs bind through strict `AptlConfig`; runtime secrets stay in `EnvVars` and `.env`. The realization record stores digests and non-secret identities, never `.env` values, rendered config, tokens, or key material. |
 | Persistence and redaction | Realization details, selected profiles for compatibility scenarios, typed realization specs for dynamic scenarios, and evaluator-only evidence enter JSON through `LocalRunStore` and `RangeSnapshot.to_dict()`, inheriting ADR-029 redaction and path-containment checks. |
+| Static and live validation gate | Static tests prove the SDL parses, plans, and lowers to a realizable typed spec without unsupported or no-op placements. The live gate remains a clean `aptl lab stop -v && aptl lab start` with health/readiness checks, not a comparison to captured inventory state. |
 
 ## Maintainability
 
@@ -290,9 +348,14 @@ The canonical incumbents this decision builds on are:
 - `src/aptl/core/deployment/` for every Docker, Compose, container, and host
   operation, including any future image pull/build/tag and network/IPAM side
   effects.
+- `src/aptl/core/seed_spec.py` and existing named-volume seed behavior for
+  project-contained source-to-runtime materialization when content placement
+  needs file or directory side effects.
 - `src/aptl/core/runstore.py`, `src/aptl/core/snapshot.py`,
   `src/aptl/core/config.py`, and `src/aptl/core/env.py` for run persistence,
   inventory evidence, config, and env binding.
+- `scenarios/techvault-operational.sdl.yaml` and `scenarios/catalog.json` for
+  the public TechVault ACES startup selection.
 
 Tests extend the existing ACES backend and realization seams
 (`tests/test_aces_backend.py` and the realization-focused tests) rather than
@@ -329,6 +392,13 @@ change is multi-architecture images, registry authentication, SBOM/attestation
 checks, or another backend provider. Those should add policy fields or typed
 backend parameters, not scenario branches or Compose-service rewrites.
 
+For content and account realization, the seam is a typed placement record:
+ACES placement address, target node/service/container, content or account
+identity, non-secret provenance, bounded source kind, destination kind, and the
+backend materialization operation. Future scenarios should be able to vary
+which checked-in source directory, inline file, target node, account fixture,
+or provider backend is used without editing TechVault-only code.
+
 ## Consequences
 
 ### Positive
@@ -348,6 +418,9 @@ backend parameters, not scenario branches or Compose-service rewrites.
 - APTL's realization support declaration must stay honest. Widening the claimed
   realization support without the interpreter and driver to back it would let
   the planner gate pass scenarios APTL cannot actually realize.
+- The honest TechVault SDL may be smaller than the captured inventory. Omitting
+  non-realizable captured facts is correct; carrying them as no-op operational
+  placements is not.
 
 ### Risks
 
@@ -355,6 +428,9 @@ backend parameters, not scenario branches or Compose-service rewrites.
   diagnostic-not-failure choice keeps the apply running, so the operator must
   read realization diagnostics rather than assume a clean apply realized every
   authored concern.
+- Manifest capability text can drift ahead of backend behavior. The static
+  lowering tests and clean-start live gate must catch claims that are parsed
+  and counted but never passed to a typed backend operation.
 
 ## Non-Goals
 
@@ -364,6 +440,9 @@ backend parameters, not scenario branches or Compose-service rewrites.
   mirror model. Realization evidence rides ADR-044's record.
 - This ADR does not change APTL's backend profile claim. The manifest and
   conformance gates remain the source of truth for that claim.
+- This ADR does not require the operational TechVault SDL to reproduce every
+  captured inventory fact. It requires every authored operational fact to be
+  dynamically realizable or rejected before startup side effects.
 
 ## Anti-Patterns
 
@@ -385,6 +464,16 @@ backend parameters, not scenario branches or Compose-service rewrites.
 - Building from raw Docker history strings, unbounded Dockerfile text, or
   unvalidated build context paths instead of typed `source.build` provenance and
   project-contained backend operations.
+- Adding `runtime-observed:` content, `datasets-in-services`, database dumps,
+  log excerpts, package manifests, or arbitrary captured filesystem trees to
+  the operational TechVault SDL.
+- Treating `content-placement` or `account-placement` resource counts as proof
+  of realization when no typed backend operation consumes the placement.
+- Hiding an unrealizable content/account fact in `metadata`, comments,
+  `x-aptl-*`, inventory ledger rows, or a TechVault scenario-name branch.
+- Duplicating the content schema, account schema, path-containment checks,
+  volume seed behavior, credential taxonomy, or redaction policy instead of
+  reusing the existing ACES/APTL owners.
 - Echoing disallowed image refs, registry credentials, build arg values,
   rendered Dockerfile text, or backend stderr in diagnostics, logs, snapshots,
   API responses, or run records.
@@ -415,6 +504,10 @@ backend parameters, not scenario branches or Compose-service rewrites.
 - Related issues: [#554](https://github.com/Brad-Edwards/aptl/issues/554),
   [#556](https://github.com/Brad-Edwards/aptl/issues/556) (superseded paper
   scenario path), [#573](https://github.com/Brad-Edwards/aptl/issues/573),
+  [#574](https://github.com/Brad-Edwards/aptl/issues/574),
+  [#575](https://github.com/Brad-Edwards/aptl/issues/575),
+  [#576](https://github.com/Brad-Edwards/aptl/issues/576),
+  [#689](https://github.com/Brad-Edwards/aptl/issues/689),
   [aces#598](https://github.com/Brad-Edwards/aces/issues/598), and
   [aces#600](https://github.com/Brad-Edwards/aces/issues/600); DSL-008 /
   [#422](https://github.com/Brad-Edwards/aptl/issues/422).

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -23,6 +23,7 @@ itself only contains tracked files, so walking it yields the same set.
 from __future__ import annotations
 
 import importlib.util
+import os
 import shutil
 import subprocess
 import tempfile
@@ -56,6 +57,23 @@ _LABDATA_PREFIX: str = _MANIFEST.LABDATA_PREFIX
 _EXCLUDED_DIR_NAMES: frozenset[str] = _MANIFEST.EXCLUDED_DIR_NAMES
 _EXCLUDED_SUFFIXES: tuple[str, ...] = _MANIFEST.EXCLUDED_SUFFIXES
 _DISTRIBUTION_MARKER: str = _MANIFEST.DISTRIBUTION_MARKER
+
+# Git env vars that redirect where git resolves the repo/worktree/index. A
+# build or pre-commit hook exports these pointing at the real repo; stripped
+# below so ``git ls-files`` selection stays scoped to the tree being built
+# rather than resolving to the ambient repo.
+_GIT_LOCATION_ENV = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_PREFIX",
+        "GIT_NAMESPACE",
+    }
+)
 
 
 class CustomBuildHook(BuildHookInterface):
@@ -117,13 +135,20 @@ class CustomBuildHook(BuildHookInterface):
 
     @staticmethod
     def _git_tracked(root: Path) -> list[Path] | None:
-        """Return tracked asset files, or ``None`` when git is unavailable."""
+        """Return tracked asset files, or ``None`` when git is unavailable.
+
+        Strips the inherited git *location* environment so a build running
+        inside a git hook cannot make ``git ls-files`` resolve to the ambient
+        repo instead of ``root``.
+        """
+        env = {k: v for k, v in os.environ.items() if k not in _GIT_LOCATION_ENV}
         try:
             completed = subprocess.run(
                 ["git", "ls-files", "-z", "--", *_ASSET_ROOTS],
                 cwd=root,
                 capture_output=True,
                 check=True,
+                env=env,
             )
         except (OSError, subprocess.CalledProcessError):
             return None

--- a/scenarios/fixtures/techvault-content/onboarding/it-setup.md
+++ b/scenarios/fixtures/techvault-content/onboarding/it-setup.md
@@ -1,0 +1,10 @@
+# IT Setup Checklist
+
+1. Collect your laptop from IT and confirm it joins the `TECHVAULT` domain.
+2. Set up VPN access through the IT-Admins onboarding form.
+3. Review the acceptable-use policy on the company wiki.
+4. Report any suspicious email to security@techvault.local.
+
+This file is checked-in fixture content realized onto the file share via
+the ACES content-placement path (issue #689); it is not runtime-observed
+or generated state.

--- a/scenarios/fixtures/techvault-content/onboarding/welcome.md
+++ b/scenarios/fixtures/techvault-content/onboarding/welcome.md
@@ -1,0 +1,9 @@
+# Welcome to TechVault Solutions
+
+This onboarding packet is planted on the company file share as part of the
+TechVault range's dynamically realized content set (issue #689). It is
+checked-in, non-sensitive fixture content: a project-contained source that
+`aptl lab start` copies onto the `fileshare` node's shared drive at range
+start, proving the content-placement realization path end-to-end.
+
+Contact IT at it-support@techvault.local for account setup help.

--- a/scenarios/techvault-operational.sdl.yaml
+++ b/scenarios/techvault-operational.sdl.yaml
@@ -292,3 +292,61 @@ vulnerabilities:
     description: Login form accepts intentionally vulnerable SQL input.
     technical: true
     class: CWE-89
+
+# Realizable content (ADR-046 TechVault Operational Standup Addendum,
+# issue #689): every entry here is either bounded inline text or a
+# project-contained, checked-in source. No runtime-observed:, dataset, or
+# captured-filesystem content is authored here — that captured inventory
+# lives in scenarios/techvault.sdl.yaml (review evidence, not a runtime
+# source). Both entries land on the `fileshare` node, whose Compose
+# service mounts the `fileshare_data` named volume the APTL content
+# realization backend seeds at `aptl lab start`.
+content:
+  fileshare-public-notice:
+    type: file
+    target: fileshare
+    path: public/notice.txt
+    text: |
+      Welcome to TechVault Solutions file server.
+      This notice is planted by the operational ACES scenario's
+      content-placement realization (issue #689) — dynamically realized
+      from inline text authored in techvault-operational.sdl.yaml, not
+      hand-copied onto the image.
+  fileshare-onboarding-packet:
+    type: directory
+    target: fileshare
+    destination: onboarding
+    source:
+      name: scenarios/fixtures/techvault-content/onboarding
+
+# Realizable accounts (same addendum): every username here is created by
+# containers/ad/provision-users.sh, which already runs unconditionally as
+# part of the `ad` container's entrypoint — no new secret-bearing backend
+# path. Declares identity only (no password material); the concrete
+# credential stays owned by the provisioner script. This is a
+# representative subset of the full weak/Kerberoastable/over-privileged
+# roster the provisioner creates, proving the account-placement
+# realization path against real, clean-start-created accounts.
+accounts:
+  ad-jessica-williams:
+    username: jessica.williams
+    node: ad
+    groups: [Sales, VPN-Users]
+    password_strength: weak
+    mail: jessica.williams@techvault.local
+  ad-svc-sql:
+    username: svc-sql
+    node: ad
+    password_strength: weak
+    spn: MSSQLSvc/db.techvault.local:1433
+  ad-emily-chen:
+    username: emily.chen
+    node: ad
+    groups: [Engineering, IT-Admins, "Domain Admins"]
+    password_strength: medium
+    mail: emily.chen@techvault.local
+  ad-former-employee:
+    username: former.employee
+    node: ad
+    password_strength: weak
+    disabled: false

--- a/src/aptl/backends/aces_account_realization.py
+++ b/src/aptl/backends/aces_account_realization.py
@@ -46,26 +46,44 @@ def resolve_account_placement(
     """Lower one account-placement resource or return fail-closed diagnostics."""
 
     spec = _placement_spec(payload)
+    username = _optional_string(spec, "username") if spec is not None else None
+    reason = _account_placement_rejection(spec, username, target_service)
+
+    account: DeploymentAccountRealization | None = None
+    diagnostics: list[Diagnostic] = []
+    if reason is not None:
+        diagnostics = [_reject(resource.address, reason)]
+    else:
+        account = DeploymentAccountRealization(
+            address=resource.address,
+            target_address=target_address,
+            username=username,
+            groups=_account_groups(spec),
+            spn=_optional_string(spec, "spn") or "",
+            mail=_optional_string(spec, "mail") or "",
+            disabled=bool(_optional_bool(spec, "disabled")),
+        )
+    return account, diagnostics
+
+
+def _account_placement_rejection(
+    spec: Mapping[str, Any] | None,
+    username: str | None,
+    target_service: str | None,
+) -> str | None:
+    """Return the first fail-closed rejection reason for an account placement.
+
+    None means the placement passed every policy check.
+    """
+
+    reason = None
     if spec is None:
-        return None, [_reject(resource.address, "invalid-account-spec")]
-
-    username = _optional_string(spec, "username")
-    if username is None:
-        return None, [_reject(resource.address, "account-missing-username")]
-
-    if target_service is None or target_service not in _ACCOUNT_PROVISIONER_SERVICES:
-        return None, [_reject(resource.address, "no-account-provisioner-for-target")]
-
-    account = DeploymentAccountRealization(
-        address=resource.address,
-        target_address=target_address,
-        username=username,
-        groups=_account_groups(spec),
-        spn=_optional_string(spec, "spn") or "",
-        mail=_optional_string(spec, "mail") or "",
-        disabled=bool(_optional_bool(spec, "disabled")),
-    )
-    return account, []
+        reason = "invalid-account-spec"
+    elif username is None:
+        reason = "account-missing-username"
+    elif target_service is None or target_service not in _ACCOUNT_PROVISIONER_SERVICES:
+        reason = "no-account-provisioner-for-target"
+    return reason
 
 
 def _reject(address: str, reason_code: str) -> Diagnostic:

--- a/src/aptl/backends/aces_account_realization.py
+++ b/src/aptl/backends/aces_account_realization.py
@@ -1,0 +1,81 @@
+"""Resolve ACES account-placement payloads into deployment account evidence.
+
+Issue #689 / ADR-046's TechVault addendum: an `account-placement` resource
+must lower into typed realization evidence (:class:`DeploymentAccountRealization`)
+or fail closed with an error diagnostic. Unlike content, accounts carry no
+secret material and need no new backend operation — the concrete credential
+stays owned by the target node's service-owned provisioner
+(``containers/ad/provision-users.sh``, which already runs unconditionally as
+part of the `ad` container's entrypoint). Realization here is a narrow,
+honest claim: the declared account's target node resolves to a backend
+service APTL knows actually provisions accounts. A placement that targets
+any other node is unrealizable and fails closed before the account is
+recorded as realized.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import PlannedResource
+
+from aptl.backends.aces_diagnostics import diagnostic
+from aptl.backends.aces_realization_values import (
+    account_groups as _account_groups,
+    optional_bool as _optional_bool,
+    optional_string as _optional_string,
+    placement_spec as _placement_spec,
+)
+from aptl.core.deployment.realization import DeploymentAccountRealization
+
+# Backend services with an existing service-owned account provisioner.
+# Adding a new account-capable service is one new entry here, not a
+# scenario-name branch (ADR-046 §Extensibility).
+_ACCOUNT_PROVISIONER_SERVICES = frozenset({"ad"})
+
+
+def resolve_account_placement(
+    *,
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+    target_address: str,
+    target_service: str | None,
+) -> tuple[DeploymentAccountRealization | None, list[Diagnostic]]:
+    """Lower one account-placement resource or return fail-closed diagnostics."""
+
+    spec = _placement_spec(payload)
+    if spec is None:
+        return None, [_reject(resource.address, "invalid-account-spec")]
+
+    username = _optional_string(spec, "username")
+    if username is None:
+        return None, [_reject(resource.address, "account-missing-username")]
+
+    if target_service is None or target_service not in _ACCOUNT_PROVISIONER_SERVICES:
+        return None, [_reject(resource.address, "no-account-provisioner-for-target")]
+
+    account = DeploymentAccountRealization(
+        address=resource.address,
+        target_address=target_address,
+        username=username,
+        groups=_account_groups(spec),
+        spn=_optional_string(spec, "spn") or "",
+        mail=_optional_string(spec, "mail") or "",
+        disabled=bool(_optional_bool(spec, "disabled")),
+    )
+    return account, []
+
+
+def _reject(address: str, reason_code: str) -> Diagnostic:
+    """Build a fail-closed account realization diagnostic."""
+
+    return diagnostic(
+        "aptl.provisioner.account-placement-rejected",
+        address,
+        (
+            "ACES account placement was rejected by the APTL account "
+            f"realization policy (reason={reason_code})."
+        ),
+    )

--- a/src/aptl/backends/aces_content_realization.py
+++ b/src/aptl/backends/aces_content_realization.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -60,6 +61,15 @@ _RUNTIME_OBSERVED_PREFIX = "runtime-observed:"
 _SAFE_DEST_RELPATH = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
 
 
+@dataclass(frozen=True)
+class _ContentPlacementInputs(object):
+    """Validated content-placement fields ready for file/directory dispatch."""
+
+    content_type: str
+    source_name: str | None
+    volume_suffix: str
+
+
 def resolve_content_placement(
     *,
     resource: PlannedResource,
@@ -71,52 +81,72 @@ def resolve_content_placement(
     """Lower one content-placement resource or return fail-closed diagnostics."""
 
     spec = _placement_spec(payload)
-    if spec is None:
-        return None, [_reject(resource.address, "invalid-content-spec")]
-
     content_name = (
         _optional_string(payload, "content_name")
         or _optional_string(payload, "name")
         or resource.address
     )
+    inputs, reason = _content_placement_inputs(spec, target_service)
 
-    content_type = spec.get("type")
-    if content_type == "dataset":
-        return None, [_reject(resource.address, "dataset-not-realizable")]
-    if content_type not in ("file", "directory"):
-        return None, [_reject(resource.address, "unknown-content-type")]
-
-    source_name = _content_source_name(spec)
-    if source_name is not None and source_name.startswith(_RUNTIME_OBSERVED_PREFIX):
-        return None, [_reject(resource.address, "runtime-observed-source")]
-
-    volume_suffix = (
-        _CONTENT_REALIZABLE_SERVICES.get(target_service)
-        if target_service is not None
-        else None
-    )
-    if volume_suffix is None:
-        return None, [_reject(resource.address, "destination-without-backing-mount")]
-
-    if content_type == "file":
-        return _resolve_file_content(
+    content: DeploymentContentRealization | None = None
+    diagnostics: list[Diagnostic] = []
+    if inputs is None:
+        diagnostics = [_reject(resource.address, reason)]
+    else:
+        resolver = (
+            _resolve_file_content
+            if inputs.content_type == "file"
+            else _resolve_directory_content
+        )
+        content, diagnostics = resolver(
             resource=resource,
             spec=spec,
             content_name=content_name,
             target_address=target_address,
-            source_name=source_name,
-            volume_suffix=volume_suffix,
+            source_name=inputs.source_name,
+            volume_suffix=inputs.volume_suffix,
             project_dir=project_dir,
         )
-    return _resolve_directory_content(
-        resource=resource,
-        spec=spec,
-        content_name=content_name,
-        target_address=target_address,
-        source_name=source_name,
-        volume_suffix=volume_suffix,
-        project_dir=project_dir,
-    )
+    return content, diagnostics
+
+
+def _content_placement_inputs(
+    spec: Mapping[str, Any] | None,
+    target_service: str | None,
+) -> tuple[_ContentPlacementInputs | None, str | None]:
+    """Validate content-placement type/source/target fields for dispatch.
+
+    Returns the validated fields on success, or the fail-closed rejection
+    reason (with no fields) on the first policy violation.
+    """
+
+    inputs = None
+    reason = None
+    if spec is None:
+        reason = "invalid-content-spec"
+    else:
+        content_type = spec.get("type")
+        source_name = _content_source_name(spec)
+        volume_suffix = (
+            _CONTENT_REALIZABLE_SERVICES.get(target_service)
+            if target_service is not None
+            else None
+        )
+        if content_type == "dataset":
+            reason = "dataset-not-realizable"
+        elif content_type not in ("file", "directory"):
+            reason = "unknown-content-type"
+        elif source_name is not None and source_name.startswith(_RUNTIME_OBSERVED_PREFIX):
+            reason = "runtime-observed-source"
+        elif volume_suffix is None:
+            reason = "destination-without-backing-mount"
+        else:
+            inputs = _ContentPlacementInputs(
+                content_type=content_type,
+                source_name=source_name,
+                volume_suffix=volume_suffix,
+            )
+    return inputs, reason
 
 
 def _resolve_file_content(
@@ -132,43 +162,72 @@ def _resolve_file_content(
     """Lower a `type: file` content spec."""
 
     dest_relpath = _optional_string(spec, "path")
+    content: DeploymentContentRealization | None = None
+    diagnostics: list[Diagnostic] = []
     if dest_relpath is None or not _safe_dest_relpath(dest_relpath):
-        return None, [_reject(resource.address, "unsafe-destination-path")]
+        diagnostics = [_reject(resource.address, "unsafe-destination-path")]
+    else:
+        text = _content_text(spec)
+        if text is not None:
+            content = DeploymentContentRealization(
+                address=resource.address,
+                target_address=target_address,
+                content_name=content_name,
+                volume_suffix=volume_suffix,
+                dest_relpath=dest_relpath,
+                source_kind="inline-text",
+                inline_text=text,
+                sensitive=_is_sensitive(spec),
+            )
+        else:
+            content, diagnostics = _resolve_file_content_from_source(
+                resource=resource,
+                content_name=content_name,
+                target_address=target_address,
+                dest_relpath=dest_relpath,
+                source_name=source_name,
+                volume_suffix=volume_suffix,
+                project_dir=project_dir,
+                sensitive=_is_sensitive(spec),
+            )
+    return content, diagnostics
 
-    text = _content_text(spec)
-    if text is not None:
-        content = DeploymentContentRealization(
-            address=resource.address,
-            target_address=target_address,
-            content_name=content_name,
-            volume_suffix=volume_suffix,
-            dest_relpath=dest_relpath,
-            source_kind="inline-text",
-            inline_text=text,
-            sensitive=_is_sensitive(spec),
-        )
-        return content, []
 
+def _resolve_file_content_from_source(
+    *,
+    resource: PlannedResource,
+    content_name: str,
+    target_address: str,
+    dest_relpath: str,
+    source_name: str | None,
+    volume_suffix: str,
+    project_dir: Path,
+    sensitive: bool,
+) -> tuple[DeploymentContentRealization | None, list[Diagnostic]]:
+    """Resolve a project-sourced `type: file` content spec (no inline text)."""
+
+    content: DeploymentContentRealization | None = None
     if source_name is None:
-        return None, [_reject(resource.address, "file-content-missing-source")]
-
-    resolved, diagnostics = _resolve_project_source(resource.address, source_name, project_dir)
-    if resolved is None:
-        return None, diagnostics
-    if not resolved.is_file():
-        return None, [_reject(resource.address, "source-file-missing")]
-
-    content = DeploymentContentRealization(
-        address=resource.address,
-        target_address=target_address,
-        content_name=content_name,
-        volume_suffix=volume_suffix,
-        dest_relpath=dest_relpath,
-        source_kind="project-file",
-        source_relpath=source_name,
-        sensitive=_is_sensitive(spec),
-    )
-    return content, []
+        diagnostics = [_reject(resource.address, "file-content-missing-source")]
+    else:
+        resolved, diagnostics = _resolve_project_source(
+            resource.address, source_name, project_dir
+        )
+        if resolved is not None:
+            if not resolved.is_file():
+                diagnostics = [_reject(resource.address, "source-file-missing")]
+            else:
+                content = DeploymentContentRealization(
+                    address=resource.address,
+                    target_address=target_address,
+                    content_name=content_name,
+                    volume_suffix=volume_suffix,
+                    dest_relpath=dest_relpath,
+                    source_kind="project-file",
+                    source_relpath=source_name,
+                    sensitive=sensitive,
+                )
+    return content, diagnostics
 
 
 def _resolve_directory_content(
@@ -184,10 +243,11 @@ def _resolve_directory_content(
     """Lower a `type: directory` content spec."""
 
     dest_relpath = _optional_string(spec, "destination")
+    content: DeploymentContentRealization | None = None
+    diagnostics: list[Diagnostic] = []
     if dest_relpath is None or not _safe_dest_relpath(dest_relpath):
-        return None, [_reject(resource.address, "unsafe-destination-path")]
-
-    if source_name is None:
+        diagnostics = [_reject(resource.address, "unsafe-destination-path")]
+    elif source_name is None:
         content = DeploymentContentRealization(
             address=resource.address,
             target_address=target_address,
@@ -197,25 +257,50 @@ def _resolve_directory_content(
             source_kind="empty-directory",
             sensitive=_is_sensitive(spec),
         )
-        return content, []
+    else:
+        content, diagnostics = _resolve_directory_content_from_source(
+            resource=resource,
+            content_name=content_name,
+            target_address=target_address,
+            dest_relpath=dest_relpath,
+            source_name=source_name,
+            volume_suffix=volume_suffix,
+            project_dir=project_dir,
+            sensitive=_is_sensitive(spec),
+        )
+    return content, diagnostics
 
+
+def _resolve_directory_content_from_source(
+    *,
+    resource: PlannedResource,
+    content_name: str,
+    target_address: str,
+    dest_relpath: str,
+    source_name: str,
+    volume_suffix: str,
+    project_dir: Path,
+    sensitive: bool,
+) -> tuple[DeploymentContentRealization | None, list[Diagnostic]]:
+    """Resolve a project-sourced `type: directory` content spec."""
+
+    content: DeploymentContentRealization | None = None
     resolved, diagnostics = _resolve_project_source(resource.address, source_name, project_dir)
-    if resolved is None:
-        return None, diagnostics
-    if not resolved.is_dir():
-        return None, [_reject(resource.address, "source-directory-missing")]
-
-    content = DeploymentContentRealization(
-        address=resource.address,
-        target_address=target_address,
-        content_name=content_name,
-        volume_suffix=volume_suffix,
-        dest_relpath=dest_relpath,
-        source_kind="project-directory",
-        source_relpath=source_name,
-        sensitive=_is_sensitive(spec),
-    )
-    return content, []
+    if resolved is not None:
+        if not resolved.is_dir():
+            diagnostics = [_reject(resource.address, "source-directory-missing")]
+        else:
+            content = DeploymentContentRealization(
+                address=resource.address,
+                target_address=target_address,
+                content_name=content_name,
+                volume_suffix=volume_suffix,
+                dest_relpath=dest_relpath,
+                source_kind="project-directory",
+                source_relpath=source_name,
+                sensitive=sensitive,
+            )
+    return content, diagnostics
 
 
 def _resolve_project_source(

--- a/src/aptl/backends/aces_content_realization.py
+++ b/src/aptl/backends/aces_content_realization.py
@@ -70,6 +70,17 @@ class _ContentPlacementInputs(object):
     volume_suffix: str
 
 
+@dataclass(frozen=True)
+class _ContentPlacement(object):
+    """Placement-identity fields shared by a resolved content realization."""
+
+    content_name: str
+    target_address: str
+    dest_relpath: str
+    volume_suffix: str
+    sensitive: bool
+
+
 def resolve_content_placement(
     *,
     resource: PlannedResource,
@@ -182,13 +193,15 @@ def _resolve_file_content(
         else:
             content, diagnostics = _resolve_file_content_from_source(
                 resource=resource,
-                content_name=content_name,
-                target_address=target_address,
-                dest_relpath=dest_relpath,
+                placement=_ContentPlacement(
+                    content_name=content_name,
+                    target_address=target_address,
+                    dest_relpath=dest_relpath,
+                    volume_suffix=volume_suffix,
+                    sensitive=_is_sensitive(spec),
+                ),
                 source_name=source_name,
-                volume_suffix=volume_suffix,
                 project_dir=project_dir,
-                sensitive=_is_sensitive(spec),
             )
     return content, diagnostics
 
@@ -196,13 +209,9 @@ def _resolve_file_content(
 def _resolve_file_content_from_source(
     *,
     resource: PlannedResource,
-    content_name: str,
-    target_address: str,
-    dest_relpath: str,
+    placement: _ContentPlacement,
     source_name: str | None,
-    volume_suffix: str,
     project_dir: Path,
-    sensitive: bool,
 ) -> tuple[DeploymentContentRealization | None, list[Diagnostic]]:
     """Resolve a project-sourced `type: file` content spec (no inline text)."""
 
@@ -219,13 +228,13 @@ def _resolve_file_content_from_source(
             else:
                 content = DeploymentContentRealization(
                     address=resource.address,
-                    target_address=target_address,
-                    content_name=content_name,
-                    volume_suffix=volume_suffix,
-                    dest_relpath=dest_relpath,
+                    target_address=placement.target_address,
+                    content_name=placement.content_name,
+                    volume_suffix=placement.volume_suffix,
+                    dest_relpath=placement.dest_relpath,
                     source_kind="project-file",
                     source_relpath=source_name,
-                    sensitive=sensitive,
+                    sensitive=placement.sensitive,
                 )
     return content, diagnostics
 
@@ -260,13 +269,15 @@ def _resolve_directory_content(
     else:
         content, diagnostics = _resolve_directory_content_from_source(
             resource=resource,
-            content_name=content_name,
-            target_address=target_address,
-            dest_relpath=dest_relpath,
+            placement=_ContentPlacement(
+                content_name=content_name,
+                target_address=target_address,
+                dest_relpath=dest_relpath,
+                volume_suffix=volume_suffix,
+                sensitive=_is_sensitive(spec),
+            ),
             source_name=source_name,
-            volume_suffix=volume_suffix,
             project_dir=project_dir,
-            sensitive=_is_sensitive(spec),
         )
     return content, diagnostics
 
@@ -274,13 +285,9 @@ def _resolve_directory_content(
 def _resolve_directory_content_from_source(
     *,
     resource: PlannedResource,
-    content_name: str,
-    target_address: str,
-    dest_relpath: str,
+    placement: _ContentPlacement,
     source_name: str,
-    volume_suffix: str,
     project_dir: Path,
-    sensitive: bool,
 ) -> tuple[DeploymentContentRealization | None, list[Diagnostic]]:
     """Resolve a project-sourced `type: directory` content spec."""
 
@@ -292,13 +299,13 @@ def _resolve_directory_content_from_source(
         else:
             content = DeploymentContentRealization(
                 address=resource.address,
-                target_address=target_address,
-                content_name=content_name,
-                volume_suffix=volume_suffix,
-                dest_relpath=dest_relpath,
+                target_address=placement.target_address,
+                content_name=placement.content_name,
+                volume_suffix=placement.volume_suffix,
+                dest_relpath=placement.dest_relpath,
                 source_kind="project-directory",
                 source_relpath=source_name,
-                sensitive=sensitive,
+                sensitive=placement.sensitive,
             )
     return content, diagnostics
 

--- a/src/aptl/backends/aces_content_realization.py
+++ b/src/aptl/backends/aces_content_realization.py
@@ -1,0 +1,259 @@
+"""Resolve ACES content-placement payloads into deployment content operations.
+
+Issue #689 / ADR-046's TechVault addendum: a `content-placement` resource
+must lower into typed backend realization (:class:`DeploymentContentRealization`)
+or fail closed with an error diagnostic before any `aptl lab start` side
+effect. Mirrors the worked pattern in `aces_image_realization.py`: parse,
+apply a narrow policy, and lower one resource, emitting redacted diagnostics
+rather than silently counting an unrealizable placement.
+
+Realizable content (ADR-046):
+
+- a bounded inline-text file (``text`` set, no ``source``);
+- a file/directory sourced from a project-contained, checked-in path
+  (``source.name`` is a project-relative path that resolves inside the
+  project root and exists);
+- an explicit empty-directory declaration (``type: directory`` with no
+  ``source``).
+
+Unrealizable content (error diagnostic, no side effects):
+
+- ``type: dataset`` (never dynamically realizable — CyRIS-style dataset
+  content has no bounded, portable materialization contract);
+- any ``source.name`` prefixed ``runtime-observed:`` (captured-but-not-
+  recreatable content per the ADR's TechVault Operational Standup Addendum);
+- a ``source.name`` that resolves outside the project root;
+- a destination whose target node has no registered content-capable
+  backend service / project-scoped volume.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import PlannedResource
+
+from aptl.backends.aces_diagnostics import diagnostic
+from aptl.backends.aces_realization_values import (
+    content_source_name as _content_source_name,
+    content_text as _content_text,
+    optional_string as _optional_string,
+    placement_spec as _placement_spec,
+)
+from aptl.core.credentials import PathContainmentError, _resolve_within_project
+from aptl.core.deployment.realization import DeploymentContentRealization
+
+# Backend services APTL knows how to plant content into, and the
+# project-scoped named-volume key (docker-compose.yml `volumes:` key,
+# unprefixed — Compose project-scopes it) that backs each one. Adding a
+# new content-capable service is one new entry here, not a scenario-name
+# branch (ADR-046 §Extensibility).
+_CONTENT_REALIZABLE_SERVICES: dict[str, str] = {
+    "fileshare": "fileshare_data",
+}
+
+_RUNTIME_OBSERVED_PREFIX = "runtime-observed:"
+_SAFE_DEST_RELPATH = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+
+
+def resolve_content_placement(
+    *,
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+    target_address: str,
+    target_service: str | None,
+    project_dir: Path,
+) -> tuple[DeploymentContentRealization | None, list[Diagnostic]]:
+    """Lower one content-placement resource or return fail-closed diagnostics."""
+
+    spec = _placement_spec(payload)
+    if spec is None:
+        return None, [_reject(resource.address, "invalid-content-spec")]
+
+    content_name = (
+        _optional_string(payload, "content_name")
+        or _optional_string(payload, "name")
+        or resource.address
+    )
+
+    content_type = spec.get("type")
+    if content_type == "dataset":
+        return None, [_reject(resource.address, "dataset-not-realizable")]
+    if content_type not in ("file", "directory"):
+        return None, [_reject(resource.address, "unknown-content-type")]
+
+    source_name = _content_source_name(spec)
+    if source_name is not None and source_name.startswith(_RUNTIME_OBSERVED_PREFIX):
+        return None, [_reject(resource.address, "runtime-observed-source")]
+
+    volume_suffix = (
+        _CONTENT_REALIZABLE_SERVICES.get(target_service)
+        if target_service is not None
+        else None
+    )
+    if volume_suffix is None:
+        return None, [_reject(resource.address, "destination-without-backing-mount")]
+
+    if content_type == "file":
+        return _resolve_file_content(
+            resource=resource,
+            spec=spec,
+            content_name=content_name,
+            target_address=target_address,
+            source_name=source_name,
+            volume_suffix=volume_suffix,
+            project_dir=project_dir,
+        )
+    return _resolve_directory_content(
+        resource=resource,
+        spec=spec,
+        content_name=content_name,
+        target_address=target_address,
+        source_name=source_name,
+        volume_suffix=volume_suffix,
+        project_dir=project_dir,
+    )
+
+
+def _resolve_file_content(
+    *,
+    resource: PlannedResource,
+    spec: Mapping[str, Any],
+    content_name: str,
+    target_address: str,
+    source_name: str | None,
+    volume_suffix: str,
+    project_dir: Path,
+) -> tuple[DeploymentContentRealization | None, list[Diagnostic]]:
+    """Lower a `type: file` content spec."""
+
+    dest_relpath = _optional_string(spec, "path")
+    if dest_relpath is None or not _safe_dest_relpath(dest_relpath):
+        return None, [_reject(resource.address, "unsafe-destination-path")]
+
+    text = _content_text(spec)
+    if text is not None:
+        content = DeploymentContentRealization(
+            address=resource.address,
+            target_address=target_address,
+            content_name=content_name,
+            volume_suffix=volume_suffix,
+            dest_relpath=dest_relpath,
+            source_kind="inline-text",
+            inline_text=text,
+            sensitive=_is_sensitive(spec),
+        )
+        return content, []
+
+    if source_name is None:
+        return None, [_reject(resource.address, "file-content-missing-source")]
+
+    resolved, diagnostics = _resolve_project_source(resource.address, source_name, project_dir)
+    if resolved is None:
+        return None, diagnostics
+    if not resolved.is_file():
+        return None, [_reject(resource.address, "source-file-missing")]
+
+    content = DeploymentContentRealization(
+        address=resource.address,
+        target_address=target_address,
+        content_name=content_name,
+        volume_suffix=volume_suffix,
+        dest_relpath=dest_relpath,
+        source_kind="project-file",
+        source_relpath=source_name,
+        sensitive=_is_sensitive(spec),
+    )
+    return content, []
+
+
+def _resolve_directory_content(
+    *,
+    resource: PlannedResource,
+    spec: Mapping[str, Any],
+    content_name: str,
+    target_address: str,
+    source_name: str | None,
+    volume_suffix: str,
+    project_dir: Path,
+) -> tuple[DeploymentContentRealization | None, list[Diagnostic]]:
+    """Lower a `type: directory` content spec."""
+
+    dest_relpath = _optional_string(spec, "destination")
+    if dest_relpath is None or not _safe_dest_relpath(dest_relpath):
+        return None, [_reject(resource.address, "unsafe-destination-path")]
+
+    if source_name is None:
+        content = DeploymentContentRealization(
+            address=resource.address,
+            target_address=target_address,
+            content_name=content_name,
+            volume_suffix=volume_suffix,
+            dest_relpath=dest_relpath,
+            source_kind="empty-directory",
+            sensitive=_is_sensitive(spec),
+        )
+        return content, []
+
+    resolved, diagnostics = _resolve_project_source(resource.address, source_name, project_dir)
+    if resolved is None:
+        return None, diagnostics
+    if not resolved.is_dir():
+        return None, [_reject(resource.address, "source-directory-missing")]
+
+    content = DeploymentContentRealization(
+        address=resource.address,
+        target_address=target_address,
+        content_name=content_name,
+        volume_suffix=volume_suffix,
+        dest_relpath=dest_relpath,
+        source_kind="project-directory",
+        source_relpath=source_name,
+        sensitive=_is_sensitive(spec),
+    )
+    return content, []
+
+
+def _resolve_project_source(
+    address: str, source_name: str, project_dir: Path
+) -> tuple[Path | None, list[Diagnostic]]:
+    """Resolve a checked-in source path, failing closed on containment escape."""
+
+    try:
+        resolved = _resolve_within_project(project_dir, Path(source_name))
+    except PathContainmentError:
+        return None, [_reject(address, "source-path-escapes-project")]
+    return resolved, []
+
+
+def _safe_dest_relpath(relpath: str) -> bool:
+    """Return whether a destination relpath is safe to embed in a seed script."""
+
+    return (
+        ".." not in PurePosixPath(relpath).parts
+        and _SAFE_DEST_RELPATH.match(relpath) is not None
+    )
+
+
+def _is_sensitive(spec: Mapping[str, Any]) -> bool:
+    """Return the Content spec's `sensitive` flag as a plain bool."""
+
+    value = spec.get("sensitive")
+    return bool(value) if isinstance(value, (bool, str)) else False
+
+
+def _reject(address: str, reason_code: str) -> Diagnostic:
+    """Build a fail-closed content realization diagnostic."""
+
+    return diagnostic(
+        "aptl.provisioner.content-placement-rejected",
+        address,
+        (
+            "ACES content placement was rejected by the APTL content "
+            f"realization policy (reason={reason_code})."
+        ),
+    )

--- a/src/aptl/backends/aces_placement_realization.py
+++ b/src/aptl/backends/aces_placement_realization.py
@@ -1,0 +1,167 @@
+"""Realize ACES placement resources (content/account/feature-binding) for APTL.
+
+Split out of ``aces_realization.py`` (issue #689 / ADR-046's TechVault
+addendum) to keep that module under the file-length gate: this module owns
+resolving a placement resource's target node, dispatching to the typed
+content/account resolvers, and building the ``PlacementRealization`` value.
+``aces_realization.interpret_provisioning_plan`` composes this module's
+``realize_placements`` alongside node/network realization.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import PlannedResource
+
+from aptl.backends.aces_account_realization import resolve_account_placement
+from aptl.backends.aces_content_realization import resolve_content_placement
+from aptl.backends.aces_diagnostics import diagnostic
+from aptl.backends.aces_profiles import normalize_identifier
+from aptl.backends.aces_realization_model import (
+    NodeRealization,
+    PlacementRealization,
+    _single_or_none,
+)
+from aptl.backends.aces_realization_values import (
+    first_nonempty_string as _first_nonempty_string,
+    placement_target_values as _placement_target_values,
+    resolve_target_address as _resolve_target_address,
+    resource_name as _resource_name,
+)
+from aptl.core.deployment.realization import (
+    DeploymentAccountRealization,
+    DeploymentContentRealization,
+)
+
+PLACEMENT_RESOURCE_TYPES = frozenset(
+    {"feature-binding", "content-placement", "account-placement"}
+)
+
+
+def realize_placements(
+    payload_resources: list[PlannedResource],
+    node_lookup: dict[str, str],
+    node_by_address: dict[str, NodeRealization],
+    project_dir: Path,
+    diagnostics: list[Diagnostic],
+) -> list[PlacementRealization]:
+    """Resolve supported placement resources against realized nodes."""
+
+    placements: list[PlacementRealization] = []
+    for resource in payload_resources:
+        if resource.resource_type in PLACEMENT_RESOURCE_TYPES:
+            placement, placement_diagnostics = _realize_placement(
+                resource,
+                resource.payload,
+                node_lookup,
+                node_by_address,
+                project_dir,
+            )
+            diagnostics.extend(placement_diagnostics)
+            if placement is not None:
+                placements.append(placement)
+    return placements
+
+
+def placement_node_lookup(nodes: list[NodeRealization]) -> dict[str, str]:
+    """Index node addresses and aliases for placement target resolution."""
+
+    lookup: dict[str, str] = {}
+    for node in nodes:
+        values = {node.address, node.name, *node.aliases}
+        for value in values:
+            if not value:
+                continue
+            lookup[value] = node.address
+            normalized = normalize_identifier(value)
+            if normalized:
+                lookup[normalized] = node.address
+    return lookup
+
+
+def _realize_placement(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+    node_lookup: dict[str, str],
+    node_by_address: dict[str, NodeRealization],
+    project_dir: Path,
+) -> tuple[PlacementRealization | None, list[Diagnostic]]:
+    """Realize a placement resource or return its diagnostics."""
+
+    target_values = _placement_target_values(resource.resource_type, payload)
+    target_address = _resolve_target_address(target_values, node_lookup)
+    if target_address is None:
+        return (
+            None,
+            [
+                diagnostic(
+                    "aptl.provisioner.binding-target-unresolved",
+                    resource.address,
+                    (
+                        "ACES provisioning binding does not target a "
+                        "declared APTL-realizable node."
+                    ),
+                )
+            ],
+        )
+
+    content, account, resource_diagnostics = _realize_placement_resource(
+        resource, payload, target_address, node_by_address, project_dir
+    )
+    return (
+        PlacementRealization(
+            address=resource.address,
+            resource_type=resource.resource_type,
+            name=_resource_name(resource.address, payload),
+            target_address=target_address,
+            target_node=_first_nonempty_string(target_values),
+            content=content,
+            account=account,
+        ),
+        resource_diagnostics,
+    )
+
+
+def _realize_placement_resource(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+    target_address: str,
+    node_by_address: dict[str, NodeRealization],
+    project_dir: Path,
+) -> tuple[
+    DeploymentContentRealization | None,
+    DeploymentAccountRealization | None,
+    list[Diagnostic],
+]:
+    """Lower a resolved content/account placement into typed backend input.
+
+    Feature bindings resolve target-only (no typed backend op today); an
+    unsupported content/account placement fails closed with the resolver's
+    diagnostic rather than silently dropping to the count-only path.
+    """
+
+    target_node = node_by_address.get(target_address)
+    target_service = _single_or_none(target_node.backend_services) if target_node else None
+
+    if resource.resource_type == "content-placement":
+        content, diagnostics = resolve_content_placement(
+            resource=resource,
+            payload=payload,
+            target_address=target_address,
+            target_service=target_service,
+            project_dir=project_dir,
+        )
+        return content, None, diagnostics
+    if resource.resource_type == "account-placement":
+        account, diagnostics = resolve_account_placement(
+            resource=resource,
+            payload=payload,
+            target_address=target_address,
+            target_service=target_service,
+        )
+        return None, account, diagnostics
+    return None, None, []

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -11,6 +11,8 @@ import yaml
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.planning import PlannedResource, ProvisioningPlan
 
+from aptl.backends.aces_account_realization import resolve_account_placement
+from aptl.backends.aces_content_realization import resolve_content_placement
 from aptl.backends.aces_diagnostics import (
     PROVISIONING_ADDRESS,
     SUPPORTED_RESOURCE_TYPES,
@@ -52,6 +54,10 @@ from aptl.backends.aces_realization_values import (
     static_addresses as _static_addresses,
 )
 from aptl.core.config import AptlConfig
+from aptl.core.deployment.realization import (
+    DeploymentAccountRealization,
+    DeploymentContentRealization,
+)
 from aptl.utils.redaction import redact
 
 PLACEMENT_RESOURCE_TYPES = frozenset(
@@ -91,7 +97,13 @@ def interpret_provisioning_plan(
         diagnostics,
     )
     append_network_topology_diagnostics(nodes, networks, diagnostics)
-    placements = _realize_placements(payload_resources, _node_lookup(nodes), diagnostics)
+    placements = _realize_placements(
+        payload_resources,
+        _node_lookup(nodes),
+        {node.address: node for node in nodes},
+        project_dir,
+        diagnostics,
+    )
     _append_profile_diagnostics(profiles, config, diagnostics)
 
     return _realization_from_parts(nodes, networks, placements, profiles, diagnostics)
@@ -188,6 +200,8 @@ def _append_node_profile_diagnostic(
 def _realize_placements(
     payload_resources: list[PlannedResource],
     node_lookup: dict[str, str],
+    node_by_address: dict[str, NodeRealization],
+    project_dir: Path,
     diagnostics: list[Diagnostic],
 ) -> list[PlacementRealization]:
     """Resolve supported placement resources against realized nodes."""
@@ -199,6 +213,8 @@ def _realize_placements(
                 resource,
                 resource.payload,
                 node_lookup,
+                node_by_address,
+                project_dir,
             )
             diagnostics.extend(placement_diagnostics)
             if placement is not None:
@@ -438,6 +454,8 @@ def _realize_placement(
     resource: PlannedResource,
     payload: Mapping[str, Any],
     node_lookup: dict[str, str],
+    node_by_address: dict[str, NodeRealization],
+    project_dir: Path,
 ) -> tuple[PlacementRealization | None, list[Diagnostic]]:
     """Realize a placement resource or return its diagnostics."""
 
@@ -457,6 +475,10 @@ def _realize_placement(
                 )
             ],
         )
+
+    content, account, resource_diagnostics = _realize_placement_resource(
+        resource, payload, target_address, node_by_address, project_dir
+    )
     return (
         PlacementRealization(
             address=resource.address,
@@ -464,9 +486,52 @@ def _realize_placement(
             name=_resource_name(resource.address, payload),
             target_address=target_address,
             target_node=_first_nonempty_string(target_values),
+            content=content,
+            account=account,
         ),
-        [],
+        resource_diagnostics,
     )
+
+
+def _realize_placement_resource(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+    target_address: str,
+    node_by_address: dict[str, NodeRealization],
+    project_dir: Path,
+) -> tuple[
+    DeploymentContentRealization | None,
+    DeploymentAccountRealization | None,
+    list[Diagnostic],
+]:
+    """Lower a resolved content/account placement into typed backend input.
+
+    Feature bindings resolve target-only (no typed backend op today); an
+    unsupported content/account placement fails closed with the resolver's
+    diagnostic rather than silently dropping to the count-only path.
+    """
+
+    target_node = node_by_address.get(target_address)
+    target_service = _single_or_none(target_node.backend_services) if target_node else None
+
+    if resource.resource_type == "content-placement":
+        content, diagnostics = resolve_content_placement(
+            resource=resource,
+            payload=payload,
+            target_address=target_address,
+            target_service=target_service,
+            project_dir=project_dir,
+        )
+        return content, None, diagnostics
+    if resource.resource_type == "account-placement":
+        account, diagnostics = resolve_account_placement(
+            resource=resource,
+            payload=payload,
+            target_address=target_address,
+            target_service=target_service,
+        )
+        return None, account, diagnostics
+    return None, None, []
 
 
 def _node_lookup(nodes: list[NodeRealization]) -> dict[str, str]:

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -11,8 +11,6 @@ import yaml
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.planning import PlannedResource, ProvisioningPlan
 
-from aptl.backends.aces_account_realization import resolve_account_placement
-from aptl.backends.aces_content_realization import resolve_content_placement
 from aptl.backends.aces_diagnostics import (
     PROVISIONING_ADDRESS,
     SUPPORTED_RESOURCE_TYPES,
@@ -21,12 +19,15 @@ from aptl.backends.aces_diagnostics import (
 )
 from aptl.backends.aces_dependency_closure import append_dependency_closure
 from aptl.backends.aces_image_realization import resolve_node_image
+from aptl.backends.aces_placement_realization import (
+    placement_node_lookup as _node_lookup,
+    realize_placements as _realize_placements,
+)
 from aptl.backends.aces_profiles import (
     ComposeProfileIndex,
     explicit_compose_profile_hints,
     load_compose_profile_index,
     node_aliases,
-    normalize_identifier,
     public_start_profiles,
 )
 from aptl.backends.aces_realization_networks import (
@@ -40,29 +41,18 @@ from aptl.backends.aces_realization_model import (
     _single_or_none,
 )
 from aptl.backends.aces_realization_values import (
-    first_nonempty_string as _first_nonempty_string,
     health_status as _health_status,
     mapping as _mapping,
     network_names as _network_names,
     optional_bool as _optional_bool,
     optional_string as _optional_string,
-    placement_target_values as _placement_target_values,
-    resolve_target_address as _resolve_target_address,
     resource_name as _resource_name,
     service_names as _service_names,
     static_address_assignments as _static_address_assignments,
     static_addresses as _static_addresses,
 )
 from aptl.core.config import AptlConfig
-from aptl.core.deployment.realization import (
-    DeploymentAccountRealization,
-    DeploymentContentRealization,
-)
 from aptl.utils.redaction import redact
-
-PLACEMENT_RESOURCE_TYPES = frozenset(
-    {"feature-binding", "content-placement", "account-placement"}
-)
 
 
 def interpret_provisioning_plan(
@@ -195,31 +185,6 @@ def _append_node_profile_diagnostic(
             ),
         )
     )
-
-
-def _realize_placements(
-    payload_resources: list[PlannedResource],
-    node_lookup: dict[str, str],
-    node_by_address: dict[str, NodeRealization],
-    project_dir: Path,
-    diagnostics: list[Diagnostic],
-) -> list[PlacementRealization]:
-    """Resolve supported placement resources against realized nodes."""
-
-    placements: list[PlacementRealization] = []
-    for resource in payload_resources:
-        if resource.resource_type in PLACEMENT_RESOURCE_TYPES:
-            placement, placement_diagnostics = _realize_placement(
-                resource,
-                resource.payload,
-                node_lookup,
-                node_by_address,
-                project_dir,
-            )
-            diagnostics.extend(placement_diagnostics)
-            if placement is not None:
-                placements.append(placement)
-    return placements
 
 
 def _append_profile_diagnostics(
@@ -448,103 +413,3 @@ def _realize_network(
         gateway=_optional_string(properties, "gateway"),
         internal=_optional_bool(properties, "internal"),
     )
-
-
-def _realize_placement(
-    resource: PlannedResource,
-    payload: Mapping[str, Any],
-    node_lookup: dict[str, str],
-    node_by_address: dict[str, NodeRealization],
-    project_dir: Path,
-) -> tuple[PlacementRealization | None, list[Diagnostic]]:
-    """Realize a placement resource or return its diagnostics."""
-
-    target_values = _placement_target_values(resource.resource_type, payload)
-    target_address = _resolve_target_address(target_values, node_lookup)
-    if target_address is None:
-        return (
-            None,
-            [
-                diagnostic(
-                    "aptl.provisioner.binding-target-unresolved",
-                    resource.address,
-                    (
-                        "ACES provisioning binding does not target a "
-                        "declared APTL-realizable node."
-                    ),
-                )
-            ],
-        )
-
-    content, account, resource_diagnostics = _realize_placement_resource(
-        resource, payload, target_address, node_by_address, project_dir
-    )
-    return (
-        PlacementRealization(
-            address=resource.address,
-            resource_type=resource.resource_type,
-            name=_resource_name(resource.address, payload),
-            target_address=target_address,
-            target_node=_first_nonempty_string(target_values),
-            content=content,
-            account=account,
-        ),
-        resource_diagnostics,
-    )
-
-
-def _realize_placement_resource(
-    resource: PlannedResource,
-    payload: Mapping[str, Any],
-    target_address: str,
-    node_by_address: dict[str, NodeRealization],
-    project_dir: Path,
-) -> tuple[
-    DeploymentContentRealization | None,
-    DeploymentAccountRealization | None,
-    list[Diagnostic],
-]:
-    """Lower a resolved content/account placement into typed backend input.
-
-    Feature bindings resolve target-only (no typed backend op today); an
-    unsupported content/account placement fails closed with the resolver's
-    diagnostic rather than silently dropping to the count-only path.
-    """
-
-    target_node = node_by_address.get(target_address)
-    target_service = _single_or_none(target_node.backend_services) if target_node else None
-
-    if resource.resource_type == "content-placement":
-        content, diagnostics = resolve_content_placement(
-            resource=resource,
-            payload=payload,
-            target_address=target_address,
-            target_service=target_service,
-            project_dir=project_dir,
-        )
-        return content, None, diagnostics
-    if resource.resource_type == "account-placement":
-        account, diagnostics = resolve_account_placement(
-            resource=resource,
-            payload=payload,
-            target_address=target_address,
-            target_service=target_service,
-        )
-        return None, account, diagnostics
-    return None, None, []
-
-
-def _node_lookup(nodes: list[NodeRealization]) -> dict[str, str]:
-    """Index node addresses and aliases for placement target resolution."""
-
-    lookup: dict[str, str] = {}
-    for node in nodes:
-        values = {node.address, node.name, *node.aliases}
-        for value in values:
-            if not value:
-                continue
-            lookup[value] = node.address
-            normalized = normalize_identifier(value)
-            if normalized:
-                lookup[normalized] = node.address
-    return lookup

--- a/src/aptl/backends/aces_realization_model.py
+++ b/src/aptl/backends/aces_realization_model.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from aces_contracts.diagnostics import Diagnostic
 
 from aptl.core.deployment.realization import (
+    DeploymentAccountRealization,
+    DeploymentContentRealization,
     DeploymentImageRealization,
     DeploymentNetworkAttachment,
     DeploymentNetworkRealization,
@@ -83,15 +85,22 @@ class PlacementRealization(object):
     name: str
     target_address: str
     target_node: str | None
+    content: DeploymentContentRealization | None = None
+    account: DeploymentAccountRealization | None = None
 
     def details(self) -> dict[str, object]:
-        return {
+        details: dict[str, object] = {
             "address": self.address,
             "resource_type": self.resource_type,
             "name": self.name,
             "target_address": self.target_address,
             "target_node": self.target_node,
         }
+        if self.content is not None:
+            details["content"] = self.content.details()
+        if self.account is not None:
+            details["account"] = self.account.details()
+        return details
 
 
 @dataclass(frozen=True)
@@ -124,6 +133,16 @@ class AptlRealization(object):
                 for network in self.networks
             ),
             images=tuple(node.image for node in self.nodes if node.image is not None),
+            content=tuple(
+                placement.content
+                for placement in self.placements
+                if placement.content is not None
+            ),
+            accounts=tuple(
+                placement.account
+                for placement in self.placements
+                if placement.account is not None
+            ),
         )
 
     def details(self) -> dict[str, object]:

--- a/src/aptl/backends/aces_realization_values.py
+++ b/src/aptl/backends/aces_realization_values.py
@@ -247,3 +247,37 @@ def mapping(value: object) -> Mapping[str, Any] | None:
     """Return mapping values while rejecting scalar payload fragments."""
 
     return value if isinstance(value, Mapping) else None
+
+
+def placement_spec(payload: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return the compiled ACES resource spec (the Content/Account dump)."""
+
+    return mapping(payload.get("spec"))
+
+
+def content_source(spec: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return the ``source`` sub-mapping of a compiled Content spec, if any."""
+
+    return mapping(spec.get("source"))
+
+
+def content_source_name(spec: Mapping[str, Any]) -> str | None:
+    """Return the checked-in/observed source name declared on a Content spec."""
+
+    source = content_source(spec)
+    return optional_string(source, "name") if source is not None else None
+
+
+def content_text(spec: Mapping[str, Any]) -> str | None:
+    """Return the inline text declared on a Content spec, if any."""
+
+    return optional_string(spec, "text")
+
+
+def account_groups(spec: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return the group memberships declared on an Account spec."""
+
+    groups = spec.get("groups")
+    if not isinstance(groups, list):
+        return ()
+    return tuple(sorted({g for g in groups if isinstance(g, str) and g.strip()}))

--- a/src/aptl/core/assets.py
+++ b/src/aptl/core/assets.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import importlib.resources
 import json
+import os
 import shutil
 import subprocess
 from collections.abc import Iterator
@@ -120,14 +121,42 @@ def default_config_json() -> str:
     return json.dumps(payload, indent=4) + "\n"
 
 
+# Git env vars that redirect where git resolves the repo/worktree/index.
+# A git hook (e.g. pre-commit) exports these pointing at the real repo; if
+# they leak into ``git ls-files`` below they make it resolve to the ambient
+# repo instead of ``root``, so a non-repo checkout is reported as carrying the
+# real repo's tracked files and materialize/bundle then fails copying paths the
+# checkout lacks. Strip them so selection is always scoped to ``root``.
+_GIT_LOCATION_ENV = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_PREFIX",
+        "GIT_NAMESPACE",
+    }
+)
+
+
 def _git_tracked(root: Path) -> list[Path] | None:
-    """Return tracked asset files under ``root``, or ``None`` without git."""
+    """Return tracked asset files under ``root``, or ``None`` without git.
+
+    Runs ``git ls-files`` with the inherited git *location* environment
+    (``GIT_DIR``/``GIT_WORK_TREE``/``GIT_INDEX_FILE`` etc.) stripped, so a
+    caller running inside a git hook cannot make selection resolve to the
+    ambient repo instead of ``root``.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_LOCATION_ENV}
     try:
         completed = subprocess.run(
             ["git", "ls-files", "-z", "--", *_ASSET_ROOTS],
             cwd=root,
             capture_output=True,
             check=True,
+            env=env,
         )
     except (OSError, subprocess.CalledProcessError):
         return None

--- a/src/aptl/core/content_seed.py
+++ b/src/aptl/core/content_seed.py
@@ -1,0 +1,121 @@
+"""Content named-volume seeding for typed ACES content-placement realization.
+
+Issue #689 / ADR-046's TechVault addendum: `content-placement` ACES
+resources must lower into typed backend realization or fail closed before
+`aptl lab start` side effects, reusing the ADR-043 named-volume seed seam
+(``NamedVolumeSeed`` / ``SeedFile`` / ``seed_named_volumes``) rather than a
+second Docker-copy mechanism. This module is the content-specific sibling of
+:mod:`aptl.core.suricata_seed`: it turns typed
+:class:`~aptl.core.deployment.realization.DeploymentContentRealization`
+records (already validated for containment and realizability by
+:mod:`aptl.backends.aces_content_realization`) into the seed specs the
+deployment backend materializes.
+
+Inline text is rendered into the ignored ``.aptl/content/`` state tree
+first — mirroring the ADR-028 credential render path — so the seed
+container always binds a real, containment-checked host directory rather
+than embedding operator/scenario text into a shell string.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
+
+from aptl.core.credentials import (
+    PathContainmentError,
+    _canonical_generated_path,
+    _resolve_within_project,
+)
+from aptl.core.deployment.realization import DeploymentContentRealization
+from aptl.core.seed_spec import NamedVolumeSeed, SeedFile
+
+__all__ = ["build_content_volume_seeds"]
+
+# Root of the rendered-content tree (ignored, mirrors `.aptl/config/`).
+_RENDERED_CONTENT_ROOT = Path(".aptl/content")
+
+_SLUG_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def build_content_volume_seeds(
+    project_dir: Path,
+    content: Sequence[DeploymentContentRealization],
+) -> tuple[NamedVolumeSeed, ...]:
+    """Build ADR-043 named-volume seed specs for typed content placements.
+
+    One seed per content item. Each source path is re-resolved through the
+    existing project-containment primitives here (independent of any
+    upstream interpreter check), so a symlink or path escaping the project
+    root is rejected before any seed container runs.
+
+    Raises:
+        PathContainmentError: if a source or rendered path escapes the
+            project root, or resolves through a symlinked component.
+        FileNotFoundError: if a project-contained source path is missing.
+    """
+    return tuple(_seed_for_content(project_dir, item) for item in content)
+
+
+def _seed_for_content(
+    project_dir: Path, item: DeploymentContentRealization
+) -> NamedVolumeSeed:
+    """Build the named-volume seed for one typed content realization."""
+    if item.source_kind == "inline-text":
+        return _inline_text_seed(project_dir, item)
+    if item.source_kind in ("project-file", "project-directory"):
+        return _project_source_seed(project_dir, item)
+    # "empty-directory": an explicit empty-directory declaration has
+    # nothing to copy. The seed still runs (a harmless no-op `set -e`
+    # script) so the operation stays uniform for every content kind.
+    return NamedVolumeSeed(
+        volume_suffix=item.volume_suffix,
+        source_dir=project_dir,
+        files=(),
+    )
+
+
+def _inline_text_seed(
+    project_dir: Path, item: DeploymentContentRealization
+) -> NamedVolumeSeed:
+    """Render bounded inline text and seed it as a single-file volume copy."""
+    basename = PurePosixPath(item.dest_relpath).name
+    rendered_dir = _canonical_generated_path(
+        project_dir, _RENDERED_CONTENT_ROOT / _content_slug(item.address)
+    )
+    rendered_dir.mkdir(parents=True, exist_ok=True)
+    rendered_file = rendered_dir / basename
+    rendered_file.write_text(item.inline_text or "", encoding="utf-8")
+    return NamedVolumeSeed(
+        volume_suffix=item.volume_suffix,
+        source_dir=rendered_dir,
+        files=(SeedFile(src=basename, dest=item.dest_relpath),),
+    )
+
+
+def _project_source_seed(
+    project_dir: Path, item: DeploymentContentRealization
+) -> NamedVolumeSeed:
+    """Bind a checked-in project-contained file or directory source."""
+    source_relpath = item.source_relpath
+    if source_relpath is None:
+        raise PathContainmentError(
+            f"Content placement {item.address!r} declared source kind "
+            f"{item.source_kind!r} without a source path."
+        )
+    resolved = _resolve_within_project(project_dir, Path(source_relpath))
+    if not resolved.exists():
+        raise FileNotFoundError(
+            f"Content source not found for {item.address!r}: {resolved}"
+        )
+    return NamedVolumeSeed(
+        volume_suffix=item.volume_suffix,
+        source_dir=resolved.parent,
+        files=(SeedFile(src=resolved.name, dest=item.dest_relpath),),
+    )
+
+
+def _content_slug(address: str) -> Path:
+    """Return a filesystem-safe, code-defined subdirectory name for an address."""
+    return Path(_SLUG_RE.sub("_", address))

--- a/src/aptl/core/deployment/__init__.py
+++ b/src/aptl/core/deployment/__init__.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING
 from aptl.core.deployment.backend import DeploymentBackend
 from aptl.core.deployment.docker_compose import DockerComposeBackend
 from aptl.core.deployment.realization import (
+    DeploymentAccountRealization,
+    DeploymentContentRealization,
     DeploymentImageRealization,
     DeploymentNetworkAttachment,
     DeploymentNetworkRealization,
@@ -37,6 +39,8 @@ if TYPE_CHECKING:
 __all__ = [
     "DeploymentBackend",
     "DockerComposeBackend",
+    "DeploymentAccountRealization",
+    "DeploymentContentRealization",
     "DeploymentImageRealization",
     "DeploymentNetworkAttachment",
     "DeploymentNetworkRealization",

--- a/src/aptl/core/deployment/_compose_content_realization.py
+++ b/src/aptl/core/deployment/_compose_content_realization.py
@@ -1,0 +1,32 @@
+"""Docker Compose content-placement realization (issue #689)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from aptl.core.content_seed import build_content_volume_seeds
+from aptl.core.deployment.realization import DeploymentContentRealization
+
+# Reuses the Suricata seeder image: it is already pulled unconditionally by
+# every lab start (Suricata is part of the default profile set), so content
+# realization introduces no new image dependency (ADR-043 "already in the
+# lab's supply chain"). The image only needs `/bin/sh`, `mkdir`, and `cp`,
+# which this Alpine-based image provides.
+CONTENT_SEEDER_IMAGE = "jasonish/suricata:7.0"
+
+
+class ComposeRealizationContentMixin:
+    """Realize typed scenario content placements through Docker Compose."""
+
+    def realize_content(
+        self,
+        content: Sequence[DeploymentContentRealization],
+        *,
+        seeder_image: str,
+    ) -> None:
+        """Materialize typed content placements via the ADR-043 seed seam."""
+
+        if not content:
+            return
+        seeds = build_content_volume_seeds(self._project_dir, content)
+        self.seed_named_volumes(seeds, seeder_image=seeder_image)

--- a/src/aptl/core/deployment/_compose_realization.py
+++ b/src/aptl/core/deployment/_compose_realization.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from aptl.core.deployment._compose_content_realization import (
+    CONTENT_SEEDER_IMAGE,
+    ComposeRealizationContentMixin,
+)
 from aptl.core.deployment._compose_image_realization import (
     ComposeRealizationImageMixin,
 )
@@ -13,6 +17,7 @@ from aptl.core.deployment._compose_realization_networks import (
     _network_name_candidates,
     _resolve_realization_networks,
 )
+from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
 from aptl.core.deployment.realization import DeploymentRealizationSpec
 from aptl.core.lab_types import LabResult
 
@@ -27,6 +32,7 @@ __all__ = [
 class ComposeRealizationMixin(
     ComposeRealizationImageMixin,
     ComposeRealizationNetworkMixin,
+    ComposeRealizationContentMixin,
 ):
     """Realize typed scenario specs through Docker Compose."""
 
@@ -49,6 +55,8 @@ class ComposeRealizationMixin(
                 else None
             )
         if result is None:
+            result = self._realize_content(realization)
+        if result is None:
             start_result = self._start_realized_services(
                 profiles,
                 build=build,
@@ -56,6 +64,28 @@ class ComposeRealizationMixin(
             )
             result = self._realization_result(start_result, realization)
         return result
+
+    def _realize_content(
+        self,
+        realization: DeploymentRealizationSpec,
+    ) -> LabResult | None:
+        """Materialize typed content placements; fail closed on any seed error.
+
+        Returns ``None`` on success (or when there is nothing to realize) so
+        the caller's ``result is None`` chain continues to the next step,
+        matching the existing image/network step shape.
+        """
+
+        if not realization.content:
+            return None
+        try:
+            self.realize_content(realization.content, seeder_image=CONTENT_SEEDER_IMAGE)
+        except (BackendSeedError, BackendTimeoutError) as exc:
+            return LabResult(
+                success=False,
+                error=f"Content placement realization failed: {exc}",
+            )
+        return None
 
     def _realization_result(
         self,

--- a/src/aptl/core/deployment/backend.py
+++ b/src/aptl/core/deployment/backend.py
@@ -19,6 +19,7 @@ from typing import Any, Protocol
 
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.core.deployment.realization import (
+    DeploymentContentRealization,
     DeploymentNetworkRealization,
     DeploymentRealizationSpec,
 )
@@ -182,6 +183,35 @@ class DeploymentBackend(Protocol):
 
         Raises:
             BackendSeedError: if a seed or retire container exits non-zero.
+            BackendTimeoutError: if a seed container exceeds its timeout.
+        """
+        ...
+
+    def realize_content(
+        self,
+        content: Sequence[DeploymentContentRealization],
+        *,
+        seeder_image: str,
+    ) -> None:
+        """Materialize typed ACES content placements (issue #689).
+
+        Mirrors :meth:`seed_named_volumes`: each realized content item is
+        lowered into a project-scoped named-volume seed (inline text is
+        rendered into the ignored ``.aptl/content/`` state tree first;
+        project-contained sources are bound read-only from their resolved,
+        containment-checked location) and materialized by the same
+        root one-off seed container mechanism, so content realization gets
+        the identical idempotency, project-scoping, and redaction behavior
+        as ADR-043 volume seeding without a second Docker-copy mechanism.
+
+        Args:
+            content: The typed content realizations to materialize, in
+                order.
+            seeder_image: Image used to run the copy containers (an image
+                already in the lab's supply chain).
+
+        Raises:
+            BackendSeedError: if a seed container exits non-zero.
             BackendTimeoutError: if a seed container exceeds its timeout.
         """
         ...

--- a/src/aptl/core/deployment/realization.py
+++ b/src/aptl/core/deployment/realization.py
@@ -73,6 +73,79 @@ class DeploymentNodeRealization(object):
     network_attachments: tuple[DeploymentNetworkAttachment, ...] = ()
 
 
+ContentSourceKind = Literal[
+    "inline-text", "project-file", "project-directory", "empty-directory"
+]
+
+
+@dataclass(frozen=True)
+class DeploymentContentRealization(object):
+    """One content-placement operation lowered from an ACES content resource.
+
+    ``source_kind`` records how the content is materialized: ``inline-text``
+    (bounded text carried on the placement itself), ``project-file`` /
+    ``project-directory`` (a checked-in, project-contained source path), or
+    ``empty-directory`` (an explicit empty-directory declaration with no
+    source). ``source_relpath`` is project-relative and only set for the two
+    project-sourced kinds; ``inline_text`` is only set for ``inline-text``.
+    Both are mutually exclusive by construction in the interpreter.
+    """
+
+    address: str
+    target_address: str
+    content_name: str
+    volume_suffix: str
+    dest_relpath: str
+    source_kind: ContentSourceKind
+    source_relpath: str | None = None
+    inline_text: str | None = None
+    sensitive: bool = False
+
+    def details(self) -> dict[str, object]:
+        return {
+            "address": self.address,
+            "target_address": self.target_address,
+            "content_name": self.content_name,
+            "volume_suffix": self.volume_suffix,
+            "dest_relpath": self.dest_relpath,
+            "source_kind": self.source_kind,
+            "source_relpath": self.source_relpath,
+            "sensitive": self.sensitive,
+        }
+
+
+@dataclass(frozen=True)
+class DeploymentAccountRealization(object):
+    """One account-placement identity lowered from an ACES account resource.
+
+    Carries non-secret identity only (ADR-046 TechVault addendum): no
+    password material crosses this record. The concrete credential stays
+    owned by the target node's service-owned provisioner (e.g.
+    ``containers/ad/provision-users.sh``); this record is realization
+    evidence proving the declared account maps to a node whose backend
+    service actually provisions it.
+    """
+
+    address: str
+    target_address: str
+    username: str
+    groups: tuple[str, ...] = ()
+    spn: str = ""
+    mail: str = ""
+    disabled: bool = False
+
+    def details(self) -> dict[str, object]:
+        return {
+            "address": self.address,
+            "target_address": self.target_address,
+            "username": self.username,
+            "groups": list(self.groups),
+            "spn": self.spn,
+            "mail": self.mail,
+            "disabled": self.disabled,
+        }
+
+
 @dataclass(frozen=True)
 class DeploymentRealizationSpec(object):
     """Portable input for typed deployment backend realization."""
@@ -81,3 +154,5 @@ class DeploymentRealizationSpec(object):
     nodes: tuple[DeploymentNodeRealization, ...]
     networks: tuple[DeploymentNetworkRealization, ...]
     images: tuple[DeploymentImageRealization, ...] = ()
+    content: tuple[DeploymentContentRealization, ...] = ()
+    accounts: tuple[DeploymentAccountRealization, ...] = ()

--- a/src/aptl/validation/_account_parity.py
+++ b/src/aptl/validation/_account_parity.py
@@ -2,9 +2,8 @@
 
 Split out of ``_gate_checks.py`` to keep that module under the file-length
 gate: this module owns ``check_account_provisioner_parity``, the sole
-consumer of the provisioner-script scraping logic. ``_gate_checks`` re-exports
-``check_account_provisioner_parity`` so ``techvault_gate.validate_scenario``'s
-``_gate_checks as checks`` alias keeps working unchanged.
+consumer of the provisioner-script scraping logic.
+``techvault_gate.validate_scenario`` calls it here directly (step 7).
 """
 
 from __future__ import annotations

--- a/src/aptl/validation/_account_parity.py
+++ b/src/aptl/validation/_account_parity.py
@@ -1,0 +1,258 @@
+"""Static SDL<->provisioner account parity check (ADR-046 TechVault addendum, #689).
+
+Split out of ``_gate_checks.py`` to keep that module under the file-length
+gate: this module owns ``check_account_provisioner_parity``, the sole
+consumer of the provisioner-script scraping logic. ``_gate_checks`` re-exports
+``check_account_provisioner_parity`` so ``techvault_gate.validate_scenario``'s
+``_gate_checks as checks`` alias keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from aces_sdl.accounts import Account
+from aces_sdl.scenario import Scenario
+
+from aptl.utils.redaction import redact
+from aptl.validation.techvault_gate import GateCheck
+
+# Static SDL<->provisioner account parity (ADR-046 TechVault addendum,
+# issue #689): the checked-in AD account provisioner the `ad` container's
+# entrypoint always runs. A declared SDL account is honest only when this
+# script actually creates it.
+_PROVISION_USERS_SCRIPT = Path("containers") / "ad" / "provision-users.sh"
+_SAMBA_USER_CREATE_RE = re.compile(r"samba-tool\s+user\s+create\s+(\S+)")
+_SAMBA_MAIL_RE = re.compile(r'--mail="([^"]*)"')
+_SAMBA_GROUP_ADDMEMBERS_RE = re.compile(
+    r'samba-tool\s+group\s+addmembers\s+("[^"]+"|\S+)\s+(\S+)'
+)
+_SAMBA_SPN_ADD_RE = re.compile(r"samba-tool\s+spn\s+add\s+(\S+)\s+(\S+)")
+_SAMBA_USER_DISABLE_RE = re.compile(r"samba-tool\s+user\s+disable\s+(\S+)")
+
+
+@dataclass(frozen=True)
+class _ProvisionerFacts(object):
+    """Per-user facts statically scraped from ``provision-users.sh``.
+
+    Each field records what the provisioner script actually,
+    machine-checkably does for a given username — the authoritative
+    boundary account realization evidence must match (issue #689).
+    """
+
+    users: frozenset[str] = frozenset()
+    mail_by_user: Mapping[str, str] = field(default_factory=dict)
+    groups_by_user: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    spns_by_user: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    disabled_users: frozenset[str] = frozenset()
+
+
+def _parse_provisioner_facts(script_text: str) -> _ProvisionerFacts:
+    """Statically scan the AD provisioner script for per-user account facts.
+
+    ``user create`` commands use ``\\``-newline continuations to spread
+    flags (including ``--mail=``) across lines; collapse those first so a
+    continuation-line flag is still captured on the logical command line.
+    """
+    collapsed = script_text.replace("\\\n", " ")
+    users: set[str] = set()
+    mail_by_user: dict[str, str] = {}
+    groups_by_user: dict[str, set[str]] = {}
+    spns_by_user: dict[str, set[str]] = {}
+    disabled_users: set[str] = set()
+
+    for line in collapsed.splitlines():
+        create_match = _SAMBA_USER_CREATE_RE.search(line)
+        if create_match is not None:
+            username = create_match.group(1)
+            users.add(username)
+            mail_match = _SAMBA_MAIL_RE.search(line)
+            if mail_match is not None:
+                mail_by_user[username] = mail_match.group(1)
+            continue
+
+        group_match = _SAMBA_GROUP_ADDMEMBERS_RE.search(line)
+        if group_match is not None:
+            group = group_match.group(1).strip('"')
+            username = group_match.group(2)
+            groups_by_user.setdefault(username, set()).add(group)
+            continue
+
+        spn_match = _SAMBA_SPN_ADD_RE.search(line)
+        if spn_match is not None:
+            spn, username = spn_match.groups()
+            spns_by_user.setdefault(username, set()).add(spn)
+            continue
+
+        disable_match = _SAMBA_USER_DISABLE_RE.search(line)
+        if disable_match is not None:
+            disabled_users.add(disable_match.group(1))
+
+    return _ProvisionerFacts(
+        users=frozenset(users),
+        mail_by_user=mail_by_user,
+        groups_by_user={k: frozenset(v) for k, v in groups_by_user.items()},
+        spns_by_user={k: frozenset(v) for k, v in spns_by_user.items()},
+        disabled_users=frozenset(disabled_users),
+    )
+
+
+def check_account_provisioner_parity(
+    *, scenario: Scenario, project_dir: Path
+) -> GateCheck:
+    """Confirm every SDL-declared account attribute is provisioner-authoritative.
+
+    Account declarations are honest only when the clean-start path actually
+    creates them, with the same groups/mail/SPN/disabled state, through an
+    existing service-owned provisioner (ADR-046 TechVault Operational Standup
+    Addendum, issue #689). This never runs Docker or ``samba-tool``; it
+    statically scans the checked-in provisioner script the ``ad`` container's
+    entrypoint always runs (``containers/ad/provision-users.sh``), so
+    SDL<->provisioner drift is caught before ``aptl lab start`` rather than
+    discovered live.
+
+    Each SDL account (``scenario.accounts``) is checked against the
+    provisioner's per-user facts:
+
+    - ``username`` must have a matching ``samba-tool user create``.
+    - every declared ``group`` must be a subset of the groups the
+      provisioner actually adds that user to via
+      ``samba-tool group addmembers``.
+    - a non-empty declared ``mail`` must equal the ``--mail=`` value on
+      that user's ``user create`` command.
+    - a non-empty declared ``spn`` must be one the provisioner actually
+      sets for that user via ``samba-tool spn add``.
+    - declared ``disabled`` must equal whether the provisioner runs
+      ``samba-tool user disable`` for that user (absent means not
+      disabled).
+
+    The check is one-directional (the provisioner may create more users,
+    groups, or SPNs than the SDL declares; a phantom SDL account or a
+    phantom SDL-declared attribute still fails).
+    """
+    script_path = project_dir / _PROVISION_USERS_SCRIPT
+    if not script_path.exists():
+        return GateCheck(
+            "account_provisioner_parity",
+            False,
+            (f"AD account provisioner script missing at {script_path}",),
+        )
+    try:
+        script_text = script_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return GateCheck(
+            "account_provisioner_parity",
+            False,
+            (redact(f"AD account provisioner script unreadable: {exc}"),),
+        )
+
+    facts = _parse_provisioner_facts(script_text)
+    diagnostics: list[str] = []
+    for name, account in scenario.accounts.items():
+        diagnostics.extend(_account_parity_diagnostics(name, account, facts))
+    return GateCheck("account_provisioner_parity", *_outcome(diagnostics))
+
+
+def _account_parity_diagnostics(
+    name: str, account: Account, facts: _ProvisionerFacts
+) -> list[str]:
+    """Check one SDL account's attributes against the provisioner's facts."""
+    username = account.username
+    label = f"SDL account {name!r} (username={username!r})"
+    if username not in facts.users:
+        return [_missing_user_diagnostic(label)]
+    return [
+        *_group_parity_diagnostics(label, account, username, facts),
+        *_mail_parity_diagnostics(label, account, username, facts),
+        *_spn_parity_diagnostics(label, account, username, facts),
+        *_disabled_parity_diagnostics(label, account, username, facts),
+    ]
+
+
+def _missing_user_diagnostic(label: str) -> str:
+    """Report an SDL account with no matching provisioner user create."""
+    return redact(
+        f"{label} has no matching `samba-tool user create` in "
+        f"{_PROVISION_USERS_SCRIPT.name}; declared accounts must "
+        "be honest, clean-start-realized fixtures"
+    )
+
+
+def _group_parity_diagnostics(
+    label: str, account: Account, username: str, facts: _ProvisionerFacts
+) -> list[str]:
+    """Report SDL-declared groups the provisioner never adds this user to."""
+    missing_groups = set(account.groups) - facts.groups_by_user.get(username, frozenset())
+    if not missing_groups:
+        return []
+    return [
+        redact(
+            f"{label} declares group(s) {sorted(missing_groups)} that "
+            f"{_PROVISION_USERS_SCRIPT.name} never adds via "
+            "`samba-tool group addmembers`"
+        )
+    ]
+
+
+def _mail_parity_diagnostics(
+    label: str, account: Account, username: str, facts: _ProvisionerFacts
+) -> list[str]:
+    """Report a declared mail address that doesn't match the provisioner's."""
+    declared_mail = account.mail
+    if not declared_mail:
+        return []
+    actual_mail = facts.mail_by_user.get(username)
+    if actual_mail == declared_mail:
+        return []
+    return [
+        redact(
+            f"{label} declares mail {declared_mail!r} but "
+            f"{_PROVISION_USERS_SCRIPT.name} sets {actual_mail!r} "
+            "via `--mail=`"
+        )
+    ]
+
+
+def _spn_parity_diagnostics(
+    label: str, account: Account, username: str, facts: _ProvisionerFacts
+) -> list[str]:
+    """Report a declared SPN the provisioner never sets for this user."""
+    declared_spn = account.spn
+    if not declared_spn or declared_spn in facts.spns_by_user.get(username, frozenset()):
+        return []
+    return [
+        redact(
+            f"{label} declares spn {declared_spn!r} that "
+            f"{_PROVISION_USERS_SCRIPT.name} never sets via "
+            "`samba-tool spn add`"
+        )
+    ]
+
+
+def _disabled_parity_diagnostics(
+    label: str, account: Account, username: str, facts: _ProvisionerFacts
+) -> list[str]:
+    """Report a declared disabled state that doesn't match the provisioner's."""
+    declared_disabled = bool(account.disabled)
+    actual_disabled = username in facts.disabled_users
+    if declared_disabled == actual_disabled:
+        return []
+    return [
+        redact(
+            f"{label} declares disabled={declared_disabled} but "
+            f"{_PROVISION_USERS_SCRIPT.name} "
+            + (
+                "never runs `samba-tool user disable` for this user"
+                if declared_disabled
+                else "runs `samba-tool user disable` for this user"
+            )
+        )
+    ]
+
+
+def _outcome(diagnostics: list[str]) -> tuple[bool, tuple[str, ...]]:
+    """Pack diagnostics into a ``(passed, diagnostics)`` pair for ``GateCheck``."""
+    return (not diagnostics, tuple(diagnostics))

--- a/src/aptl/validation/_gate_checks.py
+++ b/src/aptl/validation/_gate_checks.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import subprocess
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -52,6 +53,19 @@ _ISSUE_REF = re.compile(r"^(?:[a-z0-9][a-z0-9._-]*)?#\d+$", re.IGNORECASE)
 # dedicated gate step rather than the fast per-test suite.
 _SUBPROCESS_TIMEOUT_S = 120
 _IMPORT_LOCK_TIMEOUT_S = 600
+
+# Static SDL<->provisioner account parity (ADR-046 TechVault addendum,
+# issue #689): the checked-in AD account provisioner the `ad` container's
+# entrypoint always runs. A declared SDL account is honest only when this
+# script actually creates it.
+_PROVISION_USERS_SCRIPT = Path("containers") / "ad" / "provision-users.sh"
+_SAMBA_USER_CREATE_RE = re.compile(r"samba-tool\s+user\s+create\s+(\S+)")
+_SAMBA_MAIL_RE = re.compile(r'--mail="([^"]*)"')
+_SAMBA_GROUP_ADDMEMBERS_RE = re.compile(
+    r'samba-tool\s+group\s+addmembers\s+("[^"]+"|\S+)\s+(\S+)'
+)
+_SAMBA_SPN_ADD_RE = re.compile(r"samba-tool\s+spn\s+add\s+(\S+)\s+(\S+)")
+_SAMBA_USER_DISABLE_RE = re.compile(r"samba-tool\s+user\s+disable\s+(\S+)")
 
 
 class _NoStartBackend(object):
@@ -215,6 +229,188 @@ def check_provisioning_realization(
             f"{expected_profiles}; scenario would not instantiate the same range"
         )
     return details, GateCheck("provisioning_realization", *_outcome(diagnostics))
+
+
+@dataclass(frozen=True)
+class _ProvisionerFacts(object):
+    """Per-user facts statically scraped from ``provision-users.sh``.
+
+    Each field records what the provisioner script actually,
+    machine-checkably does for a given username — the authoritative
+    boundary account realization evidence must match (issue #689).
+    """
+
+    users: frozenset[str] = frozenset()
+    mail_by_user: Mapping[str, str] = field(default_factory=dict)
+    groups_by_user: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    spns_by_user: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    disabled_users: frozenset[str] = frozenset()
+
+
+def _parse_provisioner_facts(script_text: str) -> _ProvisionerFacts:
+    """Statically scan the AD provisioner script for per-user account facts.
+
+    ``user create`` commands use ``\\``-newline continuations to spread
+    flags (including ``--mail=``) across lines; collapse those first so a
+    continuation-line flag is still captured on the logical command line.
+    """
+    collapsed = script_text.replace("\\\n", " ")
+    users: set[str] = set()
+    mail_by_user: dict[str, str] = {}
+    groups_by_user: dict[str, set[str]] = {}
+    spns_by_user: dict[str, set[str]] = {}
+    disabled_users: set[str] = set()
+
+    for line in collapsed.splitlines():
+        create_match = _SAMBA_USER_CREATE_RE.search(line)
+        if create_match is not None:
+            username = create_match.group(1)
+            users.add(username)
+            mail_match = _SAMBA_MAIL_RE.search(line)
+            if mail_match is not None:
+                mail_by_user[username] = mail_match.group(1)
+            continue
+
+        group_match = _SAMBA_GROUP_ADDMEMBERS_RE.search(line)
+        if group_match is not None:
+            group = group_match.group(1).strip('"')
+            username = group_match.group(2)
+            groups_by_user.setdefault(username, set()).add(group)
+            continue
+
+        spn_match = _SAMBA_SPN_ADD_RE.search(line)
+        if spn_match is not None:
+            spn, username = spn_match.groups()
+            spns_by_user.setdefault(username, set()).add(spn)
+            continue
+
+        disable_match = _SAMBA_USER_DISABLE_RE.search(line)
+        if disable_match is not None:
+            disabled_users.add(disable_match.group(1))
+
+    return _ProvisionerFacts(
+        users=frozenset(users),
+        mail_by_user=mail_by_user,
+        groups_by_user={k: frozenset(v) for k, v in groups_by_user.items()},
+        spns_by_user={k: frozenset(v) for k, v in spns_by_user.items()},
+        disabled_users=frozenset(disabled_users),
+    )
+
+
+def check_account_provisioner_parity(
+    *, scenario: Scenario, project_dir: Path
+) -> GateCheck:
+    """Confirm every SDL-declared account attribute is provisioner-authoritative.
+
+    Account declarations are honest only when the clean-start path actually
+    creates them, with the same groups/mail/SPN/disabled state, through an
+    existing service-owned provisioner (ADR-046 TechVault Operational Standup
+    Addendum, issue #689). This never runs Docker or ``samba-tool``; it
+    statically scans the checked-in provisioner script the ``ad`` container's
+    entrypoint always runs (``containers/ad/provision-users.sh``), so
+    SDL<->provisioner drift is caught before ``aptl lab start`` rather than
+    discovered live.
+
+    Each SDL account (``scenario.accounts``) is checked against the
+    provisioner's per-user facts:
+
+    - ``username`` must have a matching ``samba-tool user create``.
+    - every declared ``group`` must be a subset of the groups the
+      provisioner actually adds that user to via
+      ``samba-tool group addmembers``.
+    - a non-empty declared ``mail`` must equal the ``--mail=`` value on
+      that user's ``user create`` command.
+    - a non-empty declared ``spn`` must be one the provisioner actually
+      sets for that user via ``samba-tool spn add``.
+    - declared ``disabled`` must equal whether the provisioner runs
+      ``samba-tool user disable`` for that user (absent means not
+      disabled).
+
+    The check is one-directional (the provisioner may create more users,
+    groups, or SPNs than the SDL declares; a phantom SDL account or a
+    phantom SDL-declared attribute still fails).
+    """
+    script_path = project_dir / _PROVISION_USERS_SCRIPT
+    if not script_path.exists():
+        return GateCheck(
+            "account_provisioner_parity",
+            False,
+            (f"AD account provisioner script missing at {script_path}",),
+        )
+    try:
+        script_text = script_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return GateCheck(
+            "account_provisioner_parity",
+            False,
+            (redact(f"AD account provisioner script unreadable: {exc}"),),
+        )
+
+    facts = _parse_provisioner_facts(script_text)
+    diagnostics: list[str] = []
+    for name, account in scenario.accounts.items():
+        username = account.username
+        label = f"SDL account {name!r} (username={username!r})"
+        if username not in facts.users:
+            diagnostics.append(
+                redact(
+                    f"{label} has no matching `samba-tool user create` in "
+                    f"{_PROVISION_USERS_SCRIPT.name}; declared accounts must "
+                    "be honest, clean-start-realized fixtures"
+                )
+            )
+            continue
+
+        missing_groups = set(account.groups) - facts.groups_by_user.get(username, frozenset())
+        if missing_groups:
+            diagnostics.append(
+                redact(
+                    f"{label} declares group(s) {sorted(missing_groups)} that "
+                    f"{_PROVISION_USERS_SCRIPT.name} never adds via "
+                    "`samba-tool group addmembers`"
+                )
+            )
+
+        declared_mail = account.mail
+        if declared_mail:
+            actual_mail = facts.mail_by_user.get(username)
+            if actual_mail != declared_mail:
+                diagnostics.append(
+                    redact(
+                        f"{label} declares mail {declared_mail!r} but "
+                        f"{_PROVISION_USERS_SCRIPT.name} sets {actual_mail!r} "
+                        "via `--mail=`"
+                    )
+                )
+
+        declared_spn = account.spn
+        if declared_spn and declared_spn not in facts.spns_by_user.get(
+            username, frozenset()
+        ):
+            diagnostics.append(
+                redact(
+                    f"{label} declares spn {declared_spn!r} that "
+                    f"{_PROVISION_USERS_SCRIPT.name} never sets via "
+                    "`samba-tool spn add`"
+                )
+            )
+
+        declared_disabled = bool(account.disabled)
+        actual_disabled = username in facts.disabled_users
+        if declared_disabled != actual_disabled:
+            diagnostics.append(
+                redact(
+                    f"{label} declares disabled={declared_disabled} but "
+                    f"{_PROVISION_USERS_SCRIPT.name} "
+                    + (
+                        "never runs `samba-tool user disable` for this user"
+                        if declared_disabled
+                        else "runs `samba-tool user disable` for this user"
+                    )
+                )
+            )
+
+    return GateCheck("account_provisioner_parity", *_outcome(diagnostics))
 
 
 def check_parity_manifest(

--- a/src/aptl/validation/_gate_checks.py
+++ b/src/aptl/validation/_gate_checks.py
@@ -29,9 +29,6 @@ from aptl.backends.aces_profiles import public_start_profiles, select_backend_pr
 from aptl.backends.aces_realization import interpret_provisioning_plan
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.utils.redaction import redact
-from aptl.validation._account_parity import (
-    check_account_provisioner_parity as check_account_provisioner_parity,
-)
 from aptl.validation.techvault_gate import (
     DEFAULT_PARITY_INVENTORY,
     PHASE_B,

--- a/src/aptl/validation/_gate_checks.py
+++ b/src/aptl/validation/_gate_checks.py
@@ -14,7 +14,6 @@ import re
 import shutil
 import subprocess
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -30,6 +29,9 @@ from aptl.backends.aces_profiles import public_start_profiles, select_backend_pr
 from aptl.backends.aces_realization import interpret_provisioning_plan
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.utils.redaction import redact
+from aptl.validation._account_parity import (
+    check_account_provisioner_parity as check_account_provisioner_parity,
+)
 from aptl.validation.techvault_gate import (
     DEFAULT_PARITY_INVENTORY,
     PHASE_B,
@@ -53,19 +55,6 @@ _ISSUE_REF = re.compile(r"^(?:[a-z0-9][a-z0-9._-]*)?#\d+$", re.IGNORECASE)
 # dedicated gate step rather than the fast per-test suite.
 _SUBPROCESS_TIMEOUT_S = 120
 _IMPORT_LOCK_TIMEOUT_S = 600
-
-# Static SDL<->provisioner account parity (ADR-046 TechVault addendum,
-# issue #689): the checked-in AD account provisioner the `ad` container's
-# entrypoint always runs. A declared SDL account is honest only when this
-# script actually creates it.
-_PROVISION_USERS_SCRIPT = Path("containers") / "ad" / "provision-users.sh"
-_SAMBA_USER_CREATE_RE = re.compile(r"samba-tool\s+user\s+create\s+(\S+)")
-_SAMBA_MAIL_RE = re.compile(r'--mail="([^"]*)"')
-_SAMBA_GROUP_ADDMEMBERS_RE = re.compile(
-    r'samba-tool\s+group\s+addmembers\s+("[^"]+"|\S+)\s+(\S+)'
-)
-_SAMBA_SPN_ADD_RE = re.compile(r"samba-tool\s+spn\s+add\s+(\S+)\s+(\S+)")
-_SAMBA_USER_DISABLE_RE = re.compile(r"samba-tool\s+user\s+disable\s+(\S+)")
 
 
 class _NoStartBackend(object):
@@ -229,188 +218,6 @@ def check_provisioning_realization(
             f"{expected_profiles}; scenario would not instantiate the same range"
         )
     return details, GateCheck("provisioning_realization", *_outcome(diagnostics))
-
-
-@dataclass(frozen=True)
-class _ProvisionerFacts(object):
-    """Per-user facts statically scraped from ``provision-users.sh``.
-
-    Each field records what the provisioner script actually,
-    machine-checkably does for a given username — the authoritative
-    boundary account realization evidence must match (issue #689).
-    """
-
-    users: frozenset[str] = frozenset()
-    mail_by_user: Mapping[str, str] = field(default_factory=dict)
-    groups_by_user: Mapping[str, frozenset[str]] = field(default_factory=dict)
-    spns_by_user: Mapping[str, frozenset[str]] = field(default_factory=dict)
-    disabled_users: frozenset[str] = frozenset()
-
-
-def _parse_provisioner_facts(script_text: str) -> _ProvisionerFacts:
-    """Statically scan the AD provisioner script for per-user account facts.
-
-    ``user create`` commands use ``\\``-newline continuations to spread
-    flags (including ``--mail=``) across lines; collapse those first so a
-    continuation-line flag is still captured on the logical command line.
-    """
-    collapsed = script_text.replace("\\\n", " ")
-    users: set[str] = set()
-    mail_by_user: dict[str, str] = {}
-    groups_by_user: dict[str, set[str]] = {}
-    spns_by_user: dict[str, set[str]] = {}
-    disabled_users: set[str] = set()
-
-    for line in collapsed.splitlines():
-        create_match = _SAMBA_USER_CREATE_RE.search(line)
-        if create_match is not None:
-            username = create_match.group(1)
-            users.add(username)
-            mail_match = _SAMBA_MAIL_RE.search(line)
-            if mail_match is not None:
-                mail_by_user[username] = mail_match.group(1)
-            continue
-
-        group_match = _SAMBA_GROUP_ADDMEMBERS_RE.search(line)
-        if group_match is not None:
-            group = group_match.group(1).strip('"')
-            username = group_match.group(2)
-            groups_by_user.setdefault(username, set()).add(group)
-            continue
-
-        spn_match = _SAMBA_SPN_ADD_RE.search(line)
-        if spn_match is not None:
-            spn, username = spn_match.groups()
-            spns_by_user.setdefault(username, set()).add(spn)
-            continue
-
-        disable_match = _SAMBA_USER_DISABLE_RE.search(line)
-        if disable_match is not None:
-            disabled_users.add(disable_match.group(1))
-
-    return _ProvisionerFacts(
-        users=frozenset(users),
-        mail_by_user=mail_by_user,
-        groups_by_user={k: frozenset(v) for k, v in groups_by_user.items()},
-        spns_by_user={k: frozenset(v) for k, v in spns_by_user.items()},
-        disabled_users=frozenset(disabled_users),
-    )
-
-
-def check_account_provisioner_parity(
-    *, scenario: Scenario, project_dir: Path
-) -> GateCheck:
-    """Confirm every SDL-declared account attribute is provisioner-authoritative.
-
-    Account declarations are honest only when the clean-start path actually
-    creates them, with the same groups/mail/SPN/disabled state, through an
-    existing service-owned provisioner (ADR-046 TechVault Operational Standup
-    Addendum, issue #689). This never runs Docker or ``samba-tool``; it
-    statically scans the checked-in provisioner script the ``ad`` container's
-    entrypoint always runs (``containers/ad/provision-users.sh``), so
-    SDL<->provisioner drift is caught before ``aptl lab start`` rather than
-    discovered live.
-
-    Each SDL account (``scenario.accounts``) is checked against the
-    provisioner's per-user facts:
-
-    - ``username`` must have a matching ``samba-tool user create``.
-    - every declared ``group`` must be a subset of the groups the
-      provisioner actually adds that user to via
-      ``samba-tool group addmembers``.
-    - a non-empty declared ``mail`` must equal the ``--mail=`` value on
-      that user's ``user create`` command.
-    - a non-empty declared ``spn`` must be one the provisioner actually
-      sets for that user via ``samba-tool spn add``.
-    - declared ``disabled`` must equal whether the provisioner runs
-      ``samba-tool user disable`` for that user (absent means not
-      disabled).
-
-    The check is one-directional (the provisioner may create more users,
-    groups, or SPNs than the SDL declares; a phantom SDL account or a
-    phantom SDL-declared attribute still fails).
-    """
-    script_path = project_dir / _PROVISION_USERS_SCRIPT
-    if not script_path.exists():
-        return GateCheck(
-            "account_provisioner_parity",
-            False,
-            (f"AD account provisioner script missing at {script_path}",),
-        )
-    try:
-        script_text = script_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        return GateCheck(
-            "account_provisioner_parity",
-            False,
-            (redact(f"AD account provisioner script unreadable: {exc}"),),
-        )
-
-    facts = _parse_provisioner_facts(script_text)
-    diagnostics: list[str] = []
-    for name, account in scenario.accounts.items():
-        username = account.username
-        label = f"SDL account {name!r} (username={username!r})"
-        if username not in facts.users:
-            diagnostics.append(
-                redact(
-                    f"{label} has no matching `samba-tool user create` in "
-                    f"{_PROVISION_USERS_SCRIPT.name}; declared accounts must "
-                    "be honest, clean-start-realized fixtures"
-                )
-            )
-            continue
-
-        missing_groups = set(account.groups) - facts.groups_by_user.get(username, frozenset())
-        if missing_groups:
-            diagnostics.append(
-                redact(
-                    f"{label} declares group(s) {sorted(missing_groups)} that "
-                    f"{_PROVISION_USERS_SCRIPT.name} never adds via "
-                    "`samba-tool group addmembers`"
-                )
-            )
-
-        declared_mail = account.mail
-        if declared_mail:
-            actual_mail = facts.mail_by_user.get(username)
-            if actual_mail != declared_mail:
-                diagnostics.append(
-                    redact(
-                        f"{label} declares mail {declared_mail!r} but "
-                        f"{_PROVISION_USERS_SCRIPT.name} sets {actual_mail!r} "
-                        "via `--mail=`"
-                    )
-                )
-
-        declared_spn = account.spn
-        if declared_spn and declared_spn not in facts.spns_by_user.get(
-            username, frozenset()
-        ):
-            diagnostics.append(
-                redact(
-                    f"{label} declares spn {declared_spn!r} that "
-                    f"{_PROVISION_USERS_SCRIPT.name} never sets via "
-                    "`samba-tool spn add`"
-                )
-            )
-
-        declared_disabled = bool(account.disabled)
-        actual_disabled = username in facts.disabled_users
-        if declared_disabled != actual_disabled:
-            diagnostics.append(
-                redact(
-                    f"{label} declares disabled={declared_disabled} but "
-                    f"{_PROVISION_USERS_SCRIPT.name} "
-                    + (
-                        "never runs `samba-tool user disable` for this user"
-                        if declared_disabled
-                        else "runs `samba-tool user disable` for this user"
-                    )
-                )
-            )
-
-    return GateCheck("account_provisioner_parity", *_outcome(diagnostics))
 
 
 def check_parity_manifest(

--- a/src/aptl/validation/techvault_gate.py
+++ b/src/aptl/validation/techvault_gate.py
@@ -176,8 +176,10 @@ def validate_scenario(
 
     # 7. Account provisioner parity — every SDL account is a real,
     # clean-start-realized fixture, not a phantom declaration (#689).
+    from aptl.validation import _account_parity
+
     results.append(
-        checks.check_account_provisioner_parity(
+        _account_parity.check_account_provisioner_parity(
             scenario=scenario, project_dir=project_dir
         )
     )

--- a/src/aptl/validation/techvault_gate.py
+++ b/src/aptl/validation/techvault_gate.py
@@ -174,4 +174,12 @@ def validate_scenario(
         )
     )
 
+    # 7. Account provisioner parity — every SDL account is a real,
+    # clean-start-realized fixture, not a phantom declaration (#689).
+    results.append(
+        checks.check_account_provisioner_parity(
+            scenario=scenario, project_dir=project_dir
+        )
+    )
+
     return GateReport(str(scenario_path), opts.profile, opts.phase, tuple(results))

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -2285,16 +2285,92 @@ def test_provisioner_rejects_supported_placement_without_declared_target(tmp_pat
     backend.realize.assert_not_called()
 
 
-def test_provisioner_records_supported_placement_realizations(tmp_path):
-    from aptl.backends.aces import AptlProvisioner
-
+def _fileshare_and_ad_compose(tmp_path: Path) -> None:
     _write_compose(
         tmp_path,
         {
             "kali": ["kali"],
             "aptl-otel-collector": ["otel"],
+            "fileshare": ["fileshare"],
+            "ad": ["enterprise"],
         },
     )
+
+
+def _content_resource(
+    *,
+    address: str = "provision.content-placement.notice",
+    target_node: str = "scenario.fileshare",
+    target_address: str,
+    spec_overrides: dict | None = None,
+) -> PlannedResource:
+    spec = {
+        "type": "file",
+        "description": "",
+        "target": target_node,
+        "path": "public/notice.txt",
+        "destination": "",
+        "text": "Welcome to TechVault.",
+        "source": None,
+        "format": "",
+        "items": [],
+        "sensitive": False,
+        "tags": [],
+    }
+    spec.update(spec_overrides or {})
+    return PlannedResource(
+        address=address,
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="content-placement",
+        payload={
+            "name": "notice",
+            "content_name": "notice",
+            "target_node": target_node,
+            "target_address": target_address,
+            "spec": spec,
+        },
+    )
+
+
+def _account_resource(
+    *,
+    address: str = "provision.account-placement.operator",
+    node_name: str = "scenario.ad",
+    target_address: str,
+    spec_overrides: dict | None = None,
+) -> PlannedResource:
+    spec = {
+        "username": "operator",
+        "node": node_name,
+        "groups": ["IT-Admins"],
+        "password_strength": "weak",
+        "auth_method": "password",
+        "description": "",
+        "mail": "operator@techvault.local",
+        "spn": "",
+        "shell": "",
+        "home": "",
+        "disabled": False,
+    }
+    spec.update(spec_overrides or {})
+    return PlannedResource(
+        address=address,
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="account-placement",
+        payload={
+            "name": "operator",
+            "account_name": "operator",
+            "node_name": node_name,
+            "target_address": target_address,
+            "spec": spec,
+        },
+    )
+
+
+def test_provisioner_records_supported_placement_realizations(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _fileshare_and_ad_compose(tmp_path)
     backend = MagicMock()
     backend.realize.return_value = LabResult(success=True, message="ok")
     provisioner = AptlProvisioner(
@@ -2303,6 +2379,8 @@ def test_provisioner_records_supported_placement_realizations(tmp_path):
         deployment_backend=backend,
     )
     node = _node_resource("scenario.kali")
+    fileshare_node = _node_resource("scenario.fileshare")
+    ad_node = _node_resource("scenario.ad")
     feature = PlannedResource(
         address="provision.feature-binding.ssh",
         domain=RuntimeDomain.PROVISIONING,
@@ -2313,29 +2391,12 @@ def test_provisioner_records_supported_placement_realizations(tmp_path):
             "node_name": "scenario.kali",
         },
     )
-    content = PlannedResource(
-        address="provision.content-placement.payload",
-        domain=RuntimeDomain.PROVISIONING,
-        resource_type="content-placement",
-        payload={
-            "name": "payload",
-            "content_name": "payload.exe",
-            "target_address": node.address,
-        },
-    )
-    account = PlannedResource(
-        address="provision.account-placement.operator",
-        domain=RuntimeDomain.PROVISIONING,
-        resource_type="account-placement",
-        payload={
-            "name": "operator",
-            "account_name": "operator",
-            "node_name": "scenario.kali",
-        },
-    )
+    content = _content_resource(target_address=fileshare_node.address)
+    account = _account_resource(target_address=ad_node.address)
 
     result = provisioner.apply(
-        _plan_for_resources(node, feature, content, account), RuntimeSnapshot()
+        _plan_for_resources(node, fileshare_node, ad_node, feature, content, account),
+        RuntimeSnapshot(),
     )
 
     assert result.success is True
@@ -2345,13 +2406,184 @@ def test_provisioner_records_supported_placement_realizations(tmp_path):
         "content-placement",
         "feature-binding",
     }
-    assert {placement["target_address"] for placement in placements} == {node.address}
     assert result.details["realization"]["resource_counts"] == {
         "account-placement": 1,
         "content-placement": 1,
         "feature-binding": 1,
-        "node": 1,
+        "node": 3,
     }
+
+    content_placement = next(
+        p for p in placements if p["resource_type"] == "content-placement"
+    )
+    assert content_placement["content"] == {
+        "address": "provision.content-placement.notice",
+        "target_address": fileshare_node.address,
+        "content_name": "notice",
+        "volume_suffix": "fileshare_data",
+        "dest_relpath": "public/notice.txt",
+        "source_kind": "inline-text",
+        "source_relpath": None,
+        "sensitive": False,
+    }
+
+    account_placement = next(
+        p for p in placements if p["resource_type"] == "account-placement"
+    )
+    assert account_placement["account"] == {
+        "address": "provision.account-placement.operator",
+        "target_address": ad_node.address,
+        "username": "operator",
+        "groups": ["IT-Admins"],
+        "spn": "",
+        "mail": "operator@techvault.local",
+        "disabled": False,
+    }
+
+    # Real lowering, not counting: the typed backend spec actually passed
+    # to the deployment backend carries the content/account records.
+    deployment_spec = backend.realize.call_args[0][0]
+    assert len(deployment_spec.content) == 1
+    assert deployment_spec.content[0].dest_relpath == "public/notice.txt"
+    assert deployment_spec.content[0].inline_text == "Welcome to TechVault."
+    assert len(deployment_spec.accounts) == 1
+    assert deployment_spec.accounts[0].username == "operator"
+
+
+def _apply_single_content_placement(tmp_path, *, spec_overrides: dict) -> tuple:
+    """Apply a plan with one fileshare-targeted content placement; return (result, code)."""
+    from aptl.backends.aces import AptlProvisioner
+
+    _fileshare_and_ad_compose(tmp_path)
+    backend = MagicMock()
+    backend.realize.return_value = LabResult(success=True, message="ok")
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "test"}),
+        deployment_backend=backend,
+    )
+    fileshare_node = _node_resource("scenario.fileshare")
+    content = _content_resource(
+        target_address=fileshare_node.address, spec_overrides=spec_overrides
+    )
+    result = provisioner.apply(
+        _plan_for_resources(fileshare_node, content), RuntimeSnapshot()
+    )
+    codes = {d.code for d in result.diagnostics}
+    return result, codes
+
+
+def test_content_placement_dataset_type_fails_closed(tmp_path):
+    result, codes = _apply_single_content_placement(
+        tmp_path,
+        spec_overrides={
+            "type": "dataset",
+            "text": None,
+            "source": {"name": "some-package", "version": "*", "build": None},
+            "items": [{"name": "item-1", "tags": [], "description": ""}],
+        },
+    )
+    assert result.success is False
+    assert "aptl.provisioner.content-placement-rejected" in codes
+    assert any(
+        "dataset-not-realizable" in d.message
+        for d in result.diagnostics
+        if d.code == "aptl.provisioner.content-placement-rejected"
+    )
+
+
+def test_content_placement_runtime_observed_source_fails_closed(tmp_path):
+    result, codes = _apply_single_content_placement(
+        tmp_path,
+        spec_overrides={
+            "text": None,
+            "source": {
+                "name": "runtime-observed:/var/log/nginx/access.log",
+                "version": "*",
+                "build": None,
+            },
+        },
+    )
+    assert result.success is False
+    assert "aptl.provisioner.content-placement-rejected" in codes
+    assert any(
+        "runtime-observed-source" in d.message
+        for d in result.diagnostics
+        if d.code == "aptl.provisioner.content-placement-rejected"
+    )
+
+
+def test_content_placement_source_path_escape_fails_closed(tmp_path):
+    result, codes = _apply_single_content_placement(
+        tmp_path,
+        spec_overrides={
+            "text": None,
+            "source": {"name": "../../../etc/passwd", "version": "*", "build": None},
+        },
+    )
+    assert result.success is False
+    assert "aptl.provisioner.content-placement-rejected" in codes
+    assert any(
+        "source-path-escapes-project" in d.message
+        for d in result.diagnostics
+        if d.code == "aptl.provisioner.content-placement-rejected"
+    )
+
+
+def test_content_placement_destination_without_backing_mount_fails_closed(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _fileshare_and_ad_compose(tmp_path)
+    backend = MagicMock()
+    backend.realize.return_value = LabResult(success=True, message="ok")
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "test"}),
+        deployment_backend=backend,
+    )
+    kali_node = _node_resource("scenario.kali")
+    content = _content_resource(
+        target_node="scenario.kali", target_address=kali_node.address
+    )
+    result = provisioner.apply(
+        _plan_for_resources(kali_node, content), RuntimeSnapshot()
+    )
+    codes = {d.code for d in result.diagnostics}
+    assert result.success is False
+    assert "aptl.provisioner.content-placement-rejected" in codes
+    assert any(
+        "destination-without-backing-mount" in d.message
+        for d in result.diagnostics
+        if d.code == "aptl.provisioner.content-placement-rejected"
+    )
+
+
+def test_account_placement_target_without_provisioner_fails_closed(tmp_path):
+    from aptl.backends.aces import AptlProvisioner
+
+    _fileshare_and_ad_compose(tmp_path)
+    backend = MagicMock()
+    backend.realize.return_value = LabResult(success=True, message="ok")
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "test"}),
+        deployment_backend=backend,
+    )
+    kali_node = _node_resource("scenario.kali")
+    account = _account_resource(
+        node_name="scenario.kali", target_address=kali_node.address
+    )
+    result = provisioner.apply(
+        _plan_for_resources(kali_node, account), RuntimeSnapshot()
+    )
+    codes = {d.code for d in result.diagnostics}
+    assert result.success is False
+    assert "aptl.provisioner.account-placement-rejected" in codes
+    assert any(
+        "no-account-provisioner-for-target" in d.message
+        for d in result.diagnostics
+        if d.code == "aptl.provisioner.account-placement-rejected"
+    )
 
 
 def test_provisioner_rejects_unsupported_resource_type(tmp_path):

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -237,6 +237,51 @@ def test_materialize_from_checkout_excludes_secrets(
     assert not list(target.rglob("node_modules"))
 
 
+def test_git_tracked_ignores_ambient_git_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_git_tracked`` must ignore inherited git *location* env vars.
+
+    A git hook (e.g. pre-commit) exports ``GIT_DIR`` / ``GIT_WORK_TREE`` /
+    ``GIT_INDEX_FILE`` pointing at the real repo. Without neutralizing them,
+    ``git ls-files`` run inside a non-repo checkout resolves to the ambient
+    repo and returns its tracked files (e.g. ``.dockerignore``) the checkout
+    lacks. ``_git_tracked`` must instead report nothing so the caller falls
+    back to walking ``root``.
+    """
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    _make_fake_checkout(checkout)  # deliberately not a git repo
+    monkeypatch.setenv("GIT_DIR", str(REPO_ROOT / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(REPO_ROOT))
+
+    assert assets._git_tracked(checkout) is None
+
+
+def test_materialize_ignores_ambient_git_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Materializing a non-repo checkout must not copy ambient-repo files.
+
+    Regression guard for the pre-commit-hook flake: the hook's ambient
+    ``GIT_DIR``/``GIT_WORK_TREE`` must not make materialize try to copy the
+    real repo's tracked files (which the fake checkout lacks) and raise
+    ``FileNotFoundError``.
+    """
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    _make_fake_checkout(checkout)
+    monkeypatch.setattr(assets, "resolve_asset_source", lambda: (checkout, False))
+    monkeypatch.setenv("GIT_DIR", str(REPO_ROOT / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(REPO_ROOT))
+
+    target = tmp_path / "lab"
+    materialize(target)
+
+    assert (target / "docker-compose.yml").is_file()
+    assert not (target / ".dockerignore").exists()
+
+
 def test_materialize_from_bundle_skips_pip_compiled_artifacts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_content_realization_fuzz.py
+++ b/tests/test_content_realization_fuzz.py
@@ -1,0 +1,124 @@
+"""Property-based fuzz tests for content-placement path containment (#689).
+
+Guards the ADR-046 TechVault addendum's fail-closed rule: a content
+placement whose declared source path escapes the project root must never
+be realized, at either the ACES interpreter boundary
+(`aces_content_realization.resolve_content_placement`) or the backend seed
+boundary (`content_seed.build_content_volume_seeds`, independently
+re-checked per ADR-043's defense-in-depth precedent). Mirrors the
+`../../etc/passwd`-style escape pattern already used for credential path
+containment (see `docs/testing/property-based-parser-tests.md`).
+
+Run with ``pytest -m fuzz tests/test_content_realization_fuzz.py``;
+excluded from the default suite by ``pyproject.toml`` (``addopts = "-m
+'not fuzz'"``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from aces_contracts.planning import PlannedResource, RuntimeDomain
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from aptl.backends.aces_content_realization import resolve_content_placement
+from aptl.core.content_seed import build_content_volume_seeds
+from aptl.core.credentials import PathContainmentError
+from aptl.core.deployment.realization import DeploymentContentRealization
+
+pytestmark = pytest.mark.fuzz
+
+# Lowercase-ASCII-and-digit-only segments. The project directory below is
+# named with an uppercase-containing literal ("ProjectRoot") that this
+# alphabet can never spell, so no fuzzed `../segment/...` path can ever
+# accidentally re-descend back inside the project root by coincidence —
+# every generated path is a genuine escape attempt.
+_SEGMENT = st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=10)
+_DEPTH = st.integers(min_value=1, max_value=10)
+_SEGMENTS = st.lists(_SEGMENT, min_size=1, max_size=5)
+
+
+def _escaping_source_name(depth: int, segments: list[str]) -> str:
+    return "/".join([".."] * depth + segments)
+
+
+def _content_payload(source_name: str) -> dict:
+    return {
+        "name": "fuzz",
+        "content_name": "fuzz",
+        "target_node": "fileshare",
+        "target_address": "provision.node.fileshare",
+        "spec": {
+            "type": "file",
+            "description": "",
+            "target": "fileshare",
+            "path": "public/fuzz.txt",
+            "destination": "",
+            "text": None,
+            "source": {"name": source_name, "version": "*", "build": None},
+            "format": "",
+            "items": [],
+            "sensitive": False,
+            "tags": [],
+        },
+    }
+
+
+@given(depth=_DEPTH, segments=_SEGMENTS)
+@settings(
+    max_examples=150,
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_interpreter_never_realizes_an_escaping_content_source(tmp_path, depth, segments):
+    """`resolve_content_placement` fails closed for any project-root escape."""
+    project_dir = tmp_path / "ProjectRoot"
+    project_dir.mkdir(exist_ok=True)
+    source_name = _escaping_source_name(depth, segments)
+    payload = _content_payload(source_name)
+    resource = PlannedResource(
+        address="provision.content-placement.fuzz",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="content-placement",
+        payload=payload,
+    )
+
+    content, diagnostics = resolve_content_placement(
+        resource=resource,
+        payload=payload,
+        target_address="provision.node.fileshare",
+        target_service="fileshare",
+        project_dir=project_dir,
+    )
+
+    assert content is None
+    assert len(diagnostics) == 1
+    assert diagnostics[0].code == "aptl.provisioner.content-placement-rejected"
+    assert diagnostics[0].is_error
+
+
+@given(depth=_DEPTH, segments=_SEGMENTS)
+@settings(
+    max_examples=150,
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_backend_seed_builder_rejects_escaping_source_independently(
+    tmp_path, depth, segments
+):
+    """`build_content_volume_seeds` re-checks containment (ADR-043 defense in depth)."""
+    project_dir = tmp_path / "ProjectRoot"
+    project_dir.mkdir(exist_ok=True)
+    source_relpath = _escaping_source_name(depth, segments)
+    item = DeploymentContentRealization(
+        address="provision.content-placement.fuzz",
+        target_address="provision.node.fileshare",
+        content_name="fuzz",
+        volume_suffix="fileshare_data",
+        dest_relpath="public/fuzz.txt",
+        source_kind="project-file",
+        source_relpath=source_relpath,
+    )
+
+    with pytest.raises(PathContainmentError):
+        build_content_volume_seeds(project_dir, [item])

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -2217,3 +2217,183 @@ class TestSeedNamedVolumes:
             with pytest.raises(BackendSeedError):
                 backend.seed_named_volumes([evil], seeder_image="img:1")
         mock_run.assert_not_called()
+
+
+class TestRealizeContent:
+    """Issue #689: typed content-placement realization via the ADR-043 seed seam.
+
+    ``realize_content`` mirrors ``seed_named_volumes`` (same root one-off
+    container, argv-list command, redacted failure) but takes typed
+    ``DeploymentContentRealization`` records instead of pre-built
+    ``NamedVolumeSeed``\\ s, so these tests focus on the extra translation
+    step (inline-text rendering, project-source resolution) rather than
+    re-testing the seed mechanics ``TestSeedNamedVolumes`` already covers.
+    """
+
+    def _backend(self, tmp_path):
+        return DockerComposeBackend(project_dir=tmp_path, project_name="test")
+
+    def _inline_text_item(self, **overrides):
+        from aptl.core.deployment.realization import DeploymentContentRealization
+
+        fields = {
+            "address": "provision.content-placement.notice",
+            "target_address": "provision.node.fileshare",
+            "content_name": "notice",
+            "volume_suffix": "fileshare_data",
+            "dest_relpath": "public/notice.txt",
+            "source_kind": "inline-text",
+            "inline_text": "Welcome to TechVault.",
+        }
+        fields.update(overrides)
+        return DeploymentContentRealization(**fields)
+
+    def test_inline_text_renders_and_seeds_into_project_scoped_volume(self, tmp_path):
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            backend.realize_content([self._inline_text_item()], seeder_image="img:1")
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:7] == [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "0:0",
+            "--entrypoint",
+            "/bin/sh",
+        ]
+        rendered_dir = (
+            tmp_path / ".aptl" / "content" / "provision.content-placement.notice"
+        )
+        assert f"{rendered_dir}:/src:ro" in cmd
+        assert "test_fileshare_data:/dest" in cmd
+        assert cmd[-3] == "img:1"
+        script = cmd[-1]
+        assert "mkdir -p /dest/public" in script
+        assert "cp -a /src/notice.txt /dest/public/notice.txt" in script
+
+        rendered_file = rendered_dir / "notice.txt"
+        assert rendered_file.read_text(encoding="utf-8") == "Welcome to TechVault."
+
+    def test_project_file_source_binds_resolved_parent_directory(self, tmp_path):
+        from aptl.core.deployment.realization import DeploymentContentRealization
+
+        source_dir = tmp_path / "scenarios" / "fixtures" / "techvault-content"
+        source_dir.mkdir(parents=True)
+        (source_dir / "onboarding.md").write_text("hello", encoding="utf-8")
+        item = DeploymentContentRealization(
+            address="provision.content-placement.onboarding",
+            target_address="provision.node.fileshare",
+            content_name="onboarding",
+            volume_suffix="fileshare_data",
+            dest_relpath="onboarding/onboarding.md",
+            source_kind="project-file",
+            source_relpath="scenarios/fixtures/techvault-content/onboarding.md",
+        )
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            backend.realize_content([item], seeder_image="img:1")
+
+        cmd = mock_run.call_args[0][0]
+        assert f"{source_dir}:/src:ro" in cmd
+        assert "test_fileshare_data:/dest" in cmd
+        script = cmd[-1]
+        assert "mkdir -p /dest/onboarding" in script
+        assert "cp -a /src/onboarding.md /dest/onboarding/onboarding.md" in script
+
+    def test_project_source_escaping_project_root_raises(self, tmp_path):
+        from aptl.core.credentials import PathContainmentError
+        from aptl.core.deployment.realization import DeploymentContentRealization
+
+        item = DeploymentContentRealization(
+            address="provision.content-placement.evil",
+            target_address="provision.node.fileshare",
+            content_name="evil",
+            volume_suffix="fileshare_data",
+            dest_relpath="public/evil.txt",
+            source_kind="project-file",
+            source_relpath="../../etc/passwd",
+        )
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            with pytest.raises(PathContainmentError):
+                backend.realize_content([item], seeder_image="img:1")
+        mock_run.assert_not_called()
+
+    def test_realize_content_is_idempotent_across_runs(self, tmp_path):
+        backend = self._backend(tmp_path)
+        item = self._inline_text_item()
+        commands = []
+        for _ in range(2):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+                backend.realize_content([item], seeder_image="img:1")
+                commands.append(mock_run.call_args[0][0])
+        assert commands[0] == commands[1]
+
+    def test_empty_content_list_runs_no_container(self, tmp_path):
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            backend.realize_content([], seeder_image="img:1")
+        mock_run.assert_not_called()
+
+    def test_nonzero_exit_raises_without_leaking_stderr(self, tmp_path):
+        from aptl.core.deployment.errors import BackendSeedError
+
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="secret docker stderr"
+            )
+            with pytest.raises(BackendSeedError) as exc_info:
+                backend.realize_content(
+                    [self._inline_text_item()], seeder_image="img:1"
+                )
+        assert "fileshare_data" in str(exc_info.value)
+        assert "secret docker stderr" not in str(exc_info.value)
+
+
+class TestComposeRealizeContentStep:
+    """Issue #689: content realization wired into ``ComposeRealizationMixin.realize``."""
+
+    def _backend(self, tmp_path):
+        return DockerComposeBackend(project_dir=tmp_path, project_name="test")
+
+    def test_realize_content_failure_is_fail_closed_lab_result(self, tmp_path):
+        from aptl.core.deployment.errors import BackendSeedError
+        from aptl.core.deployment.realization import DeploymentContentRealization
+
+        backend = self._backend(tmp_path)
+        item = DeploymentContentRealization(
+            address="provision.content-placement.notice",
+            target_address="provision.node.fileshare",
+            content_name="notice",
+            volume_suffix="fileshare_data",
+            dest_relpath="public/notice.txt",
+            source_kind="inline-text",
+            inline_text="hi",
+        )
+        spec = DeploymentRealizationSpec(
+            profiles=(), nodes=(), networks=(), content=(item,)
+        )
+        # BackendSeedError itself only ever carries the artifact name, never
+        # raw Docker stderr (see TestRealizeContent's own leak test); this
+        # test proves the wrapping step fails closed rather than raising.
+        with patch.object(
+            backend,
+            "realize_content",
+            side_effect=BackendSeedError("Seeding named volume 'fileshare_data' failed"),
+        ):
+            result = backend._realize_content(spec)
+        assert result is not None
+        assert result.success is False
+        assert "fileshare_data" in (result.error or "")
+
+    def test_no_content_is_a_no_op(self, tmp_path):
+        backend = self._backend(tmp_path)
+        spec = DeploymentRealizationSpec(profiles=(), nodes=(), networks=(), content=())
+        assert backend._realize_content(spec) is None

--- a/tests/test_hatch_build_hook.py
+++ b/tests/test_hatch_build_hook.py
@@ -117,6 +117,30 @@ def test_initialize_maps_assets_under_labdata(tmp_path: Path) -> None:
     assert hook._staging_dir is None
 
 
+def test_initialize_ignores_ambient_git_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The build hook must ignore inherited git *location* env vars.
+
+    Regression guard: a build (or pre-commit hook) that exports ``GIT_DIR`` /
+    ``GIT_WORK_TREE`` pointing at the real repo must not make ``_git_tracked``
+    resolve to the ambient repo and try to bundle files the synthetic
+    (non-repo) tree lacks — which raised ``FileNotFoundError``.
+    """
+    hatch_build = _load_hatch_build()
+    _make_fake_checkout(tmp_path)
+    monkeypatch.setenv("GIT_DIR", str(REPO_ROOT / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(REPO_ROOT))
+
+    hook = hatch_build.CustomBuildHook(str(tmp_path))
+    build_data: dict[str, object] = {}
+    hook.initialize("0", build_data)
+
+    targets = set(build_data["force_include"].values())
+    assert "aptl/_labdata/docker-compose.yml" in targets
+    assert not any(t.endswith(".dockerignore") for t in targets)
+
+
 def test_initialize_skips_minimal_context(tmp_path: Path) -> None:
     """A build context without docker-compose.yml (service images) bundles nothing."""
     hatch_build = _load_hatch_build()

--- a/tests/test_paper_scenario_static_gate.py
+++ b/tests/test_paper_scenario_static_gate.py
@@ -62,7 +62,57 @@ def test_paper_scenario_realizes_declared_topology_and_evaluator_surfaces():
         config=config,
     )
 
-    assert realization.diagnostics == ()
+    # #689 makes content-placement realization real (fail closed) instead of
+    # the prior count-only behavior. The paper scenario's `content:` entries
+    # are either evaluator-evidence contracts (`dataset` type: consumed by
+    # the evaluator through `plan.evaluation`, never planted as file/dir
+    # content) or a Kali-targeted task brief/runtime binding with no
+    # registered APTL content mount — none of them are project-contained
+    # file/directory content backed by a typed backend volume, so every one
+    # now correctly fails closed with a diagnostic rather than being
+    # silently counted as realized (the exact anti-pattern ADR-046 removes).
+    # Non-content diagnostics still must be empty.
+    content_diagnostics = {
+        d.address: d
+        for d in realization.diagnostics
+        if d.code == "aptl.provisioner.content-placement-rejected"
+    }
+    assert set(content_diagnostics) == {
+        "provision.content.task-brief",
+        "provision.content.participant-observation",
+        "provision.content.aptl-participant-runtime-binding",
+        "provision.content.wazuh-evidence",
+        "provision.content.boundary-check-evidence",
+        "provision.content.evaluator-notes",
+    }
+    assert all(d.is_error for d in content_diagnostics.values())
+    assert [d for d in realization.diagnostics if d.address not in content_diagnostics] == []
+    assert (
+        "dataset-not-realizable"
+        in content_diagnostics["provision.content.participant-observation"].message
+    )
+    assert (
+        "dataset-not-realizable"
+        in content_diagnostics["provision.content.wazuh-evidence"].message
+    )
+    assert (
+        "dataset-not-realizable"
+        in content_diagnostics["provision.content.boundary-check-evidence"].message
+    )
+    assert (
+        "destination-without-backing-mount"
+        in content_diagnostics["provision.content.task-brief"].message
+    )
+    assert (
+        "destination-without-backing-mount"
+        in content_diagnostics[
+            "provision.content.aptl-participant-runtime-binding"
+        ].message
+    )
+    assert (
+        "destination-without-backing-mount"
+        in content_diagnostics["provision.content.evaluator-notes"].message
+    )
     assert select_backend_profiles(config, realization.profiles) == [
         "wazuh",
         "kali",

--- a/tests/test_techvault_static_gate.py
+++ b/tests/test_techvault_static_gate.py
@@ -47,6 +47,7 @@ from aptl.validation._gate_checks import (
     _surface_evidence,
     _target_conformance_diagnostics,
     _verify_imports_diagnostics,
+    check_account_provisioner_parity,
     check_backend_conformance,
     check_compile,
     check_import_lock,
@@ -641,6 +642,181 @@ def test_check_provisioning_realization_fails_on_profile_mismatch(tmp_path):
     assert any("public lab start profiles" in d for d in check.diagnostics)
 
 
+# --------------------------------------------------------------------------- #
+# Content/account honesty (ADR-046 TechVault Operational Standup Addendum,
+# issue #689): unrealizable content fails the existing provisioning
+# realization check (its error diagnostics now cover content/account
+# placements too); SDL<->provisioner account drift fails the new dedicated
+# account_provisioner_parity check.
+# --------------------------------------------------------------------------- #
+
+
+def test_operational_scenario_content_and_accounts_are_honest():
+    """The shipped operational SDL's content/accounts realize with no errors."""
+    config = load_config(PROJECT_ROOT / "aptl.json")
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert parse_check.passed
+    assert scenario is not None
+    assert scenario.content
+    assert scenario.accounts
+
+    details, check = check_provisioning_realization(
+        scenario=scenario, project_dir=PROJECT_ROOT, config=config
+    )
+    assert details is not None
+    assert check.passed, check.diagnostics
+    placements = details["placements"]
+    content_placements = [p for p in placements if p["resource_type"] == "content-placement"]
+    account_placements = [p for p in placements if p["resource_type"] == "account-placement"]
+    assert content_placements and all("content" in p for p in content_placements)
+    assert account_placements and all("account" in p for p in account_placements)
+
+
+def test_provisioning_realization_fails_on_unrealizable_content(tmp_path):
+    from textwrap import dedent
+
+    from aces_sdl.parser import parse_sdl
+
+    _write_compose(tmp_path, {"fileshare": ["fileshare"]})
+    scenario = parse_sdl(
+        dedent(
+            """
+            name: bad-content
+            nodes:
+              fileshare:
+                type: vm
+                services:
+                  - {name: smb, port: 445, protocol: tcp}
+            content:
+              leaked-log:
+                type: file
+                target: fileshare
+                path: var/log/leak.log
+                source:
+                  name: "runtime-observed:/var/log/leak.log"
+            """
+        )
+    )
+    config = AptlConfig(
+        lab={"name": "t"},
+        containers={
+            "wazuh": False,
+            "victim": False,
+            "kali": False,
+            "reverse": False,
+            "enterprise": False,
+            "soc": False,
+            "mail": False,
+            "fileshare": True,
+            "dns": False,
+        },
+    )
+
+    details, check = check_provisioning_realization(
+        scenario=scenario, project_dir=tmp_path, config=config
+    )
+
+    assert details is not None
+    assert not check.passed
+    assert any("content-placement-rejected" in d for d in check.diagnostics)
+    assert any("runtime-observed-source" in d for d in check.diagnostics)
+
+
+def test_account_provisioner_parity_passes_for_operational_scenario():
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert parse_check.passed
+    assert scenario is not None
+
+    check = check_account_provisioner_parity(scenario=scenario, project_dir=PROJECT_ROOT)
+
+    assert check.passed, check.diagnostics
+
+
+def test_account_provisioner_parity_fails_on_phantom_account():
+    from aces_sdl.accounts import Account, PasswordStrength
+
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert parse_check.passed
+    assert scenario is not None
+    scenario.accounts["phantom-user"] = Account(
+        username="not-a-real-provisioner-user",
+        node="ad",
+        password_strength=PasswordStrength.WEAK,
+    )
+
+    check = check_account_provisioner_parity(scenario=scenario, project_dir=PROJECT_ROOT)
+
+    assert not check.passed
+    assert any("not-a-real-provisioner-user" in d for d in check.diagnostics)
+
+
+def test_account_provisioner_parity_fails_closed_when_script_missing(tmp_path):
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert parse_check.passed
+    assert scenario is not None
+
+    check = check_account_provisioner_parity(scenario=scenario, project_dir=tmp_path)
+
+    assert not check.passed
+    assert any("provisioner script missing" in d.lower() for d in check.diagnostics)
+
+
+def test_account_provisioner_parity_fails_on_undeclared_group():
+    """A declared group the provisioner never adds must fail closed."""
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert parse_check.passed
+    assert scenario is not None
+    account = scenario.accounts["ad-jessica-williams"]
+    account.groups = [*account.groups, "Finance"]
+
+    check = check_account_provisioner_parity(scenario=scenario, project_dir=PROJECT_ROOT)
+
+    assert not check.passed
+    assert any("Finance" in d and "group" in d.lower() for d in check.diagnostics)
+
+
+def test_account_provisioner_parity_fails_on_mail_mismatch():
+    """A declared mail address that doesn't match the provisioner's --mail must fail closed."""
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert parse_check.passed
+    assert scenario is not None
+    account = scenario.accounts["ad-jessica-williams"]
+    account.mail = "jessica.williams@example.com"
+
+    check = check_account_provisioner_parity(scenario=scenario, project_dir=PROJECT_ROOT)
+
+    assert not check.passed
+    assert any("mail" in d.lower() for d in check.diagnostics)
+
+
+def test_account_provisioner_parity_fails_on_spn_mismatch():
+    """A declared SPN the provisioner never sets via `samba-tool spn add` must fail closed."""
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert parse_check.passed
+    assert scenario is not None
+    account = scenario.accounts["ad-svc-sql"]
+    account.spn = "HTTP/bogus.techvault.local"
+
+    check = check_account_provisioner_parity(scenario=scenario, project_dir=PROJECT_ROOT)
+
+    assert not check.passed
+    assert any("spn" in d.lower() for d in check.diagnostics)
+
+
+def test_account_provisioner_parity_fails_on_undisabled_account():
+    """A declared disabled=True account the provisioner never disables must fail closed."""
+    scenario, parse_check = check_parse(OPERATIONAL_SCENARIO)
+    assert parse_check.passed
+    assert scenario is not None
+    account = scenario.accounts["ad-former-employee"]
+    account.disabled = True
+
+    check = check_account_provisioner_parity(scenario=scenario, project_dir=PROJECT_ROOT)
+
+    assert not check.passed
+    assert any("disabled" in d.lower() for d in check.diagnostics)
+
+
 def test_validate_scenario_composes_checks(monkeypatch, tmp_path):
     monkeypatch.setattr(gc, "check_parse", lambda p: ("scn", GateCheck("parse", True)))
     monkeypatch.setattr(
@@ -660,6 +836,11 @@ def test_validate_scenario_composes_checks(monkeypatch, tmp_path):
     monkeypatch.setattr(
         gc, "check_parity_manifest", lambda **k: GateCheck("parity_manifest", True)
     )
+    monkeypatch.setattr(
+        gc,
+        "check_account_provisioner_parity",
+        lambda **k: GateCheck("account_provisioner_parity", True),
+    )
     report = validate_scenario(
         tmp_path / "s.sdl.yaml",
         project_dir=tmp_path,
@@ -674,6 +855,7 @@ def test_validate_scenario_composes_checks(monkeypatch, tmp_path):
         "backend_conformance",
         "provisioning_realization",
         "parity_manifest",
+        "account_provisioner_parity",
     }
 
 

--- a/tests/test_techvault_static_gate.py
+++ b/tests/test_techvault_static_gate.py
@@ -33,7 +33,9 @@ from aptl.backends.aces_profiles import (
 )
 from aptl.backends.aces_realization import interpret_provisioning_plan
 from aptl.core.config import AptlConfig, load_config
+from aptl.validation import _account_parity
 from aptl.validation import _gate_checks as gc
+from aptl.validation._account_parity import check_account_provisioner_parity
 from aptl.validation._gate_checks import (
     _NoStartBackend,
     _cli_detail,
@@ -47,7 +49,6 @@ from aptl.validation._gate_checks import (
     _surface_evidence,
     _target_conformance_diagnostics,
     _verify_imports_diagnostics,
-    check_account_provisioner_parity,
     check_backend_conformance,
     check_compile,
     check_import_lock,
@@ -837,7 +838,7 @@ def test_validate_scenario_composes_checks(monkeypatch, tmp_path):
         gc, "check_parity_manifest", lambda **k: GateCheck("parity_manifest", True)
     )
     monkeypatch.setattr(
-        gc,
+        _account_parity,
         "check_account_provisioner_parity",
         lambda **k: GateCheck("account_provisioner_parity", True),
     )


### PR DESCRIPTION
## Summary

Extends the honest techvault-operational SDL into a full dynamic standup by making ACES content-placement and account-placement resources lower into typed backend realization or fail closed before any `aptl lab start` side effect — closing the count-only anti-pattern the ADR-046 TechVault operational-standup addendum prohibits. Content realizes through the existing ADR-043 named-volume seed seam (bounded to inline text and project-contained checked-in files/dirs); accounts record only provisioner-authoritative identity, statically verified against the service-owned AD provisioner. Also bundles a required build/test isolation fix so asset selection ignores the inherited git location environment.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #689

## ADR Impact

- ADR-046
- ADR-043
- ADR-021

## Changes

- Lower content-placement/account-placement into typed DeploymentContentRealization/DeploymentAccountRealization records; fail closed with a redacted diagnostic on dataset content, runtime-observed sources, project-root path escape, or a destination with no backing mount
- Add a narrow realize_content backend operation reusing the ADR-043 named-volume seed seam (content_seed.py); wire it into the Compose realize() path after networks
- Account realization records only provisioner-authoritative identity (username/groups/mail/spn/disabled); the static account-parity gate verifies every declared attribute against containers/ad/provision-users.sh and fails closed on drift; password_strength dropped from realized evidence as it is not machine-verifiable
- Add a representative realizable content set (inline-text file + checked-in fixture directory on fileshare) and four accounts matching the AD provisioner roster to techvault-operational.sdl.yaml
- Finalize the ADR-046 TechVault operational-standup addendum
- Isolate asset selection (aptl.core.assets and the hatch build hook) from the inherited git location environment (GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/...), preventing git ls-files from resolving to the ambient repo inside a git hook

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Full quick suite green (pytest -n auto -k "not integration"): 2070+ passed. Property tests green (pytest -m fuzz). Integration static gates green (tests/test_techvault_static_gate.py -m integration, real ACES conformance backend CLI). Both AI-assisted pre-push reviewers clean (codex ship-with-fixes → fixed; test-quality clean). New git-env isolation regression tests reproduce the pre-commit-hook flake and confirm the fix. NOTE: the live full-range `aptl lab stop -v && aptl lab start` health check (issue acceptance criterion 3) was not run in this session — recommended before merge; the changed runtime behavior (fileshare content seeding) is covered by backend-op unit tests and the integration-marked operational gate.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-046 ← scenarios/techvault-operational.sdl.yaml, ADR-046 ← src/aptl/backends/aces_content_realization.py, ADR-046 ← src/aptl/backends/aces_account_realization.py, ADR-046 ← src/aptl/core/deployment/realization.py, ADR-021 ← .ground-control workflow (gated /implement run)
- TESTS: ADR-046 ← tests/test_aces_backend.py, ADR-046 ← tests/test_deployment_backend.py, ADR-046 ← tests/test_techvault_static_gate.py, ADR-046 ← tests/test_content_realization_fuzz.py, ADR-046 ← tests/test_paper_scenario_static_gate.py, git-env isolation ← tests/test_assets.py, git-env isolation ← tests/test_hatch_build_hook.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/689.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
