### PR TITLE
fix: reuse generated credentials in manual SOC seeding

### DIFF
--- a/scripts/aptl-env.sh
+++ b/scripts/aptl-env.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Load one literal value from an APTL-generated .env file without sourcing or
+# evaluating the file. An explicit process environment value always wins.
+aptl_load_env_key() {
+    local env_file="$1"
+    local key="$2"
+    local value=""
+
+    if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        return 2
+    fi
+    if [ -n "${!key:-}" ] || [ ! -f "$env_file" ]; then
+        return 0
+    fi
+
+    value=$(awk -v key="$key" '
+        index($0, key "=") == 1 {
+            sub(/^[^=]*=/, "")
+            print
+            exit
+        }
+    ' "$env_file")
+    if [ -z "$value" ]; then
+        return 0
+    fi
+
+    # hydrate_dotenv writes unquoted values, but accept a matching quote pair
+    # for participant-maintained files without evaluating shell syntax.
+    if [ "${#value}" -ge 2 ]; then
+        if [[ "$value" == \"*\" ]] || [[ "$value" == \'*\' ]]; then
+            value="${value:1:${#value}-2}"
+        fi
+    fi
+    printf -v "$key" '%s' "$value"
+    export "$key"
+}

--- a/scripts/seed-misp.sh
+++ b/scripts/seed-misp.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Usage:
 #   ./scripts/seed-misp.sh
 #
-# Uses ADMIN_KEY from docker-compose.yml by default. Override with:
+# Uses MISP_API_KEY from the project .env by default. Override with:
 #   MISP_API_KEY="custom-key" ./scripts/seed-misp.sh
 #
 # The script is idempotent -- re-running it will skip event creation if the
@@ -25,6 +25,12 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$PROJECT_DIR/.env"
+source "$SCRIPT_DIR/aptl-env.sh"
+aptl_load_env_key "$ENV_FILE" MISP_API_KEY
+
 MISP_URL="${MISP_URL:-https://localhost:8443}"
 # SEC-006 / ADR-034: MISP now serves a lab-CA-signed certificate.
 # The seed script verifies against the lab CA bundle by default; the
@@ -44,7 +50,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Preflight checks — default to ADMIN_KEY from docker-compose.yml
+# Preflight checks — the generated .env key matches Compose's ADMIN_KEY
 # ---------------------------------------------------------------------------
 MISP_API_KEY="${MISP_API_KEY:-JHxBbGPnAtyut0FTwkeuhVFnbMksGRCRwsE0V9Xw}"
 

--- a/scripts/seed-prime.sh
+++ b/scripts/seed-prime.sh
@@ -52,6 +52,16 @@ update_env_var() {
     chmod 600 "$ENV_FILE"
 }
 
+# Manual reruns start in a fresh shell, unlike `aptl lab start`, which passes
+# the hydrated lab environment explicitly. Reuse the running lab's credentials
+# so recovery cannot replace a randomized service key with a baked-in default.
+source "$SCRIPT_DIR/aptl-env.sh"
+for key in \
+    INDEXER_USERNAME INDEXER_PASSWORD MISP_API_KEY SHUFFLE_API_KEY CORTEX_API_KEY
+do
+    aptl_load_env_key "$ENV_FILE" "$key"
+done
+
 echo "============================================="
 echo "  APTL Prime Scenario Seed"
 echo "============================================="
@@ -248,7 +258,7 @@ echo "  Prime Scenario Seed Complete"
 echo "============================================="
 echo ""
 echo "Seeded state:"
-echo "  - TheHive API key: provisioned (export THEHIVE_API_KEY=${THEHIVE_API_KEY:-not set})"
+echo "  - TheHive API key: provisioned and stored in .env"
 echo "  - Cortex API key: provisioned for TheHive connector"
 echo "  - Wazuh Indexer: healthy"
 echo "  - MISP: Kali IOCs and attack patterns"

--- a/scripts/seed-shuffle.sh
+++ b/scripts/seed-shuffle.sh
@@ -24,6 +24,14 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$PROJECT_DIR/.env"
+source "$SCRIPT_DIR/aptl-env.sh"
+for key in SHUFFLE_API_KEY MISP_API_KEY THEHIVE_API_KEY; do
+    aptl_load_env_key "$ENV_FILE" "$key"
+done
+
 # SEC-006 / ADR-034: the host-facing Shuffle backend moved from
 # http://localhost:5001 to the HTTPS frontend at localhost:3443. The
 # seed script is a host-side CLIENT of Shuffle, so it verifies against
@@ -54,7 +62,6 @@ fi
 
 # Auto-provision TheHive API key if not set in env
 if [ -z "${THEHIVE_API_KEY:-}" ]; then
-    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
     if [ -x "$SCRIPT_DIR/thehive-apikey.sh" ]; then
         THEHIVE_API_KEY=$("$SCRIPT_DIR/thehive-apikey.sh" 2>/dev/null) || true
     fi

--- a/tests/test_seed_script_env.py
+++ b/tests/test_seed_script_env.py
@@ -1,0 +1,82 @@
+"""Credential discovery for participant-invoked SOC seed scripts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+HELPER = PROJECT_ROOT / "scripts" / "aptl-env.sh"
+
+
+def _load_key(env_file: Path, key: str, *, existing: str = "") -> str:
+    env = {
+        **os.environ,
+        "APTL_ENV_HELPER": str(HELPER),
+        "APTL_TEST_ENV_FILE": str(env_file),
+        "APTL_TEST_KEY": key,
+    }
+    if existing:
+        env[key] = existing
+    else:
+        env.pop(key, None)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$APTL_ENV_HELPER"; '
+            'aptl_load_env_key "$APTL_TEST_ENV_FILE" "$APTL_TEST_KEY"; '
+            'printf "%s" "${!APTL_TEST_KEY}"',
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def test_loads_generated_key_from_project_env(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("MISP_API_KEY=fresh-lab-key\n")
+
+    assert _load_key(env_file, "MISP_API_KEY") == "fresh-lab-key"
+
+
+def test_explicit_process_environment_wins(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("MISP_API_KEY=file-key\n")
+
+    assert _load_key(env_file, "MISP_API_KEY", existing="operator-key") == (
+        "operator-key"
+    )
+
+
+def test_env_value_is_not_evaluated(tmp_path):
+    marker = tmp_path / "must-not-exist"
+    literal = f"$(touch {marker})"
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"MISP_API_KEY={literal}\n")
+
+    assert _load_key(env_file, "MISP_API_KEY") == literal
+    assert not marker.exists()
+
+
+def test_manual_seed_entrypoints_load_their_required_credentials():
+    expected = {
+        "seed-prime.sh": ("MISP_API_KEY", "SHUFFLE_API_KEY"),
+        "seed-misp.sh": ("MISP_API_KEY",),
+        "seed-shuffle.sh": (
+            "MISP_API_KEY",
+            "SHUFFLE_API_KEY",
+            "THEHIVE_API_KEY",
+        ),
+    }
+    for name, keys in expected.items():
+        text = (PROJECT_ROOT / "scripts" / name).read_text()
+        assert 'source "$SCRIPT_DIR/aptl-env.sh"' in text
+        for key in keys:
+            assert key in text


### PR DESCRIPTION
## Summary

- load required service keys literally from the project `.env` for participant-invoked SOC seed scripts
- preserve explicit process-environment overrides
- avoid sourcing or evaluating `.env` as shell code
- stop printing the full provisioned TheHive API key in the seed summary

## Participant impact

`aptl lab start` passes generated credentials to the seed scripts, but the documented manual rerun commands start in a fresh shell. `seed-misp.sh`, `seed-shuffle.sh`, and `seed-prime.sh` then fell back to baked-in keys. Because fresh APTL installs randomize `MISP_API_KEY`, manual recovery failed authentication; `seed-prime.sh` could also overwrite the correct `.env` key with the incompatible default. Manual reruns now use the credentials of the running lab.

## Validation

- `bash -n scripts/aptl-env.sh scripts/seed-prime.sh scripts/seed-misp.sh scripts/seed-shuffle.sh`
- `pytest tests/test_seed_script_env.py tests/test_cortex_integration_config.py -q` (9 passed)
- repository Python pre-commit gate
