### PR TITLE
fix: keep Shuffle writable on high-usage hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -641,6 +641,11 @@ services:
     environment:
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.type=single-node
+      # This is a disposable, single-node lab datastore sharing the host
+      # filesystem. Percentage watermarks can make it read-only even when the
+      # host still has tens of GiB free, leaving Shuffle healthy but unable to
+      # accept the seeded workflow. Match the Wazuh indexer's lab policy.
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=StrongPassword123!
     volumes:
       - shuffle_opensearch_data:/usr/share/opensearch/data

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -160,6 +160,24 @@ class TestComposeConsistency:
             "/etc/otelcol-contrib/config.yaml",
         ]
 
+    def test_shuffle_opensearch_stays_writable_on_full_host(
+        self, compose_config
+    ):
+        """Shuffle's lab datastore must not use host percentage watermarks.
+
+        A container can share a large, mostly-full host filesystem and still
+        have ample absolute free space. OpenSearch's default flood-stage
+        watermark then makes indices read-only while its healthcheck remains
+        green, so the first-load Shuffle workflow silently fails to seed.
+        """
+        environment = compose_config["services"]["shuffle-opensearch"][
+            "environment"
+        ]
+        assert (
+            "cluster.routing.allocation.disk.threshold_enabled=false"
+            in environment
+        )
+
     def test_web_api_token_does_not_block_inactive_profiles(self, compose_config):
         """Compose expands environment substitutions for inactive profiles, so
         the optional web token must be validated by the web runtime instead of


### PR DESCRIPTION
## Summary

- disable percentage-based disk allocation watermarks for the disposable single-node Shuffle OpenSearch datastore
- keep the policy consistent with the Wazuh indexer used by the same lab
- add a compose regression test for the first-load failure

## Participant impact

On hosts above OpenSearch's default flood-stage percentage, Shuffle OpenSearch reported healthy but marked its indices read-only. APTL then reported the lab ready even though the Alert to Case workflow could not be seeded. This can happen with tens of GiB still free on a large local disk.

## Validation

- `pytest tests/test_consistency.py -q`
- `docker compose --profile soc config --no-interpolate --quiet`
- `pre-commit run --all-files`