### PR TITLE
test: align live smoke tests with current SDL lab

### DIFF
--- a/docs/components/mcp-smoke-test-protocol.md
+++ b/docs/components/mcp-smoke-test-protocol.md
@@ -44,12 +44,11 @@ API keys are pre-configured in `.env` and `docker-compose.yml` so no manual expo
 ### What the automated tests prove
 
 - **Precondition gate**: All 12 expected containers are running (fail fast, no skip)
-- **Detection pipeline**: Victim log -> archives, Kali red-team log -> archives, Kali SSH to victim, Wazuh agent registration
+- **Detection pipeline**: Victim log -> archives, Kali SSH to victim, Wazuh agent registration. Kali activity stays in per-session evidence under ADR-033 rather than contaminating the blue SIEM.
 - **Attack -> Detection**: SQLi (rule 302010), XSS (rule 302020), CmdInj (rule 302030) from Kali generate real Wazuh alerts
 - **SOC tools**: MISP IOC lookup, TheHive case lifecycle, Shuffle workflow execution to FINISHED
 - **Full loop**: SQLi from Kali -> Wazuh alert -> MISP lookup -> Shuffle workflow -> TheHive case (6 systems)
-- **Scenario harness**: detect-brute-force lifecycle (start -> SSH brute force from Kali -> evaluate -> stop -> verify report)
-- **MCP protocol**: JSON-RPC initialize + tools/list for all 7 servers (4 custom Node.js + 3 published binaries)
+- **MCP protocol**: JSON-RPC initialize + tools/list for the seven enabled custom Node.js servers (reverse is optional)
 - **MCP tool calls**: Real tool invocations against live services (kali_info, kali_run_command, indexer_query, soar_list_workflows)
 
 ---

--- a/docs/testing/smoke-test-plan.md
+++ b/docs/testing/smoke-test-plan.md
@@ -11,7 +11,7 @@ Acceptance testing for the enterprise infrastructure, SOC stack, MCP layer, and 
 **Prerequisites:**
 - Docker Engine with Docker Compose v2
 - 24GB+ RAM available (32GB recommended)
-- Python 3.11+ with `pip install -e .` (APTL CLI)
+- Python 3.11+ with `pip install -e '.[dev]'` (APTL CLI and smoke-test dependencies)
 - Node.js 20+ (MCP server builds)
 - Native Linux Docker Engine: `vm.max_map_count >= 262144`
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,8 +5,11 @@ import os
 import selectors
 import subprocess
 import time
+from pathlib import Path
 
 import pytest
+
+from aptl.core.env import load_dotenv
 
 # ---------------------------------------------------------------------------
 # Live-lab shared constants
@@ -14,15 +17,25 @@ import pytest
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+try:
+    PROJECT_ENV = load_dotenv(Path(PROJECT_ROOT) / ".env")
+except (OSError, ValueError):
+    PROJECT_ENV = {}
+
+
+def _credential(name: str, fallback: str = "") -> str:
+    """Prefer the process environment, then the generated project .env."""
+    return os.getenv(name, PROJECT_ENV.get(name, fallback))
+
 INDEXER_URL = os.getenv("APTL_INDEXER_URL", "https://localhost:9200")
-INDEXER_USER = os.getenv("INDEXER_USERNAME", "admin")
-INDEXER_PASS = os.getenv("INDEXER_PASSWORD", "SecretPassword")
-API_USER = os.getenv("API_USERNAME", "wazuh-wui")
-API_PASS = os.getenv("API_PASSWORD", "WazuhPass123!")
+INDEXER_USER = _credential("INDEXER_USERNAME", "admin")
+INDEXER_PASS = _credential("INDEXER_PASSWORD", "SecretPassword")
+API_USER = _credential("API_USERNAME", "wazuh-wui")
+API_PASS = _credential("API_PASSWORD", "WazuhPass123!")
 SSH_KEY = os.path.expanduser(os.getenv("APTL_SSH_KEY", "~/.ssh/aptl_lab_key"))
 
 MISP_URL = os.getenv("MISP_URL", "https://localhost:8443")
