### PR TITLE
fix: flush Kali captures before session close

### DIFF
--- a/mcp/aptl-mcp-common/src/ssh.ts
+++ b/mcp/aptl-mcp-common/src/ssh.ts
@@ -605,7 +605,13 @@ export class PersistentSession extends EventEmitter {
   async close(): Promise<void> {
     this.doCleanup();
     if (this.shell) {
-      this.shell.end();
+      // Send a shell-level exit before EOF. A bare channel EOF can make sshd
+      // tear down the ForceCommand process group before the Kali capture
+      // wrapper's inner `script(1)` process flushes its transcript FIFO. All
+      // supported shell types accept `exit`; stream.end preserves write order
+      // and then half-closes the SSH channel so the wrapper can wait for its
+      // capture client and exit cleanly.
+      this.shell.end('exit\n');
     }
     // Run the postcondition before flipping cleanupVerified so a violation
     // cannot mark the session as cleanly torn down. If assertion throws,

--- a/mcp/aptl-mcp-common/tests/ssh.test.ts
+++ b/mcp/aptl-mcp-common/tests/ssh.test.ts
@@ -1532,6 +1532,11 @@ describe('#304: PersistentSession.close() awaits remote stream-close', () => {
     let resolved = false;
     closeP.then(() => { resolved = true; });
 
+    // The Kali ForceCommand wrapper needs its child shell to exit normally so
+    // `script(1)` closes the transcript FIFO and the capture client can flush
+    // before sshd closes the channel. Bare EOF truncated live captures.
+    expect(mockStream.end).toHaveBeenCalledWith('exit\n');
+
     // Microtask drain — local cleanup is sync, but the close promise must
     // still be pending because remote 'close' has not fired.
     await Promise.resolve();


### PR DESCRIPTION
## Summary

- send a portable shell-level `exit` before closing persistent SSH channel input
- allow the Kali ForceCommand wrapper to finish `script(1)`, drain its capture FIFO, and wait for the sidecar client
- pin the graceful-close behavior in the shared SSH session tests

## Participant impact

Persistent Kali MCP sessions returned successful command and close responses, but their harvested transcript could be empty because bare channel EOF let sshd tear down the capture process group before the transcript FIFO flushed.

## Validation

- 456 `aptl-mcp-common` tests passed
- all eight dependent MCP packages rebuilt; packages with test suites passed and the remaining packages completed Vitest with `--passWithNoTests`
- full `pre-commit run --all-files` passed
- live MCP JSON-RPC session opened, emitted a unique terminator, closed, harvested one 1,788-byte transcript, and found the terminator intact