### PR TITLE
fix: remove seeded volumes during full lab cleanup

### DIFF
--- a/src/aptl/core/deployment/_compose_volume_cleanup.py
+++ b/src/aptl/core/deployment/_compose_volume_cleanup.py
@@ -1,0 +1,89 @@
+"""Project-bounded cleanup for Compose volumes created before ``up``."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+import yaml
+
+from aptl.core.deployment.errors import BackendTimeoutError
+from aptl.utils.redaction import redact
+
+DockerRun = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _declared_volumes(compose: object) -> tuple[dict[object, object] | None, str]:
+    """Validate and return the top-level Compose volume mapping."""
+    if not isinstance(compose, dict):
+        return None, "invalid Compose"
+    declared = compose.get("volumes") or {}
+    if not isinstance(declared, dict):
+        return None, "invalid volumes"
+    return declared, ""
+
+
+def project_scoped_volume_names(
+    project_dir: Path, project_name: str
+) -> tuple[set[str], str]:
+    """Return implicit, non-external volume names scoped to one project."""
+    compose_path = project_dir / "docker-compose.yml"
+    try:
+        compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        return set(), f"Failed to read project volumes for cleanup: {exc}"
+
+    declared, error = _declared_volumes(compose)
+    if declared is None:
+        return set(), f"Failed to read project volumes for cleanup: {error}"
+
+    names = set()
+    for key, config in declared.items():
+        settings = config if isinstance(config, dict) else {}
+        if isinstance(key, str) and not (
+            settings.get("external") or settings.get("name")
+        ):
+            names.add(f"{project_name}_{key}")
+    return names, ""
+
+
+def _run_volume_command(
+    run: DockerRun,
+    command: list[str],
+    failure_message: str,
+    *,
+    timeout: int,
+) -> tuple[subprocess.CompletedProcess[str] | None, list[str]]:
+    """Run one Docker volume command and normalize its failure."""
+    try:
+        result = run(command, timeout=timeout)
+    except (BackendTimeoutError, OSError) as exc:
+        return None, [f"{failure_message}: {exc}"]
+    if result.returncode != 0:
+        return None, [f"{failure_message}: {redact(result.stderr.strip())}"]
+    return result, []
+
+
+def remove_leftover_project_volumes(
+    expected: set[str], run: DockerRun, *, timeout: int
+) -> list[str]:
+    """Remove only expected project volumes still present after ``down -v``."""
+    failures: list[str] = []
+    if expected:
+        listed, failures = _run_volume_command(
+            run,
+            ["docker", "volume", "ls", "--format", "{{.Name}}"],
+            "Failed to list project volumes for cleanup",
+            timeout=timeout,
+        )
+        if listed is not None:
+            leftovers = sorted(expected & set(listed.stdout.splitlines()))
+            if leftovers:
+                _, failures = _run_volume_command(
+                    run,
+                    ["docker", "volume", "rm", *leftovers],
+                    "Failed to remove project volumes",
+                    timeout=timeout,
+                )
+    return failures

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -1,12 +1,6 @@
-"""Docker Compose deployment backend.
+"""Local Docker Compose deployment backend.
 
-Implements the DeploymentBackend protocol using local Docker Compose
-subprocess calls. This is the default backend and wraps the logic
-previously embedded directly in lab.py and kill.py.
-
-Host- and container-level docker query/inspect operations live in
-``ComposeQueryMixin`` (``_compose_queries.py``) to keep this module within
-the size budget; they are mixed into ``DockerComposeBackend`` below.
+Query, realization, and cleanup helpers live in focused sibling modules.
 """
 
 import json
@@ -16,14 +10,16 @@ from collections.abc import Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-import yaml
-
 from aptl.core.deployment._compose_build_dedupe import (
     write_duplicate_build_override,
 )
 from aptl.core.deployment._compose_lifecycle import kill_compose_lab
 from aptl.core.deployment._compose_queries import ComposeQueryMixin
 from aptl.core.deployment._compose_realization import ComposeRealizationMixin
+from aptl.core.deployment._compose_volume_cleanup import (
+    project_scoped_volume_names,
+    remove_leftover_project_volumes,
+)
 from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.core.seed_spec import NamedVolumeSeed
@@ -246,7 +242,9 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
         volume_names: set[str] = set()
         volume_discovery_error = ""
         if remove_volumes:
-            volume_names, volume_discovery_error = self._project_scoped_volume_names()
+            volume_names, volume_discovery_error = project_scoped_volume_names(
+                self._project_dir, self._project_name
+            )
 
         cmd = self._build_command("down", profiles=profiles)
         if remove_volumes:
