### PR TITLE
docs: align ACES backend capability claims

### DIFF
--- a/changelog.d/607.changed.md
+++ b/changelog.d/607.changed.md
@@ -1,0 +1,3 @@
+ACES backend documentation and adapter descriptions now identify APTL's
+declared `full-remote-control-plane` profile, explain each manifest capability,
+and label earlier profile preflights as historical milestones.

--- a/docs/aces/dsl-008-realization-preflight.md
+++ b/docs/aces/dsl-008-realization-preflight.md
@@ -1,6 +1,6 @@
 # DSL-008 ACES Topology Realization Preflight
 
-!!! warning "Superseded in part (2026-07-12, issue #690)"
+!!! warning "Historical backend-profile milestone"
     This is a dated preflight record, kept as written. Where it names the
     captured `scenarios/techvault.sdl.yaml`, the SCN-010 parity inventory
     (`docs/aces/parity-inventory.yaml`), the parity-manifest gate check, the
@@ -10,6 +10,9 @@
     `scenarios/techvault-operational.sdl.yaml` as its only driving contract.
     See the Capture Inventory and Parity-Inventory Removal Addendum in
     [ADR-046](../adrs/adr-046-dynamic-aces-scenario-realization.md).
+    Its `orchestration-evaluation` references also describe the profile at that
+    milestone, not APTL's current `full-remote-control-plane` claim. See the
+    current [backend manifest](techvault-static-validation-gate.md#backend-manifest).
 
 This note is the architecture preflight for DSL-008 / issue #422. It is
 guidance, not an implementation plan. ADR-035 remains the binding ACES SDL

--- a/docs/aces/dsl-010-participant-runtime-preflight.md
+++ b/docs/aces/dsl-010-participant-runtime-preflight.md
@@ -1,5 +1,11 @@
 # DSL-010 Participant Runtime Preflight
 
+!!! warning "Historical backend-profile milestone"
+    This is a dated preflight record, kept as written. Its description of the
+    promotion from `orchestration-evaluation` records the profile transition at
+    that milestone. APTL's current claim is `full-remote-control-plane`; see the
+    current [backend manifest](techvault-static-validation-gate.md#backend-manifest).
+
 This note is the architecture preflight for DSL-010 / issue #554. It is
 guidance, not an implementation plan. ADR-035 remains the binding ACES adoption
 decision, and the existing DSL-008/live-gate notes remain the topology and live

--- a/docs/aces/orchestration-capable-profile-preflight.md
+++ b/docs/aces/orchestration-capable-profile-preflight.md
@@ -1,5 +1,11 @@
 # ACES Orchestration-Capable Profile Preflight
 
+!!! warning "Historical backend-profile milestone"
+    This is a dated preflight record for APTL's earlier
+    `orchestration-capable` promotion, kept as written. APTL's current claim is
+    `full-remote-control-plane`; see the current
+    [backend manifest](techvault-static-validation-gate.md#backend-manifest).
+
 This note is the architecture preflight for SCN-010 follow-on issue #311. It
 is guidance, not an implementation plan. ADR-035 remains the binding ACES SDL
 adoption decision, and the TechVault static and live preflight notes remain the

--- a/docs/aces/techvault-live-validation-gate.md
+++ b/docs/aces/techvault-live-validation-gate.md
@@ -96,8 +96,9 @@ schema `aptl.live-gate.manifest/v1`. It records:
   endpoints).
 - **`evidence`**: the telemetry-path summary (event types and counts, never raw
   payloads).
-- **`evaluator_surfaces`**: the declared `full-remote-control-plane` evaluator
-  profile and ACES evaluation result/history contracts for conditions and
+- **`evaluator_surfaces`**: the evaluator component of the declared
+  `full-remote-control-plane` backend profile and its ACES evaluation
+  result/history contracts for conditions and
   objectives. This is an evidence index, not a score source; live evaluator
   progression belongs in ACES `evaluation_results` and `evaluation_history`
   derived from observed run state.

--- a/docs/aces/techvault-live-validation-preflight.md
+++ b/docs/aces/techvault-live-validation-preflight.md
@@ -1,6 +1,6 @@
 # TechVault ACES Live Validation Preflight
 
-!!! warning "Superseded in part (2026-07-12, issue #690)"
+!!! warning "Historical backend-profile milestone"
     This is a dated preflight record, kept as written. Where it names the
     captured `scenarios/techvault.sdl.yaml`, the SCN-010 parity inventory
     (`docs/aces/parity-inventory.yaml`), the parity-manifest gate check, the
@@ -10,6 +10,9 @@
     `scenarios/techvault-operational.sdl.yaml` as its only driving contract.
     See the Capture Inventory and Parity-Inventory Removal Addendum in
     [ADR-046](../adrs/adr-046-dynamic-aces-scenario-realization.md).
+    Its `provisioning-only` references describe the profile at that milestone,
+    not APTL's current `full-remote-control-plane` claim. See the current
+    [backend manifest](techvault-static-validation-gate.md#backend-manifest).
 
 This note is the architecture preflight for SCN-010F / issue #323. It is
 guidance, not an implementation plan. ADR-035 remains the binding ACES adoption

--- a/docs/aces/techvault-static-validation-gate.md
+++ b/docs/aces/techvault-static-validation-gate.md
@@ -56,6 +56,33 @@ APTL publishes its capability declaration as the canonical ACES
 `create_aptl_manifest()`. The previous APTL-local manifest shim is removed: a
 local dataclass approximation is not accepted as conformance evidence.
 
+The conformance profile applied to that manifest and its runtime target is
+`full-remote-control-plane`. The profile name is a conformance input, not a
+serialized manifest field, and it is unrelated to the Docker Compose profiles
+that select APTL services. On the reference APTL backend, the declared manifest
+components mean:
+
+| Manifest component | APTL declaration |
+| --- | --- |
+| `provisioner` | Realizes `switch` and `vm` nodes across the declared OS families; `dataset`, `directory`, and `file` content; accounts and ACLs; and the listed account features through typed realization and `DeploymentBackend`. |
+| `orchestrator` | Drives RTE-001 workflows through `WorkflowEngine`, including decision, parallel-barrier, failure-transition, outcome-matching, condition-reference, and inject-binding surfaces. |
+| `evaluator` | Evaluates conditions and objectives and publishes result/history envelopes. It does not support scoring or the deprecated SDL scoring chain. |
+| `participant_runtime` | Supports the bounded red-participant episode, behavior-history, observation, and shared-state-change surface through `DeploymentBackend.container_exec()`. It does not claim other roles or general multi-party semantics. |
+| `observation` | Is `null`: participant observations are participant-runtime contract data, not a standalone observation component. |
+
+Realization support is constrained to declared-capability matching and the
+listed node, OS, content, and account constraint kinds, with disclosure through
+the manifest, operation-status, and runtime-snapshot contracts. The compatible
+processors, concept-authority bindings, and supported contract versions are
+separate compatibility declarations rather than additional capabilities.
+
+The profile defines the minimum component and contract surface required for
+conformance. APTL may publish a compatible contract superset, such as
+participant lifecycle and observation envelopes, without turning those
+contracts into extra manifest components or broader role claims. The manifest
+created by `create_aptl_manifest()` remains the authority when this explanation
+and runtime behavior differ.
+
 ## Advisory today, blocking at cutover
 
 The gate runs today as the advisory `aces-scenario-gate` CI job

--- a/docs/aces/techvault-static-validation-preflight.md
+++ b/docs/aces/techvault-static-validation-preflight.md
@@ -1,6 +1,6 @@
 # TechVault Static Validation Preflight
 
-!!! warning "Superseded in part (2026-07-12, issue #690)"
+!!! warning "Historical backend-profile milestone"
     This is a dated preflight record, kept as written. Where it names the
     captured `scenarios/techvault.sdl.yaml`, the SCN-010 parity inventory
     (`docs/aces/parity-inventory.yaml`), the parity-manifest gate check, the
@@ -10,6 +10,10 @@
     `scenarios/techvault-operational.sdl.yaml` as its only driving contract.
     See the Capture Inventory and Parity-Inventory Removal Addendum in
     [ADR-046](../adrs/adr-046-dynamic-aces-scenario-realization.md).
+    Its `provisioning-only` references and provisional-manifest description
+    record that milestone, not APTL's current `full-remote-control-plane`
+    target. See the current
+    [backend manifest](techvault-static-validation-gate.md#backend-manifest).
 
 This note is the architecture preflight for SCN-010E / issue #322. It is
 guidance, not an implementation plan. ADR-035 remains the binding adoption

--- a/docs/adrs/adr-044-aces-aligned-run-reproducibility-record.md
+++ b/docs/adrs/adr-044-aces-aligned-run-reproducibility-record.md
@@ -21,9 +21,10 @@ APTL already has the pieces this record must compose:
   and the ACES `RuntimeManager`.
 - APTL's backend capability claim is published by
   `src/aptl/backends/aces_manifest.py:create_aptl_manifest()`. The current
-  code claims the `orchestration-evaluation` profile and passes the
-  corresponding conformance tests; do not copy older `orchestration-capable`
-  wording from stale planning text into new records.
+  code satisfies the `full-remote-control-plane` profile and passes the
+  corresponding conformance tests; do not copy older `provisioning-only`,
+  `orchestration-capable`, or `orchestration-evaluation` wording from dated
+  planning records into new records.
 - ACES provisioning, orchestration, and evaluation state is adapted through
   `AptlProvisioner`, `AptlOrchestrator`, `AptlEvaluator`,
   `AptlRealization`, `ApplyResult`, `RuntimeSnapshot`, operation

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -1,4 +1,4 @@
-"""APTL ACES runtime target and deployment handoff."""
+"""Compose APTL's full remote-control-plane ACES target and deployment handoff."""
 
 from __future__ import annotations
 
@@ -54,7 +54,7 @@ def create_aptl_runtime_target(
     backend: "DeploymentBackend",
     participant_action_specs: Mapping[str, ParticipantActionSpec] | None = None,
 ) -> RuntimeTarget:
-    """Build the ACES runtime target for APTL."""
+    """Build APTL's canonical ``full-remote-control-plane`` runtime target."""
 
     provisioner = AptlProvisioner(
         project_dir=project_dir,

--- a/src/aptl/backends/aces_evaluator.py
+++ b/src/aptl/backends/aces_evaluator.py
@@ -174,7 +174,7 @@ def _apply_plan_operations(
 
 @dataclass
 class AptlEvaluator(object):
-    """ACES evaluation adapter for APTL's full remote-control-plane target."""
+    """Evaluation component of APTL's ``full-remote-control-plane`` target."""
 
     _results: dict[str, dict[str, object]] = field(default_factory=dict, init=False)
     _history: dict[str, list[dict[str, object]]] = field(default_factory=dict, init=False)

--- a/src/aptl/backends/aces_orchestrator.py
+++ b/src/aptl/backends/aces_orchestrator.py
@@ -118,7 +118,7 @@ def _objective_outcomes_from_evaluation(
 
 @dataclass
 class AptlOrchestrator(object):
-    """ACES orchestration adapter for APTL's full remote-control-plane target."""
+    """Orchestration component of APTL's ``full-remote-control-plane`` target."""
 
     _engine: WorkflowEngine = field(default_factory=WorkflowEngine, init=False)
     _workflow_payloads: dict[str, dict[str, object]] = field(default_factory=dict, init=False)

--- a/src/aptl/backends/aces_participant_runtime.py
+++ b/src/aptl/backends/aces_participant_runtime.py
@@ -1,4 +1,4 @@
-"""APTL ACES participant runtime adapter.
+"""Participant-runtime component of APTL's full remote-control-plane target.
 
 APTL's participant runtime is intentionally narrow: it exposes the ACES
 participant episode lifecycle through the published DTOs and records a bounded
@@ -56,7 +56,7 @@ PARTICIPANT_ACTION_ADDRESS = _PARTICIPANT_ACTION_ADDRESS
 
 @dataclass
 class AptlParticipantRuntime:
-    """ACES ``ParticipantRuntime`` backed by APTL's deployment boundary."""
+    """Participant component of APTL's ``full-remote-control-plane`` target."""
 
     deployment_backend: "DeploymentBackend"
     action_specs: Mapping[str, ParticipantActionSpec] = field(

--- a/src/aptl/backends/aces_provisioner.py
+++ b/src/aptl/backends/aces_provisioner.py
@@ -1,4 +1,4 @@
-"""Provisioning-only ACES backend adapter for APTL."""
+"""Provisioning component of APTL's full remote-control-plane ACES target."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class AptlProvisioner(object):
-    """Provisioning-only ACES backend adapter for APTL."""
+    """Provisioning component of APTL's ``full-remote-control-plane`` target."""
 
     project_dir: Path
     config: AptlConfig

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -1,5 +1,6 @@
 """Tests for the APTL ACES runtime handoff."""
 
+import inspect
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -354,6 +355,67 @@ def test_create_aptl_manifest_is_canonical_backend_manifest_v2():
         {"red"}
     )
     assert payload["capabilities"]["participant_runtime"] is not None
+
+
+def test_current_backend_docs_cover_declared_manifest_components():
+    from aces_backend_protocols.manifest import backend_manifest_payload
+
+    from aptl.backends.aces_manifest import create_aptl_manifest
+
+    payload = backend_manifest_payload(create_aptl_manifest())
+    documentation = " ".join(
+        (
+            PROJECT_ROOT / "docs" / "aces" / "techvault-static-validation-gate.md"
+        )
+        .read_text()
+        .split()
+    )
+
+    assert "full-remote-control-plane" in documentation
+    for component in payload["capabilities"]:
+        assert f"`{component}`" in documentation
+    assert "standalone observation component" in documentation
+    assert "compatible processors" in documentation
+    assert "concept-authority bindings" in documentation
+    assert "supported contract versions" in documentation
+
+
+def test_backend_adapter_docstrings_describe_component_scope():
+    from aptl.backends.aces import create_aptl_runtime_target
+    from aptl.backends.aces_evaluator import AptlEvaluator
+    from aptl.backends.aces_orchestrator import AptlOrchestrator
+    from aptl.backends.aces_participant_runtime import AptlParticipantRuntime
+    from aptl.backends.aces_provisioner import AptlProvisioner
+
+    adapters = (
+        AptlProvisioner,
+        AptlOrchestrator,
+        AptlEvaluator,
+        AptlParticipantRuntime,
+    )
+    for adapter in adapters:
+        assert "component of APTL's ``full-remote-control-plane`` target" in (
+            inspect.getdoc(adapter) or ""
+        )
+    assert "full-remote-control-plane" in (inspect.getdoc(create_aptl_runtime_target) or "")
+    assert "Provisioning-only" not in (inspect.getdoc(AptlProvisioner) or "")
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "docs/aces/dsl-008-realization-preflight.md",
+        "docs/aces/dsl-010-participant-runtime-preflight.md",
+        "docs/aces/orchestration-capable-profile-preflight.md",
+        "docs/aces/techvault-live-validation-preflight.md",
+        "docs/aces/techvault-static-validation-preflight.md",
+    ],
+)
+def test_dated_profile_preflights_direct_readers_to_current_truth(relative_path):
+    documentation = (PROJECT_ROOT / relative_path).read_text()
+
+    assert '!!! warning "Historical backend-profile milestone"' in documentation
+    assert "techvault-static-validation-gate.md#backend-manifest" in documentation
 
 
 def test_aptl_target_passes_provisioning_only_conformance():


### PR DESCRIPTION
## Summary

Align APTL's ACES documentation and adapter descriptions with the canonical full-remote-control-plane manifest while preserving earlier profile milestones as explicitly historical records.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #607

## ADR Impact

- ADR-035
- ADR-044 (amended)

## Changes

- Document every declared manifest component, realization boundary, and compatibility declaration in the current static-gate reference.
- Label dated lower-profile preflights as historical and correct the stale current-profile claim in ADR-044.
- Scope runtime-target adapter docstrings consistently and add regression coverage tied to the serialized manifest.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

`pytest -n auto -k "not integration"` (2,085 passed, 91 skipped); `pytest -n auto tests/test_techvault_static_gate.py -m integration` (2 passed); `pre-commit run --all-files` passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #607 ← docs/aces/techvault-static-validation-gate.md and ACES adapter docstrings
- TESTS: Issue #607 ← tests/test_aces_backend.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/607.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.