### PR TITLE
fix: hide disabled reverse access

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Purple-team lab where AI agents drive the red and blue sides against an enterprise target stack.**
 
-One `aptl lab start` brings up: a fictional company's infrastructure (AD, web, DB, file share, DNS, mail), a Kali red-team box, a SOC stack (Wazuh + Suricata + MISP + TheHive + Cortex + Shuffle), a malware-analysis container, and MCP servers giving AI agents programmatic control over all of it. Scenarios are [ACES SDL](docs/sdl/index.md) documents, selectable at startup; the Compose topology is realized from the nodes the scenario declares rather than a fixed preset, and each run captures a telemetry archive.
+One `aptl lab start` brings up: a fictional company's infrastructure (AD, web, DB, file share, and DNS), a Kali red-team box, a SOC stack (Wazuh + Suricata + MISP + TheHive + Cortex + Shuffle), and MCP servers giving AI agents programmatic control over it. Scenarios are [ACES SDL](docs/sdl/index.md) documents, selectable at startup; the Compose topology is realized from the nodes the scenario declares rather than a fixed preset, and each run captures a telemetry archive. Mail and reverse-engineering services are optional profiles and are not part of the default `techvault-operational` scenario.
 
 **Use cases:** autonomous cyber-operations research, purple-team training, AI threat-actor assessment.
 
@@ -69,7 +69,6 @@ Once it's up:
 | Wazuh Dashboard | <https://localhost:443> (`admin` / your `INDEXER_PASSWORD` from `.env`) |
 | Victim shell | `aptl container shell aptl-victim` |
 | Kali shell | `aptl container shell aptl-kali` |
-| Reverse engineering SSH | `ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027` |
 
 Lifecycle:
 
@@ -89,7 +88,7 @@ aptl kill -c      # emergency: kill MCP processes AND all lab containers
 - RAM: 8 GB runs the smaller curated scenarios; the full `techvault-operational` stack needs more than 20 GB
 - 20 GB+ disk
 - Linux, macOS, or Windows with Docker Desktop/WSL2
-- Open ports: 443, 2027, 8443, 9000, 9001, 9200, 55000 (and the rest of the published ports in `docker-compose.yml`)
+- Open ports: 443, 8443, 9000, 9001, 9200, 55000 (and the rest of the published ports in `docker-compose.yml`)
 
 ## Architecture
 
@@ -104,7 +103,7 @@ flowchart TD
     end
 
     Kali[Kali Red Team]
-    Reverse[Malware Analysis]
+    Reverse[Optional Malware Analysis<br/>not in the default scenario]
 
     subgraph Scenario[Scenario Environment]
         Targets[Scenario-defined target topology<br/>AD · web · DB · file share · DNS · mail · victim hosts · etc.]
@@ -135,7 +134,7 @@ The catalog ships the operational default plus four curated slices:
 
 | Scenario id | Boots | Omits |
 |---|---|---|
-| `techvault-operational` | Full TechVault stack (default) | — |
+| `techvault-operational` | TechVault enterprise, Kali, SOC, and observability (default) | Mail and reverse engineering |
 | `techvault-attacker-target` | Kali + one monitored victim + Wazuh core + observability | Enterprise web tier, wider SOC stack |
 | `techvault-enterprise-web` | Vulnerable webapp + DB + AD + Wazuh core + observability | Red-team apparatus, wider SOC stack |
 | `techvault-defensive-min` | Wazuh manager / indexer / dashboard + observability | Attacker and enterprise components, wider SOC stack |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -73,4 +73,6 @@ Access lab components:
 - Access summary: `aptl lab info`
 - Victim shell: `aptl container shell aptl-victim`
 - Kali shell: `aptl container shell aptl-kali`
