### PR TITLE
fix: report live host-port remaps accurately

### DIFF
--- a/src/aptl/cli/lab_render.py
+++ b/src/aptl/cli/lab_render.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import typer
 
-from aptl.core.host_ports import ResolvedPort
+from aptl.core.host_ports import PortSpec, ResolvedPort, published_port_specs
 from aptl.core.lab import LabResult
 from aptl.core.lab_types import StartupDiagnostic, StartupOutcome
 
@@ -101,7 +101,11 @@ def _cli_backend(project_dir: Path) -> DeploymentBackend | None:
 
 
 def _binding_to_resolved_port(
-    service: str, default_port: int, proto: str, binding: dict[str, str]
+    service: str,
+    container_port: int,
+    proto: str,
+    binding: dict[str, str],
+    spec: PortSpec | None,
 ) -> ResolvedPort | None:
     """Turn one docker port binding into a ResolvedPort, or None if unusable."""
     try:
@@ -112,17 +116,22 @@ def _binding_to_resolved_port(
         return None
     return ResolvedPort(
         service=service,
-        env_var=None,
-        default_port=default_port,
+        env_var=spec.env_var if spec is not None else None,
+        default_port=spec.default_port if spec is not None else container_port,
         resolved_port=host_port,
         protos=(proto or "tcp",),
-        host_ip=binding.get("HostIp"),
-        remapped=(host_port != default_port),
+        host_ip=spec.host_ip if spec is not None else binding.get("HostIp"),
+        remapped=(
+            host_port != (spec.default_port if spec is not None else container_port)
+        ),
     )
 
 
 def _container_resolved_ports(
-    backend: DeploymentBackend, name: str, service: str
+    backend: DeploymentBackend,
+    name: str,
+    service: str,
+    specs: dict[tuple[str, int, str], PortSpec],
 ) -> list[ResolvedPort]:
     """Return the published ResolvedPorts for one running container."""
     try:
@@ -136,14 +145,44 @@ def _container_resolved_ports(
     for container_port_proto, bindings in ports.items():
         container_port_str, _, proto = container_port_proto.partition("/")
         try:
-            default_port = int(container_port_str)
+            container_port = int(container_port_str)
         except ValueError:
             continue
+        spec = specs.get((service, container_port, proto or "tcp"))
         for binding in bindings or ():
-            entry = _binding_to_resolved_port(service, default_port, proto, binding)
+            entry = _binding_to_resolved_port(
+                service, container_port, proto, binding, spec
+            )
             if entry is not None:
                 resolved.append(entry)
     return resolved
+
+
+def _coalesce_resolved_ports(entries: list[ResolvedPort]) -> list[ResolvedPort]:
+    """Collapse duplicate address bindings and shared TCP/UDP mappings."""
+    grouped: dict[tuple[str, str | None, int, int], tuple[ResolvedPort, set[str]]] = {}
+    for entry in entries:
+        key = (
+            entry.service,
+            entry.env_var,
+            entry.default_port,
+            entry.resolved_port,
+        )
+        if key not in grouped:
+            grouped[key] = (entry, set())
+        grouped[key][1].update(entry.protos)
+    return [
+        ResolvedPort(
+            service=entry.service,
+            env_var=entry.env_var,
+            default_port=entry.default_port,
+            resolved_port=entry.resolved_port,
+            protos=tuple(sorted(protos)),
+            host_ip=entry.host_ip,
+            remapped=entry.remapped,
+        )
+        for entry, protos in grouped.values()
+    ]
 
 
 def live_resolved_ports(project_dir: Path) -> list[ResolvedPort]:
@@ -167,13 +206,17 @@ def live_resolved_ports(project_dir: Path) -> list[ResolvedPort]:
         containers = backend.container_list(all_containers=False)
     except Exception:
         return []
+    specs = {
+        (spec.service, spec.container_port, spec.proto): spec
+        for spec in published_port_specs(project_dir)
+    }
     resolved: list[ResolvedPort] = []
     for entry in containers:
         service = entry.get("Service") or ""
         name = (entry.get("Name") or "").lstrip("/")
         if service and name:
-            resolved.extend(_container_resolved_ports(backend, name, service))
-    return resolved
+            resolved.extend(_container_resolved_ports(backend, name, service, specs))
+    return _coalesce_resolved_ports(resolved)
 
 
 def _emit_host_port_remaps(resolved_ports: list[ResolvedPort]) -> None:

--- a/src/aptl/core/host_ports.py
+++ b/src/aptl/core/host_ports.py
@@ -196,6 +196,12 @@ def parse_published_ports(compose: dict[str, object]) -> list[PortSpec]:
     return specs
 
 
+def published_port_specs(project_dir: Path) -> list[PortSpec]:
+    """Load the published-port declarations for a Compose project."""
+    compose = _load_compose(project_dir)
+    return parse_published_ports(compose) if compose is not None else []
+
+
 def _load_compose(project_dir: Path) -> dict[str, object] | None:
     """Load the project compose file if it exists and is a mapping."""
     compose_path = project_dir / _COMPOSE_FILENAME
@@ -279,14 +285,10 @@ def resolve_host_ports(
     real host port of each service.
     """
     reserved = set(reserved_env or set())
-    compose = _load_compose(project_dir)
-    if compose is None:
-        return []
-
     # Group entries that share an env var (e.g. DNS tcp+udp on one host port)
     # so they move together and land on a port free for every protocol.
     groups: dict[str, list[PortSpec]] = {}
-    for spec in parse_published_ports(compose):
+    for spec in published_port_specs(project_dir):
         if spec.env_var is None:
             continue
         groups.setdefault(spec.env_var, []).append(spec)

--- a/src/aptl/core/host_ports.py
+++ b/src/aptl/core/host_ports.py
@@ -235,6 +235,38 @@ def _resolved_for_pinned(
     )
 
 
+def _resolve_available_port(
+    first: PortSpec,
+    env_var: str,
+    default_port: int,
+    protos: tuple[str, ...],
+    taken: set[int],
+) -> int:
+    """Resolve and export an available port for an unpinned mapping."""
+    if _group_available(default_port, protos, first.host_ip):
+        return default_port
+
+    free = _find_free_port(protos, first.host_ip, taken)
+    if free is None:
+        log.warning(
+            "No free host port found to remap %s (default %d); leaving default.",
+            first.service,
+            default_port,
+        )
+        return default_port
+
+    taken.add(free)
+    os.environ[env_var] = str(free)
+    log.info(
+        "Host port %d for %s is in use; publishing on %d instead (%s).",
+        default_port,
+        first.service,
+        free,
+        env_var,
+    )
+    return free
+
+
 def _resolve_group(
     env_var: str,
     specs: list[PortSpec],
@@ -248,28 +280,10 @@ def _resolve_group(
     if env_var in reserved or env_var in os.environ:
         return _resolved_for_pinned(first, env_var, default_port, protos)
 
-    if _group_available(default_port, protos, first.host_ip):
-        return _resolved(first, env_var, default_port, default_port, protos)
-
-    free = _find_free_port(protos, first.host_ip, taken)
-    if free is None:
-        log.warning(
-            "No free host port found to remap %s (default %d); leaving default.",
-            first.service,
-            default_port,
-        )
-        return _resolved(first, env_var, default_port, default_port, protos)
-
-    taken.add(free)
-    os.environ[env_var] = str(free)
-    log.info(
-        "Host port %d for %s is in use; publishing on %d instead (%s).",
-        default_port,
-        first.service,
-        free,
-        env_var,
+    resolved_port = _resolve_available_port(
+        first, env_var, default_port, protos, taken
     )
-    return _resolved(first, env_var, default_port, free, protos)
+    return _resolved(first, env_var, default_port, resolved_port, protos)
 
 
 def resolve_host_ports(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -259,6 +259,90 @@ class TestLabStartCommand:
         assert entry.remapped is True
         assert entry.host_ip == "127.0.0.1"
 
+    def test_live_resolved_ports_uses_compose_host_defaults_and_deduplicates(
+        self, tmp_path, mocker
+    ):
+        """Runtime bindings are compared with declared host, not container, ports."""
+        from aptl.cli.lab_render import live_resolved_ports
+        from aptl.core.host_ports import PortSpec
+
+        backend = mocker.MagicMock()
+        backend.container_list.return_value = [
+            {"Name": "aptl-grafana", "Service": "aptl-grafana-otel"},
+            {"Name": "aptl-dns", "Service": "dns"},
+        ]
+        backend.container_inspect.side_effect = [
+            {
+                "NetworkSettings": {
+                    "Ports": {
+                        "3000/tcp": [
+                            {"HostIp": "0.0.0.0", "HostPort": "3100"},
+                            {"HostIp": "::", "HostPort": "3100"},
+                        ]
+                    }
+                }
+            },
+            {
+                "NetworkSettings": {
+                    "Ports": {
+                        "53/tcp": [
+                            {"HostIp": "0.0.0.0", "HostPort": "20000"},
+                            {"HostIp": "::", "HostPort": "20000"},
+                        ],
+                        "53/udp": [
+                            {"HostIp": "0.0.0.0", "HostPort": "20000"},
+                            {"HostIp": "::", "HostPort": "20000"},
+                        ],
+                    }
+                }
+            },
+        ]
+        mocker.patch(
+            "aptl.cli._common.resolve_config_for_cli",
+            return_value=(mocker.MagicMock(), tmp_path),
+        )
+        mocker.patch("aptl.core.deployment.get_backend", return_value=backend)
+        mocker.patch(
+            "aptl.cli.lab_render.published_port_specs",
+            return_value=[
+                PortSpec(
+                    service="aptl-grafana-otel",
+                    env_var="APTL_HP_GRAFANA_3000",
+                    default_port=3100,
+                    container_port=3000,
+                    proto="tcp",
+                    host_ip=None,
+                ),
+                PortSpec(
+                    service="dns",
+                    env_var="APTL_DNS_HOST_PORT",
+                    default_port=5353,
+                    container_port=53,
+                    proto="tcp",
+                    host_ip=None,
+                ),
+                PortSpec(
+                    service="dns",
+                    env_var="APTL_DNS_HOST_PORT",
+                    default_port=5353,
+                    container_port=53,
+                    proto="udp",
+                    host_ip=None,
+                ),
+            ],
+        )
+
+        result = live_resolved_ports(tmp_path)
+
+        assert len(result) == 2
+        by_service = {entry.service: entry for entry in result}
+        assert by_service["aptl-grafana-otel"].default_port == 3100
+        assert by_service["aptl-grafana-otel"].remapped is False
+        assert by_service["dns"].default_port == 5353
+        assert by_service["dns"].resolved_port == 20000
+        assert by_service["dns"].protos == ("tcp", "udp")
+        assert by_service["dns"].remapped is True
+
     def test_start_handles_failure_gracefully(self, runner, mocker):
         """start command should exit 1 and show error on failure.
 

--- a/tests/test_host_ports.py
+++ b/tests/test_host_ports.py
@@ -44,14 +44,14 @@ def test_parse_entry(entry, expect):
     service = expect[0]
     spec = host_ports._parse_entry(service, entry)
     assert spec is not None
-    assert (
+    assert expect == (
         spec.service,
         spec.env_var,
         spec.default_port,
         spec.container_port,
         spec.proto,
         spec.host_ip,
-    ) == expect
+    )
 
 
 def test_parse_entry_skips_varref_without_default():


### PR DESCRIPTION
## Summary

- reconstruct live port state against the declared Compose host-port defaults
- collapse duplicate IPv4/IPv6 bindings and shared TCP/UDP mappings
- keep runtime fallback behavior for bindings that are not represented in Compose

## Participant impact

`aptl lab info` treated container ports as the defaults. A healthy default deployment therefore appeared to have remapped Grafana, Wazuh, MISP, and Shuffle, while DNS was printed four times because Docker exposes IPv4/IPv6 and TCP/UDP bindings separately. This also triggered misleading MCP remediation advice. The command now reports only genuine conflicts, once per host mapping.

## Validation

- `pytest tests/test_cli.py tests/test_host_ports.py -q` (73 passed)
- `pre-commit run --files src/aptl/core/host_ports.py src/aptl/cli/lab_render.py tests/test_cli.py`
- live `aptl lab info` against the full TechVault deployment; only the genuine DNS `5353 -> 20000 (tcp/udp)` conflict was reported