-MISP_API_KEY = os.getenv(
+MISP_API_KEY = _credential(
     "MISP_API_KEY", "JHxBbGPnAtyut0FTwkeuhVFnbMksGRCRwsE0V9Xw",
 )
 # SEC-006 / ADR-034: TheHive and Shuffle's host-facing surfaces moved
@@ -50,9 +63,9 @@ def _provision_thehive_key() -> str:
     return ""
 
 
-THEHIVE_API_KEY = os.getenv("THEHIVE_API_KEY", "") or _provision_thehive_key()
+THEHIVE_API_KEY = _credential("THEHIVE_API_KEY") or _provision_thehive_key()
 SHUFFLE_URL = os.getenv("SHUFFLE_URL", "https://localhost:3443")
-SHUFFLE_API_KEY = os.getenv(
+SHUFFLE_API_KEY = _credential(
     "SHUFFLE_API_KEY", "31a211c4-ea5c-4a49-b022-5e2434e758a7",
 )
 
@@ -93,17 +106,17 @@ def _find_node() -> str:
     return shutil.which("node") or "node"
 
 
-# Custom Node.js MCP servers (built from source in mcp/)
-CUSTOM_MCP_SERVERS = ["mcp-red", "mcp-reverse", "mcp-soar", "mcp-indexer"]
-
-# Published MCP server binaries/scripts (downloaded to tools/)
-PUBLISHED_MCP_PATHS = {
-    "wazuh": os.path.join(PROJECT_ROOT, "tools", "bin", "mcp-server-wazuh"),
-    "thehive": os.path.join(PROJECT_ROOT, "tools", "bin", "thehivemcp"),
-    "misp": os.path.join(
-        PROJECT_ROOT, "tools", "misp-mcp-server", "misp_server.py",
-    ),
-}
+# Custom Node.js MCP servers built by `aptl lab start`.
+CUSTOM_MCP_SERVERS = [
+    "mcp-red",
+    "mcp-reverse",
+    "mcp-indexer",
+    "mcp-wazuh",
+    "mcp-network",
+    "mcp-threatintel",
+    "mcp-casemgmt",
+    "mcp-soar",
+]
 
 
 def mcp_server_cmd(name: str) -> tuple[list[str], dict]:
@@ -160,38 +173,54 @@ def mcp_server_cmd(name: str) -> tuple[list[str], dict]:
             },
         },
         "wazuh": {
-            "cmd": [PUBLISHED_MCP_PATHS["wazuh"]],
+            "cmd": [
+                node_bin,
+                os.path.join(
+                    PROJECT_ROOT, "mcp", "mcp-wazuh", "build", "index.js"
+                ),
+            ],
             "env": {
-                "WAZUH_API_HOST": "localhost",
-                "WAZUH_API_PORT": "55000",
-                "WAZUH_API_USERNAME": API_USER,
-                "WAZUH_API_PASSWORD": API_PASS,
-                "WAZUH_INDEXER_HOST": "localhost",
-                "WAZUH_INDEXER_PORT": "9200",
-                "WAZUH_INDEXER_USERNAME": INDEXER_USER,
-                "WAZUH_INDEXER_PASSWORD": INDEXER_PASS,
-                "WAZUH_VERIFY_SSL": "false",
-                "RUST_LOG": "warn",
+                "INDEXER_USERNAME": INDEXER_USER,
+                "INDEXER_PASSWORD": INDEXER_PASS,
+            },
+        },
+        "network": {
+            "cmd": [
+                node_bin,
+                os.path.join(
+                    PROJECT_ROOT, "mcp", "mcp-network", "build", "index.js"
+                ),
+            ],
+            "env": {
+                "INDEXER_USERNAME": INDEXER_USER,
+                "INDEXER_PASSWORD": INDEXER_PASS,
             },
         },
         "misp": {
             "cmd": [
-                os.path.join(PROJECT_ROOT, "tools", "misp-mcp-server", ".venv", "bin", "python"),
-                PUBLISHED_MCP_PATHS["misp"],
+                node_bin,
+                os.path.join(
+                    PROJECT_ROOT,
+                    "mcp",
+                    "mcp-threatintel",
+                    "build",
+                    "index.js",
+                ),
             ],
-            "env": {
-                "MISP_URL": MISP_URL,
-                "MISP_API_KEY": MISP_API_KEY,
-                "MISP_VERIFY_SSL": "False",
-            },
+            "env": {"MISP_API_KEY": MISP_API_KEY},
         },
         "thehive": {
-            "cmd": [PUBLISHED_MCP_PATHS["thehive"], "--transport", "stdio"],
-            "env": {
-                "THEHIVE_URL": THEHIVE_URL,
-                "THEHIVE_API_KEY": THEHIVE_API_KEY,
-                "THEHIVE_ORGANISATION": "admin",
-            },
+            "cmd": [
+                node_bin,
+                os.path.join(
+                    PROJECT_ROOT,
+                    "mcp",
+                    "mcp-casemgmt",
+                    "build",
+                    "index.js",
+                ),
+            ],
+            "env": {"THEHIVE_API_KEY": THEHIVE_API_KEY},
         },
     }
 
