### PR TITLE
feat(web): add /config summary, Settings dialog, and local-use notice

### DIFF
--- a/changelog.d/567.added.md
+++ b/changelog.d/567.added.md
@@ -1,0 +1,8 @@
+Web GUI configuration summary (`/config`), a local-preferences Settings drawer,
+and a first-run local-use/privacy notice. `/config` shows non-secret lab and
+web-serve facts only (never tokens or secrets); Settings persists versioned,
+browser-local UI preferences (color mode with light/high-contrast themes,
+density, motion, locale, time display, SIEM defaults, terminal rendering) with a
+reset control; the local-use notice is acknowledged once before the first
+mutating lab action or terminal launch, with a persistent Privacy link in the
+app shell.

--- a/docs/specs/web-gui-design-preflight.md
+++ b/docs/specs/web-gui-design-preflight.md
@@ -362,6 +362,65 @@ endpoint/trust registry.
   `web/tests/components/Terminal.test.ts` plus workbench block tests for the
   component states and lazy mounting.
 
+## UI-008f Config, Settings, and Privacy Guardrails
+
+UI-008f (`/config`, the Settings dialog, and the local-use/privacy notice) is a
+read-only configuration and browser-local preference slice. It must not become a
+second runtime-settings authority, consent platform, server-side preference
+store, secret viewer, or terminal/lab lifecycle gate.
+
+- Keep backend configuration facts in `src/aptl/api/routers/config.py` and
+  `src/aptl/api/schemas.py`, projected from `get_config()` /
+  `aptl.core.config.AptlConfig`. The route may add non-secret first-party fields
+  only when they already exist in the strict `AptlConfig` schema or another
+  named non-secret owner. Do not read `.env`, generated `.aptl/config/*`, private
+  keys, token settings, cookies, session factors, service passwords, or raw
+  Compose environment blocks for the config summary.
+- Keep the web DTO mirror in `web/src/lib/types.ts` and fetch through
+  `web/src/lib/api.ts` with the shared `sessionHeaders()` path. Route components
+  should not call authenticated `/api/*` endpoints directly unless they preserve
+  that carrier, and `/config` remains a read-only route with no mutation
+  capability.
+- Treat Settings as browser-local, non-secret UI preference state. A versioned
+  key such as `aptl.web.preferences.v1` should be owned by one helper/store that
+  validates stored shape, falls back to defaults on corrupt or unknown data, and
+  exposes reset. Do not put preferences in `aptl.json`, `.env`, server state,
+  run archives, cookies, route params, or API DTOs.
+- Keep the preference schema narrow and explicit. Acceptable v1 values are
+  appearance/density/motion/locale/time-display/terminal-rendering defaults plus
+  the acknowledged local-use notice version and timestamp. Never persist API
+  tokens, terminal tickets, session factors, terminal input/output, command
+  history, copied commands, SIEM custom query bodies, investigation notes, raw
+  API errors, hints viewed, or scenario progress.
+- Gate the first mutating lab action and terminal launch through one reusable
+  local-use acknowledgement helper instead of scattering modal checks across
+  buttons. The acknowledgement is a local UI precondition only: it does not
+  authorize an action, weaken the FastAPI BFF auth/CSRF gates, replace terminal
+  ticket/origin/allow-list/known-host checks, or change lab lifecycle semantics.
+- Use the existing accessible `Dialog` primitive for Settings and the
+  local-use notice. Settings should be a dialog or side drawer opened from the
+  app shell; the privacy disclosure should remain persistently reachable from a
+  Help/footer affordance after acknowledgement.
+- Privacy copy must describe the actual v1 behavior: browser-local preference
+  storage, no token storage by the SPA, ephemeral terminal I/O/no transcript
+  persistence, local API/server logs that may record route names, component
+  names, sanitized target identifiers, statuses, and validation/error
+  categories, and no non-essential analytics, tracking, or third-party scripts.
+  If analytics or synchronized preferences are added later, that is a new
+  product and security decision.
+- Use existing observability and redaction conventions. Config and preference
+  code may log route/component/state transitions and validation-layer labels,
+  but not stored preference payloads wholesale, notice timestamps as identifiers,
+  auth/session material, raw `.env` values, generated config, terminal bytes, or
+  exception payloads that might carry secrets.
+- Tests should extend existing seams: `tests/test_api_config.py` for the
+  backend projection and secret-exclusion cases, `web/tests/lib/api.test.ts` for
+  `/api/config` carrier behavior, preference-helper tests for versioning,
+  validation, corrupt storage fallback, and reset, route/component tests for
+  `/config`, `SettingsDialog`, `LocalUseNoticeDialog`, and the persistent privacy
+  entry point, plus existing terminal/lab action tests to prove the
+  acknowledgement wraps but does not replace the server gates.
+
 ## Extensibility Seams
 
 The design specification should include a compact page contract table for each
@@ -387,7 +446,9 @@ Use existing extension points for obvious follow-up changes:
 - new scenario browsing data uses a narrow ACES/catalog projection rather than
   a local scenario parser;
 - new runtime web settings extend the typed env settings boundary, not
-  `aptl.json`; and
+  `aptl.json`;
+- new browser-local UI preferences extend the versioned preference helper/store,
+  not API DTOs or server-side config; and
 - the web asset root, bind host, and allowed origins are parameterized at the
   app/serve/runtime-settings boundary; future remote/shared modes must change
   that boundary deliberately instead of scattering path, host, or origin

--- a/src/aptl/api/middleware/bff.py
+++ b/src/aptl/api/middleware/bff.py
@@ -67,6 +67,17 @@ def _allowed_hosts() -> set[str]:
     return set(_DEFAULT_HOSTS) | extra
 
 
+def effective_allowed_hosts() -> list[str]:
+    """Return the effective Host allow-list, sorted, for non-secret projection.
+
+    The single owner of Host allow-list parsing is :func:`_allowed_hosts`; this
+    public wrapper exposes its result (loopback defaults plus
+    ``APTL_ALLOWED_HOSTS``) so the ``/config`` projection can display it without
+    re-implementing the env parsing. Hostnames are non-secret.
+    """
+    return sorted(_allowed_hosts())
+
+
 def _hostname(host_header: str) -> str:
     """Extract the hostname (no port) from a ``Host`` header value."""
     if not host_header:

--- a/src/aptl/api/routers/config.py
+++ b/src/aptl/api/routers/config.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
@@ -54,7 +55,7 @@ def _load_config_response(project_dir: Path) -> ConfigResponse:
 
 @router.get("/config")
 async def get_config_endpoint(
-    project_dir: Path = Depends(get_project_dir),
+    project_dir: Annotated[Path, Depends(get_project_dir)],
 ) -> ConfigResponse:
     """Get the current APTL configuration."""
     log.info("GET /config")

--- a/src/aptl/api/routers/config.py
+++ b/src/aptl/api/routers/config.py
@@ -1,18 +1,40 @@
 """Configuration API endpoints."""
 
 import asyncio
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, Depends
 
+from aptl import __version__
 from aptl.api.deps import get_config, get_project_dir
-from aptl.api.schemas import ConfigResponse
+from aptl.api.middleware.bff import effective_allowed_hosts
+from aptl.api.schemas import ConfigResponse, WebServeInfo
 from aptl.core.config import ContainerSettings
 from aptl.utils.logging import get_logger
 
 log = get_logger("api.config")
 
 router = APIRouter(tags=["config"])
+
+
+def _web_serve_info(deployment_provider: str) -> WebServeInfo:
+    """Project non-secret web-serve facts (UI-008f).
+
+    Sources only non-secret values: the package build version, the effective
+    Host allow-list (loopback plus ``APTL_ALLOWED_HOSTS``), the browser-facing
+    public origin (``APTL_WEB_PUBLIC_ORIGIN``, trailing slash trimmed to match
+    the launch-URL normalisation in ``aptl.cli.web``), and the deployment
+    provider. Never reads the API token, session factors, cookies, private keys,
+    or raw ``.env`` content.
+    """
+    public_origin = os.environ.get("APTL_WEB_PUBLIC_ORIGIN")
+    return WebServeInfo(
+        build_version=__version__,
+        allowed_hosts=effective_allowed_hosts(),
+        public_origin=public_origin.rstrip("/") if public_origin else None,
+        deployment_provider=deployment_provider,
+    )
 
 
 def _load_config_response(project_dir: Path) -> ConfigResponse:
@@ -26,6 +48,7 @@ def _load_config_response(project_dir: Path) -> ConfigResponse:
             for name in ContainerSettings.model_fields
         },
         run_storage_backend=config.run_storage.backend,
+        web=_web_serve_info(config.deployment.provider),
     )
 
 

--- a/src/aptl/api/schemas.py
+++ b/src/aptl/api/schemas.py
@@ -300,6 +300,23 @@ class ScenarioDetailResponse(BaseModel):
     blocks: list[WorkbenchBlock] = Field(default_factory=list)
 
 
+class WebServeInfo(BaseModel):
+    """Non-secret web-serve facts for the ``/config`` orientation view (UI-008f).
+
+    Read-only projection of the shipped web surface. Deliberately excludes every
+    secret-bearing value (``APTL_API_TOKEN``, session factors, cookies, private
+    keys, raw ``.env``): only the operator-facing, non-secret facts the design's
+    Config "Web serve" section lists. ``allowed_hosts`` is the effective Host
+    allow-list (loopback plus ``APTL_ALLOWED_HOSTS``); ``public_origin`` is the
+    browser-facing origin the launch URL targets when set behind a proxy.
+    """
+
+    build_version: str = ""
+    allowed_hosts: list[str] = Field(default_factory=list)
+    public_origin: Optional[str] = None
+    deployment_provider: str = "docker-compose"
+
+
 class ConfigResponse(BaseModel):
     """Response for GET /api/config."""
 
@@ -307,3 +324,4 @@ class ConfigResponse(BaseModel):
     network_subnet: str = ""
     containers: dict[str, bool] = {}
     run_storage_backend: str = "local"
+    web: WebServeInfo = Field(default_factory=WebServeInfo)

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -69,6 +69,81 @@ class TestConfigEndpoint:
             assert field_name in data["containers"], f"Missing container: {field_name}"
 
 