@@ -265,7 +263,11 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
             if volume_discovery_error:
                 failures.append(volume_discovery_error)
             else:
-                failures.extend(self._remove_leftover_project_volumes(volume_names))
+                failures.extend(
+                    remove_leftover_project_volumes(
+                        volume_names, self._run, timeout=_DOCKER_TIMEOUT
+                    )
+                )
         if failures:
             error = "; ".join(failures[:5])
             log.error("Lab cleanup failed: %s", error)
@@ -273,69 +275,6 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
 
         log.info("Lab stopped successfully")
         return LabResult(success=True, message="Lab stopped")
-
-    def _project_scoped_volume_names(self) -> tuple[set[str], str]:
-        """Return auto-scoped volume names declared by this Compose project.
-
-        Typed seed containers can create a named volume before Compose first
-        attaches its management labels.  Compose therefore leaves that volume
-        behind during ``down -v``.  Only implicit, non-external volume names
-        are returned here; explicit/global names are deliberately excluded so
-        cleanup cannot cross the project boundary.
-        """
-        compose_path = self._project_dir / "docker-compose.yml"
-        try:
-            compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
-        except (OSError, yaml.YAMLError) as exc:
-            return set(), f"Failed to read project volumes for cleanup: {exc}"
-        if not isinstance(compose, dict):
-            return set(), "Failed to read project volumes for cleanup: invalid Compose"
-        declared = compose.get("volumes") or {}
-        if not isinstance(declared, dict):
-            return set(), "Failed to read project volumes for cleanup: invalid volumes"
-
-        names = set()
-        for key, config in declared.items():
-            if not isinstance(key, str):
-                continue
-            settings = config if isinstance(config, dict) else {}
-            if settings.get("external") or settings.get("name"):
-                continue
-            names.add(f"{self._project_name}_{key}")
-        return names, ""
-
-    def _remove_leftover_project_volumes(self, expected: set[str]) -> list[str]:
-        """Remove remaining declared volumes after Compose ``down -v``."""
-        if not expected:
-            return []
-        try:
-            listed = self._run(
-                ["docker", "volume", "ls", "--format", "{{.Name}}"],
-                timeout=_DOCKER_TIMEOUT,
-            )
-        except (BackendTimeoutError, OSError) as exc:
-            return [f"Failed to list project volumes for cleanup: {exc}"]
-        if listed.returncode != 0:
-            return [
-                "Failed to list project volumes for cleanup: "
-                f"{redact(listed.stderr.strip())}"
-            ]
-        leftovers = sorted(expected & set(listed.stdout.splitlines()))
-        if not leftovers:
-            return []
-        try:
-            removed = self._run(
-                ["docker", "volume", "rm", *leftovers],
-                timeout=_DOCKER_TIMEOUT,
-            )
-        except (BackendTimeoutError, OSError) as exc:
-            return [f"Failed to remove project volumes: {exc}"]
-        if removed.returncode != 0:
-            return [
-                "Failed to remove project volumes: "
-                f"{redact(removed.stderr.strip())}"
-            ]
-        return []
 
     def status(self) -> LabStatus:
         """Query current lab status via docker compose ps.

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -16,6 +16,8 @@ from collections.abc import Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+import yaml
+
 from aptl.core.deployment._compose_build_dedupe import (
     write_duplicate_build_override,
 )
@@ -241,6 +243,11 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
         Returns:
             LabResult indicating success or failure.
         """
+        volume_names: set[str] = set()
+        volume_discovery_error = ""
+        if remove_volumes:
+            volume_names, volume_discovery_error = self._project_scoped_volume_names()
+
         cmd = self._build_command("down", profiles=profiles)
         if remove_volumes:
             cmd.append("-v")
@@ -253,14 +260,82 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
             log.error("Lab stop failed: %s", result.stderr)
             return LabResult(success=False, error=result.stderr)
 
-        network_failures = self.remove_project_networks()
-        if network_failures:
-            error = "; ".join(network_failures[:5])
-            log.error("Lab network cleanup failed: %s", error)
+        failures = self.remove_project_networks()
+        if remove_volumes:
+            if volume_discovery_error:
+                failures.append(volume_discovery_error)
+            else:
+                failures.extend(self._remove_leftover_project_volumes(volume_names))
+        if failures:
+            error = "; ".join(failures[:5])
+            log.error("Lab cleanup failed: %s", error)
             return LabResult(success=False, error=error)
 
         log.info("Lab stopped successfully")
         return LabResult(success=True, message="Lab stopped")
