### PR TITLE
fix(ci): clear Sonar test code smells

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -98,8 +98,9 @@ def test_default_config_json_round_trips(tmp_path: Path) -> None:
 
 
 def test_resolve_within_rejects_escape(tmp_path: Path) -> None:
+    escape = Path("../escape")
     with pytest.raises(AssetError, match="outside target directory"):
-        assets._resolve_within(tmp_path, Path("../escape"))
+        assets._resolve_within(tmp_path, escape)
 
 
 def test_resolve_within_allows_nested(tmp_path: Path) -> None:

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -297,8 +297,8 @@ services:
         assert "unique:" not in override
         cmd = mock_run.call_args[0][0]
         assert cmd[:4] == ["docker", "compose", "-p", "test"]
-        assert ["-f", str(tmp_path / "docker-compose.yml")] == cmd[4:6]
-        assert ["-f", str(override_path)] == cmd[6:8]
+        assert cmd[4:6] == ["-f", str(tmp_path / "docker-compose.yml")]
+        assert cmd[6:8] == ["-f", str(override_path)]
         assert "--build" in cmd
 
     def test_start_returns_failure_on_error(self, tmp_path):
@@ -2193,12 +2193,13 @@ class TestSeedNamedVolumes:
         from aptl.core.deployment.errors import BackendSeedError
 
         backend = self._backend(tmp_path)
+        seed = [self._config_seed()]
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=1, stdout="", stderr="secret docker stderr"
             )
             with pytest.raises(BackendSeedError) as exc_info:
-                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+                backend.seed_named_volumes(seed, seeder_image="img:1")
         assert "suricata_config_seed" in str(exc_info.value)
         assert "secret docker stderr" not in str(exc_info.value)
 
@@ -2213,11 +2214,12 @@ class TestSeedNamedVolumes:
             "docker: Error response from daemon: pull access denied"
         )
         backend = self._backend(tmp_path)
+        seed = [self._config_seed()]
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
             caplog.set_level(logging.ERROR, logger="aptl")
             with pytest.raises(BackendSeedError) as exc_info:
-                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+                backend.seed_named_volumes(seed, seeder_image="img:1")
         message = "\n".join(rec.getMessage() for rec in caplog.records)
         assert "Error response from daemon: pull access denied" in message
         assert "suricata_config_seed" in message
@@ -2234,11 +2236,12 @@ class TestSeedNamedVolumes:
             "Authorization: Bearer sk-supersecrettoken123"
         )
         backend = self._backend(tmp_path)
+        seed = [self._config_seed()]
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
             caplog.set_level(logging.ERROR, logger="aptl")
             with pytest.raises(BackendSeedError):
-                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+                backend.seed_named_volumes(seed, seeder_image="img:1")
         message = "\n".join(rec.getMessage() for rec in caplog.records)
         assert "sk-supersecrettoken123" not in message
         assert "[REDACTED]" in message
@@ -2248,11 +2251,12 @@ class TestSeedNamedVolumes:
         from aptl.core.deployment.errors import BackendSeedError
 
         backend = self._backend(tmp_path)
+        seed = [self._config_seed()]
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="   ")
             caplog.set_level(logging.ERROR, logger="aptl")
             with pytest.raises(BackendSeedError):
-                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+                backend.seed_named_volumes(seed, seeder_image="img:1")
         message = "\n".join(rec.getMessage() for rec in caplog.records)
         assert "stderr:" not in message
         assert "suricata_config_seed" in message
@@ -2265,11 +2269,12 @@ class TestSeedNamedVolumes:
 
         stderr = "HEAD_NOISE " + ("x" * 2000) + " TAIL_DAEMON_ERROR"
         backend = self._backend(tmp_path)
+        seed = [self._config_seed()]
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
             caplog.set_level(logging.ERROR, logger="aptl")
             with pytest.raises(BackendSeedError):
-                backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+                backend.seed_named_volumes(seed, seeder_image="img:1")
         message = "\n".join(rec.getMessage() for rec in caplog.records)
         assert "TAIL_DAEMON_ERROR" in message
         assert "HEAD_NOISE" not in message
@@ -2282,13 +2287,12 @@ class TestSeedNamedVolumes:
 
         stderr = "docker: Error response from daemon: permission denied on /legacy"
         backend = self._backend(tmp_path)
+        seed = [self._misp_seed_with_legacy()]
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
             caplog.set_level(logging.ERROR, logger="aptl")
             with pytest.raises(BackendSeedError) as exc_info:
-                backend.seed_named_volumes(
-                    [self._misp_seed_with_legacy()], seeder_image="img:1"
-                )
+                backend.seed_named_volumes(seed, seeder_image="img:1")
         message = "\n".join(rec.getMessage() for rec in caplog.records)
         assert "Retire of legacy seed path" in message
         assert "permission denied on /legacy" in message
@@ -2437,14 +2441,13 @@ class TestRealizeContent:
         from aptl.core.deployment.errors import BackendSeedError
 
         backend = self._backend(tmp_path)
+        content = [self._inline_text_item()]
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=1, stdout="", stderr="secret docker stderr"
             )
             with pytest.raises(BackendSeedError) as exc_info:
-                backend.realize_content(
-                    [self._inline_text_item()], seeder_image="img:1"
-                )
+                backend.realize_content(content, seeder_image="img:1")
         assert "fileshare_data" in str(exc_info.value)
         assert "secret docker stderr" not in str(exc_info.value)
 


### PR DESCRIPTION
Fixes the SonarCloud new-issue failures seen while preparing PR 769 by cleaning up test-only code-smell findings.

Changes:
- Swap two assertion operands to match Sonar's actual/expected convention.
- Move setup expressions outside affected pytest.raises blocks so only the expected throwing call remains inside each block.

Validation:
- uv run pytest -q tests/test_assets.py tests/test_deployment_backend.py
- uv run pre-commit run --all-files