### PR TITLE
feat(deployment): surface a redacted stderr hint when a volume seed exits nonzero

### DIFF
--- a/changelog.d/716.added.md
+++ b/changelog.d/716.added.md
@@ -1,0 +1,6 @@
+A failed named-volume seed (or legacy-seed retire) now logs a redacted,
+length-bounded tail of the underlying `docker run` stderr, so the operator can
+diagnose the failure from the log instead of reproducing the docker command by
+hand. The stderr is scrubbed through the shared serialization-boundary redactor
+before truncation (fail closed), and the raised `BackendSeedError` still carries
+only the artifact name — never raw docker output.

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -26,6 +26,7 @@ from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.core.seed_spec import NamedVolumeSeed
 from aptl.utils.logging import get_logger
+from aptl.utils.redaction import redact
 
 log = get_logger("deployment.docker_compose")
 
@@ -45,6 +46,13 @@ _SEED_TIMEOUT = 600
 # validated defensively: a strict charset, no leading separator, and no
 # parent-traversal component, so nothing can escape /src or /dest.
 _SAFE_SEED_RELPATH = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+
+# Character budget for the redacted stderr tail appended to a failed
+# seed/retire log line (issue #716). Bounds a verbose or hostile Docker
+# stderr to a one-line tail; the value is redacted over its FULL length
+# before this truncation, so the cap can never turn a straddling secret
+# into a partial leak (fail closed).
+_SEED_STDERR_HINT_MAX = 500
 
 
 class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
@@ -369,16 +377,40 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
         ]
         result = self._run(cmd, timeout=_SEED_TIMEOUT)
         if result.returncode != 0:
-            # Name only the artifact — raw Docker stderr stays out of the
-            # raised message and is surfaced through the redacted log line.
+            # Name only the artifact in the raised message — raw Docker
+            # stderr never reaches the exception (test_nonzero_exit_raises_
+            # without_leaking_stderr). The operator-facing log line carries
+            # a redacted stderr tail so a seed failure is diagnosable
+            # without rerunning the docker command by hand (issue #716).
             log.error(
-                "Seed of volume %s failed (exit %s)",
+                "Seed of volume %s failed (exit %s)%s",
                 seed.volume_suffix,
                 result.returncode,
+                self._redacted_stderr_hint(result.stderr),
             )
             raise BackendSeedError(
                 f"Seeding named volume '{seed.volume_suffix}' failed"
             )
