### PR TITLE
fix: serialize first-run Vale bootstrap

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,6 +120,10 @@ repos:
         # contracts, dated point-in-time records) — keep the two in sync.
         entry: tools/vale-lint-hook.sh
         language: system
+        # The hook installs Vale and syncs its style packages on first use.
+        # Pre-commit otherwise shards file arguments across concurrent hook
+        # processes, which race while replacing the same binary and styles.
+        require_serial: true
         types_or: [markdown]
         exclude: ^(\.claude/|\.gc/|\.github/|changelog\.d/|CHANGELOG\.md|AGENTS\.md|CLAUDE\.md|node_modules/|\.tools/|\.vale/)
 

--- a/tests/test_precommit_config.py
+++ b/tests/test_precommit_config.py
@@ -1,0 +1,22 @@
+"""Regression checks for contributor-facing pre-commit behavior."""
+
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_vale_bootstrap_runs_serially() -> None:
+    """A fresh Vale install must not race across pre-commit file batches."""
+    config = yaml.safe_load(
+        (PROJECT_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    )
+    hooks = {
+        hook["id"]: hook
+        for repo in config["repos"]
+        for hook in repo["hooks"]
+    }
+
+    assert hooks["vale-prose-lint"].get("require_serial") is True


### PR DESCRIPTION
## Summary

- run the bootstrap-capable Vale pre-commit hook serially
- prevent concurrent file batches from replacing the same binary and syncing the same style tree
- add a regression check that pins the pre-commit configuration

## Participant impact

On a fresh checkout, `pre-commit run --all-files` could start many Vale installers simultaneously. The first completion gate then failed with `Text file busy` or a partially synchronized Google style package and only passed on a retry.

## Validation

- fresh worktree had no Vale cache
- `pytest tests/test_precommit_config.py -q` passed
- first `pre-commit run vale-prose-lint --all-files` installed and passed in one attempt
- full `pre-commit run --all-files` passed