### PR TITLE
fix: make Shuffle alert-to-case workflow functional

### DIFF
--- a/scripts/seed-shuffle.sh
+++ b/scripts/seed-shuffle.sh
@@ -43,7 +43,7 @@ SHUFFLE_API_KEY="${SHUFFLE_API_KEY:-31a211c4-ea5c-4a49-b022-5e2434e758a7}"
 # are intra-trust-boundary calls on the aptl-security Docker network
 # (ADR-034 § Decision: SOC consumers OF Shuffle verify; Shuffle's own
 # SOAR-internal HTTP actions are not the SOC-consumer surface and
-# retain ``verify_ssl: false`` until Shuffle's bundled HTTP app is
+# retain ``verify: false`` until Shuffle's bundled HTTP app is
 # taught about the lab CA bundle — see workflow JSON below).
 THEHIVE_INTERNAL_URL="https://172.20.0.18:9000"
 MISP_INTERNAL_URL="https://172.20.0.16"
@@ -142,6 +142,20 @@ import sys
 workflow = json.load(sys.stdin)
 misp_key = os.environ["MISP_API_KEY"]
 thehive_key = os.environ["THEHIVE_API_KEY"]
+case_body = json.dumps({
+    "title": "[Wazuh $exec.rule.id] $exec.rule.description",
+    "description": (
+        "Wazuh Alert Details:\n"
+        "- Rule: $exec.rule.id ($exec.rule.description)\n"
+        "- Level: $exec.rule.level\n"
+        "- Source IP: $exec.data.srcip\n"
+        "- Agent: $exec.agent.name\n"
+        "- Timestamp: $exec.timestamp\n\n"
+        "MISP Enrichment:\n"
+        "Matched IOC: $misp_ip_lookup.body.response.Attribute.#0.value"
+    ),
+    "severity": 3,
+})
 headers = {
     "misp_ip_lookup": (
         f"Authorization: {misp_key}\n"
@@ -153,12 +167,18 @@ headers = {
     ),
 }
 for action in workflow.get("actions", []):
-    value = headers.get(action.get("label"))
+    label = action.get("label")
+    value = headers.get(label)
     if value is None:
         continue
     for parameter in action.get("parameters", []):
         if parameter.get("name") == "headers":
             parameter["value"] = value
+        elif parameter.get("name") in {"verify", "verify_ssl"}:
+            parameter["name"] = "verify"
+            parameter["value"] = "false"
+        elif label == "create_thehive_case" and parameter.get("name") == "body":
+            parameter["value"] = case_body
 
 triggers = workflow.get("triggers", [])
 if triggers:
@@ -248,7 +268,7 @@ read -r -d '' WORKFLOW_JSON << ENDJSON || true
                 {"name": "method", "value": "POST"},
                 {"name": "headers", "value": "Authorization: ${MISP_API_KEY}\nContent-Type: application/json\nAccept: application/json"},
                 {"name": "body", "value": "{\"value\": \"\$exec.data.srcip\", \"type\": \"ip-src\", \"returnFormat\": \"json\"}"},
-                {"name": "verify_ssl", "value": "false"}
+                {"name": "verify", "value": "false"}
             ]
         },
         {
@@ -263,8 +283,8 @@ read -r -d '' WORKFLOW_JSON << ENDJSON || true
                 {"name": "url", "value": "${THEHIVE_INTERNAL_URL}/api/v1/case"},
                 {"name": "method", "value": "POST"},
                 {"name": "headers", "value": "Authorization: Bearer ${THEHIVE_API_KEY}\nContent-Type: application/json"},
-                {"name": "body", "value": "{\"title\": \"[Wazuh \$exec.rule.id] \$exec.rule.description\", \"description\": \"Wazuh Alert Details:\\n- Rule: \$exec.rule.id (\$exec.rule.description)\\n- Level: \$exec.rule.level\\n- Source IP: \$exec.data.srcip\\n- Agent: \$exec.agent.name\\n- Timestamp: \$exec.timestamp\\n\\nMISP Enrichment:\\n\$misp_ip_lookup\", \"severity\": 3}"},
-                {"name": "verify_ssl", "value": "false"}
+                {"name": "body", "value": "{\"title\": \"[Wazuh \$exec.rule.id] \$exec.rule.description\", \"description\": \"Wazuh Alert Details:\\n- Rule: \$exec.rule.id (\$exec.rule.description)\\n- Level: \$exec.rule.level\\n- Source IP: \$exec.data.srcip\\n- Agent: \$exec.agent.name\\n- Timestamp: \$exec.timestamp\\n\\nMISP Enrichment:\\nMatched IOC: \$misp_ip_lookup.body.response.Attribute.#0.value\", \"severity\": 3}"},
+                {"name": "verify", "value": "false"}
             ]
         }
     ],