-- Reverse engineering SSH: `ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027`
+- Reverse engineering SSH, only when the optional reverse service is enabled
+  and appears in `aptl lab status`:
+  `ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027`

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -61,8 +61,10 @@ aptl container shell aptl-victim
 aptl container shell aptl-kali
 ```
 
-The reverse engineering container is the only one with host SSH:
-`ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027`.
+The optional reverse engineering container uses host SSH when enabled:
+`ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p 2027`. The default
+TechVault scenario does not realize this service, so use the command only when
+`reverse` appears in `aptl lab status`.
 
 ## Test
 

--- a/src/aptl/cli/lab_render.py
+++ b/src/aptl/cli/lab_render.py
@@ -176,6 +176,28 @@ def live_resolved_ports(project_dir: Path) -> list[ResolvedPort]:
     return resolved
 
 
+def live_services(project_dir: Path) -> set[str]:
+    """Return the Compose service names that are currently running.
+
+    Access instructions must describe the realized scenario, not every
+    optional service declared in Compose.  Best-effort failures deliberately
+    return an empty set so the CLI never advertises an endpoint it could not
+    verify.
+    """
+    backend = _cli_backend(project_dir)
+    if backend is None:
+        return set()
+    try:
+        containers = backend.container_list(all_containers=False)
+    except Exception:
+        return set()
+    return {
+        str(entry.get("Service"))
+        for entry in containers
+        if isinstance(entry, dict) and entry.get("Service")
+    }
+
+
 def _emit_host_port_remaps(resolved_ports: list[ResolvedPort]) -> None:
     """List any ports that were remapped off an in-use default."""
     remapped = [r for r in (resolved_ports or ()) if getattr(r, "remapped", False)]
@@ -206,7 +228,9 @@ def _emit_host_port_remaps(resolved_ports: list[ResolvedPort]) -> None:
 
 
 def emit_lab_access_summary(
-    project_dir: Path, resolved_ports: list[ResolvedPort] | None = None
+    project_dir: Path,
+    resolved_ports: list[ResolvedPort] | None = None,
+    active_services: set[str] | None = None,
 ) -> None:
     """Print the credential locations and common lab entry points.
 
@@ -215,6 +239,8 @@ def emit_lab_access_summary(
     a default port was in use and the service was remapped to a free one.
     """
     resolved_ports = resolved_ports or []
+    if active_services is None:
+        active_services = live_services(project_dir)
     env_path = project_dir / ".env"
     dashboard_port = _resolved_port(
         resolved_ports, _WAZUH_DASHBOARD_SVC, _WAZUH_DASHBOARD_DEFAULT
@@ -235,6 +261,9 @@ def emit_lab_access_summary(
     typer.echo(f"  Grafana: http://localhost:{grafana_port}")
     typer.echo("    username: admin")
     typer.echo("    password: see GRAFANA_ADMIN_PASSWORD in .env")
-    typer.echo("  Reverse engineering SSH:")
-    typer.echo(f"    ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p {reverse_port}")
+    if _REVERSE_SVC in active_services:
+        typer.echo("  Reverse engineering SSH:")
+        typer.echo(
+            f"    ssh -i ~/.ssh/aptl_lab_key labadmin@localhost -p {reverse_port}"
+        )
     _emit_host_port_remaps(resolved_ports)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,6 +165,53 @@ class TestLabStartCommand:
         assert f"Credentials file: {tmp_path / '.env'}" in result.stdout
         assert "Grafana: http://localhost:3100" in result.stdout
 
+    def test_lab_info_omits_reverse_access_when_service_is_not_running(
+        self, runner, tmp_path, mocker
+    ):
+        """The default TechVault scenario does not realize reverse."""
+        from aptl.cli.main import app
+
+        (tmp_path / ".env").touch()
+        mocker.patch("aptl.cli.lab_render.live_services", return_value=set())
+
+        result = runner.invoke(app, ["lab", "info", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "Reverse engineering SSH" not in result.stdout
+        assert "aptl_lab_key" not in result.stdout
+
+    def test_lab_info_prints_reverse_access_when_service_is_running(
+        self, runner, tmp_path, mocker
+    ):
+        """An explicitly realized reverse service remains discoverable."""
+        from aptl.cli.main import app
+        from aptl.core.host_ports import ResolvedPort
+
+        (tmp_path / ".env").touch()
+        mocker.patch(
+            "aptl.cli.lab.live_resolved_ports",
+            return_value=[
+                ResolvedPort(
+                    service="reverse",
+                    env_var="REVERSE_SSH_PORT",
+                    default_port=2027,
+                    resolved_port=20027,
+                    protos=("tcp",),
+                    host_ip="127.0.0.1",
+                    remapped=True,
+                )
+            ],
+        )
+        mocker.patch(
+            "aptl.cli.lab_render.live_services", return_value={"reverse"}
+        )
+
+        result = runner.invoke(app, ["lab", "info", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "Reverse engineering SSH" in result.stdout
+        assert "localhost -p 20027" in result.stdout
+
     def test_lab_info_fails_without_env(self, runner, tmp_path):
         """lab info should tell users to start the lab before .env exists."""
         from aptl.cli.main import app


### PR DESCRIPTION
## Summary

- report reverse-engineering SSH access only when the reverse Compose service is actually running
- keep the endpoint visible for scenarios that explicitly realize reverse
- avoid advertising an unavailable participant endpoint in the default TechVault scenario

## Participant impact

The default TechVault scenario disables and does not realize the reverse node. Both `aptl lab start` and `aptl lab info` nevertheless printed an SSH command for it, sending a new participant to a nonexistent service. The summary now reflects the realized runtime.

## Validation

- `pytest tests/test_cli.py -q` (60 passed)
- `pre-commit run --files src/aptl/cli/lab_render.py tests/test_cli.py`
- live `aptl lab info` against the full TechVault deployment with reverse disabled