+class TestWebServeInfo:
+    """The non-secret web-serve projection (UI-008f)."""
+
+    def test_reports_build_version(self, api_client):
+        from aptl import __version__
+
+        data = api_client.get("/api/config").json()
+
+        assert data["web"]["build_version"] == __version__
+
+    def test_allowed_hosts_includes_loopback_defaults(self, api_client):
+        data = api_client.get("/api/config").json()
+
+        hosts = data["web"]["allowed_hosts"]
+        assert "127.0.0.1" in hosts
+        assert "localhost" in hosts
+
+    def test_allowed_hosts_reflects_env(self, api_client):
+        # Keep "testserver" so the TestClient Host still passes the BFF gate
+        # (conftest sets it); add an extra host and assert it is projected.
+        with patch.dict(
+            os.environ, {"APTL_ALLOWED_HOSTS": "testserver,box.example.ts.net"}
+        ):
+            data = api_client.get("/api/config").json()
+
+        assert "box.example.ts.net" in data["web"]["allowed_hosts"]
+        # Loopback defaults are still present alongside the extra host.
+        assert "127.0.0.1" in data["web"]["allowed_hosts"]
+
+    def test_public_origin_from_env_trims_trailing_slash(self, api_client):
+        with patch.dict(
+            os.environ, {"APTL_WEB_PUBLIC_ORIGIN": "https://box.example.ts.net/"}
+        ):
+            data = api_client.get("/api/config").json()
+
+        assert data["web"]["public_origin"] == "https://box.example.ts.net"
+
+    def test_public_origin_null_when_unset(self, api_client):
+        # Don't clear the whole env (conftest's APTL_ALLOWED_HOSTS must survive so
+        # the Host gate still admits the TestClient); just ensure the origin is
+        # unset. patch.dict restores the popped key on exit.
+        with patch.dict(os.environ, {}):
+            os.environ.pop("APTL_WEB_PUBLIC_ORIGIN", None)
+            data = api_client.get("/api/config").json()
+
+        assert data["web"]["public_origin"] is None
+
+    def test_deployment_provider_reflects_config(self, api_client, tmp_path):
+        config = {
+            "lab": {"name": "test-lab"},
+            "deployment": {"provider": "ssh-compose", "ssh_host": "10.0.0.5"},
+        }
+        (tmp_path / "aptl.json").write_text(json.dumps(config))
+
+        data = api_client.get("/api/config").json()
+
+        assert data["web"]["deployment_provider"] == "ssh-compose"
+
+    def test_response_never_contains_the_api_token(self, api_client):
+        """The projection must not leak any secret, e.g. an SSH host or token."""
+        token = "s3cr3t-token-value-should-never-appear"
+        with patch.dict(os.environ, {"APTL_API_TOKEN": token}):
+            body = api_client.get("/api/config").text
+
+        assert token not in body
+        # The web sub-object exposes no secret-bearing keys.
+        web = api_client.get("/api/config").json()["web"]
+        assert set(web.keys()) == {
+            "build_version",
+            "allowed_hosts",
+            "public_origin",
+            "deployment_provider",
+        }
+
+
 class TestGetProjectDir:
     """Test the get_project_dir dependency directly."""
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -42,6 +42,86 @@
 	--font-mono: 'JetBrains Mono', ui-monospace, monospace;
 }
 
+/*
+ * Color-mode palettes (UI-008f). The base @theme above is the dark palette. The
+ * SettingsDialog writes `data-color-mode` onto <html>; overriding the same
+ * `--color-aptl-*` custom properties here re-tints every `*-aptl-*` utility (and
+ * `body`, which reads the variables directly) without touching component markup.
+ * `system` follows `prefers-color-scheme` (dark base, light override below);
+ * `dark` is the base; `light` and `high-contrast` are explicit. Accent shades are
+ * darkened in light mode and brightened in high-contrast so status/link contrast
+ * stays legible (WCAG 2.2 AA target).
+ */
+
+/* Light palette — applied for explicit light mode, and for system mode when the
+   OS prefers light. The two selectors share identical values (one is gated on
+   the media query, so they cannot be merged into a single selector list). */
+html[data-color-mode='light'] {
+	--color-aptl-bg: #f8fafc;
+	--color-aptl-surface: #ffffff;
+	--color-aptl-surface-hover: #f1f5f9;
+	--color-aptl-border: #cbd5e1;
+	--color-aptl-text: #0f172a;
+	--color-aptl-text-muted: #475569;
+	--color-aptl-indigo: #4f46e5;
+	--color-aptl-indigo-hover: #4338ca;
+	--color-aptl-violet: #7c3aed;
+	--color-aptl-teal: #0d9488;
+	--color-aptl-red: #dc2626;
+	--color-aptl-green: #16a34a;
+	--color-aptl-amber: #b45309;
+	--color-aptl-focus: #4f46e5;
+}
+
+@media (prefers-color-scheme: light) {
+	html[data-color-mode='system'] {
+		--color-aptl-bg: #f8fafc;
+		--color-aptl-surface: #ffffff;
+		--color-aptl-surface-hover: #f1f5f9;
+		--color-aptl-border: #cbd5e1;
+		--color-aptl-text: #0f172a;
+		--color-aptl-text-muted: #475569;
+		--color-aptl-indigo: #4f46e5;
+		--color-aptl-indigo-hover: #4338ca;
+		--color-aptl-violet: #7c3aed;
+		--color-aptl-teal: #0d9488;
+		--color-aptl-red: #dc2626;
+		--color-aptl-green: #16a34a;
+		--color-aptl-amber: #b45309;
+		--color-aptl-focus: #4f46e5;
+	}
+}
+
+/* High-contrast palette — maximal foreground/background separation on black,
+   with bright accents and a white focus ring for a highly visible focus cue. */
+html[data-color-mode='high-contrast'] {
+	--color-aptl-bg: #000000;
+	--color-aptl-surface: #000000;
+	--color-aptl-surface-hover: #1f1f1f;
+	--color-aptl-border: #ffffff;
+	--color-aptl-text: #ffffff;
+	--color-aptl-text-muted: #e5e5e5;
+	--color-aptl-indigo: #a5b4fc;
+	--color-aptl-indigo-hover: #c7d2fe;
+	--color-aptl-violet: #c084fc;
+	--color-aptl-teal: #2dd4bf;
+	--color-aptl-red: #f87171;
+	--color-aptl-green: #4ade80;
+	--color-aptl-amber: #fbbf24;
+	--color-aptl-focus: #ffffff;
+}
+
+/* Forced reduced motion (Motion = reduced), mirroring the prefers-reduced-motion
+   block below for operators who set the preference explicitly in Settings. */
+html[data-motion='reduced'] *,
+html[data-motion='reduced'] *::before,
+html[data-motion='reduced'] *::after {
+	animation-duration: 0.01ms !important;
+	animation-iteration-count: 1 !important;
+	transition-duration: 0.01ms !important;
+	scroll-behavior: auto !important;
+}
+
 /* Reduced-motion safety: honour `prefers-reduced-motion` globally so kit
    affordances (e.g. the StatusBadge pulse) never animate against the user's
    stated preference, even where a component forgets the `motion-safe:` guard. */

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -89,8 +89,8 @@ export async function getScenario(
 	);
 }
 