@@ -468,6 +497,15 @@ def curl_json(
     (SEC-004 territory) and for fallback when the lab CA bundle is
     unavailable. Mutually exclusive — ``insecure`` wins when both set.
     """
+    lab_ca_urls = (MISP_URL, THEHIVE_URL, SHUFFLE_URL)
+    if (
+        not insecure
+        and ca_cert_path is None
+        and any(url == base or url.startswith(f"{base}/") for base in lab_ca_urls)
+        and os.path.isfile(LAB_CA_PATH)
+    ):
+        ca_cert_path = LAB_CA_PATH
+
     cmd = ["curl", "-sf", url]
     if insecure:
         cmd.insert(1, "-k")

--- a/tests/test_live_helpers.py
+++ b/tests/test_live_helpers.py
@@ -1,0 +1,39 @@
+"""Unit coverage for live-smoke configuration helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+from tests import helpers
+
+
+def test_credential_falls_back_to_generated_project_env(monkeypatch):
+    monkeypatch.delenv("MISP_API_KEY", raising=False)
+    monkeypatch.setattr(helpers, "PROJECT_ENV", {"MISP_API_KEY": "generated"})
+
+    assert helpers._credential("MISP_API_KEY", "legacy") == "generated"
+
+
+def test_credential_prefers_explicit_process_environment(monkeypatch):
+    monkeypatch.setenv("MISP_API_KEY", "operator")
+    monkeypatch.setattr(helpers, "PROJECT_ENV", {"MISP_API_KEY": "generated"})
+
+    assert helpers._credential("MISP_API_KEY", "legacy") == "operator"
+
+
+def test_curl_json_uses_lab_ca_for_soc_https(tmp_path, monkeypatch):
+    ca_path = tmp_path / "lab-ca.pem"
+    ca_path.touch()
+    monkeypatch.setattr(helpers, "LAB_CA_PATH", str(ca_path))
+    run = monkeypatch.setattr
+    captured = {}
+
+    def fake_run(cmd, timeout):
+        captured["cmd"] = cmd
+        captured["timeout"] = timeout
+        return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+
+    run(helpers, "run_cmd", fake_run)
+
+    assert helpers.curl_json(f"{helpers.MISP_URL}/events/restSearch") == {}
+    assert captured["cmd"][1:3] == ["--cacert", str(ca_path)]

--- a/tests/test_range_integration.py
+++ b/tests/test_range_integration.py
@@ -140,34 +140,6 @@ class TestDetectionPipeline:
             f"Log '{tag}' not in Wazuh archives within 240s"
         )
 
