### PR TITLE
fix: keep SOC seed credentials stable on rerun

### DIFF
--- a/scripts/seed-shuffle.sh
+++ b/scripts/seed-shuffle.sh
@@ -60,11 +60,15 @@ fi
 # Preflight checks
 # ---------------------------------------------------------------------------
 
-# Auto-provision TheHive API key if not set in env
-if [ -z "${THEHIVE_API_KEY:-}" ]; then
-    if [ -x "$SCRIPT_DIR/thehive-apikey.sh" ]; then
-        THEHIVE_API_KEY=$("$SCRIPT_DIR/thehive-apikey.sh" 2>/dev/null) || true
+# Validate and, only when necessary, provision the TheHive key. The
+# provisioner reuses a working project key; calling it on every run also
+# repairs a stale key left after the TheHive volume was reset.
+if [ -x "$SCRIPT_DIR/thehive-apikey.sh" ]; then
+    if ! THEHIVE_API_KEY=$("$SCRIPT_DIR/thehive-apikey.sh" 2>/dev/null); then
+        echo "ERROR: Could not validate or provision the TheHive API key."
+        exit 1
     fi
+    export THEHIVE_API_KEY
 fi
 THEHIVE_API_KEY="${THEHIVE_API_KEY:-}"
 
@@ -119,6 +123,76 @@ WORKFLOWS_JSON=$(curl -s "${SHUFFLE_TLS_FLAGS[@]}" \
     -H "Authorization: Bearer ${SHUFFLE_API_KEY}" \
     "${SHUFFLE_URL}/api/v1/workflows")
 