+
+    @staticmethod
+    def _redacted_stderr_hint(stderr: str | None) -> str:
+        """Build a redacted, length-bounded stderr tail for a failed seed.
+
+        Returns ``""`` when there is nothing to show, otherwise a
+        `` — stderr: <hint>`` fragment ready to append to the failure log
+        line. The full stderr is scrubbed through the shared
+        serialization-boundary redactor (:func:`redact`) *before*
+        truncation, so a credential straddling the cut point can never
+        survive as a partial value — the hint fails closed. Only the log
+        carries this text; the raised ``BackendSeedError`` still names the
+        artifact and nothing else.
+        """
+        if not stderr or not stderr.strip():
+            return ""
+        redacted = redact(stderr).strip()
+        if len(redacted) > _SEED_STDERR_HINT_MAX:
+            redacted = "…" + redacted[-_SEED_STDERR_HINT_MAX:]
+        return f" — stderr: {redacted}"
 
     def _build_seed_script(self, seed: NamedVolumeSeed) -> str:
         """Build the fixed-path copy script for one seed.
@@ -432,10 +464,14 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
         ]
         result = self._run(cmd, timeout=_SEED_TIMEOUT)
         if result.returncode != 0:
+            # Same redacted-hint contract as the seed path (issue #716): the
+            # raised message names only the artifact; the log line carries a
+            # redacted stderr tail for diagnosis.
             log.error(
-                "Retire of legacy seed path %s failed (exit %s)",
+                "Retire of legacy seed path %s failed (exit %s)%s",
                 legacy,
                 result.returncode,
+                self._redacted_stderr_hint(result.stderr),
             )
             raise BackendSeedError(f"Retiring legacy seed path '{name}' failed")
 

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -2202,6 +2202,98 @@ class TestSeedNamedVolumes:
         assert "suricata_config_seed" in str(exc_info.value)
         assert "secret docker stderr" not in str(exc_info.value)
 
+    def test_nonzero_exit_logs_stderr_hint(self, tmp_path, caplog):
+        # Issue #716: a seed failure must be diagnosable from the log alone.
+        # The real docker error text reaches the operator-facing log line
+        # while the raised message stays artifact-name-only.
+        from aptl.core.deployment.errors import BackendSeedError
+
+        stderr = (
+            "Unable to find image 'jasonish/suricata:7.0' locally\n"
+            "docker: Error response from daemon: pull access denied"
+        )
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
+            caplog.set_level(logging.ERROR, logger="aptl")
+            with pytest.raises(BackendSeedError) as exc_info:
+                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+        message = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "Error response from daemon: pull access denied" in message
+        assert "suricata_config_seed" in message
+        # The exception itself still leaks nothing beyond the artifact name.
+        assert "Error response from daemon" not in str(exc_info.value)
+
+    def test_stderr_hint_is_redacted(self, tmp_path, caplog):
+        # A credential-shaped token in docker stderr must be scrubbed before
+        # it reaches the log; the shared redactor owns the masking.
+        from aptl.core.deployment.errors import BackendSeedError
+
+        stderr = (
+            "docker: Error response from daemon: failed to auth: "
+            "Authorization: Bearer sk-supersecrettoken123"
+        )
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
+            caplog.set_level(logging.ERROR, logger="aptl")
+            with pytest.raises(BackendSeedError):
+                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+        message = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "sk-supersecrettoken123" not in message
+        assert "[REDACTED]" in message
+
+    def test_empty_stderr_adds_no_hint_fragment(self, tmp_path, caplog):
+        # No stderr means no dangling " — stderr:" suffix on the log line.
+        from aptl.core.deployment.errors import BackendSeedError
+
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="   ")
+            caplog.set_level(logging.ERROR, logger="aptl")
+            with pytest.raises(BackendSeedError):
+                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+        message = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "stderr:" not in message
+        assert "suricata_config_seed" in message
+
+    def test_long_stderr_hint_is_tail_truncated(self, tmp_path, caplog):
+        # A verbose stderr collapses to a bounded tail; the daemon error at
+        # the end (the useful part) survives, the leading progress noise does
+        # not, and an ellipsis marks the cut.
+        from aptl.core.deployment.errors import BackendSeedError
+
+        stderr = "HEAD_NOISE " + ("x" * 2000) + " TAIL_DAEMON_ERROR"
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
+            caplog.set_level(logging.ERROR, logger="aptl")
+            with pytest.raises(BackendSeedError):
+                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+        message = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "TAIL_DAEMON_ERROR" in message
+        assert "HEAD_NOISE" not in message
+        assert "…" in message
+
+    def test_retire_failure_logs_stderr_hint(self, tmp_path, caplog):
+        # The legacy-retire error path shares the same redacted-hint contract
+        # as the seed path. Retire runs first, so a nonzero exit fails there.
+        from aptl.core.deployment.errors import BackendSeedError
+
+        stderr = "docker: Error response from daemon: permission denied on /legacy"
+        backend = self._backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
+            caplog.set_level(logging.ERROR, logger="aptl")
+            with pytest.raises(BackendSeedError) as exc_info:
+                backend.seed_named_volumes(
+                    [self._misp_seed_with_legacy()], seeder_image="img:1"
+                )
+        message = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "Retire of legacy seed path" in message
+        assert "permission denied on /legacy" in message
+        assert "permission denied" not in str(exc_info.value)
+
     def test_unsafe_relpath_rejected_before_any_container(self, tmp_path):
         from aptl.core.deployment.errors import BackendSeedError
         from aptl.core.seed_spec import NamedVolumeSeed, SeedFile


### PR DESCRIPTION
## Summary

On a nonzero exit from a named-volume seed (or legacy-seed retire) container, `_seed_one_named_volume` / `_retire_legacy_seed_path` previously logged only the exit code, so the operator had to reproduce the docker command by hand to see what actually broke — despite the docstring claiming stderr was "surfaced through the redacted log line". This adds a redacted, length-bounded stderr tail to the existing `log.error`. The stderr is scrubbed through the shared serialization-boundary redactor (`aptl.utils.redaction.redact`) over its full length *before* truncation, so no credential-shaped output leaks and a secret straddling the cut point cannot survive as a partial value (fail closed). The raised `BackendSeedError` message is unchanged and still names only the artifact.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #716

## ADR Impact

- ADR-012
- ADR-043

## Changes

- Add `_redacted_stderr_hint` helper on `DockerComposeBackend`: redacts full stderr via the shared `redact` scrubber, then appends a `…`-marked tail bounded by `_SEED_STDERR_HINT_MAX` (500 chars); returns empty for blank stderr
- Wire the hint into the `_seed_one_named_volume` nonzero-exit `log.error` while leaving the `BackendSeedError` message artifact-name-only
- Apply the identical hint contract to the adjacent `_retire_legacy_seed_path` error path, which shared the same thin-log limitation
- Extend `TestSeedNamedVolumes` with cases for: hint reaches the log while the exception stays clean, credential-shaped stderr is redacted, empty stderr adds no fragment, long stderr is tail-truncated with an ellipsis, and the retire path emits the hint

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Five new pytest cases in tests/test_deployment_backend.py::TestSeedNamedVolumes assert the redacted hint reaches the operator log, that credential shapes (e.g. `Bearer <token>`) become `[REDACTED]`, that empty stderr adds no dangling suffix, that an over-budget stderr collapses to its tail with a `…` marker, and that the legacy-retire path emits the same hint. The existing `test_nonzero_exit_raises_without_leaking_stderr` (both seed and realize-content paths) continues to hold, proving the exception message never leaks stderr. Full non-integration suite (2088 passed) and the techvault static gate (2 passed) are green.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/716.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.