-export async function getConfig(): Promise<AppConfig> {
-	return fetchJSON<AppConfig>('/config');
+export async function getConfig(fetchFn: typeof fetch = fetch): Promise<AppConfig> {
+	return fetchJSON<AppConfig>('/config', undefined, fetchFn);
 }
 
 /** A cancellable subscription to the lab events stream. */

--- a/web/src/lib/components/ConfigSummaryList.svelte
+++ b/web/src/lib/components/ConfigSummaryList.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import type { AppConfig } from '$lib/types';
+	import { preferences } from '$lib/stores/preferences';
+
+	interface Props {
+		config: AppConfig;
+	}
+
+	let { config }: Props = $props();
+
+	const enabledFamilies = $derived(
+		Object.entries(config.containers)
+			.filter(([, on]) => on)
+			.map(([name]) => name)
+	);
+
+	// Density honoured on this shipped surface: compact tightens the row rhythm.
+	const rowPad = $derived($preferences.density === 'compact' ? 'py-1' : 'py-2');
+
+	const publicOrigin = $derived(config.web.public_origin ?? 'default (loopback)');
+	const allowedHosts = $derived(
+		config.web.allowed_hosts.length > 0 ? config.web.allowed_hosts.join(', ') : '—'
+	);
+	const enabledFamiliesLabel = $derived(
+		enabledFamilies.length > 0 ? enabledFamilies.join(', ') : 'none'
+	);
+</script>
+
+<div class="space-y-8">
+	<section>
+		<h2 class="mb-2 text-sm font-semibold text-aptl-text">Lab profile</h2>
+		<dl class="divide-y divide-aptl-border border-y border-aptl-border text-sm">
+			<div class="flex justify-between gap-6 {rowPad}">
+				<dt class="text-aptl-text-muted">Name</dt>
+				<dd class="text-right font-medium text-aptl-text">{config.lab_name}</dd>
+			</div>
+			<div class="flex justify-between gap-6 {rowPad}">
+				<dt class="text-aptl-text-muted">Network subnet</dt>
+				<dd class="text-right font-mono text-aptl-text">{config.network_subnet}</dd>
+			</div>
+			<div class="flex justify-between gap-6 {rowPad}">
+				<dt class="text-aptl-text-muted">Run storage</dt>
+				<dd class="text-right text-aptl-text">{config.run_storage_backend}</dd>
+			</div>
+			<div class="flex justify-between gap-6 {rowPad}">
+				<dt class="text-aptl-text-muted">Enabled families</dt>
+				<dd class="text-right text-aptl-text">{enabledFamiliesLabel}</dd>
+			</div>
+		</dl>
+	</section>
+
+	<section>
+		<h2 class="mb-2 text-sm font-semibold text-aptl-text">Web serve</h2>
+		<dl class="divide-y divide-aptl-border border-y border-aptl-border text-sm">
+			<div class="flex justify-between gap-6 {rowPad}">
+				<dt class="text-aptl-text-muted">Build version</dt>
+				<dd class="text-right font-mono text-aptl-text">{config.web.build_version}</dd>
+			</div>
+			<div class="flex justify-between gap-6 {rowPad}">
+				<dt class="text-aptl-text-muted">Allowed hosts</dt>
+				<dd class="text-right font-mono text-aptl-text">{allowedHosts}</dd>
+			</div>
+			<div class="flex justify-between gap-6 {rowPad}">
+				<dt class="text-aptl-text-muted">Public origin</dt>
+				<dd class="text-right font-mono text-aptl-text">{publicOrigin}</dd>
+			</div>
+			<div class="flex justify-between gap-6 {rowPad}">
+				<dt class="text-aptl-text-muted">Deployment provider</dt>
+				<dd class="text-right text-aptl-text">{config.web.deployment_provider}</dd>
+			</div>
+		</dl>
+	</section>
+
+	<section>
+		<h2 class="mb-2 text-sm font-semibold text-aptl-text">Secrets</h2>
+		<p
+			class="rounded-lg border border-aptl-border bg-aptl-bg p-3 text-sm text-aptl-text-muted"
+			role="note"
+		>
+			Tokens, private keys, generated secrets, and service credentials are intentionally hidden.
+			This page is read-only.
+		</p>
+	</section>
+</div>

--- a/web/src/lib/components/LocalUseNoticeDialog.svelte
+++ b/web/src/lib/components/LocalUseNoticeDialog.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import Dialog from '$lib/components/kit/Dialog.svelte';
+	import Button from '$lib/components/kit/Button.svelte';
+
+	interface Props {
+		/** Open state. Bindable so the app shell can also close it. */
+		open?: boolean;
+		/** Acknowledge: record the notice version and run the deferred action. */
+		onAcknowledge: () => void;
+		/** Dismiss without acknowledging (Cancel, Escape, backdrop). */
+		onCancel?: () => void;
+		/** Open the persistent privacy details from within the notice. */
+		onPrivacyDetails?: () => void;
+	}
+
+	let { open = $bindable(false), onAcknowledge, onCancel, onPrivacyDetails }: Props = $props();
+
+	function cancel(): void {
+		onCancel?.();
+	}
+</script>
+
+<Dialog
+	bind:open
+	title="Authorized local lab use"
+	description="APTL controls a local security lab. Use this surface only for authorized lab activity."
+	onClose={cancel}
+>
+	{#snippet body()}
+		<p>
+			This browser stores local UI preferences. It does not store API tokens, and it does not
+			persist terminal input or output in v1. Local API/server logs may record route names,
+			timestamps, status codes, and redacted error categories.
+		</p>
+		<p class="mt-3 text-aptl-text-muted">
+			Acknowledging records only the notice version and the time you acknowledged it.
+		</p>
+	{/snippet}
+	{#snippet footer()}
+		{#if onPrivacyDetails}
+			<Button variant="secondary" onclick={onPrivacyDetails}>Privacy details</Button>
+		{/if}
+		<Button variant="primary" onclick={onAcknowledge}>Acknowledge</Button>
+	{/snippet}
+</Dialog>

--- a/web/src/lib/components/NavBar.svelte
+++ b/web/src/lib/components/NavBar.svelte
@@ -1,25 +1,32 @@
 <script lang="ts">
 	import { labStatus } from '../stores/lab';
 	import LabStatusBadge from './LabStatusBadge.svelte';
+	import Menu from './kit/Menu.svelte';
+	import { focusRing } from './kit/tone';
+	import { openSettings, openPrivacy } from '../stores/ui';
+
+	const navLink = 'text-sm text-aptl-text-muted transition-colors hover:text-aptl-text';
 </script>
 
 <nav class="border-b border-aptl-border bg-aptl-surface">
 	<div class="mx-auto flex h-14 max-w-7xl items-center justify-between px-6">
 		<div class="flex items-center gap-6">
-			<a href="/" class="text-lg font-semibold tracking-tight text-aptl-text">
-				APTL
-			</a>
+			<a href="/" class="text-lg font-semibold tracking-tight text-aptl-text"> APTL </a>
 			<div class="hidden items-center gap-4 sm:flex">
-				<a
-					href="/"
-					class="text-sm text-aptl-text-muted transition-colors hover:text-aptl-text"
-				>
-					Lab Home
-				</a>
+				<a href="/" class={navLink}>Lab Home</a>
+				<a href="/config" class={navLink}>Config</a>
 			</div>
 		</div>
-		<div class="flex items-center gap-4">
+		<div class="flex items-center gap-3">
 			<LabStatusBadge running={$labStatus.running} />
+			<button
+				type="button"
+				onclick={openSettings}
+				class="rounded-md border border-aptl-border bg-aptl-surface px-3 py-1.5 text-sm text-aptl-text hover:bg-aptl-surface-hover {focusRing}"
+			>
+				Settings
+			</button>
+			<Menu label="Help" align="right" items={[{ label: 'Privacy', onSelect: openPrivacy }]} />
 		</div>
 	</div>
 </nav>

--- a/web/src/lib/components/PrivacyDetailsPanel.svelte
+++ b/web/src/lib/components/PrivacyDetailsPanel.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import Dialog from '$lib/components/kit/Dialog.svelte';
+	import Button from '$lib/components/kit/Button.svelte';
+	import { preferences, PREFERENCES_KEY } from '$lib/stores/preferences';
+	import { formatTimestamp } from '$lib/time';
+
+	interface Props {
+		/** Open state. Bindable so the app shell can also close it. */
+		open?: boolean;
+		onClose?: () => void;
+	}
+
+	let { open = $bindable(false), onClose }: Props = $props();
+
+	const ack = $derived($preferences.noticeAck);
+	const acknowledgedAt = $derived(
+		ack
+			? formatTimestamp(ack.timestamp, {
+					timeDisplay: $preferences.timeDisplay,
+					locale: $preferences.locale
+				})
+			: null
+	);
+</script>
+
+<Dialog
+	bind:open
+	title="Privacy"
+	description="What this local operator surface stores and logs."
+	{onClose}
+>
+	{#snippet body()}
+		<div class="space-y-3">
+			<p>
+				APTL is a local lab operator tool, not a hosted service. It uses no non-essential
+				analytics, tracking pixels, or third-party scripts in v1.
+			</p>
+			<ul class="list-disc space-y-1 pl-5 text-aptl-text-muted">
+				<li>
+					This browser stores only non-secret UI preferences, under the
+					<code class="rounded bg-aptl-bg px-1 py-0.5 font-mono text-xs">{PREFERENCES_KEY}</code>
+					key.
+				</li>
+				<li>It never stores API tokens, bearer headers, or service credentials.</li>
+				<li>It does not persist terminal input or output in v1.</li>
+				<li>
+					Local API/server logs may record route names, timestamps, status codes, and redacted
+					error categories — not request bodies or secrets.
+				</li>
+			</ul>
+			{#if acknowledgedAt}
+				<p class="text-xs text-aptl-text-muted">
+					Local-use notice acknowledged {acknowledgedAt}.
+				</p>
+			{/if}
+		</div>
+	{/snippet}
+	{#snippet footer()}
+		<Button variant="primary" onclick={() => (open = false)}>Close</Button>
+	{/snippet}
+</Dialog>

--- a/web/src/lib/components/SettingsDialog.svelte
+++ b/web/src/lib/components/SettingsDialog.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+	import Dialog from '$lib/components/kit/Dialog.svelte';
+	import Button from '$lib/components/kit/Button.svelte';
+	import Field from '$lib/components/kit/Field.svelte';
+	import Select from '$lib/components/kit/Select.svelte';
+	import {
+		preferences,
+		setPreference,
+		setTerminalFontSize,
+		resetPreferences,
+		COLOR_MODE_OPTIONS,
+		DENSITY_OPTIONS,
+		MOTION_OPTIONS,
+		LOCALE_OPTIONS,
+		TIME_DISPLAY_OPTIONS,
+		SIEM_TIME_RANGE_OPTIONS,
+		SIEM_ROW_LIMITS,
+		TERMINAL_SCROLLBACKS,
+		TERMINAL_FONT_SIZE_MIN,
+		TERMINAL_FONT_SIZE_MAX,
+		type ColorMode,
+		type Density,
+		type Motion,
+		type TimeDisplay,
+		type SiemTimeRange
+	} from '$lib/stores/preferences';
+
+	interface Props {
+		/** Open state. Bindable so the parent (app shell) can also close it. */
+		open?: boolean;
+		onClose?: () => void;
+	}
+
+	let { open = $bindable(false), onClose }: Props = $props();
+
+	const rowLimitOptions = SIEM_ROW_LIMITS.map((n) => ({ value: String(n), label: String(n) }));
+	const scrollbackOptions = TERMINAL_SCROLLBACKS.map((n) => ({
+		value: String(n),
+		label: `${n} lines`
+	}));
+
+	const legend = 'text-xs font-semibold uppercase tracking-wide text-aptl-text-muted';
+</script>
+
+<Dialog
+	bind:open
+	title="Settings"
+	description="Local workbench preferences. These change how the UI looks and behaves in this browser only — they never change the lab."
+	placement="right"
+	{onClose}
+>
+	{#snippet body()}
+		<div class="space-y-6">
+			<fieldset class="space-y-3">
+				<legend class={legend}>Appearance</legend>
+				<Field label="Color mode">
+					<Select
+						options={COLOR_MODE_OPTIONS}
+						bind:value={
+							() => $preferences.colorMode, (v) => setPreference('colorMode', v as ColorMode)
+						}
+					/>
+				</Field>
+				<Field label="Density">
+					<Select
+						options={DENSITY_OPTIONS}
+						bind:value={() => $preferences.density, (v) => setPreference('density', v as Density)}
+					/>
+				</Field>
+				<Field
+					label="Motion"
+					description="Reduced also honours your system reduced-motion setting."
+				>
+					<Select
+						options={MOTION_OPTIONS}
+						bind:value={() => $preferences.motion, (v) => setPreference('motion', v as Motion)}
+					/>
+				</Field>
+			</fieldset>
+
+			<fieldset class="space-y-3">
+				<legend class={legend}>Locale and time</legend>
+				<Field label="Language">
+					<Select
+						options={LOCALE_OPTIONS}
+						bind:value={() => $preferences.locale, (v) => setPreference('locale', v)}
+					/>
+				</Field>
+				<Field label="Time display">
+					<Select
+						options={TIME_DISPLAY_OPTIONS}
+						bind:value={
+							() => $preferences.timeDisplay, (v) => setPreference('timeDisplay', v as TimeDisplay)
+						}
+					/>
+				</Field>
+			</fieldset>
+
+			<fieldset class="space-y-3">
+				<legend class={legend}>SIEM defaults</legend>
+				<p class="text-xs text-aptl-text-muted">
+					Saved for the SIEM explorer, which is not available yet. The backend will still
+					enforce time-range and row maximums when it ships.
+				</p>
+				<Field label="Default time range">
+					<Select
+						options={SIEM_TIME_RANGE_OPTIONS}
+						bind:value={
+							() => $preferences.siemTimeRange,
+							(v) => setPreference('siemTimeRange', v as SiemTimeRange)
+						}
+					/>
+				</Field>
+				<Field label="Row limit">
+					<Select
+						options={rowLimitOptions}
+						bind:value={
+							() => String($preferences.siemRowLimit),
+							(v) => setPreference('siemRowLimit', Number(v))
+						}
+					/>
+				</Field>
+			</fieldset>
+
+			<fieldset class="space-y-3">
+				<legend class={legend}>Terminal</legend>
+				<div role="group" aria-label="Terminal font size" class="flex flex-col gap-1">
+					<span class="text-sm font-medium text-aptl-text">Font size</span>
+					<div class="flex items-center gap-3">
+						<Button
+							size="sm"
+							variant="secondary"
+							label="Decrease terminal font size"
+							disabled={$preferences.terminalFontSize <= TERMINAL_FONT_SIZE_MIN}
+							onclick={() => setTerminalFontSize($preferences.terminalFontSize - 1)}
+						>
+							&minus;
+						</Button>
+						<span class="min-w-[3ch] text-center tabular-nums text-sm" aria-live="polite">
+							{$preferences.terminalFontSize}
+						</span>
+						<Button
+							size="sm"
+							variant="secondary"
+							label="Increase terminal font size"
+							disabled={$preferences.terminalFontSize >= TERMINAL_FONT_SIZE_MAX}
+							onclick={() => setTerminalFontSize($preferences.terminalFontSize + 1)}
+						>
+							+
+						</Button>
+					</div>
+				</div>
+				<Field label="Scrollback">
+					<Select
+						options={scrollbackOptions}
+						bind:value={
+							() => String($preferences.terminalScrollback),
+							(v) => setPreference('terminalScrollback', Number(v))
+						}
+					/>
+				</Field>
+			</fieldset>
+		</div>
+	{/snippet}
+	{#snippet footer()}
+		<Button variant="secondary" onclick={resetPreferences}>Reset preferences</Button>
+		<Button variant="primary" onclick={() => (open = false)}>Done</Button>
+	{/snippet}
+</Dialog>

--- a/web/src/lib/components/Terminal.svelte
+++ b/web/src/lib/components/Terminal.svelte
@@ -21,9 +21,13 @@
 		 * host surface (e.g. the focused terminal header) can reflect the state.
 		 */
 		onstatechange?: (status: TerminalStatus) => void;
+		/** xterm font size (px); sourced from operator preferences (UI-008f). */
+		fontSize?: number;
+		/** xterm scrollback (lines); sourced from operator preferences (UI-008f). */
+		scrollback?: number;
 	}
 
-	let { container, onstatechange }: Props = $props();
+	let { container, onstatechange, fontSize = 14, scrollback = 1000 }: Props = $props();
 
 	let terminalDiv: HTMLDivElement;
 	let term: Terminal | null = null;
@@ -66,7 +70,8 @@
 		term = new Terminal({
 			cursorBlink: true,
 			fontFamily: 'monospace',
-			fontSize: 14,
+			fontSize,
+			scrollback,
 			theme: {
 				background: '#1a1d23',
 				foreground: '#e2e8f0',

--- a/web/src/lib/stores/preferences.ts
+++ b/web/src/lib/stores/preferences.ts
@@ -215,9 +215,10 @@ function persist(prefs: Preferences): void {
 export function applyPreferenceEffects(prefs: Preferences): void {
 	const el = globalThis.document?.documentElement;
 	if (!el) return;
-	el.setAttribute('data-color-mode', prefs.colorMode);
-	el.setAttribute('data-density', prefs.density);
-	el.setAttribute('data-motion', prefs.motion);
+	// `dataset` writes the same `data-*` attributes app.css keys off of.
+	el.dataset.colorMode = prefs.colorMode;
+	el.dataset.density = prefs.density;
+	el.dataset.motion = prefs.motion;
 }
 
 /** The live preferences store. Loaded from storage; persisted + applied on change. */

--- a/web/src/lib/stores/preferences.ts
+++ b/web/src/lib/stores/preferences.ts
@@ -1,0 +1,258 @@
+/**
+ * Local operator preferences (UI-008f).
+ *
+ * A single schema-versioned, browser-local store — the one extensibility seam
+ * for non-secret UI preferences (per the design spec's "Settings and
+ * Persistence" table and the UI-008f preflight guardrails). It is deliberately
+ * NOT an API DTO, `aptl.json`, a cookie, or server-side state: preferences never
+ * leave the browser in v1.
+ *
+ * Invariants:
+ * - **Never persist secrets** — no API tokens, bearer headers, service
+ *   credentials, terminal I/O, or raw SIEM query bodies. Only the non-secret
+ *   fields below.
+ * - **Schema-versioned** — stored under `aptl.web.preferences.v1` with an inner
+ *   `v` guard. A version mismatch or corrupt JSON resets to defaults; unknown
+ *   keys are ignored; out-of-range values fall back per field.
+ * - **Reset** — `resetPreferences()` returns every field to its default.
+ *
+ * Reading/writing storage and applying document effects are guarded on
+ * `globalThis` (mirroring `$lib/session`) so the module is import-safe under SSR
+ * and in tests.
+ */
+import { get, writable } from 'svelte/store';
+
+export const PREFERENCES_VERSION = 1;
+export const PREFERENCES_KEY = 'aptl.web.preferences.v1';
+
+/** Bumped whenever the local-use/privacy notice text materially changes, so a
+ *  prior acknowledgement no longer counts (the notice re-appears). */
+export const NOTICE_VERSION = '1';
+
+export type ColorMode = 'system' | 'dark' | 'light' | 'high-contrast';
+export type Density = 'comfortable' | 'compact';
+export type Motion = 'system' | 'reduced';
+export type TimeDisplay = 'local' | 'utc';
+export type SiemTimeRange = '15m' | '1h' | '24h';
+
+/** Stored acknowledgement of the local-use/privacy notice — version + when. */
+export interface NoticeAck {
+	version: string;
+	timestamp: string;
+}
+
+export interface Preferences {
+	colorMode: ColorMode;
+	density: Density;
+	motion: Motion;
+	/** `'system'` (browser default) or a BCP-47 language tag. */
+	locale: string;
+	timeDisplay: TimeDisplay;
+	siemTimeRange: SiemTimeRange;
+	siemRowLimit: number;
+	terminalFontSize: number;
+	terminalScrollback: number;
+	noticeAck: NoticeAck | null;
+}
+
+export const TERMINAL_FONT_SIZE_MIN = 10;
+export const TERMINAL_FONT_SIZE_MAX = 20;
+
+export const SIEM_ROW_LIMITS = [50, 100, 250, 500] as const;
+export const TERMINAL_SCROLLBACKS = [500, 1000, 5000, 10000] as const;
+
+export const DEFAULT_PREFERENCES: Preferences = {
+	colorMode: 'system',
+	density: 'comfortable',
+	motion: 'system',
+	locale: 'system',
+	timeDisplay: 'local',
+	siemTimeRange: '1h',
+	siemRowLimit: 100,
+	terminalFontSize: 14,
+	terminalScrollback: 1000,
+	noticeAck: null
+};
+
+/** Labelled option lists — the single source shared by the dialog and tests. */
+export const COLOR_MODE_OPTIONS: { value: ColorMode; label: string }[] = [
+	{ value: 'system', label: 'System' },
+	{ value: 'dark', label: 'Dark' },
+	{ value: 'light', label: 'Light' },
+	{ value: 'high-contrast', label: 'High contrast' }
+];
+export const DENSITY_OPTIONS: { value: Density; label: string }[] = [
+	{ value: 'comfortable', label: 'Comfortable' },
+	{ value: 'compact', label: 'Compact' }
+];
+export const MOTION_OPTIONS: { value: Motion; label: string }[] = [
+	{ value: 'system', label: 'System' },
+	{ value: 'reduced', label: 'Reduced' }
+];
+export const LOCALE_OPTIONS: { value: string; label: string }[] = [
+	{ value: 'system', label: 'Browser default' },
+	{ value: 'en', label: 'English' },
+	{ value: 'en-GB', label: 'English (UK)' },
+	{ value: 'de', label: 'Deutsch' },
+	{ value: 'es', label: 'Español' },
+	{ value: 'fr', label: 'Français' },
+	{ value: 'ja', label: '日本語' }
+];
+export const TIME_DISPLAY_OPTIONS: { value: TimeDisplay; label: string }[] = [
+	{ value: 'local', label: 'Browser local time' },
+	{ value: 'utc', label: 'UTC' }
+];
+export const SIEM_TIME_RANGE_OPTIONS: { value: SiemTimeRange; label: string }[] = [
+	{ value: '15m', label: 'Last 15 minutes' },
+	{ value: '1h', label: 'Last hour' },
+	{ value: '24h', label: 'Last 24 hours' }
+];
+
+function oneOf<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+	return typeof value === 'string' && (allowed as readonly string[]).includes(value)
+		? (value as T)
+		: fallback;
+}
+
+function boundedInt(
+	value: unknown,
+	min: number,
+	max: number,
+	fallback: number
+): number {
+	return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max
+		? value
+		: fallback;
+}
+
+function memberOf(value: unknown, allowed: readonly number[], fallback: number): number {
+	return typeof value === 'number' && allowed.includes(value) ? value : fallback;
+}
+
+function sanitizeLocale(value: unknown): string {
+	if (value === 'system') return 'system';
+	// Accept a plausible BCP-47 tag (e.g. `en`, `en-GB`, `zh-Hant`); anything
+	// else falls back to the browser default rather than persisting garbage.
+	if (typeof value === 'string' && /^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(value)) {
+		return value;
+	}
+	return DEFAULT_PREFERENCES.locale;
+}
+
+function sanitizeNoticeAck(value: unknown): NoticeAck | null {
+	if (
+		value &&
+		typeof value === 'object' &&
+		typeof (value as NoticeAck).version === 'string' &&
+		typeof (value as NoticeAck).timestamp === 'string'
+	) {
+		return { version: (value as NoticeAck).version, timestamp: (value as NoticeAck).timestamp };
+	}
+	return null;
+}
+
+/** Coerce arbitrary parsed input into a valid `Preferences`, field by field. */
+export function sanitizePreferences(raw: unknown): Preferences {
+	const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+	return {
+		colorMode: oneOf(r.colorMode, ['system', 'dark', 'light', 'high-contrast'], DEFAULT_PREFERENCES.colorMode),
+		density: oneOf(r.density, ['comfortable', 'compact'], DEFAULT_PREFERENCES.density),
+		motion: oneOf(r.motion, ['system', 'reduced'], DEFAULT_PREFERENCES.motion),
+		locale: sanitizeLocale(r.locale),
+		timeDisplay: oneOf(r.timeDisplay, ['local', 'utc'], DEFAULT_PREFERENCES.timeDisplay),
+		siemTimeRange: oneOf(r.siemTimeRange, ['15m', '1h', '24h'], DEFAULT_PREFERENCES.siemTimeRange),
+		siemRowLimit: memberOf(r.siemRowLimit, SIEM_ROW_LIMITS, DEFAULT_PREFERENCES.siemRowLimit),
+		terminalFontSize: boundedInt(
+			r.terminalFontSize,
+			TERMINAL_FONT_SIZE_MIN,
+			TERMINAL_FONT_SIZE_MAX,
+			DEFAULT_PREFERENCES.terminalFontSize
+		),
+		terminalScrollback: memberOf(
+			r.terminalScrollback,
+			TERMINAL_SCROLLBACKS,
+			DEFAULT_PREFERENCES.terminalScrollback
+		),
+		noticeAck: sanitizeNoticeAck(r.noticeAck)
+	};
+}
+
+/** Load and validate preferences from local storage, defaulting on any fault. */
+export function loadPreferences(): Preferences {
+	try {
+		const raw = globalThis.localStorage?.getItem(PREFERENCES_KEY);
+		if (!raw) return { ...DEFAULT_PREFERENCES };
+		const parsed = JSON.parse(raw) as { v?: unknown };
+		if (!parsed || typeof parsed !== 'object' || parsed.v !== PREFERENCES_VERSION) {
+			// Unknown/absent schema version — ignore the stored blob and reset.
+			return { ...DEFAULT_PREFERENCES };
+		}
+		return sanitizePreferences(parsed);
+	} catch {
+		return { ...DEFAULT_PREFERENCES };
+	}
+}
+
+function persist(prefs: Preferences): void {
+	try {
+		globalThis.localStorage?.setItem(
+			PREFERENCES_KEY,
+			JSON.stringify({ v: PREFERENCES_VERSION, ...prefs })
+		);
+	} catch {
+		// Storage unavailable (private-mode edge cases) — preferences stay
+		// in-memory for the session; nothing else to do.
+	}
+}
+
+/**
+ * Apply the preferences that drive global presentation to `<html>` as data
+ * attributes. `app.css` keys its light/high-contrast palettes off
+ * `data-color-mode`, its forced-reduced-motion block off `data-motion`, and the
+ * component kit reads `data-density`. No-op when there is no document (SSR/tests
+ * without jsdom).
+ */
+export function applyPreferenceEffects(prefs: Preferences): void {
+	const el = globalThis.document?.documentElement;
+	if (!el) return;
+	el.setAttribute('data-color-mode', prefs.colorMode);
+	el.setAttribute('data-density', prefs.density);
+	el.setAttribute('data-motion', prefs.motion);
+}
+
+/** The live preferences store. Loaded from storage; persisted + applied on change. */
+export const preferences = writable<Preferences>(loadPreferences());
+
+preferences.subscribe((prefs) => {
+	persist(prefs);
+	applyPreferenceEffects(prefs);
+});
+
+/** Update a single preference field. */
+export function setPreference<K extends keyof Preferences>(key: K, value: Preferences[K]): void {
+	preferences.update((prefs) => ({ ...prefs, [key]: value }));
+}
+
+/** Clamp + set the terminal font size within its bounded range. */
+export function setTerminalFontSize(size: number): void {
+	const clamped = Math.max(
+		TERMINAL_FONT_SIZE_MIN,
+		Math.min(TERMINAL_FONT_SIZE_MAX, Math.round(size))
+	);
+	setPreference('terminalFontSize', clamped);
+}
+
+/** Return every preference to its default (the visible "Reset preferences"). */
+export function resetPreferences(): void {
+	preferences.set({ ...DEFAULT_PREFERENCES });
+}
+
+/** Whether the current notice version has been acknowledged. */
+export function isNoticeAcknowledged(prefs: Preferences = get(preferences)): boolean {
+	return prefs.noticeAck?.version === NOTICE_VERSION;
+}
+
+/** Record acknowledgement of the current notice version with a timestamp. */
+export function acknowledgeNotice(): void {
+	setPreference('noticeAck', { version: NOTICE_VERSION, timestamp: new Date().toISOString() });
+}

--- a/web/src/lib/stores/ui.ts
+++ b/web/src/lib/stores/ui.ts
@@ -1,0 +1,60 @@
+/**
+ * App-shell UI state and the first-run local-use gate (UI-008f).
+ *
+ * The Settings drawer, Privacy panel, and local-use notice are mounted once in
+ * the app shell (`+layout.svelte`) and opened from anywhere (NavBar, footer, a
+ * guarded action) through this shared store, so their open state has a single
+ * owner.
+ *
+ * `guardControlledAction` is the acknowledgement gate: the design requires the
+ * "Authorized local lab use" notice *before the first mutating lab action,
+ * terminal launch, or SIEM query* — not on every page load. This is a UI
+ * precondition only; it never replaces the server's auth/CSRF/terminal gates
+ * (UI-008f preflight guardrail).
+ */
+import { get, writable } from 'svelte/store';
+import { acknowledgeNotice, isNoticeAcknowledged, preferences } from './preferences';
+
+export const settingsOpen = writable(false);
+export const privacyOpen = writable(false);
+export const noticeOpen = writable(false);
+
+/** The controlled action deferred until the notice is acknowledged, if any. */
+let pendingAction: (() => void) | null = null;
+
+export function openSettings(): void {
+	settingsOpen.set(true);
+}
+
+export function openPrivacy(): void {
+	privacyOpen.set(true);
+}
+
+/**
+ * Run a controlled action, gating it behind the first-run acknowledgement.
+ * Runs immediately when the current notice version is already acknowledged;
+ * otherwise defers the action and opens the notice.
+ */
+export function guardControlledAction(run: () => void): void {
+	if (isNoticeAcknowledged(get(preferences))) {
+		run();
+		return;
+	}
+	pendingAction = run;
+	noticeOpen.set(true);
+}
+
+/** Acknowledge the notice, close it, and run any deferred controlled action. */
+export function acknowledgeAndRun(): void {
+	acknowledgeNotice();
+	noticeOpen.set(false);
+	const action = pendingAction;
+	pendingAction = null;
+	action?.();
+}
+
+/** Dismiss the notice without acknowledging; the deferred action is cancelled. */
+export function dismissNotice(): void {
+	pendingAction = null;
+	noticeOpen.set(false);
+}

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared timestamp formatting (UI-008f, localization groundwork).
+ *
+ * The design spec requires dates/times to be formatted through shared helpers
+ * that honour the operator's time-display and locale preferences, rather than
+ * scattering `toLocaleString` calls (or hard-coded formats) through routes. This
+ * is the single formatter; surfaces that render timestamps (SIEM alerts, run
+ * status, diagnostics, the privacy panel's acknowledgement line) route through
+ * it so a preference change applies everywhere at once.
+ */
+import type { TimeDisplay } from './stores/preferences';
+
+/** Map a stored locale preference to an `Intl` locale (or `undefined` = default). */
+export function resolveLocale(locale: string): string | undefined {
+	return locale && locale !== 'system' ? locale : undefined;
+}
+
+/**
+ * Format an ISO-8601 instant per the operator's preferences.
+ *
+ * `timeDisplay: 'utc'` renders the instant in UTC with a trailing `UTC` marker;
+ * `'local'` uses the browser time zone. `locale` is a BCP-47 tag or `'system'`.
+ * Returns `''` for an unparseable input so callers can render an empty cell
+ * rather than `Invalid Date`.
+ */
+export function formatTimestamp(
+	iso: string,
+	opts: { timeDisplay: TimeDisplay; locale: string }
+): string {
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return '';
+	const utc = opts.timeDisplay === 'utc';
+	try {
+		const formatted = new Intl.DateTimeFormat(resolveLocale(opts.locale), {
+			dateStyle: 'medium',
+			timeStyle: 'medium',
+			timeZone: utc ? 'UTC' : undefined
+		}).format(date);
+		return utc ? `${formatted} UTC` : formatted;
+	} catch {
+		// Invalid locale/timeZone combination — fall back to the ISO string.
+		return date.toISOString();
+	}
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -186,10 +186,27 @@ export interface ScenarioDetail {
 	blocks: WorkbenchBlock[];
 }
 
-/** APTL configuration. */
+/** Non-secret web-serve facts (UI-008f).
+ *
+ *  Mirrors `aptl.api.schemas.WebServeInfo`. Read-only orientation facts only:
+ *  never carries the API token, session factors, cookies, or private keys.
+ */
+export interface WebServeInfo {
+	build_version: string;
+	allowed_hosts: string[];
+	public_origin: string | null;
+	deployment_provider: string;
+}
+
+/** APTL configuration (non-secret projection).
+ *
+ *  Mirrors `aptl.api.schemas.ConfigResponse`. The `web` sub-object carries the
+ *  non-secret web-serve facts for the `/config` orientation view.
+ */
 export interface AppConfig {
 	lab_name: string;
 	network_subnet: string;
 	containers: Record<string, boolean>;
 	run_storage_backend: string;
+	web: WebServeInfo;
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
 	import '../app.css';
 	import NavBar from '$lib/components/NavBar.svelte';
+	import SettingsDialog from '$lib/components/SettingsDialog.svelte';
+	import PrivacyDetailsPanel from '$lib/components/PrivacyDetailsPanel.svelte';
+	import LocalUseNoticeDialog from '$lib/components/LocalUseNoticeDialog.svelte';
 	import { initLabStore, destroyLabStore } from '$lib/stores/lab';
+	import {
+		settingsOpen,
+		privacyOpen,
+		noticeOpen,
+		openPrivacy,
+		acknowledgeAndRun,
+		dismissNotice
+	} from '$lib/stores/ui';
 	import { onMount } from 'svelte';
 	import type { Snippet } from 'svelte';
 
@@ -18,4 +29,25 @@
 	<main class="flex-1">
 		{@render children()}
 	</main>
+	<footer class="border-t border-aptl-border bg-aptl-surface">
+		<div class="mx-auto flex max-w-7xl items-center justify-end px-6 py-3">
+			<button
+				type="button"
+				class="text-xs text-aptl-text-muted underline-offset-2 hover:text-aptl-text hover:underline"
+				onclick={openPrivacy}
+			>
+				Privacy
+			</button>
+		</div>
+	</footer>
 </div>
+
+<!-- App-shell dialogs, mounted once and driven by the shared ui store. -->
+<SettingsDialog bind:open={$settingsOpen} />
+<PrivacyDetailsPanel bind:open={$privacyOpen} />
+<LocalUseNoticeDialog
+	bind:open={$noticeOpen}
+	onAcknowledge={acknowledgeAndRun}
+	onCancel={dismissNotice}
+	onPrivacyDetails={openPrivacy}
+/>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	import LabStartNotice from '$lib/components/LabStartNotice.svelte';
 	import KillConfirmDialog from '$lib/components/KillConfirmDialog.svelte';
 	import ScenarioCard from '$lib/components/ScenarioCard.svelte';
+	import { guardControlledAction } from '$lib/stores/ui';
 	import type { LabActionResponse, KillActionResponse, ScenarioSummary } from '$lib/types';
 
 	let { data }: { data: { scenarios: ScenarioSummary[]; scenariosError: boolean } } = $props();
@@ -130,18 +131,26 @@
 			</div>
 			<div class="flex items-center gap-2">
 				{#if $labStatus.running}
-					<Button variant="secondary" disabled={actionPending} onclick={handleStop}>
+					<Button
+						variant="secondary"
+						disabled={actionPending}
+						onclick={() => guardControlledAction(handleStop)}
+					>
 						{pendingAction === 'stop' ? 'Stopping…' : 'Stop'}
 					</Button>
 				{:else}
-					<Button variant="primary" disabled={actionPending} onclick={handleStart}>
+					<Button
+						variant="primary"
+						disabled={actionPending}
+						onclick={() => guardControlledAction(handleStart)}
+					>
 						{pendingAction === 'start' ? 'Starting…' : 'Start'}
 					</Button>
 				{/if}
 				<Button
 					variant="danger"
 					disabled={actionPending}
-					onclick={() => (killDialogOpen = true)}
+					onclick={() => guardControlledAction(() => (killDialogOpen = true))}
 				>
 					Kill
 				</Button>

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { AppConfig } from '$lib/types';
+	import ConfigSummaryList from '$lib/components/ConfigSummaryList.svelte';
+
+	let { data }: { data: { config: AppConfig | null; configError: boolean } } = $props();
+</script>
+
+<div class="mx-auto max-w-3xl space-y-6 px-6 py-8">
+	<div>
+		<h1 class="text-xl font-semibold text-aptl-text">Config</h1>
+		<p class="mt-1 text-sm text-aptl-text-muted">
+			Non-secret lab and web-serve settings. Read-only in v1.
+		</p>
+	</div>
+
+	{#if data.configError || !data.config}
+		<div
+			class="rounded-lg border border-aptl-amber/20 bg-aptl-amber/5 p-8 text-center text-sm text-aptl-amber"
+			role="status"
+		>
+			Configuration is currently unavailable.
+		</div>
+	{:else}
+		<ConfigSummaryList config={data.config} />
+	{/if}
+</div>

--- a/web/src/routes/config/+page.ts
+++ b/web/src/routes/config/+page.ts
@@ -1,0 +1,21 @@
+import { getConfig } from '$lib/api';
+import type { AppConfig } from '$lib/types';
+
+/**
+ * Load the non-secret configuration projection for the `/config` route.
+ *
+ * Routes through `getConfig()` (shared API boundary, carries the
+ * `X-APTL-Session` header) and threads the load-provided `event.fetch` so the
+ * request resolves in every load context. A failure degrades to a stable
+ * error state rather than crashing the route.
+ */
+export async function load({ fetch }): Promise<{
+	config: AppConfig | null;
+	configError: boolean;
+}> {
+	try {
+		return { config: await getConfig(fetch), configError: false };
+	} catch {
+		return { config: null, configError: true };
+	}
+}

--- a/web/src/routes/terminal/[container]/+page.svelte
+++ b/web/src/routes/terminal/[container]/+page.svelte
@@ -1,15 +1,33 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
 	import Terminal from '$lib/components/Terminal.svelte';
 	import type { TerminalStatus } from '$lib/bff';
+	import { guardControlledAction } from '$lib/stores/ui';
+	import { preferences } from '$lib/stores/preferences';
+	import { focusRing } from '$lib/components/kit/tone';
 
 	const container = $derived($page.params.container ?? '');
 
 	let status = $state<TerminalStatus | null>(null);
+	// The PTY is not opened until the first-run local-use notice is acknowledged
+	// (a UI precondition; the server still enforces every terminal gate).
+	let launched = $state(false);
+
+	// Re-enterable: also invoked from the placeholder's launch control, so a user
+	// who dismisses the notice (Escape/backdrop) can retry without reloading.
+	function launch(): void {
+		guardControlledAction(() => (launched = true));
+	}
+
+	onMount(() => {
+		launch();
+	});
 
 	// Short header label for the connection phase (the full, accessible status
 	// text lives in the Terminal component's status region).
 	const phaseLabel = $derived.by(() => {
+		if (!launched) return 'awaiting acknowledgement';
 		switch (status?.phase) {
 			case 'connected':
 				return 'connected';
@@ -23,6 +41,7 @@
 	});
 
 	const phaseColor = $derived.by(() => {
+		if (!launched) return 'text-aptl-amber';
 		switch (status?.phase) {
 			case 'connected':
 				return 'text-aptl-green';
@@ -51,6 +70,26 @@
 		<span class="ml-auto text-xs font-medium {phaseColor}">{phaseLabel}</span>
 	</div>
 	<div class="flex-1 overflow-hidden bg-[#1a1d23] p-1">
-		<Terminal {container} onstatechange={(s) => (status = s)} />
+		{#if launched}
+			<Terminal
+				{container}
+				fontSize={$preferences.terminalFontSize}
+				scrollback={$preferences.terminalScrollback}
+				onstatechange={(s) => (status = s)}
+			/>
+		{:else}
+			<div class="flex h-full flex-col items-center justify-center gap-4 p-6 text-center">
+				<p class="text-sm text-aptl-text-muted">
+					Review and acknowledge the local-use notice to open the terminal.
+				</p>
+				<button
+					type="button"
+					onclick={launch}
+					class="rounded-md border border-aptl-border bg-aptl-surface px-3 py-1.5 text-sm text-aptl-text hover:bg-aptl-surface-hover {focusRing}"
+				>
+					Open terminal
+				</button>
+			</div>
+		{/if}
 	</div>
 </div>

--- a/web/tests/components/ConfigSummaryList.test.ts
+++ b/web/tests/components/ConfigSummaryList.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ConfigSummaryList from '../../src/lib/components/ConfigSummaryList.svelte';
+import { resetPreferences, setPreference } from '../../src/lib/stores/preferences';
+import type { AppConfig } from '../../src/lib/types';
+
+function config(overrides: Partial<AppConfig> = {}): AppConfig {
+	return {
+		lab_name: 'aptl',
+		network_subnet: '172.20.0.0/16',
+		containers: { wazuh: true, kali: true, reverse: false },
+		run_storage_backend: 'local',
+		web: {
+			build_version: '3.0.10',
+			allowed_hosts: ['127.0.0.1', 'localhost'],
+			public_origin: null,
+			deployment_provider: 'docker-compose'
+		},
+		...overrides
+	};
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	resetPreferences();
+});
+
+describe('ConfigSummaryList', () => {
+	it('renders lab profile facts', () => {
+		render(ConfigSummaryList, { props: { config: config() } });
+		expect(screen.getByText('aptl')).toBeTruthy();
+		expect(screen.getByText('172.20.0.0/16')).toBeTruthy();
+		expect(screen.getByText('local')).toBeTruthy();
+	});
+
+	it('lists only the enabled container families', () => {
+		render(ConfigSummaryList, { props: { config: config() } });
+		expect(screen.getByText('wazuh, kali')).toBeTruthy();
+	});
+
+	it('renders web-serve facts and defaults the public origin to loopback', () => {
+		render(ConfigSummaryList, { props: { config: config() } });
+		expect(screen.getByText('3.0.10')).toBeTruthy();
+		expect(screen.getByText('127.0.0.1, localhost')).toBeTruthy();
+		expect(screen.getByText('default (loopback)')).toBeTruthy();
+		expect(screen.getByText('docker-compose')).toBeTruthy();
+	});
+
+	it('shows the public origin when it is set', () => {
+		render(ConfigSummaryList, {
+			props: {
+				config: config({
+					web: {
+						build_version: '1',
+						allowed_hosts: [],
+						public_origin: 'https://box.example.ts.net',
+						deployment_provider: 'docker-compose'
+					}
+				})
+			}
+		});
+		expect(screen.getByText('https://box.example.ts.net')).toBeTruthy();
+	});
+
+	it('always shows the secrets-hidden note', () => {
+		render(ConfigSummaryList, { props: { config: config() } });
+		expect(screen.getByText(/intentionally hidden/i)).toBeTruthy();
+	});
+
+	it('honours compact density on the row rhythm', () => {
+		setPreference('density', 'compact');
+		const { container } = render(ConfigSummaryList, { props: { config: config() } });
+		expect(container.querySelector('.py-1')).toBeTruthy();
+		expect(container.querySelector('.py-2')).toBeNull();
+	});
+});

--- a/web/tests/components/LocalUseNoticeDialog.test.ts
+++ b/web/tests/components/LocalUseNoticeDialog.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import LocalUseNoticeDialog from '../../src/lib/components/LocalUseNoticeDialog.svelte';
+
+function open(props: Record<string, unknown> = {}) {
+	return render(LocalUseNoticeDialog, {
+		props: { open: true, onAcknowledge: vi.fn(), ...props }
+	});
+}
+
+describe('LocalUseNoticeDialog', () => {
+	it('is not rendered when closed', () => {
+		render(LocalUseNoticeDialog, { props: { open: false, onAcknowledge: vi.fn() } });
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+	it('names the authorized local lab use title', async () => {
+		open();
+		const dialog = await screen.findByRole('dialog');
+		const labelledBy = dialog.getAttribute('aria-labelledby');
+		expect(document.getElementById(labelledBy!)?.textContent).toContain('Authorized local lab use');
+	});
+
+	it('states the no-token / no-terminal-persistence posture', () => {
+		open();
+		expect(screen.getByText(/does not store API tokens/i)).toBeTruthy();
+	});
+
+	it('acknowledge calls onAcknowledge', async () => {
+		const onAcknowledge = vi.fn();
+		open({ onAcknowledge });
+		await fireEvent.click(screen.getByRole('button', { name: /acknowledge/i }));
+		expect(onAcknowledge).toHaveBeenCalled();
+	});
+
+	it('cancels on Escape', async () => {
+		const onCancel = vi.fn();
+		open({ onCancel });
+		const dialog = await screen.findByRole('dialog');
+		await fireEvent.keyDown(dialog, { key: 'Escape' });
+		await waitFor(() => expect(onCancel).toHaveBeenCalled());
+	});
+
+	it('exposes Privacy details only when a handler is provided', async () => {
+		const onPrivacyDetails = vi.fn();
+		open({ onPrivacyDetails });
+		await fireEvent.click(screen.getByRole('button', { name: /privacy details/i }));
+		expect(onPrivacyDetails).toHaveBeenCalled();
+	});
+
+	it('omits Privacy details when no handler is provided', () => {
+		open();
+		expect(screen.queryByRole('button', { name: /privacy details/i })).toBeNull();
+	});
+});

--- a/web/tests/components/NavBar.test.ts
+++ b/web/tests/components/NavBar.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import NavBar from '../../src/lib/components/NavBar.svelte';
+import { settingsOpen, privacyOpen } from '../../src/lib/stores/ui';
+
+beforeEach(() => {
+	settingsOpen.set(false);
+	privacyOpen.set(false);
+});
+
+describe('NavBar', () => {
+	it('shows the Lab Home and Config nav links', () => {
+		render(NavBar);
+		expect(screen.getByRole('link', { name: 'Lab Home' })).toBeTruthy();
+		expect(screen.getByRole('link', { name: 'Config' }).getAttribute('href')).toBe('/config');
+	});
+
+	it('opens Settings from the Settings button', async () => {
+		render(NavBar);
+		await fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+		expect(get(settingsOpen)).toBe(true);
+	});
+
+	it('opens Privacy from the Help menu', async () => {
+		render(NavBar);
+		await fireEvent.click(screen.getByRole('button', { name: 'Help' }));
+		await fireEvent.click(screen.getByRole('menuitem', { name: 'Privacy' }));
+		expect(get(privacyOpen)).toBe(true);
+	});
+});

--- a/web/tests/components/PrivacyDetailsPanel.test.ts
+++ b/web/tests/components/PrivacyDetailsPanel.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import PrivacyDetailsPanel from '../../src/lib/components/PrivacyDetailsPanel.svelte';
+import { preferences, resetPreferences, PREFERENCES_KEY } from '../../src/lib/stores/preferences';
+
+beforeEach(() => {
+	localStorage.clear();
+	resetPreferences();
+});
+
+describe('PrivacyDetailsPanel', () => {
+	it('is not rendered when closed', () => {
+		render(PrivacyDetailsPanel, { props: { open: false } });
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+	it('states the no-analytics and no-token-storage posture and the storage key', async () => {
+		render(PrivacyDetailsPanel, { props: { open: true } });
+		await screen.findByRole('dialog');
+		expect(screen.getByText(/no non-essential\s+analytics/i)).toBeTruthy();
+		expect(screen.getByText(/never stores API tokens/i)).toBeTruthy();
+		expect(screen.getByText(PREFERENCES_KEY)).toBeTruthy();
+	});
+
+	it('shows an acknowledgement time when the notice has been acknowledged', async () => {
+		preferences.update((p) => ({
+			...p,
+			noticeAck: { version: '1', timestamp: '2026-01-02T03:04:05Z' }
+		}));
+		render(PrivacyDetailsPanel, { props: { open: true } });
+		await screen.findByRole('dialog');
+		expect(screen.getByText(/notice acknowledged/i)).toBeTruthy();
+	});
+
+	it('omits the acknowledgement line when never acknowledged', async () => {
+		render(PrivacyDetailsPanel, { props: { open: true } });
+		await screen.findByRole('dialog');
+		expect(screen.queryByText(/notice acknowledged/i)).toBeNull();
+	});
+});

--- a/web/tests/components/SettingsDialog.test.ts
+++ b/web/tests/components/SettingsDialog.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import SettingsDialog from '../../src/lib/components/SettingsDialog.svelte';
+import {
+	preferences,
+	resetPreferences,
+	DEFAULT_PREFERENCES
+} from '../../src/lib/stores/preferences';
+
+beforeEach(() => {
+	localStorage.clear();
+	resetPreferences();
+});
+
+describe('SettingsDialog', () => {
+	it('is not rendered when closed', () => {
+		render(SettingsDialog, { props: { open: false } });
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+	it('renders an accessible drawer titled Settings', async () => {
+		render(SettingsDialog, { props: { open: true } });
+		const dialog = await screen.findByRole('dialog');
+		const labelledBy = dialog.getAttribute('aria-labelledby');
+		expect(document.getElementById(labelledBy!)?.textContent).toContain('Settings');
+	});
+
+	it('changing color mode updates and persists the preference', async () => {
+		render(SettingsDialog, { props: { open: true } });
+		const select = screen.getByLabelText('Color mode');
+		await fireEvent.change(select, { target: { value: 'high-contrast' } });
+		expect(get(preferences).colorMode).toBe('high-contrast');
+	});
+
+	it('changing density updates the preference', async () => {
+		render(SettingsDialog, { props: { open: true } });
+		await fireEvent.change(screen.getByLabelText('Density'), { target: { value: 'compact' } });
+		expect(get(preferences).density).toBe('compact');
+	});
+
+	it('changing the SIEM row limit stores it as a number', async () => {
+		render(SettingsDialog, { props: { open: true } });
+		await fireEvent.change(screen.getByLabelText('Row limit'), { target: { value: '250' } });
+		expect(get(preferences).siemRowLimit).toBe(250);
+	});
+
+	it('the font-size stepper increments within bounds', async () => {
+		render(SettingsDialog, { props: { open: true } });
+		await fireEvent.click(screen.getByRole('button', { name: /increase terminal font size/i }));
+		expect(get(preferences).terminalFontSize).toBe(DEFAULT_PREFERENCES.terminalFontSize + 1);
+	});
+
+	it('reset returns preferences to defaults', async () => {
+		render(SettingsDialog, { props: { open: true } });
+		await fireEvent.change(screen.getByLabelText('Density'), { target: { value: 'compact' } });
+		await fireEvent.click(screen.getByRole('button', { name: /reset preferences/i }));
+		expect(get(preferences)).toEqual(DEFAULT_PREFERENCES);
+	});
+});

--- a/web/tests/lib/preferences.test.ts
+++ b/web/tests/lib/preferences.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+	preferences,
+	DEFAULT_PREFERENCES,
+	PREFERENCES_KEY,
+	PREFERENCES_VERSION,
+	NOTICE_VERSION,
+	TERMINAL_FONT_SIZE_MIN,
+	TERMINAL_FONT_SIZE_MAX,
+	sanitizePreferences,
+	loadPreferences,
+	setPreference,
+	setTerminalFontSize,
+	resetPreferences,
+	isNoticeAcknowledged,
+	acknowledgeNotice,
+	applyPreferenceEffects
+} from '../../src/lib/stores/preferences';
+
+beforeEach(() => {
+	localStorage.clear();
+	resetPreferences();
+});
+
+describe('sanitizePreferences', () => {
+	it('passes a fully valid object through unchanged', () => {
+		const valid = {
+			...DEFAULT_PREFERENCES,
+			colorMode: 'light' as const,
+			density: 'compact' as const,
+			terminalFontSize: 16
+		};
+		expect(sanitizePreferences(valid)).toEqual(valid);
+	});
+
+	it('falls back per field on invalid values', () => {
+		const r = sanitizePreferences({
+			colorMode: 'neon',
+			density: 5,
+			motion: 'x',
+			siemRowLimit: 999,
+			terminalFontSize: 99,
+			terminalScrollback: 3
+		});
+		expect(r.colorMode).toBe(DEFAULT_PREFERENCES.colorMode);
+		expect(r.density).toBe(DEFAULT_PREFERENCES.density);
+		expect(r.motion).toBe(DEFAULT_PREFERENCES.motion);
+		expect(r.siemRowLimit).toBe(DEFAULT_PREFERENCES.siemRowLimit);
+		expect(r.terminalFontSize).toBe(DEFAULT_PREFERENCES.terminalFontSize);
+		expect(r.terminalScrollback).toBe(DEFAULT_PREFERENCES.terminalScrollback);
+	});
+
+	it('ignores unknown keys and non-object input', () => {
+		expect(sanitizePreferences({ bogus: 1 })).toEqual(DEFAULT_PREFERENCES);
+		expect(sanitizePreferences(null)).toEqual(DEFAULT_PREFERENCES);
+		expect(sanitizePreferences('nope')).toEqual(DEFAULT_PREFERENCES);
+	});
+
+	it('accepts a plausible BCP-47 locale and rejects garbage', () => {
+		expect(sanitizePreferences({ locale: 'en-GB' }).locale).toBe('en-GB');
+		expect(sanitizePreferences({ locale: 'system' }).locale).toBe('system');
+		expect(sanitizePreferences({ locale: '!!' }).locale).toBe(DEFAULT_PREFERENCES.locale);
+	});
+
+	it('keeps a well-formed noticeAck and drops a malformed one', () => {
+		expect(sanitizePreferences({ noticeAck: { version: '1', timestamp: 't' } }).noticeAck).toEqual({
+			version: '1',
+			timestamp: 't'
+		});
+		expect(sanitizePreferences({ noticeAck: { version: 1 } }).noticeAck).toBeNull();
+	});
+});
+
+describe('loadPreferences', () => {
+	it('returns defaults when nothing is stored', () => {
+		localStorage.clear();
+		expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+	});
+
+	it('resets on a schema-version mismatch', () => {
+		localStorage.setItem(PREFERENCES_KEY, JSON.stringify({ v: 999, colorMode: 'light' }));
+		expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+	});
+
+	it('loads and sanitizes a valid stored blob', () => {
+		localStorage.setItem(
+			PREFERENCES_KEY,
+			JSON.stringify({ v: PREFERENCES_VERSION, colorMode: 'light', density: 'compact' })
+		);
+		const p = loadPreferences();
+		expect(p.colorMode).toBe('light');
+		expect(p.density).toBe('compact');
+	});
+
+	it('resets on corrupt JSON', () => {
+		localStorage.setItem(PREFERENCES_KEY, '{not json');
+		expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+	});
+});
+
+describe('preferences store', () => {
+	it('setPreference updates the store and persists with the version tag', () => {
+		setPreference('colorMode', 'high-contrast');
+		expect(get(preferences).colorMode).toBe('high-contrast');
+		const stored = JSON.parse(localStorage.getItem(PREFERENCES_KEY)!);
+		expect(stored.v).toBe(PREFERENCES_VERSION);
+		expect(stored.colorMode).toBe('high-contrast');
+	});
+
+	it('setTerminalFontSize clamps to the bounded range', () => {
+		setTerminalFontSize(999);
+		expect(get(preferences).terminalFontSize).toBe(TERMINAL_FONT_SIZE_MAX);
+		setTerminalFontSize(1);
+		expect(get(preferences).terminalFontSize).toBe(TERMINAL_FONT_SIZE_MIN);
+	});
+
+	it('resetPreferences returns every field to default', () => {
+		setPreference('colorMode', 'light');
+		setPreference('density', 'compact');
+		resetPreferences();
+		expect(get(preferences)).toEqual(DEFAULT_PREFERENCES);
+	});
+});
+
+describe('notice acknowledgement', () => {
+	it('is unacknowledged by default', () => {
+		expect(isNoticeAcknowledged(get(preferences))).toBe(false);
+	});
+
+	it('acknowledgeNotice records the current version and a timestamp', () => {
+		acknowledgeNotice();
+		const ack = get(preferences).noticeAck!;
+		expect(ack.version).toBe(NOTICE_VERSION);
+		expect(typeof ack.timestamp).toBe('string');
+		expect(isNoticeAcknowledged(get(preferences))).toBe(true);
+	});
+
+	it('treats a stale notice version as unacknowledged', () => {
+		setPreference('noticeAck', { version: 'stale', timestamp: 't' });
+		expect(isNoticeAcknowledged(get(preferences))).toBe(false);
+	});
+});
+
+describe('applyPreferenceEffects', () => {
+	it('writes the presentation preferences as data attributes on <html>', () => {
+		applyPreferenceEffects({
+			...DEFAULT_PREFERENCES,
+			colorMode: 'light',
+			density: 'compact',
+			motion: 'reduced'
+		});
+		const el = document.documentElement;
+		expect(el.getAttribute('data-color-mode')).toBe('light');
+		expect(el.getAttribute('data-density')).toBe('compact');
+		expect(el.getAttribute('data-motion')).toBe('reduced');
+	});
+});

--- a/web/tests/lib/time.test.ts
+++ b/web/tests/lib/time.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { formatTimestamp, resolveLocale } from '../../src/lib/time';
+
+describe('resolveLocale', () => {
+	it('maps system/empty to undefined and passes tags through', () => {
+		expect(resolveLocale('system')).toBeUndefined();
+		expect(resolveLocale('')).toBeUndefined();
+		expect(resolveLocale('en-GB')).toBe('en-GB');
+	});
+});
+
+describe('formatTimestamp', () => {
+	const iso = '2026-01-02T03:04:05Z';
+
+	it('formats a UTC instant with a trailing UTC marker', () => {
+		const out = formatTimestamp(iso, { timeDisplay: 'utc', locale: 'en' });
+		expect(out).toContain('2026');
+		expect(out.endsWith('UTC')).toBe(true);
+	});
+
+	it('formats local time without a UTC marker', () => {
+		const out = formatTimestamp(iso, { timeDisplay: 'local', locale: 'en' });
+		expect(out).toContain('2026');
+		expect(out.endsWith('UTC')).toBe(false);
+	});
+
+	it('returns an empty string for an unparseable instant', () => {
+		expect(formatTimestamp('not-a-date', { timeDisplay: 'local', locale: 'system' })).toBe('');
+	});
+});

--- a/web/tests/lib/ui.test.ts
+++ b/web/tests/lib/ui.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+	settingsOpen,
+	privacyOpen,
+	noticeOpen,
+	openSettings,
+	openPrivacy,
+	guardControlledAction,
+	acknowledgeAndRun,
+	dismissNotice
+} from '../../src/lib/stores/ui';
+import {
+	preferences,
+	resetPreferences,
+	isNoticeAcknowledged,
+	NOTICE_VERSION
+} from '../../src/lib/stores/preferences';
+
+beforeEach(() => {
+	localStorage.clear();
+	resetPreferences();
+	settingsOpen.set(false);
+	privacyOpen.set(false);
+	noticeOpen.set(false);
+});
+
+describe('openSettings / openPrivacy', () => {
+	it('open the respective app-shell dialogs', () => {
+		openSettings();
+		expect(get(settingsOpen)).toBe(true);
+		openPrivacy();
+		expect(get(privacyOpen)).toBe(true);
+	});
+});
+
+describe('guardControlledAction', () => {
+	it('runs immediately when the notice is already acknowledged', () => {
+		preferences.update((p) => ({
+			...p,
+			noticeAck: { version: NOTICE_VERSION, timestamp: 't' }
+		}));
+		const run = vi.fn();
+		guardControlledAction(run);
+		expect(run).toHaveBeenCalledOnce();
+		expect(get(noticeOpen)).toBe(false);
+	});
+
+	it('defers the action and opens the notice when not acknowledged', () => {
+		const run = vi.fn();
+		guardControlledAction(run);
+		expect(run).not.toHaveBeenCalled();
+		expect(get(noticeOpen)).toBe(true);
+	});
+});
+
+describe('acknowledgeAndRun', () => {
+	it('acknowledges, runs the deferred action, and closes the notice', () => {
+		const run = vi.fn();
+		guardControlledAction(run);
+		acknowledgeAndRun();
+		expect(run).toHaveBeenCalledOnce();
+		expect(get(noticeOpen)).toBe(false);
+		expect(isNoticeAcknowledged(get(preferences))).toBe(true);
+	});
+
+	it('is a no-op action-wise when nothing was deferred', () => {
+		acknowledgeAndRun();
+		expect(get(noticeOpen)).toBe(false);
+		expect(isNoticeAcknowledged(get(preferences))).toBe(true);
+	});
+});
+
+describe('dismissNotice', () => {
+	it('drops the deferred action and closes the notice', () => {
+		const run = vi.fn();
+		guardControlledAction(run);
+		dismissNotice();
+		// A later acknowledgement must not resurrect the discarded action.
+		acknowledgeAndRun();
+		expect(run).not.toHaveBeenCalled();
+		expect(get(noticeOpen)).toBe(false);
+	});
+});

--- a/web/tests/routes/config-page.test.ts
+++ b/web/tests/routes/config-page.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { AppConfig } from '../../src/lib/types';
+
+function config(): AppConfig {
+	return {
+		lab_name: 'aptl',
+		network_subnet: '172.20.0.0/16',
+		containers: {},
+		run_storage_backend: 'local',
+		web: {
+			build_version: '1',
+			allowed_hosts: [],
+			public_origin: null,
+			deployment_provider: 'docker-compose'
+		}
+	};
+}
+
+describe('config route load', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+
+	it('fetches /api/config and returns the projection', async () => {
+		const data = config();
+		const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(data) });
+
+		const { load } = await import('../../src/routes/config/+page');
+		const result = await load({ fetch: mockFetch } as any);
+
+		expect(result.config).toEqual(data);
+		expect(result.configError).toBe(false);
+		expect(mockFetch).toHaveBeenCalledWith(
+			'/api/config',
+			expect.objectContaining({ headers: expect.any(Headers) })
+		);
+	});
+
+	it('degrades to an error state on fetch failure', async () => {
+		const mockFetch = vi.fn().mockRejectedValue(new Error('boom'));
+
+		const { load } = await import('../../src/routes/config/+page');
+		const result = await load({ fetch: mockFetch } as any);
+
+		expect(result.config).toBeNull();
+		expect(result.configError).toBe(true);
+	});
+});
+
+describe('config page render', () => {
+	it('renders the config summary when data is present', async () => {
+		const Page = (await import('../../src/routes/config/+page.svelte')).default;
+		render(Page, { props: { data: { config: config(), configError: false } } });
+		expect(screen.getByRole('heading', { name: 'Config' })).toBeTruthy();
+		expect(screen.getByText('aptl')).toBeTruthy();
+	});
+
+	it('renders an unavailable state on error', async () => {
+		const Page = (await import('../../src/routes/config/+page.svelte')).default;
+		render(Page, { props: { data: { config: null, configError: true } } });
+		expect(screen.getByText(/currently unavailable/i)).toBeTruthy();
+	});
+});

--- a/web/tests/routes/fixtures/LayoutHarness.svelte
+++ b/web/tests/routes/fixtures/LayoutHarness.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import Layout from '../../../src/routes/+layout.svelte';
+</script>
+
+<Layout>
+	<span data-testid="child">child content</span>
+</Layout>

--- a/web/tests/routes/layout.test.ts
+++ b/web/tests/routes/layout.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { writable, get } from 'svelte/store';
+
+// The layout initialises the lab store on mount; stub it so no fetch/SSE runs.
+vi.mock('$lib/stores/lab', () => ({
+	initLabStore: vi.fn(),
+	destroyLabStore: vi.fn(),
+	labStatus: writable({ running: false, containers: [], error: null })
+}));
+
+import LayoutHarness from './fixtures/LayoutHarness.svelte';
+import { privacyOpen } from '../../src/lib/stores/ui';
+
+beforeEach(() => {
+	localStorage.clear();
+	privacyOpen.set(false);
+});
+
+describe('app shell layout', () => {
+	it('renders route children and a persistent Privacy link', () => {
+		render(LayoutHarness);
+		expect(screen.getByText('child content')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Privacy' })).toBeTruthy();
+	});
+
+	it('opens the privacy panel from the footer Privacy link', async () => {
+		render(LayoutHarness);
+		await fireEvent.click(screen.getByRole('button', { name: 'Privacy' }));
+		expect(get(privacyOpen)).toBe(true);
+	});
+});

--- a/web/tests/routes/page.test.ts
+++ b/web/tests/routes/page.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import type { LabStatus, ScenarioSummary } from '../../src/lib/types';
+import { noticeOpen } from '../../src/lib/stores/ui';
+import { resetPreferences, acknowledgeNotice } from '../../src/lib/stores/preferences';
 
 function summary(overrides: Partial<ScenarioSummary> = {}): ScenarioSummary {
 	return {
@@ -44,6 +46,12 @@ describe('Lab Home route', () => {
 		labLoading.set(false);
 		vi.clearAllMocks();
 		refreshLabStatus.mockResolvedValue(undefined);
+		// Pre-acknowledge the local-use notice so guarded lifecycle actions run;
+		// the deferral path is covered by its own test below.
+		localStorage.clear();
+		resetPreferences();
+		acknowledgeNotice();
+		noticeOpen.set(false);
 	});
 
 	it('leads with a stopped readiness headline and a Start control', async () => {
@@ -166,5 +174,14 @@ describe('Lab Home route', () => {
 	it('shows a catalog-unavailable state on load error', async () => {
 		await renderPage({ scenarios: [], scenariosError: true });
 		expect(screen.getByText(/catalog is currently unavailable/i)).toBeTruthy();
+	});
+
+	it('defers a lifecycle action behind the local-use notice when unacknowledged', async () => {
+		// Un-acknowledge so the guard must open the notice instead of acting.
+		resetPreferences();
+		await renderPage();
+		await fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+		expect(startLab).not.toHaveBeenCalled();
+		expect(get(noticeOpen)).toBe(true);
 	});
 });

--- a/web/tests/routes/terminal-page.test.ts
+++ b/web/tests/routes/terminal-page.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { readable, get } from 'svelte/store';
+import { resetPreferences, acknowledgeNotice } from '../../src/lib/stores/preferences';
+import { noticeOpen } from '../../src/lib/stores/ui';
+
+// The route reads the container from $app/stores' page store.
+vi.mock('$app/stores', () => ({ page: readable({ params: { container: 'kali' } }) }));
+
+// Stub heavy DOM-canvas dependencies that jsdom cannot handle (mirrors the
+// Terminal component test).
+vi.mock('@xterm/xterm', () => ({
+	Terminal: vi.fn(() => ({
+		loadAddon: vi.fn(),
+		open: vi.fn(),
+		onData: vi.fn(),
+		onResize: vi.fn(),
+		write: vi.fn(),
+		dispose: vi.fn(),
+		cols: 80,
+		rows: 24
+	}))
+}));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn(() => ({ fit: vi.fn(), dispose: vi.fn() })) }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })) }));
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+
+beforeEach(() => {
+	localStorage.clear();
+	resetPreferences();
+	noticeOpen.set(false);
+	vi.stubGlobal(
+		'fetch',
+		vi.fn().mockResolvedValue({ ok: false, status: 503, text: () => Promise.resolve('') })
+	);
+	vi.stubGlobal(
+		'WebSocket',
+		vi.fn(function (this: Record<string, unknown>) {
+			this.close = vi.fn();
+			this.send = vi.fn();
+		})
+	);
+	vi.stubGlobal('ResizeObserver', vi.fn(() => ({ observe: vi.fn(), disconnect: vi.fn() })));
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+async function renderTerminalPage() {
+	const Page = (await import('../../src/routes/terminal/[container]/+page.svelte')).default;
+	return render(Page);
+}
+
+describe('terminal route acknowledgement gate', () => {
+	it('does not open the PTY until the local-use notice is acknowledged', async () => {
+		await renderTerminalPage();
+		expect(screen.getByText(/acknowledge the local-use notice/i)).toBeTruthy();
+		// The Terminal component (and its status region) is not mounted yet.
+		expect(screen.queryByRole('status')).toBeNull();
+		// The guard opened the notice.
+		expect(get(noticeOpen)).toBe(true);
+	});
+
+	it('opens the terminal immediately when already acknowledged', async () => {
+		acknowledgeNotice();
+		await renderTerminalPage();
+		expect(screen.queryByText(/acknowledge the local-use notice/i)).toBeNull();
+		// The Terminal component mounts and surfaces its connection status region.
+		expect(screen.getByRole('status')).toBeTruthy();
+	});
+
+	it('is re-enterable: the placeholder launch control retries after a dismissal', async () => {
+		await renderTerminalPage();
+		// Notice was opened on mount; simulate the user dismissing it.
+		noticeOpen.set(false);
+		const launchButton = screen.getByRole('button', { name: /open terminal/i });
+
+		// Re-triggering while still unacknowledged re-opens the notice (not stranded).
+		await fireEvent.click(launchButton);
+		expect(get(noticeOpen)).toBe(true);
+		expect(screen.queryByRole('status')).toBeNull();
+
+		// After acknowledging, the launch control opens the terminal.
+		acknowledgeNotice();
+		await fireEvent.click(screen.getByRole('button', { name: /open terminal/i }));
+		expect(screen.getByRole('status')).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Summary

Implements UI-008f under UI-008 (#541): the web GUI configuration summary (`/config`), a local-preferences Settings drawer, and a first-run local-use/privacy notice. `/config` projects non-secret lab and web-serve facts only; Settings persists versioned, browser-local UI preferences with a reset control; the notice is acknowledged once before the first mutating lab action or terminal launch, with a persistent Privacy link in the app shell. Server auth/CSRF/terminal gates are untouched — acknowledgement is a UI precondition only.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #567

## ADR Impact

- ADR-021
- ADR-025
- ADR-039

## Changes

- Backend: extend `/api/config` with a non-secret `WebServeInfo` projection (build version, effective allowed hosts, public origin, deployment provider); reuse the BFF Host allow-list parsing via a new `effective_allowed_hosts()` wrapper — no tokens/secrets/.env
- Frontend: versioned browser-local preferences store (`aptl.web.preferences.v1`) with per-field validation, reset, and `data-color-mode`/`data-density`/`data-motion` application
- Frontend: real light + high-contrast color-mode palettes and a forced-reduced-motion block in `app.css`
- Frontend: `SettingsDialog` drawer (appearance, locale/time, SIEM defaults, terminal rendering) + reset; SIEM defaults are stored for the not-yet-shipped SIEM explorer (#421)
- Frontend: `LocalUseNoticeDialog` first-run acknowledgement gate + `PrivacyDetailsPanel`; NavBar Config link, Settings button, Help/Privacy menu; persistent footer Privacy link
- Frontend: `/config` route + `ConfigSummaryList`; terminal font-size/scrollback wired into xterm; lab actions and terminal launch gated behind the notice (re-enterable)
- Docs: UI-008f guardrails added to `docs/specs/web-gui-design-preflight.md` (architecture preflight)

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Python: `pytest -n auto -k "not integration"` (2056 passed) + techvault static gate (2 passed). Web: `vitest` (238 passed across 37 files) + `svelte-check` (0 errors). `pre-commit run --all-files` green (ruff/eslint complexity, Vale, full suites).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #567 ← src/aptl/api/routers/config.py (non-secret /config projection), #567 ← web/src/lib/stores/preferences.ts (versioned local preferences), #567 ← web/src/lib/components/SettingsDialog.svelte, #567 ← web/src/lib/components/LocalUseNoticeDialog.svelte, #567 ← web/src/routes/config/+page.svelte
- TESTS: tests/test_api_config.py ← /api/config web projection, web/tests/lib/preferences.test.ts, web/tests/lib/ui.test.ts, web/tests/components/SettingsDialog.test.ts, web/tests/routes/config-page.test.ts, web/tests/routes/terminal-page.test.ts

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/567.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