+refresh_workflow_credentials() {
+    local workflow_id="$1"
+    local workflow_json updated response code real_trigger_id
+
+    if ! workflow_json=$(curl -fsS "${SHUFFLE_TLS_FLAGS[@]}" \
+        -H "Authorization: Bearer ${SHUFFLE_API_KEY}" \
+        "${SHUFFLE_URL}/api/v1/workflows/${workflow_id}"); then
+        echo "ERROR: Could not fetch existing workflow ${workflow_id}."
+        return 1
+    fi
+
+    if ! updated=$(printf '%s' "$workflow_json" | python3 -c '
+import json
+import os
+import sys
+
+workflow = json.load(sys.stdin)
+misp_key = os.environ["MISP_API_KEY"]
+thehive_key = os.environ["THEHIVE_API_KEY"]
+headers = {
+    "misp_ip_lookup": (
+        f"Authorization: {misp_key}\n"
+        "Content-Type: application/json\nAccept: application/json"
+    ),
+    "create_thehive_case": (
+        f"Authorization: Bearer {thehive_key}\n"
+        "Content-Type: application/json"
+    ),
+}
+for action in workflow.get("actions", []):
+    value = headers.get(action.get("label"))
+    if value is None:
+        continue
+    for parameter in action.get("parameters", []):
+        if parameter.get("name") == "headers":
+            parameter["value"] = value
+
+triggers = workflow.get("triggers", [])
+if triggers:
+    workflow["start"] = triggers[0].get("id", workflow.get("start", ""))
+print(json.dumps(workflow))
+'); then
+        echo "ERROR: Could not refresh existing workflow credentials."
+        return 1
+    fi
+
+    response=$(curl -sS "${SHUFFLE_TLS_FLAGS[@]}" -w "\n%{http_code}" \
+        -X PUT \
+        -H "Authorization: Bearer ${SHUFFLE_API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d "$updated" \
+        "${SHUFFLE_URL}/api/v1/workflows/${workflow_id}")
+    code=$(printf '%s\n' "$response" | tail -n1)
+    if [[ "$code" -lt 200 ]] || [[ "$code" -ge 300 ]]; then
+        echo "ERROR: Could not update existing workflow (HTTP ${code})."
+        return 1
+    fi
+
+    real_trigger_id=$(printf '%s' "$updated" | python3 -c '
+import json
+import sys
+triggers = json.load(sys.stdin).get("triggers", [])
+print(triggers[0].get("id", "") if triggers else "")
+')
+    if [ -n "$real_trigger_id" ]; then
+        echo "http://shuffle-backend:5001/api/v1/hooks/webhook_${real_trigger_id}" \
+            > /tmp/aptl_shuffle_webhook_url
+    fi
+}
+
 # Search for our workflow by name
 EXISTING_ID=""
 if command -v jq &>/dev/null; then
@@ -138,9 +212,10 @@ fi
 
 if [[ -n "${EXISTING_ID}" ]]; then
     echo "Workflow '${WORKFLOW_NAME}' already exists (id: ${EXISTING_ID})."
-    echo "Skipping creation."
+    echo "Refreshing credentials and webhook metadata..."
+    refresh_workflow_credentials "$EXISTING_ID"
     echo ""
-    echo "=== Seed Complete (no changes) ==="
+    echo "=== Seed Complete (existing workflow refreshed) ==="
     exit 0
 fi
 

--- a/scripts/thehive-apikey.sh
+++ b/scripts/thehive-apikey.sh
@@ -45,7 +45,7 @@ fi
 # project key when TheHive accepts it so an idempotent seed rerun cannot leave
 # an already-created Shuffle workflow holding a revoked credential. A stale
 # key left by `lab stop -v` fails this probe and falls through to renewal.
-if [[ "${THEHIVE_API_KEY:-}" =~ ^[A-Za-z0-9]+$ ]] && \
+if [[ -n "${THEHIVE_API_KEY:-}" && ! "${THEHIVE_API_KEY}" =~ [[:space:]] ]] && \
     curl -sf "${TLS_FLAGS[@]}" -X POST "${THEHIVE_URL}/api/v1/query" \
         -H "Authorization: Bearer ${THEHIVE_API_KEY}" \
         -H "Content-Type: application/json" \

--- a/scripts/thehive-apikey.sh
+++ b/scripts/thehive-apikey.sh
@@ -5,12 +5,19 @@ set -euo pipefail
 # TheHive API Key Provisioner
 # =============================================================================
 # Ensures the APTL organisation exists in TheHive, creates an org-admin user,
-# and outputs a fresh API key. Prints the key to stdout:
+# and outputs a working API key. An existing generated key is reused while it
+# remains valid so downstream integrations are not invalidated by a rerun.
+# Prints the key to stdout:
 #
 #   THEHIVE_API_KEY=$(./scripts/thehive-apikey.sh)
 #
 # Idempotent -- safe to re-run. Creates org/user only if missing.
 # =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/aptl-env.sh"
+aptl_load_env_key "$PROJECT_DIR/.env" THEHIVE_API_KEY
 
 # SEC-006 / ADR-034: TheHive now serves HTTPS on 9000 using the
 # lab-managed CA. Seed paths verify against the CA bundle that
@@ -32,6 +39,20 @@ trap 'rm -f "$COOKIE"' EXIT
 TLS_FLAGS=()
 if [ -f "$THEHIVE_CACERT" ]; then
     TLS_FLAGS+=(--cacert "$THEHIVE_CACERT")
+fi
+
+# Renewing a TheHive key immediately revokes the previous one. Reuse the
+# project key when TheHive accepts it so an idempotent seed rerun cannot leave
+# an already-created Shuffle workflow holding a revoked credential. A stale
+# key left by `lab stop -v` fails this probe and falls through to renewal.
+if [[ "${THEHIVE_API_KEY:-}" =~ ^[A-Za-z0-9]+$ ]] && \
+    curl -sf "${TLS_FLAGS[@]}" -X POST "${THEHIVE_URL}/api/v1/query" \
+        -H "Authorization: Bearer ${THEHIVE_API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d '{"query":[{"_name":"listCase"},{"_name":"page","from":0,"to":1}]}' \
+        >/dev/null 2>&1; then
+    echo "$THEHIVE_API_KEY"
+    exit 0
 fi
 
 _curl() {

--- a/tests/test_seed_script_env.py
+++ b/tests/test_seed_script_env.py
@@ -80,3 +80,54 @@ def test_manual_seed_entrypoints_load_their_required_credentials():
         assert 'source "$SCRIPT_DIR/aptl-env.sh"' in text
         for key in keys:
             assert key in text
+
+
+def test_thehive_provisioner_reuses_a_working_key(tmp_path):
+    """A seed rerun must not revoke the key held by the Shuffle workflow."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env python3
+import sys
+
+args = sys.argv[1:]
+if (
+    "https://thehive.invalid/api/v1/query" in args
+    and "Authorization: Bearer ExistingKey123" in args
+):
+    raise SystemExit(0)
+raise SystemExit(88)
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "THEHIVE_API_KEY": "ExistingKey123",
+        "THEHIVE_URL": "https://thehive.invalid",
+        "THEHIVE_CACERT": str(tmp_path / "missing-ca.pem"),
+    }
+
+    result = subprocess.run(
+        [PROJECT_ROOT / "scripts" / "thehive-apikey.sh"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ExistingKey123"
+
+
+def test_existing_shuffle_workflow_refreshes_seeded_credentials():
+    """An idempotent rerun must repair credentials and webhook metadata."""
+    text = (PROJECT_ROOT / "scripts" / "seed-shuffle.sh").read_text()
+
+    assert "refresh_workflow_credentials()" in text
+    assert 'refresh_workflow_credentials "$EXISTING_ID"' in text
+    assert 'os.environ["MISP_API_KEY"]' in text
+    assert 'os.environ["THEHIVE_API_KEY"]' in text
+    assert "> /tmp/aptl_shuffle_webhook_url" in text

--- a/tests/test_seed_script_env.py
+++ b/tests/test_seed_script_env.py
@@ -94,7 +94,7 @@ import sys
 args = sys.argv[1:]
 if (
     "https://thehive.invalid/api/v1/query" in args
-    and "Authorization: Bearer ExistingKey123" in args
+    and "Authorization: Bearer Existing/Key123" in args
 ):
     raise SystemExit(0)
 raise SystemExit(88)
@@ -105,7 +105,10 @@ raise SystemExit(88)
     env = {
         **os.environ,
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
-        "THEHIVE_API_KEY": "ExistingKey123",
+        # Real TheHive keys can contain base64 punctuation such as ``/``.
+        # Rejecting every non-alphanumeric key renews it twice during one
+        # seed-prime run and leaves .env holding the already-revoked first key.
+        "THEHIVE_API_KEY": "Existing/Key123",
         "THEHIVE_URL": "https://thehive.invalid",
         "THEHIVE_CACERT": str(tmp_path / "missing-ca.pem"),
     }
@@ -119,7 +122,7 @@ raise SystemExit(88)
     )
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "ExistingKey123"
+    assert result.stdout.strip() == "Existing/Key123"
 
 
 def test_existing_shuffle_workflow_refreshes_seeded_credentials():


### PR DESCRIPTION
## Summary

- reuse an existing TheHive service key when the live API accepts it, renewing only after a volume reset or other invalidation
- validate/provision the key on every Shuffle seed run
- refresh credentials and webhook metadata in an existing APTL workflow instead of skipping it unchanged
- add behavior and script-contract regression coverage

## Participant impact

`seed-prime.sh` is documented as safe to rerun, but it renewed TheHive's key every time. Shuffle then skipped its existing workflow, leaving that workflow with the revoked key. Workflow runs appeared `FINISHED` while case creation failed.

This is stacked on #777 because it uses that PR's literal `.env` loader.

## Validation

- 6 focused tests passed
- shell syntax checks passed
- full `pre-commit run --all-files` passed
- live seed ran twice, preserved the TheHive key hash, refreshed the existing workflow, and regenerated webhook metadata