+
+    def _project_scoped_volume_names(self) -> tuple[set[str], str]:
+        """Return auto-scoped volume names declared by this Compose project.
+
+        Typed seed containers can create a named volume before Compose first
+        attaches its management labels.  Compose therefore leaves that volume
+        behind during ``down -v``.  Only implicit, non-external volume names
+        are returned here; explicit/global names are deliberately excluded so
+        cleanup cannot cross the project boundary.
+        """
+        compose_path = self._project_dir / "docker-compose.yml"
+        try:
+            compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            return set(), f"Failed to read project volumes for cleanup: {exc}"
+        if not isinstance(compose, dict):
+            return set(), "Failed to read project volumes for cleanup: invalid Compose"
+        declared = compose.get("volumes") or {}
+        if not isinstance(declared, dict):
+            return set(), "Failed to read project volumes for cleanup: invalid volumes"
+
+        names = set()
+        for key, config in declared.items():
+            if not isinstance(key, str):
+                continue
+            settings = config if isinstance(config, dict) else {}
+            if settings.get("external") or settings.get("name"):
+                continue
+            names.add(f"{self._project_name}_{key}")
+        return names, ""
+
+    def _remove_leftover_project_volumes(self, expected: set[str]) -> list[str]:
+        """Remove remaining declared volumes after Compose ``down -v``."""
+        if not expected:
+            return []
+        try:
+            listed = self._run(
+                ["docker", "volume", "ls", "--format", "{{.Name}}"],
+                timeout=_DOCKER_TIMEOUT,
+            )
+        except (BackendTimeoutError, OSError) as exc:
+            return [f"Failed to list project volumes for cleanup: {exc}"]
+        if listed.returncode != 0:
+            return [
+                "Failed to list project volumes for cleanup: "
+                f"{redact(listed.stderr.strip())}"
+            ]
+        leftovers = sorted(expected & set(listed.stdout.splitlines()))
+        if not leftovers:
+            return []
+        try:
+            removed = self._run(
+                ["docker", "volume", "rm", *leftovers],
+                timeout=_DOCKER_TIMEOUT,
+            )
+        except (BackendTimeoutError, OSError) as exc:
+            return [f"Failed to remove project volumes: {exc}"]
+        if removed.returncode != 0:
+            return [
+                "Failed to remove project volumes: "
+                f"{redact(removed.stderr.strip())}"
+            ]
+        return []
 
     def status(self) -> LabStatus:
         """Query current lab status via docker compose ps.

--- a/tests/test_compose_volume_cleanup.py
+++ b/tests/test_compose_volume_cleanup.py
@@ -1,0 +1,96 @@
+"""Tests for project-bounded cleanup of pre-created Compose volumes."""
+
+from __future__ import annotations
+
+from subprocess import CompletedProcess
+
+import pytest
+
+from aptl.core.deployment._compose_volume_cleanup import (
+    project_scoped_volume_names,
+    remove_leftover_project_volumes,
+)
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ("volumes: [\n", "while parsing"),
+        ("- not-a-compose-mapping\n", "invalid Compose"),
+        ("volumes: [invalid]\n", "invalid volumes"),
+    ],
+)
+def test_project_scoped_volume_names_rejects_invalid_compose(
+    tmp_path, content, message
+):
+    (tmp_path / "docker-compose.yml").write_text(content, encoding="utf-8")
+
+    names, error = project_scoped_volume_names(tmp_path, "test")
+
+    assert names == set()
+    assert message in error
+
+
+def test_project_scoped_volume_names_reports_missing_compose(tmp_path):
+    names, error = project_scoped_volume_names(tmp_path, "test")
+
+    assert names == set()
+    assert "Failed to read project volumes for cleanup" in error
+
+
+def test_project_scoped_volume_names_excludes_global_and_invalid_names(tmp_path):
+    (tmp_path / "docker-compose.yml").write_text(
+        "volumes:\n"
+        "  1: {}\n"
+        "  seeded_data:\n"
+        "  shared_data: {external: true}\n"
+        "  explicit_data: {name: global-data}\n",
+        encoding="utf-8",
+    )
+
+    names, error = project_scoped_volume_names(tmp_path, "test")
+
+    assert error == ""
+    assert names == {"test_seeded_data"}
+
+
+def test_remove_leftover_project_volumes_skips_docker_when_none_expected(mocker):
+    run = mocker.Mock()
+
+    assert remove_leftover_project_volumes(set(), run, timeout=30) == []
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize("failure", [OSError("daemon unavailable"), None])
+def test_remove_leftover_project_volumes_reports_list_failure(mocker, failure):
+    run = mocker.Mock()
+    if failure is not None:
+        run.side_effect = failure
+    else:
+        run.return_value = CompletedProcess([], 1, stdout="", stderr="list failed")
+
+    errors = remove_leftover_project_volumes({"test_data"}, run, timeout=30)
+
+    assert errors and "Failed to list project volumes for cleanup" in errors[0]
+
+
+def test_remove_leftover_project_volumes_skips_remove_when_absent(mocker):
+    run = mocker.Mock(
+        return_value=CompletedProcess([], 0, stdout="other_data\n", stderr="")
+    )
+
+    assert remove_leftover_project_volumes({"test_data"}, run, timeout=30) == []
+    assert run.call_count == 1
+
+
+def test_remove_leftover_project_volumes_reports_remove_exception(mocker):
+    run = mocker.Mock(
+        side_effect=[
+            CompletedProcess([], 0, stdout="test_data\n", stderr=""),
+            OSError("volume busy"),
+        ]
+    )
+
+    errors = remove_leftover_project_volumes({"test_data"}, run, timeout=30)
+
+    assert errors and "Failed to remove project volumes" in errors[0]

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -977,6 +977,9 @@ services:
 
     def test_stop_with_volumes(self, tmp_path):
         backend = self._make_backend(tmp_path)
+        (tmp_path / "docker-compose.yml").write_text(
+            "volumes:\n  seeded_data:\n"
+        )
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -985,6 +988,67 @@ services:
         assert result.success is True
         cmd = mock_run.call_args_list[0][0][0]
         assert "-v" in cmd
+
+    def test_stop_with_volumes_removes_only_declared_project_leftovers(
+        self, tmp_path
+    ):
+        backend = self._make_backend(tmp_path)
+        (tmp_path / "docker-compose.yml").write_text(
+            "volumes:\n"
+            "  seeded_data:\n"
+            "  compose_data: {}\n"
+            "  shared_data:\n"
+            "    external: true\n"
+            "  explicit_data:\n"
+            "    name: global-data\n"
+        )
+
+        def fake_run(cmd, **kwargs):
+            del kwargs
+            if cmd[:3] == ["docker", "volume", "ls"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "test_seeded_data\n"
+                        "other_seeded_data\n"
+                        "global-data\n"
+                    ),
+                    stderr="",
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            result = backend.stop(["wazuh"], remove_volumes=True)
+
+        assert result.success is True
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        assert ["docker", "volume", "rm", "test_seeded_data"] in commands
+        assert all("other_seeded_data" not in command for command in commands)
+        assert all("global-data" not in command for command in commands)
+
+    def test_stop_with_volumes_fails_when_seeded_volume_cannot_be_removed(
+        self, tmp_path
+    ):
+        backend = self._make_backend(tmp_path)
+        (tmp_path / "docker-compose.yml").write_text(
+            "volumes:\n  seeded_data:\n"
+        )
+
+        def fake_run(cmd, **kwargs):
+            del kwargs
+            if cmd[:3] == ["docker", "volume", "ls"]:
+                return MagicMock(
+                    returncode=0, stdout="test_seeded_data\n", stderr=""
+                )
+            if cmd[:3] == ["docker", "volume", "rm"]:
+                return MagicMock(returncode=1, stdout="", stderr="still in use")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = backend.stop(["wazuh"], remove_volumes=True)
+
+        assert result.success is False
+        assert "Failed to remove project volumes" in result.error
 
     def test_stop_removes_leftover_project_networks(self, tmp_path):
         backend = self._make_backend(tmp_path)
@@ -1757,6 +1821,7 @@ class TestSSHComposeBackend:
 
     def test_inherits_stop_behavior(self, tmp_path):
         backend = self._make_backend(tmp_path)
+        (tmp_path / "docker-compose.yml").write_text("volumes: {}\n")
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")


### PR DESCRIPTION
## Summary

- identify implicit, project-scoped volumes declared by the APTL Compose file
- after `docker compose down -v`, remove only those declared project volumes that remain
- exclude external and explicitly named/global volumes from supplemental cleanup
- surface a cleanup failure instead of reporting a false successful reset

## Participant impact

Typed content and Suricata seed containers can create volumes before Compose attaches its management labels. `aptl lab stop -v` therefore reported success while leaving `aptl_fileshare_data`, `aptl_suricata_config_seed`, and `aptl_suricata_misp_rules` behind. The next supposedly clean install reused participant data and seeded state. Full cleanup now removes those project-owned leftovers without enumerating or mutating containers or volumes from other applications.

## Validation

- `pytest tests/test_deployment_backend.py -q` (184 passed)
- `pre-commit run --files src/aptl/core/deployment/docker_compose.py tests/test_deployment_backend.py`