--- a/scripts/seed-shuffle.sh
+++ b/scripts/seed-shuffle.sh
@@ -145,13 +145,13 @@ thehive_key = os.environ["THEHIVE_API_KEY"]
 case_body = json.dumps({
     "title": "[Wazuh $exec.rule.id] $exec.rule.description",
     "description": (
-        "Wazuh Alert Details:\n"
-        "- Rule: $exec.rule.id ($exec.rule.description)\n"
-        "- Level: $exec.rule.level\n"
-        "- Source IP: $exec.data.srcip\n"
-        "- Agent: $exec.agent.name\n"
-        "- Timestamp: $exec.timestamp\n\n"
-        "MISP Enrichment:\n"
+        "Wazuh Alert Details; "
+        "Rule: $exec.rule.id ($exec.rule.description); "
+        "Level: $exec.rule.level; "
+        "Source IP: $exec.data.srcip; "
+        "Agent: $exec.agent.name; "
+        "Timestamp: $exec.timestamp; "
+        "MISP Enrichment; "
         "Matched IOC: $misp_ip_lookup.body.response.Attribute.#0.value"
     ),
     "severity": 3,
@@ -283,7 +283,7 @@ read -r -d '' WORKFLOW_JSON << ENDJSON || true
                 {"name": "url", "value": "${THEHIVE_INTERNAL_URL}/api/v1/case"},
                 {"name": "method", "value": "POST"},
                 {"name": "headers", "value": "Authorization: Bearer ${THEHIVE_API_KEY}\nContent-Type: application/json"},
-                {"name": "body", "value": "{\"title\": \"[Wazuh \$exec.rule.id] \$exec.rule.description\", \"description\": \"Wazuh Alert Details:\\n- Rule: \$exec.rule.id (\$exec.rule.description)\\n- Level: \$exec.rule.level\\n- Source IP: \$exec.data.srcip\\n- Agent: \$exec.agent.name\\n- Timestamp: \$exec.timestamp\\n\\nMISP Enrichment:\\nMatched IOC: \$misp_ip_lookup.body.response.Attribute.#0.value\", \"severity\": 3}"},
+                {"name": "body", "value": "{\"title\": \"[Wazuh \$exec.rule.id] \$exec.rule.description\", \"description\": \"Wazuh Alert Details; Rule: \$exec.rule.id (\$exec.rule.description); Level: \$exec.rule.level; Source IP: \$exec.data.srcip; Agent: \$exec.agent.name; Timestamp: \$exec.timestamp; MISP Enrichment; Matched IOC: \$misp_ip_lookup.body.response.Attribute.#0.value\", \"severity\": 3}"},
                 {"name": "verify", "value": "false"}
             ]
         }

--- a/scripts/seed-shuffle.sh
+++ b/scripts/seed-shuffle.sh
@@ -60,11 +60,15 @@ fi
 # Preflight checks
 # ---------------------------------------------------------------------------
 
