### PR TITLE
fix: preserve participant endpoints on repeated starts

### DIFF
--- a/src/aptl/core/host_ports.py
+++ b/src/aptl/core/host_ports.py
@@ -120,11 +120,11 @@ def _inspected_port_candidates(
         info = backend.container_inspect(name)
     except Exception:
         return {}
-    if not isinstance(info, dict):
-        return {}
-    ports = (info.get("NetworkSettings") or {}).get("Ports") or {}
-    if not isinstance(ports, dict):
-        return {}
+    ports: dict[object, object] = {}
+    if isinstance(info, dict):
+        inspected = (info.get("NetworkSettings") or {}).get("Ports") or {}
+        if isinstance(inspected, dict):
+            ports = inspected
 
     candidates: dict[PortBindingKey, set[int]] = {}
     for container_port_proto, bindings in ports.items():

--- a/src/aptl/core/host_ports.py
+++ b/src/aptl/core/host_ports.py
@@ -29,10 +29,14 @@ import re
 import socket
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 
 from aptl.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from aptl.core.deployment.backend import DeploymentBackend
 
 log = get_logger("host_ports")
 
@@ -79,6 +83,59 @@ class ResolvedPort:
     protos: tuple[str, ...]
     host_ip: str | None
     remapped: bool
+
+
+PortBindingKey = tuple[str, int, str]
+
+
+def project_port_bindings(
+    backend: DeploymentBackend,
+) -> dict[PortBindingKey, int]:
+    """Return published host ports already owned by this Compose project.
+
+    Docker exposes the same binding once for IPv4 and once for IPv6.  A key is
+    returned only when every address agrees on one host port; ambiguous runtime
+    state falls back to the normal availability probe.
+    """
+    try:
+        containers = backend.container_list(all_containers=False)
+    except Exception:
+        return {}
+
+    candidates: dict[PortBindingKey, set[int]] = {}
+    for entry in containers:
+        if not isinstance(entry, dict):
+            continue
+        service = str(entry.get("Service") or "")
+        name = str(entry.get("Name") or "").lstrip("/")
+        if not service or not name:
+            continue
+        try:
+            info = backend.container_inspect(name)
+        except Exception:
+            continue
+        ports = (info.get("NetworkSettings") or {}).get("Ports") or {}
+        if not isinstance(ports, dict):
+            continue
+        for container_port_proto, bindings in ports.items():
+            port_raw, _, proto = str(container_port_proto).partition("/")
+            try:
+                container_port = int(port_raw)
+            except ValueError:
+                continue
+            key = (service, container_port, proto or "tcp")
+            for binding in bindings or ():
+                try:
+                    host_port = int(binding.get("HostPort", 0))
+                except (AttributeError, TypeError, ValueError):
+                    continue
+                if host_port:
+                    candidates.setdefault(key, set()).add(host_port)
+    return {
+        key: next(iter(host_ports))
+        for key, host_ports in candidates.items()
+        if len(host_ports) == 1
+    }
 
 
 def _proto_socktype(proto: str) -> int:
@@ -234,6 +291,7 @@ def _resolve_group(
     specs: list[PortSpec],
     reserved: set[str],
     taken: set[int],
+    existing_port: int | None = None,
 ) -> ResolvedPort:
     """Resolve one env-var port group and update environment overrides."""
     first = specs[0]
@@ -241,6 +299,16 @@ def _resolve_group(
     default_port = first.default_port
     if env_var in reserved or env_var in os.environ:
         return _resolved_for_pinned(first, env_var, default_port, protos)
+
+    # A repeated `aptl lab start` must preserve this project's current
+    # binding. The ordinary socket probe cannot distinguish our own container
+    # from an unrelated process and would otherwise move every endpoint on
+    # each run.
+    if existing_port is not None:
+        taken.add(existing_port)
+        if existing_port != default_port:
+            os.environ[env_var] = str(existing_port)
+        return _resolved(first, env_var, default_port, existing_port, protos)
 
     if _group_available(default_port, protos, first.host_ip):
         return _resolved(first, env_var, default_port, default_port, protos)
@@ -267,7 +335,9 @@ def _resolve_group(
 
 
 def resolve_host_ports(
-    project_dir: Path, reserved_env: set[str] | None = None
+    project_dir: Path,
+    reserved_env: set[str] | None = None,
+    existing_bindings: dict[PortBindingKey, int] | None = None,
 ) -> list[ResolvedPort]:
     """Detect occupied published host ports, remap them, and export overrides.
 
@@ -292,9 +362,29 @@ def resolve_host_ports(
         groups.setdefault(spec.env_var, []).append(spec)
 
     resolved: list[ResolvedPort] = []
+    current = existing_bindings or {}
     taken: set[int] = {s.default_port for specs in groups.values() for s in specs}
+    taken.update(current.values())
     for env_var, specs in sorted(groups.items()):
-        resolved.append(_resolve_group(env_var, specs, reserved, taken))
+        current_ports = {
+            current.get((spec.service, spec.container_port, spec.proto))
+            for spec in specs
+        }
+        current_ports.discard(None)
+        complete = len(current_ports) == 1 and all(
+            (spec.service, spec.container_port, spec.proto) in current
+            for spec in specs
+        )
+        existing_port = next(iter(current_ports)) if complete else None
+        resolved.append(
+            _resolve_group(
+                env_var,
+                specs,
+                reserved,
+                taken,
+                existing_port=existing_port,
+            )
+        )
 
     return resolved
 

--- a/src/aptl/core/host_ports.py
+++ b/src/aptl/core/host_ports.py
@@ -88,6 +88,57 @@ class ResolvedPort:
 PortBindingKey = tuple[str, int, str]
 
 
+def _container_identity(entry: object) -> tuple[str, str] | None:
+    """Return a Compose service and container name from one ``ps`` entry."""
+    if not isinstance(entry, dict):
+        return None
+    service = str(entry.get("Service") or "")
+    name = str(entry.get("Name") or "").lstrip("/")
+    return (service, name) if service and name else None
+
+
+def _binding_host_ports(bindings: object) -> set[int]:
+    """Return valid, non-zero host ports from an inspected port binding."""
+    host_ports: set[int] = set()
+    if not isinstance(bindings, list):
+        return host_ports
+    for binding in bindings:
+        try:
+            host_port = int(binding.get("HostPort", 0))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if host_port:
+            host_ports.add(host_port)
+    return host_ports
+
+
+def _inspected_port_candidates(
+    backend: DeploymentBackend, service: str, name: str
+) -> dict[PortBindingKey, set[int]]:
+    """Return valid published-port candidates for one running container."""
+    try:
+        info = backend.container_inspect(name)
+    except Exception:
+        return {}
+    if not isinstance(info, dict):
+        return {}
+    ports = (info.get("NetworkSettings") or {}).get("Ports") or {}
+    if not isinstance(ports, dict):
+        return {}
+
+    candidates: dict[PortBindingKey, set[int]] = {}
+    for container_port_proto, bindings in ports.items():
+        port_raw, _, proto = str(container_port_proto).partition("/")
+        try:
+            container_port = int(port_raw)
+        except ValueError:
+            continue
+        host_ports = _binding_host_ports(bindings)
+        if host_ports:
+            candidates[(service, container_port, proto or "tcp")] = host_ports
+    return candidates
+
+
 def project_port_bindings(
     backend: DeploymentBackend,
 ) -> dict[PortBindingKey, int]:
@@ -104,33 +155,14 @@ def project_port_bindings(
 
     candidates: dict[PortBindingKey, set[int]] = {}
     for entry in containers:
-        if not isinstance(entry, dict):
+        identity = _container_identity(entry)
+        if identity is None:
             continue
-        service = str(entry.get("Service") or "")
-        name = str(entry.get("Name") or "").lstrip("/")
-        if not service or not name:
-            continue
-        try:
-            info = backend.container_inspect(name)
-        except Exception:
-            continue
-        ports = (info.get("NetworkSettings") or {}).get("Ports") or {}
-        if not isinstance(ports, dict):
-            continue
-        for container_port_proto, bindings in ports.items():
-            port_raw, _, proto = str(container_port_proto).partition("/")
-            try:
-                container_port = int(port_raw)
-            except ValueError:
-                continue
-            key = (service, container_port, proto or "tcp")
-            for binding in bindings or ():
-                try:
-                    host_port = int(binding.get("HostPort", 0))
-                except (AttributeError, TypeError, ValueError):
-                    continue
-                if host_port:
-                    candidates.setdefault(key, set()).add(host_port)
+        service, name = identity
+        for key, host_ports in _inspected_port_candidates(
+            backend, service, name
+        ).items():
+            candidates.setdefault(key, set()).update(host_ports)
     return {
         key: next(iter(host_ports))
         for key, host_ports in candidates.items()
@@ -286,6 +318,38 @@ def _resolved_for_pinned(
     )
 
 
+def _resolve_available_port(
+    first: PortSpec,
+    env_var: str,
+    default_port: int,
+    protos: tuple[str, ...],
+    taken: set[int],
+) -> int:
+    """Resolve and export an available port for an unpinned mapping."""
+    if _group_available(default_port, protos, first.host_ip):
+        return default_port
+
+    free = _find_free_port(protos, first.host_ip, taken)
+    if free is None:
+        log.warning(
+            "No free host port found to remap %s (default %d); leaving default.",
+            first.service,
+            default_port,
+        )
+        return default_port
+
+    taken.add(free)
+    os.environ[env_var] = str(free)
+    log.info(
+        "Host port %d for %s is in use; publishing on %d instead (%s).",
+        default_port,
+        first.service,
+        free,
+        env_var,
+    )
+    return free
+
+
 def _resolve_group(
     env_var: str,
     specs: list[PortSpec],
@@ -300,38 +364,18 @@ def _resolve_group(
     if env_var in reserved or env_var in os.environ:
         return _resolved_for_pinned(first, env_var, default_port, protos)
 
-    # A repeated `aptl lab start` must preserve this project's current
-    # binding. The ordinary socket probe cannot distinguish our own container
-    # from an unrelated process and would otherwise move every endpoint on
-    # each run.
-    if existing_port is not None:
+    if existing_port is None:
+        resolved_port = _resolve_available_port(
+            first, env_var, default_port, protos, taken
+        )
+    else:
+        # The ordinary socket probe cannot distinguish this project's own
+        # container from an unrelated process. Preserve its current binding.
         taken.add(existing_port)
         if existing_port != default_port:
             os.environ[env_var] = str(existing_port)
-        return _resolved(first, env_var, default_port, existing_port, protos)
-
-    if _group_available(default_port, protos, first.host_ip):
-        return _resolved(first, env_var, default_port, default_port, protos)
-
-    free = _find_free_port(protos, first.host_ip, taken)
-    if free is None:
-        log.warning(
-            "No free host port found to remap %s (default %d); leaving default.",
-            first.service,
-            default_port,
-        )
-        return _resolved(first, env_var, default_port, default_port, protos)
-
-    taken.add(free)
-    os.environ[env_var] = str(free)
-    log.info(
-        "Host port %d for %s is in use; publishing on %d instead (%s).",
-        default_port,
-        first.service,
-        free,
-        env_var,
-    )
-    return _resolved(first, env_var, default_port, free, protos)
+        resolved_port = existing_port
+    return _resolved(first, env_var, default_port, resolved_port, protos)
 
 
 def resolve_host_ports(

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -755,8 +755,12 @@ def _step_resolve_host_ports(ctx: _LabStartContext) -> LabResult | None:
     """
     from aptl.core import host_ports
 
+    assert ctx.backend is not None
+    existing_bindings = host_ports.project_port_bindings(ctx.backend)
     ctx.resolved_ports = host_ports.resolve_host_ports(
-        ctx.project_dir, reserved_env=set(ctx.raw_env)
+        ctx.project_dir,
+        reserved_env=set(ctx.raw_env),
+        existing_bindings=existing_bindings,
     )
     for resolved in ctx.resolved_ports:
         if resolved.remapped:
@@ -1984,8 +1988,8 @@ def _step_sync_mcp_config(ctx: _LabStartContext) -> LabResult | None:
 # stay aligned.
 _LAB_START_STEPS = (
     _step_load_env,
-    _step_resolve_host_ports,
     _step_load_config,
+    _step_resolve_host_ports,
     _step_ensure_ssh_keys,
     _step_check_sysreqs,
     _step_sync_credentials,
@@ -2007,8 +2011,8 @@ _LAB_START_STEPS = (
 
 _LAB_START_PROGRESS_MESSAGES = {
     "_step_load_env": "Preparing environment and credentials.",
-    "_step_resolve_host_ports": "Checking host port availability.",
     "_step_load_config": "Loading lab configuration.",
+    "_step_resolve_host_ports": "Checking host port availability.",
     "_step_ensure_ssh_keys": "Preparing SSH keys.",
     "_step_check_sysreqs": "Checking host requirements.",
     "_step_sync_credentials": "Rendering service configuration.",

--- a/tests/test_host_ports.py
+++ b/tests/test_host_ports.py
@@ -20,7 +20,7 @@ from aptl.core import host_ports
 # _parse_entry — short-syntax port mappings, with and without ${VAR:-default}
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(
-    ("entry", "expect"),
+    ("entry", "expected"),
     [
         (
             "127.0.0.1:${APTL_HP_WAZUH_DASHBOARD_5601:-443}:5601",
@@ -40,8 +40,8 @@ from aptl.core import host_ports
         ),
     ],
 )
-def test_parse_entry(entry, expect):
-    service = expect[0]
+def test_parse_entry(entry, expected):
+    service = expected[0]
     spec = host_ports._parse_entry(service, entry)
     assert spec is not None
     assert (
@@ -51,7 +51,7 @@ def test_parse_entry(entry, expect):
         spec.container_port,
         spec.proto,
         spec.host_ip,
-    ) == expect
+    ) == expected
 
 
 def test_parse_entry_skips_varref_without_default():
@@ -274,4 +274,55 @@ def test_project_port_bindings_deduplicates_address_families(mocker):
     assert result == {
         ("dns", 53, "tcp"): 20000,
         ("dns", 53, "udp"): 20000,
+    }
+
+
+def test_project_port_bindings_returns_empty_when_list_fails(mocker):
+    backend = mocker.MagicMock()
+    backend.container_list.side_effect = OSError("daemon unavailable")
+
+    assert host_ports.project_port_bindings(backend) == {}
+
+
+def test_project_port_bindings_ignores_malformed_runtime_state(mocker):
+    backend = mocker.MagicMock()
+    backend.container_list.return_value = [
+        "not-a-container",
+        {"Service": "dns"},
+        {"Name": "aptl-missing-service"},
+        {"Name": "aptl-inspect-error", "Service": "dns"},
+        {"Name": "aptl-invalid-info", "Service": "dns"},
+        {"Name": "aptl-invalid-ports", "Service": "dns"},
+        {"Name": "/aptl-dns", "Service": "dns"},
+    ]
+
+    def inspect(name):
+        if name == "aptl-inspect-error":
+            raise OSError("container disappeared")
+        if name == "aptl-invalid-info":
+            return []
+        if name == "aptl-invalid-ports":
+            return {"NetworkSettings": {"Ports": []}}
+        return {
+            "NetworkSettings": {
+                "Ports": {
+                    "not-a-port": [{"HostPort": "20000"}],
+                    "53/tcp": [
+                        None,
+                        {},
+                        {"HostPort": "invalid"},
+                        {"HostPort": "0"},
+                        {"HostPort": "20000"},
+                        {"HostPort": "20001"},
+                    ],
+                    "54": [{"HostPort": "20002"}],
+                    "55/tcp": None,
+                }
+            }
+        }
+
+    backend.container_inspect.side_effect = inspect
+
+    assert host_ports.project_port_bindings(backend) == {
+        ("dns", 54, "tcp"): 20002,
     }

--- a/tests/test_host_ports.py
+++ b/tests/test_host_ports.py
@@ -44,14 +44,14 @@ def test_parse_entry(entry, expected):
     service = expected[0]
     spec = host_ports._parse_entry(service, entry)
     assert spec is not None
-    assert (
+    assert expected == (
         spec.service,
         spec.env_var,
         spec.default_port,
         spec.container_port,
         spec.proto,
         spec.host_ip,
-    ) == expected
+    )
 
 
 def test_parse_entry_skips_varref_without_default():

--- a/tests/test_host_ports.py
+++ b/tests/test_host_ports.py
@@ -209,3 +209,69 @@ def test_operator_pinned_value_is_honored(mocker, tmp_path, monkeypatch):
     assert not dns.remapped
     # The pinned port must not be probed/remapped.
     assert all(call.args[0] != 5353 for call in probe.call_args_list)
+
+
+def test_existing_project_remap_is_reused(mocker, tmp_path, _clean_env):
+    import os
+
+    mocker.patch("aptl.core.host_ports._load_compose", return_value=_compose())
+    probe = mocker.patch("aptl.core.host_ports.port_available", return_value=False)
+
+    resolved = host_ports.resolve_host_ports(
+        tmp_path,
+        existing_bindings={
+            ("dns", 53, "tcp"): 20000,
+            ("dns", 53, "udp"): 20000,
+        },
+    )
+    dns = next(r for r in resolved if r.service == "dns")
+
+    assert dns.default_port == 5353
+    assert dns.resolved_port == 20000
+    assert dns.remapped is True
+    assert os.environ["APTL_DNS_HOST_PORT"] == "20000"
+    assert all(call.args[0] != 5353 for call in probe.call_args_list)
+
+
+def test_incomplete_existing_group_falls_back_to_probe(
+    mocker, tmp_path, _clean_env
+):
+    mocker.patch("aptl.core.host_ports._load_compose", return_value=_compose())
+    mocker.patch("aptl.core.host_ports.port_available", return_value=True)
+
+    resolved = host_ports.resolve_host_ports(
+        tmp_path,
+        existing_bindings={("dns", 53, "tcp"): 20000},
+    )
+    dns = next(r for r in resolved if r.service == "dns")
+
+    assert dns.resolved_port == 5353
+    assert dns.remapped is False
+
+
+def test_project_port_bindings_deduplicates_address_families(mocker):
+    backend = mocker.MagicMock()
+    backend.container_list.return_value = [
+        {"Name": "aptl-dns", "Service": "dns"},
+    ]
+    backend.container_inspect.return_value = {
+        "NetworkSettings": {
+            "Ports": {
+                "53/tcp": [
+                    {"HostIp": "0.0.0.0", "HostPort": "20000"},
+                    {"HostIp": "::", "HostPort": "20000"},
+                ],
+                "53/udp": [
+                    {"HostIp": "0.0.0.0", "HostPort": "20000"},
+                    {"HostIp": "::", "HostPort": "20000"},
+                ],
+            }
+        }
+    }
+
+    result = host_ports.project_port_bindings(backend)
+
+    assert result == {
+        ("dns", 53, "tcp"): 20000,
+        ("dns", 53, "udp"): 20000,
+    }

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1745,6 +1745,7 @@ class TestResolveHostPortsStep:
             skip_seed=False,
             raw_env=raw_env or {},
             progress=progress,
+            backend=MagicMock(),
         )
 
     def test_stores_resolution_and_passes_reserved_env(self, mocker, tmp_path):
@@ -1765,14 +1766,20 @@ class TestResolveHostPortsStep:
         resolve = mocker.patch(
             "aptl.core.host_ports.resolve_host_ports", return_value=resolution
         )
+        bindings = mocker.patch(
+            "aptl.core.host_ports.project_port_bindings", return_value={}
+        )
         ctx = self._ctx(tmp_path, raw_env={"APTL_DNS_HOST_PORT": "9"})
 
         result = _step_resolve_host_ports(ctx)
 
         assert result is None
         assert ctx.resolved_ports is resolution
+        bindings.assert_called_once_with(ctx.backend)
         resolve.assert_called_once_with(
-            tmp_path, reserved_env={"APTL_DNS_HOST_PORT"}
+            tmp_path,
+            reserved_env={"APTL_DNS_HOST_PORT"},
+            existing_bindings={},
         )
 
     def test_announces_remaps_via_progress(self, mocker, tmp_path):
@@ -1791,6 +1798,7 @@ class TestResolveHostPortsStep:
         mocker.patch(
             "aptl.core.host_ports.resolve_host_ports", return_value=[remapped]
         )
+        mocker.patch("aptl.core.host_ports.project_port_bindings", return_value={})
         progress = MagicMock()
 
         _step_resolve_host_ports(self._ctx(tmp_path, progress=progress))


### PR DESCRIPTION
## Summary

- discover host-port bindings already owned by the configured APTL Compose project
- reuse those bindings on subsequent `aptl lab start` runs
- continue probing and remapping ports when the project does not already own a complete binding
- preserve operator-pinned port overrides

## Participant impact

Running `aptl lab start` a second time treated APTL's own containers as foreign port conflicts. The command moved nearly every participant and MCP endpoint to a new `20000+` port, recreated containers, and left fixed-port SOC seed helpers unable to reach Cortex, MISP, TheHive, and Shuffle. Repeated starts now retain the project's current endpoints while remaining isolated from containers belonging to other applications.

## Validation

- `pytest tests/test_host_ports.py tests/test_lab.py -q` (187 passed)
- `pre-commit run --files src/aptl/core/host_ports.py src/aptl/core/lab.py tests/test_host_ports.py tests/test_lab.py`
- live repeated start against a running full TechVault lab; before/after published-port maps were identical
