### PR TITLE
test(smoke): probe victim/workstation SSH by container IP; skip optional MCPs; fix walkthrough count

### DIFF
--- a/docs/workshop/walkthrough.md
+++ b/docs/workshop/walkthrough.md
@@ -246,8 +246,9 @@ Path A (agent):
 > specifically rule IDs 5710 and 302011. What fired, and from which source IP?
 
 Expect rule 5710 (sshd non-existent user) about 6 times and rule 302011 (SQL
-injection special characters in URL) about 4 times. The source addresses are
-Kali's `172.20.2.35` for the SSH path and `172.20.1.30` for the web path.
+injection special characters in URL) about a dozen times (roughly three alerts
+per probe). The source addresses are Kali's `172.20.2.35` for the SSH path and
+`172.20.1.30` for the web path.
 
 Path B (direct):
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -486,17 +486,26 @@ def curl_json(
 
 
 def ssh_cmd(
-    port: int, user: str, cmd: str = "echo OK",
+    port: int, user: str, cmd: str = "echo OK", host: str = "localhost",
 ) -> subprocess.CompletedProcess:
-    """Run a command via SSH to a lab container."""
+    """Run a command via SSH to a lab container.
+
+    ``host`` defaults to ``localhost`` for services published to the host
+    (e.g. the kali SSH proxy on 2023). Internal-only targets such as victim
+    and workstation publish NO host port by design (issue #293) — they attach
+    only to an internal Docker network and are reached by container IP over the
+    bridge with the same lab key. For those, pass ``host=VICTIM_IP`` /
+    ``host=WS_IP`` with ``port=22``.
+    """
     return run_cmd([
         "ssh",
         "-i", SSH_KEY,
         "-o", "ConnectTimeout=5",
         "-o", "StrictHostKeyChecking=no",
+        "-o", "UserKnownHostsFile=/dev/null",
         "-o", "BatchMode=yes",
         "-p", str(port),
-        f"{user}@localhost",
+        f"{user}@{host}",
         cmd,
     ])
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -19,7 +19,8 @@ from tests.helpers import (
     LIVE_LAB,
     PROJECT_ROOT,
     PUBLISHED_MCP_PATHS,
-    WS_SSH_PORT,
+    VICTIM_IP,
+    WS_IP,
     container_running,
     curl_indexer,
     docker_exec,
@@ -84,10 +85,16 @@ class TestContainerHealth:
 
 @LIVE_LAB
 class TestSSHAccess:
-    """SSH key auth works for all SSH-accessible containers."""
+    """SSH key auth works for all SSH-accessible containers.
+
+    Kali publishes a loopback SSH proxy on host port 2023. Victim and
+    workstation publish NO host port by design (issue #293): they sit on an
+    internal-only Docker network and are reached by container IP over the
+    bridge with the same lab key — the path the control plane / MCP hosts use.
+    """
 
     def test_victim_ssh(self):
-        result = ssh_cmd(2022, "labadmin")
+        result = ssh_cmd(22, "labadmin", host=VICTIM_IP)
         assert result.returncode == 0, f"SSH failed: {result.stderr}"
         assert "OK" in result.stdout
 
@@ -97,7 +104,7 @@ class TestSSHAccess:
         assert "OK" in result.stdout
 
     def test_workstation_ssh(self):
-        result = ssh_cmd(WS_SSH_PORT, "labadmin")
+        result = ssh_cmd(22, "labadmin", host=WS_IP)
         assert result.returncode == 0, f"SSH failed: {result.stderr}"
         assert "OK" in result.stdout
 
@@ -226,11 +233,21 @@ class TestMCPServers:
         ids=list(PUBLISHED_MCP_PATHS.keys()),
     )
     def test_published_binary_exists(self, name, path):
-        """Published MCP server binary or script is installed."""
-        assert os.path.isfile(path), (
-            f"Published MCP '{name}' not found at {path} -- "
-            "see tools/.gitignore for install instructions"
-        )
+        """Published MCP server binary or script is installed (optional).
+
+        The published wazuh/thehive/misp MCP servers are third-party, installed
+        per-machine and gitignored (``tools/.gitignore``); they back only the
+        optional full-SOC MCP path. Skip when absent so a core-workshop setup
+        (red + indexer, built from source) reports a clean smoke run, while
+        still validating the binary when a facilitator has installed it.
+        """
+        if not os.path.isfile(path):
+            pytest.skip(
+                f"Published MCP '{name}' not installed at {path} -- optional "
+                "per-machine install (see tools/.gitignore); required only for "
+                "the full-SOC MCP path."
+            )
+        assert os.path.isfile(path)
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-ups found while live-driving the TechVault range end-to-end for the Black Hat Arsenal lab (fresh `aptl lab start --clean` → smoke suite → full walkthrough, run twice for reproducibility). The range itself stands up flawlessly; these fix the **smoke suite** and one **walkthrough doc** number so the verification signal is trustworthy for facilitators.

## Changes

1. **`test(smoke)`** — the live smoke suite hard-failed on a correctly-configured range:
   - Victim/workstation SSH were probed on host ports 2022/2028, but those targets are internal-only with **no host port published by design** (issue #293) — the control plane reaches them by container IP over the bridge. Added a `host=` param to `ssh_cmd` and probe victim (`172.20.2.20:22`) / workstation (`172.20.2.40:22`) at their container IPs (the real, supported path; verified live).
   - The published wazuh/thehive/misp MCP binary checks now **skip when absent** — they're third-party, gitignored, per-machine installs (`tools/.gitignore`) backing only the optional full-SOC MCP path, so a core-workshop setup reports a clean run.
   - Result: `APTL_SMOKE=1 pytest tests/test_smoke.py` → **45 passed, 3 skipped** on a fresh range (was 5 spurious failures).

2. **`docs(workshop)`** — the walkthrough said the SQLi probe fires rule 302011 "about 4 times"; a default four-probe run deterministically produces **about a dozen** (≈3 per probe), confirmed across two fresh clean-boot cycles. Matched the doc to observed behavior.

## Verification

Two independent fresh `--clean` boots, identical clean results: 31 healthy containers, smoke 45/3, recon + anonymous SMB (6 shares), SSH brute-force → rule 5710 ×6 from `172.20.2.35`, SQLi → rule 302011 ×12 from `172.20.1.30`, all six SOC dashboards reachable.

Test-and-docs only; no application-source change (no changelog fragment).