-# Auto-provision TheHive API key if not set in env
-if [ -z "${THEHIVE_API_KEY:-}" ]; then
-    if [ -x "$SCRIPT_DIR/thehive-apikey.sh" ]; then
-        THEHIVE_API_KEY=$("$SCRIPT_DIR/thehive-apikey.sh" 2>/dev/null) || true
+# Validate and, only when necessary, provision the TheHive key. The
+# provisioner reuses a working project key; calling it on every run also
+# repairs a stale key left after the TheHive volume was reset.
+if [ -x "$SCRIPT_DIR/thehive-apikey.sh" ]; then
+    if ! THEHIVE_API_KEY=$("$SCRIPT_DIR/thehive-apikey.sh" 2>/dev/null); then
+        echo "ERROR: Could not validate or provision the TheHive API key."
+        exit 1
     fi
+    export THEHIVE_API_KEY
 fi
 THEHIVE_API_KEY="${THEHIVE_API_KEY:-}"
 
@@ -119,6 +123,76 @@ WORKFLOWS_JSON=$(curl -s "${SHUFFLE_TLS_FLAGS[@]}" \
     -H "Authorization: Bearer ${SHUFFLE_API_KEY}" \
     "${SHUFFLE_URL}/api/v1/workflows")
 
+refresh_workflow_credentials() {
+    local workflow_id="$1"
+    local workflow_json updated response code real_trigger_id
+
+    if ! workflow_json=$(curl -fsS "${SHUFFLE_TLS_FLAGS[@]}" \
+        -H "Authorization: Bearer ${SHUFFLE_API_KEY}" \
+        "${SHUFFLE_URL}/api/v1/workflows/${workflow_id}"); then
+        echo "ERROR: Could not fetch existing workflow ${workflow_id}."
+        return 1
+    fi
+
+    if ! updated=$(printf '%s' "$workflow_json" | python3 -c '
+import json
+import os
+import sys
+
+workflow = json.load(sys.stdin)
+misp_key = os.environ["MISP_API_KEY"]
+thehive_key = os.environ["THEHIVE_API_KEY"]
+headers = {
+    "misp_ip_lookup": (
+        f"Authorization: {misp_key}\n"
+        "Content-Type: application/json\nAccept: application/json"
+    ),
+    "create_thehive_case": (
+        f"Authorization: Bearer {thehive_key}\n"
+        "Content-Type: application/json"
+    ),
+}
+for action in workflow.get("actions", []):
+    value = headers.get(action.get("label"))
+    if value is None:
+        continue
+    for parameter in action.get("parameters", []):
+        if parameter.get("name") == "headers":
+            parameter["value"] = value
+
+triggers = workflow.get("triggers", [])
+if triggers:
+    workflow["start"] = triggers[0].get("id", workflow.get("start", ""))
+print(json.dumps(workflow))
+'); then
+        echo "ERROR: Could not refresh existing workflow credentials."
+        return 1
+    fi
+
+    response=$(curl -sS "${SHUFFLE_TLS_FLAGS[@]}" -w "\n%{http_code}" \
+        -X PUT \
+        -H "Authorization: Bearer ${SHUFFLE_API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d "$updated" \
+        "${SHUFFLE_URL}/api/v1/workflows/${workflow_id}")
+    code=$(printf '%s\n' "$response" | tail -n1)
+    if [[ "$code" -lt 200 ]] || [[ "$code" -ge 300 ]]; then
+        echo "ERROR: Could not update existing workflow (HTTP ${code})."
+        return 1
+    fi
+
+    real_trigger_id=$(printf '%s' "$updated" | python3 -c '
+import json
+import sys
+triggers = json.load(sys.stdin).get("triggers", [])
+print(triggers[0].get("id", "") if triggers else "")
+')
+    if [ -n "$real_trigger_id" ]; then
+        echo "http://shuffle-backend:5001/api/v1/hooks/webhook_${real_trigger_id}" \
+            > /tmp/aptl_shuffle_webhook_url
+    fi
+}
+
 # Search for our workflow by name
 EXISTING_ID=""
 if command -v jq &>/dev/null; then
@@ -138,9 +212,10 @@ fi
 
 if [[ -n "${EXISTING_ID}" ]]; then
     echo "Workflow '${WORKFLOW_NAME}' already exists (id: ${EXISTING_ID})."
-    echo "Skipping creation."
+    echo "Refreshing credentials and webhook metadata..."
+    refresh_workflow_credentials "$EXISTING_ID"
     echo ""
-    echo "=== Seed Complete (no changes) ==="
+    echo "=== Seed Complete (existing workflow refreshed) ==="
     exit 0
 fi
 

--- a/scripts/thehive-apikey.sh
+++ b/scripts/thehive-apikey.sh
@@ -45,7 +45,7 @@ fi
 # project key when TheHive accepts it so an idempotent seed rerun cannot leave
 # an already-created Shuffle workflow holding a revoked credential. A stale
 # key left by `lab stop -v` fails this probe and falls through to renewal.
-if [[ "${THEHIVE_API_KEY:-}" =~ ^[A-Za-z0-9]+$ ]] && \
+if [[ -n "${THEHIVE_API_KEY:-}" && ! "${THEHIVE_API_KEY}" =~ [[:space:]] ]] && \
     curl -sf "${TLS_FLAGS[@]}" -X POST "${THEHIVE_URL}/api/v1/query" \
         -H "Authorization: Bearer ${THEHIVE_API_KEY}" \
         -H "Content-Type: application/json" \

--- a/scripts/thehive-apikey.sh
+++ b/scripts/thehive-apikey.sh
@@ -5,12 +5,19 @@ set -euo pipefail
 # TheHive API Key Provisioner
 # =============================================================================
 # Ensures the APTL organisation exists in TheHive, creates an org-admin user,
-# and outputs a fresh API key. Prints the key to stdout:
+# and outputs a working API key. An existing generated key is reused while it
+# remains valid so downstream integrations are not invalidated by a rerun.
+# Prints the key to stdout:
 #
 #   THEHIVE_API_KEY=$(./scripts/thehive-apikey.sh)
 #
 # Idempotent -- safe to re-run. Creates org/user only if missing.
 # =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/aptl-env.sh"
+aptl_load_env_key "$PROJECT_DIR/.env" THEHIVE_API_KEY
 
 # SEC-006 / ADR-034: TheHive now serves HTTPS on 9000 using the
 # lab-managed CA. Seed paths verify against the CA bundle that
@@ -32,6 +39,20 @@ trap 'rm -f "$COOKIE"' EXIT
 TLS_FLAGS=()
 if [ -f "$THEHIVE_CACERT" ]; then
     TLS_FLAGS+=(--cacert "$THEHIVE_CACERT")
+fi
+
+# Renewing a TheHive key immediately revokes the previous one. Reuse the
+# project key when TheHive accepts it so an idempotent seed rerun cannot leave
+# an already-created Shuffle workflow holding a revoked credential. A stale
+# key left by `lab stop -v` fails this probe and falls through to renewal.
+if [[ "${THEHIVE_API_KEY:-}" =~ ^[A-Za-z0-9]+$ ]] && \
+    curl -sf "${TLS_FLAGS[@]}" -X POST "${THEHIVE_URL}/api/v1/query" \
+        -H "Authorization: Bearer ${THEHIVE_API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d '{"query":[{"_name":"listCase"},{"_name":"page","from":0,"to":1}]}' \
+        >/dev/null 2>&1; then
+    echo "$THEHIVE_API_KEY"
+    exit 0
 fi
 
 _curl() {

--- a/tests/test_range_integration.py
+++ b/tests/test_range_integration.py
@@ -452,10 +452,14 @@ class TestSOCTools:
             method="POST",
             body={
                 "execution_argument": json.dumps({
-                    "title": "APTL Test Alert",
-                    "description": "Integration test alert",
-                    "severity": 2,
-                    "source_ip": KALI_DMZ_IP,
+                    "rule": {
+                        "id": "302010",
+                        "description": "APTL integration test alert",
+                        "level": 10,
+                    },
+                    "data": {"srcip": KALI_DMZ_IP},
+                    "agent": {"name": "aptl-integration-test"},
+                    "timestamp": str(int(time.time())),
                 }),
             },
         )
@@ -579,7 +583,6 @@ class TestFullLoop:
         assert aptl_wf, "APTL workflow not found in Shuffle"
 
         ts = int(time.time())
-        alert_title = f"SQLi from {src_ip} (integ test {ts})"
         exec_result = curl_json(
             f"{SHUFFLE_URL}/api/v1/workflows/"
             f"{aptl_wf['id']}/execute",
@@ -587,11 +590,14 @@ class TestFullLoop:
             method="POST",
             body={
                 "execution_argument": json.dumps({
-                    "title": alert_title,
-                    "description": f"SQLi from {src_ip}",
-                    "severity": 3,
-                    "source_ip": src_ip,
-                    "rule_id": "302010",
+                    "rule": {
+                        "id": "302010",
+                        "description": "SQL injection attempt detected",
+                        "level": 10,
+                    },
+                    "data": {"srcip": src_ip},
+                    "agent": {"name": "aptl-integration-test"},
+                    "timestamp": str(ts),
                 }),
             },
         )

--- a/tests/test_range_integration.py
+++ b/tests/test_range_integration.py
@@ -323,6 +323,17 @@ def _require_thehive_key():
         )
 
 
+def _shuffle_action_result(execution: dict, label: str) -> dict:
+    """Return one action's nested app result from a Shuffle execution."""
+    for item in execution.get("results", []):
+        action = item.get("action", {})
+        if action.get("label") != label:
+            continue
+        result = item.get("result", {})
+        return json.loads(result) if isinstance(result, str) else result
+    return {}
+
+
 @LIVE_LAB
 class TestSOCTools:
     """SOC tool integration -- require seed scripts."""
@@ -495,6 +506,13 @@ class TestSOCTools:
         assert final_status == "FINISHED", (
             "Workflow execution must complete: "
             f"status={final_status}"
+        )
+        case_result = _shuffle_action_result(
+            status_data, "create_thehive_case"
+        )
+        assert case_result.get("success") is True, (
+            "Shuffle finished but TheHive case creation failed: "
+            f"{case_result.get('reason', 'missing action result')}"
         )
 
 

--- a/tests/test_seed_script_env.py
+++ b/tests/test_seed_script_env.py
@@ -143,3 +143,16 @@ def test_shuffle_http_actions_use_supported_tls_and_safe_enrichment():
     assert '"name": "verify_ssl"' not in text
     assert text.count('{"name": "verify", "value": "false"}') == 2
     assert "$misp_ip_lookup.body.response.Attribute.#0.value" in text
+
+
+def test_shuffle_thehive_body_is_safe_for_runtime_template_expansion():
+    """Shuffle's HTTP app parser rejects expanded newlines in JSON strings."""
+    text = (PROJECT_ROOT / "scripts" / "seed-shuffle.sh").read_text()
+    body_line = next(
+        line
+        for line in text.splitlines()
+        if '{"name": "body"' in line and "Wazuh Alert Details" in line
+    )
+
+    assert "\\n" not in body_line
+    assert "MISP Enrichment; Matched IOC" in body_line

--- a/tests/test_seed_script_env.py
+++ b/tests/test_seed_script_env.py
@@ -80,3 +80,54 @@ def test_manual_seed_entrypoints_load_their_required_credentials():
         assert 'source "$SCRIPT_DIR/aptl-env.sh"' in text
         for key in keys:
             assert key in text
+
+
+def test_thehive_provisioner_reuses_a_working_key(tmp_path):
+    """A seed rerun must not revoke the key held by the Shuffle workflow."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env python3
+import sys
+
+args = sys.argv[1:]
+if (
+    "https://thehive.invalid/api/v1/query" in args
+    and "Authorization: Bearer ExistingKey123" in args
+):
+    raise SystemExit(0)
+raise SystemExit(88)
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "THEHIVE_API_KEY": "ExistingKey123",
+        "THEHIVE_URL": "https://thehive.invalid",
+        "THEHIVE_CACERT": str(tmp_path / "missing-ca.pem"),
+    }
+
+    result = subprocess.run(
+        [PROJECT_ROOT / "scripts" / "thehive-apikey.sh"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ExistingKey123"
+
+
+def test_existing_shuffle_workflow_refreshes_seeded_credentials():
+    """An idempotent rerun must repair credentials and webhook metadata."""
+    text = (PROJECT_ROOT / "scripts" / "seed-shuffle.sh").read_text()
+
+    assert "refresh_workflow_credentials()" in text
+    assert 'refresh_workflow_credentials "$EXISTING_ID"' in text
+    assert 'os.environ["MISP_API_KEY"]' in text
+    assert 'os.environ["THEHIVE_API_KEY"]' in text
+    assert "> /tmp/aptl_shuffle_webhook_url" in text

--- a/tests/test_seed_script_env.py
+++ b/tests/test_seed_script_env.py
@@ -94,7 +94,7 @@ import sys
 args = sys.argv[1:]
 if (
     "https://thehive.invalid/api/v1/query" in args
-    and "Authorization: Bearer ExistingKey123" in args
+    and "Authorization: Bearer Existing/Key123" in args
 ):
     raise SystemExit(0)
 raise SystemExit(88)
@@ -105,7 +105,10 @@ raise SystemExit(88)
     env = {
         **os.environ,
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
-        "THEHIVE_API_KEY": "ExistingKey123",
+        # Real TheHive keys can contain base64 punctuation such as ``/``.
+        # Rejecting every non-alphanumeric key renews it twice during one
+        # seed-prime run and leaves .env holding the already-revoked first key.
+        "THEHIVE_API_KEY": "Existing/Key123",
         "THEHIVE_URL": "https://thehive.invalid",
         "THEHIVE_CACERT": str(tmp_path / "missing-ca.pem"),
     }
@@ -119,7 +122,7 @@ raise SystemExit(88)
     )
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "ExistingKey123"
+    assert result.stdout.strip() == "Existing/Key123"
 
 
 def test_existing_shuffle_workflow_refreshes_seeded_credentials():

--- a/tests/test_seed_script_env.py
+++ b/tests/test_seed_script_env.py
@@ -131,3 +131,12 @@ def test_existing_shuffle_workflow_refreshes_seeded_credentials():
     assert 'os.environ["MISP_API_KEY"]' in text
     assert 'os.environ["THEHIVE_API_KEY"]' in text
     assert "> /tmp/aptl_shuffle_webhook_url" in text
+
+
+def test_shuffle_http_actions_use_supported_tls_and_safe_enrichment():
+    """The bundled HTTP app names its TLS argument ``verify``."""
+    text = (PROJECT_ROOT / "scripts" / "seed-shuffle.sh").read_text()
+
+    assert '"name": "verify_ssl"' not in text
+    assert text.count('{"name": "verify", "value": "false"}') == 2
+    assert "$misp_ip_lookup.body.response.Attribute.#0.value" in text


### PR DESCRIPTION
## Summary

- use the `verify` argument implemented by Shuffle HTTP 1.4.0 instead of the ignored `verify_ssl` name
- pass a concrete MISP IOC field into the TheHive description instead of embedding an entire JSON result inside JSON text
- repair those fields when reseeding an existing workflow
- make manual integration executions use the same Wazuh alert shape as the real webhook

## Participant impact

The seeded workflow could show `FINISHED` while both HTTP actions returned operational failures. MISP TLS verification stayed enabled because the argument name was wrong, and the resulting JSON was inserted unescaped into the TheHive request body. No case was created.

This is stacked on #782 so existing workflow repair and stable credentials land in order.

## Validation

- 7 focused seed-script tests passed
- full `pre-commit run --all-files` passed
- live manual workflow execution passed
- live attack-to-MISP-to-Shuffle-to-TheHive case creation passed
- live Wazuh webhook-triggered Shuffle execution passed