-    def test_kali_redteam_log_reaches_manager(self):
-        """Red-team log on Kali reaches Wazuh archives."""
-        tag = f"APTL_INTEG_KALI_{int(time.time())}"
-        kali_exec(
-            "logger -t kali_redteam "
-            f'"RedTeamActivity: command={tag} '
-            'target=172.20.2.20"'
-        )
-
-        deadline = time.monotonic() + 180
-        while time.monotonic() < deadline:
-            time.sleep(5)
-            result = docker_exec(
-                "aptl-wazuh-manager",
-                [
-                    "grep", "-c", tag,
-                    "/var/ossec/logs/archives/archives.log",
-                ],
-            )
-            if (
-                result.returncode == 0
-                and result.stdout.strip() != "0"
-            ):
-                return
-        pytest.fail(
-            f"Log '{tag}' not in Wazuh archives within 180s"
-        )
-
     def test_wazuh_agents_registered(self):
         """Wazuh Manager API shows registered agents."""
         result = docker_exec(
@@ -739,6 +711,7 @@ class TestFullLoop:
 
 
 @LIVE_LAB
+@pytest.mark.skip(reason="Legacy pre-SDL scenario CLI was removed")
 class TestScenarioHarness:
     """Exercise the scenario system against live infrastructure."""
 
@@ -859,13 +832,12 @@ class TestScenarioHarness:
 MCP_SERVERS = {
     # Custom Node.js servers (known tool names)
     "kali-ssh": "kali_info",
-    "reverse-sandbox-ssh": "reverse_info",
     "shuffle": "soar_list_workflows",
     "indexer": "indexer_query",
-    # Published servers (verify they start and list tools)
-    "wazuh": None,
-    "misp": None,
-    "thehive": None,
+    "wazuh": "wazuh_query_alerts",
+    "network": "network_query_ids_alerts",
+    "misp": "threatintel_search_iocs",
+    "thehive": "cases_list_cases",
 }
 
 
@@ -873,7 +845,9 @@ def _server_available(name: str) -> bool:
     """Check if an MCP server's binary/build exists."""
     try:
         cmd, _ = mcp_server_cmd(name)
-        return os.path.isfile(cmd[0])
+        return os.path.isfile(cmd[0]) and (
+            len(cmd) < 2 or os.path.isfile(cmd[1])
+        )
     except (ValueError, IndexError):
         return False
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -18,7 +18,6 @@ from tests.helpers import (
     CUSTOM_MCP_SERVERS,
     LIVE_LAB,
     PROJECT_ROOT,
-    PUBLISHED_MCP_PATHS,
     VICTIM_IP,
     WS_IP,
     container_running,
@@ -214,7 +213,7 @@ class TestNetworkConnectivity:
 
 @LIVE_LAB
 class TestMCPServers:
-    """MCP server builds and published binaries exist."""
+    """Every repository-owned MCP server has a compiled build."""
 
     @pytest.mark.parametrize("server", CUSTOM_MCP_SERVERS)
     def test_custom_build_exists(self, server):
@@ -226,29 +225,6 @@ class TestMCPServers:
             f"{entry} not found -- "
             "run ./mcp/build-all-mcps.sh"
         )
-
-    @pytest.mark.parametrize(
-        "name,path",
-        list(PUBLISHED_MCP_PATHS.items()),
-        ids=list(PUBLISHED_MCP_PATHS.keys()),
-    )
-    def test_published_binary_exists(self, name, path):
-        """Published MCP server binary or script is installed (optional).
-
-        The published wazuh/thehive/misp MCP servers are third-party, installed
-        per-machine and gitignored (``tools/.gitignore``); they back only the
-        optional full-SOC MCP path. Skip when absent so a core-workshop setup
-        (red + indexer, built from source) reports a clean smoke run, while
-        still validating the binary when a facilitator has installed it.
-        """
-        if not os.path.isfile(path):
-            pytest.skip(
-                f"Published MCP '{name}' not installed at {path} -- optional "
-                "per-machine install (see tools/.gitignore); required only for "
-                "the full-SOC MCP path."
-            )
-        assert os.path.isfile(path)
-
 
 # -------------------------------------------------------------------
 # Section 7: Workstation credential artifacts


### PR DESCRIPTION
## Summary

- read generated credentials from the project `.env` and verify SOC HTTPS with the lab CA
- validate all eight repository-owned Node MCP builds and the seven enabled MCP protocol surfaces
- stop expecting retired third-party MCP binaries
- retire pre-SDL scenario CLI assertions and the Kali-to-blue-SIEM assertion that contradicts ADR-033
- document the `dev` extra required to run the smoke suites

## Participant impact

The documented clean smoke command produced false failures after a successful first load: it used a baked-in MISP key instead of the generated key, omitted the lab CA for TheHive and Shuffle, checked obsolete third-party MCP binaries, expected a removed scenario CLI, and waited three minutes for Kali activity that ADR-033 intentionally isolates from Wazuh. The harness now measures the current SDL-only participant experience and current custom MCP stack.

## Validation

- collection/unit checks for both live suites (`3 passed, 140 skipped` without `APTL_SMOKE=1`)
- Vale documentation lint
- repository Python pre-commit gate
- full live rerun is part of the accumulated clean-install validation
