### PR TITLE
ci: skip SonarCloud gate on Dependabot PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -502,6 +502,16 @@ jobs:
   sonarcloud:
     name: SonarCloud quality gate
     needs: [python-tests, mcp-tests, web-tests]
+    # Dependabot-triggered runs are handed the Dependabot secret store, not the
+    # Actions one, so `secrets.SONAR_TOKEN` is empty and the scan can only ever
+    # fail with "Not authorized or project not found". Mirroring the token into
+    # Dependabot secrets would hand it to the very third-party action version
+    # the PR is bumping, which defeats the SHA pinning above, so skip instead:
+    # Dependabot never touches first-party source, so there is no new code for
+    # the gate to judge. A job skipped by a condition reports success, which
+    # keeps this satisfiable as a required check. Human PRs and pushes to
+    # main/dev still run the full gate.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
## Problem

The `SonarCloud quality gate` job is a required check on `dev`, but it fails on **every** Dependabot PR with:

```
ERROR Not authorized or project not found. Please check the 'SONAR_TOKEN' environment variable,
the 'sonar.projectKey' and 'sonar.organization' properties...
```

This is structural, not flaky. GitHub hands Dependabot-triggered runs the **Dependabot** secret store, not the Actions one. `SONAR_TOKEN` exists only as an Actions secret (the repo has no Dependabot secrets), so `secrets.SONAR_TOKEN` resolves to an empty string and the scanner cannot authenticate. Net effect: a required check that no Dependabot PR can ever pass. #761, #762 and #763 are all blocked on exactly this and nothing else.

## Why not just give Dependabot the token

Mirroring `SONAR_TOKEN` into Dependabot secrets would make it available to the run that executes the *new, unreviewed* third-party action version the PR is bumping — handing the token to the thing under review. That cuts against the SHA-pinning this workflow already practices, so it is the wrong trade for a token whose scan adds no signal here.

## Fix

Skip the job for Dependabot. It never touches first-party source (it only moves pinned SHAs and lockfiles), so the gate has no new code to judge. A job skipped by a condition reports success to branch protection, so the required check stays satisfiable.

Human PRs and pushes to `main`/`dev` are unaffected and still run the full gate.

## Verification

Every other check already passes on #761–#763; Sonar is the only red one. The three bumps themselves were exercised with secrets available in a separate token-bearing run, since the Sonar job is the only consumer of `download-artifact` and `sonarqube-scan-action`.

## Out of scope (filed separately)

Pushes to `dev` are also failing Sonar, for an unrelated reason: the SonarCloud org has hit its 100k private-LOC quota. That is an account-side fix and is not addressed here.