### PR TITLE
fix: isolate fresh-start certificate generation

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -44,10 +44,11 @@ If you need to run steps individually:
 1. Generate SSH keys: `./scripts/generate-ssh-keys.sh`
 2. Set vm.max_map_count if using a native Linux Docker Engine:
    `sudo sysctl -w vm.max_map_count=262144`
-3. Generate SSL certificates: `docker compose -f generate-indexer-certs.yml run --rm generator`
-4. Start lab: `aptl lab start`
+3. Start the lab: `aptl lab start`. The CLI generates SSL certificates in an
+   isolated temporary Compose project and removes that project before it
+   creates the lab networks.
 
-> Step 4 must be `aptl lab start`, not a raw `docker compose up`: `aptl lab
+> Step 3 must be `aptl lab start`, not a raw `docker compose up`: `aptl lab
 > start` also renders the credentialized Wazuh config from the checked-in
 > templates into the gitignored `.aptl/config/` tree (ADR-028), which the
 > manager and dashboard containers bind-mount. There is no standalone command

--- a/generate-indexer-certs.yml
+++ b/generate-indexer-certs.yml
@@ -1,5 +1,4 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-version: '3'
 
 services:
   generator:

--- a/src/aptl/core/certs.py
+++ b/src/aptl/core/certs.py
@@ -1,5 +1,6 @@
 """SSL certificate generation for Wazuh Indexer."""
 
+import hashlib
 import os
 import shutil
 import subprocess
@@ -15,6 +16,7 @@ _CERTS_SUBDIR = "config/wazuh_indexer_ssl_certs"
 _CERT_COMPOSE_FILE = "generate-indexer-certs.yml"
 _ROOT_CA = "root-ca.pem"
 _MANAGER_ROOT_CA = "root-ca-manager.pem"
+_CERT_CLEANUP_TIMEOUT = 60
 
 
 @dataclass
@@ -146,7 +148,7 @@ def _run_cert_generator(project_dir: Path, certs_dir: Path) -> CertResult | None
     error_msg = None
     try:
         result = subprocess.run(
-            _cert_generator_command(certs_dir),
+            _cert_generator_command(project_dir, certs_dir),
             capture_output=True,
             text=True,
             # Decode as UTF-8 (not the host locale codec) so Docker's image
@@ -168,8 +170,16 @@ def _run_cert_generator(project_dir: Path, certs_dir: Path) -> CertResult | None
         error_msg = str(exc)
     else:
         if result.returncode != 0:
-            error_msg = result.stderr.strip() or "Certificate generation failed"
+            error_msg = _command_failure_detail(result)
             log.error("Certificate generation failed: %s", error_msg)
+
+    cleanup_error = _cleanup_cert_generator(project_dir)
+    if cleanup_error is not None:
+        log.error("Certificate generator cleanup failed: %s", cleanup_error)
+        if error_msg is None:
+            error_msg = f"Certificate generator cleanup failed: {cleanup_error}"
+        else:
+            error_msg = f"{error_msg}; cleanup failed: {cleanup_error}"
 
     failure = None
     if error_msg is not None:
@@ -182,13 +192,15 @@ def _run_cert_generator(project_dir: Path, certs_dir: Path) -> CertResult | None
     return failure
 
 
-def _cert_generator_command(certs_dir: Path) -> list[str]:
-    """Build the Docker Compose command for the certificate generator."""
+def _cert_generator_command(project_dir: Path, certs_dir: Path) -> list[str]:
+    """Build the isolated Docker Compose command for the cert generator."""
     if _native_linux_user() is not None:
         certs_dir.mkdir(parents=True, exist_ok=True)
     command = [
         "docker",
         "compose",
+        "-p",
+        _cert_generator_project_name(project_dir),
         "-f",
         _CERT_COMPOSE_FILE,
         "run",
@@ -196,6 +208,62 @@ def _cert_generator_command(certs_dir: Path) -> list[str]:
     ]
     command.append("generator")
     return command
+
+
+def _cert_generator_project_name(project_dir: Path) -> str:
+    """Return a stable project-scoped name for temporary generator resources."""
+
+    digest = hashlib.sha256(str(project_dir.resolve()).encode("utf-8")).hexdigest()[:12]
+    return f"aptl-certs-{digest}"
+
+
+def _cleanup_cert_generator(project_dir: Path) -> str | None:
+    """Remove the generator's temporary container and overlapping bridge.
+
+    ``docker compose run --rm`` removes the container but leaves its default
+    network behind. Docker commonly assigns that bridge ``172.20.0.0/16``,
+    which overlaps every TechVault network and blocks the SDL realization that
+    immediately follows certificate generation on a fresh install.
+    """
+
+    command = [
+        "docker",
+        "compose",
+        "-p",
+        _cert_generator_project_name(project_dir),
+        "-f",
+        _CERT_COMPOSE_FILE,
+        "down",
+        "--remove-orphans",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=project_dir,
+            timeout=_CERT_CLEANUP_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return f"timed out after {_CERT_CLEANUP_TIMEOUT}s"
+    except OSError as exc:
+        return str(exc)
+    if result.returncode != 0:
+        return _command_failure_detail(result)
+    return None
+
+
+def _command_failure_detail(result: subprocess.CompletedProcess) -> str:
+    """Return bounded useful output from a failed Docker command."""
+
+    detail = "\n".join(
+        part.strip()
+        for part in (result.stdout or "", result.stderr or "")
+        if part.strip()
+    )
+    return detail or "Certificate generation failed"
 
 
 def _repair_native_linux_cert_ownership(certs_dir: Path) -> str | None:

--- a/src/aptl/core/certs.py
+++ b/src/aptl/core/certs.py
@@ -236,6 +236,7 @@ def _cleanup_cert_generator(project_dir: Path) -> str | None:
         "down",
         "--remove-orphans",
     ]
+    error: str | None = None
     try:
         result = subprocess.run(
             command,
@@ -247,12 +248,13 @@ def _cleanup_cert_generator(project_dir: Path) -> str | None:
             timeout=_CERT_CLEANUP_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
-        return f"timed out after {_CERT_CLEANUP_TIMEOUT}s"
+        error = f"timed out after {_CERT_CLEANUP_TIMEOUT}s"
     except OSError as exc:
-        return str(exc)
-    if result.returncode != 0:
-        return _command_failure_detail(result)
-    return None
+        error = str(exc)
+    else:
+        if result.returncode != 0:
+            error = _command_failure_detail(result)
+    return error
 
 
 def _command_failure_detail(result: subprocess.CompletedProcess) -> str:

--- a/tests/test_certs.py
+++ b/tests/test_certs.py
@@ -31,6 +31,8 @@ def linux_native(mocker):
 
 def _successful_generator(mocker, certs_dir):
     def fake_run(cmd, **kwargs):
+        if "down" in cmd:
+            return MagicMock(returncode=0, stdout="", stderr="")
         if cmd[:2] == ["docker", "run"]:
             certs_dir.chmod(0o700)
             for path in certs_dir.iterdir():
@@ -138,18 +140,25 @@ class TestEnsureSSLCerts:
         _assert_posix_mode(certs_dir / "root-ca.pem", 0o644)
         _assert_posix_mode(certs_dir / "wazuh.manager-key.pem", 0o644)
         _assert_posix_mode(certs_dir, 0o700)
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
         generator_cmd = mock_run.call_args_list[0][0][0]
-        assert generator_cmd == [
+        assert generator_cmd[:3] == ["docker", "compose", "-p"]
+        assert generator_cmd[3].startswith("aptl-certs-")
+        assert generator_cmd[4:] == [
+            "-f", "generate-indexer-certs.yml", "run", "--rm", "generator"
+        ]
+        cleanup_cmd = mock_run.call_args_list[1][0][0]
+        assert cleanup_cmd == [
             "docker",
             "compose",
+            "-p",
+            generator_cmd[3],
             "-f",
             "generate-indexer-certs.yml",
-            "run",
-            "--rm",
-            "generator",
+            "down",
+            "--remove-orphans",
         ]
-        repair_cmd = mock_run.call_args_list[1][0][0]
+        repair_cmd = mock_run.call_args_list[2][0][0]
         assert repair_cmd[:6] == [
             "docker",
             "run",
@@ -223,7 +232,9 @@ class TestEnsureSSLCerts:
         certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
 
         def fake_run(cmd, **kwargs):
-            if cmd[:3] == ["docker", "compose", "-f"]:
+            if cmd[:2] == ["docker", "compose"]:
+                if "down" in cmd:
+                    return MagicMock(returncode=0, stdout="", stderr="")
                 certs_dir.mkdir(parents=True, exist_ok=True)
                 (certs_dir / "root-ca.pem").write_text("fake-cert")
                 return MagicMock(returncode=0, stdout="", stderr="")
@@ -295,20 +306,46 @@ class TestEnsureSSLCerts:
 
         (tmp_path / "config").mkdir()
 
-        mocker.patch(
+        mock_run = mocker.patch(
             "aptl.core.certs.subprocess.run",
-            return_value=MagicMock(
-                returncode=1,
-                stdout="",
-                stderr="Error: service 'generator' failed",
-            ),
+            side_effect=[
+                MagicMock(
+                    returncode=1,
+                    stdout="generator detail",
+                    stderr="Error: service 'generator' failed",
+                ),
+                MagicMock(returncode=0, stdout="", stderr=""),
+            ],
         )
 
         result = ensure_ssl_certs(tmp_path)
 
         assert result.success is False
         assert result.generated is False
-        assert "generator" in result.error.lower() or "failed" in result.error.lower()
+        assert "generator detail" in result.error
+        assert mock_run.call_args_list[1][0][0][-2:] == ["down", "--remove-orphans"]
+
+    def test_cleanup_failure_blocks_start(self, tmp_path, mocker):
+        """A leftover generator network would overlap TechVault and must fail."""
+        from aptl.core.certs import ensure_ssl_certs
+
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
+
+        def fake_run(cmd, **kwargs):
+            if "down" in cmd:
+                return MagicMock(returncode=1, stdout="", stderr="network is in use")
+            certs_dir.mkdir(parents=True, exist_ok=True)
+            (certs_dir / "root-ca.pem").write_text("fake-cert")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mocker.patch("aptl.core.certs.subprocess.run", side_effect=fake_run)
+
+        result = ensure_ssl_certs(tmp_path)
+
+        assert result.success is False
+        assert "cleanup failed" in result.error.lower()
+        assert "network is in use" in result.error
 
     def test_handles_subprocess_exception(self, tmp_path, mocker):
         """Should handle the generator subprocess raising an exception."""


### PR DESCRIPTION
## What changed

- run the Wazuh certificate generator in a stable, project-scoped temporary Compose project
- always tear that project down after generation, including failure paths
- fail startup if cleanup cannot remove the temporary network
- surface both stdout and stderr when certificate generation fails
- remove the obsolete Compose schema version warning

## Why

On a clean source install, `docker compose run --rm generator` removed its container but left a default bridge behind. Docker assigned that bridge `172.20.0.0/16`, which overlaps all four TechVault `/24` networks. The subsequent SDL realization therefore failed before creating any lab containers, while the outer runtime gate masked the network error as missing node-type realization.

The generator needs network access, so the fix preserves that access and removes its temporary Compose project before the main SDL handoff.

## Impact

A documented first run can proceed from certificate generation into the full TechVault startup without a manual `docker network rm` recovery step. Failed generator runs also clean up after themselves and report the useful generator output.

## Validation

- `python -m pytest tests/test_certs.py -q` — 16 passed
- repository commit hooks, including the gated Python suite — passed
- fresh worktree at this commit: `python3 -m venv .venv`, `pip install -e .`, `aptl lab start` — reached `Lab is ready`
- live Docker inspection during startup confirmed the temporary cert project was removed and only the four SDL-declared TechVault networks remained