### PR TITLE
fix: make MISP event seeding idempotent

### DIFF
--- a/scripts/seed-misp.sh
+++ b/scripts/seed-misp.sh
@@ -73,6 +73,19 @@ misp_api() {
     curl "${args[@]}" "${MISP_URL}${endpoint}"
 }
 
+misp_search_event_field() {
+    local field="$1"
+    python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+events = payload.get("response", []) if isinstance(payload, dict) else payload
+event = events[0].get("Event", {}) if events else {}
+print(event.get(sys.argv[1], ""))
+' "$field"
+}
+
 # ---------------------------------------------------------------------------
 # Step 1: Check if the event already exists
 # ---------------------------------------------------------------------------
@@ -85,9 +98,9 @@ EVENT_ID=""
 EVENT_UUID=""
 if echo "${SEARCH_RESULT}" | grep -q '"id"'; then
     EVENT_ID=$(echo "${SEARCH_RESULT}" \
-        | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0]['Event']['id'] if d else '')" 2>/dev/null || true)
+        | misp_search_event_field id 2>/dev/null || true)
     EVENT_UUID=$(echo "${SEARCH_RESULT}" \
-        | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0]['Event']['uuid'] if d else '')" 2>/dev/null || true)
+        | misp_search_event_field uuid 2>/dev/null || true)
 fi
 
 if [[ -n "${EVENT_ID}" ]]; then

--- a/tests/test_seed_misp_script.py
+++ b/tests/test_seed_misp_script.py
@@ -1,0 +1,67 @@
+"""Behavioral tests for the participant-invoked MISP seed script."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SEED_SCRIPT = PROJECT_ROOT / "scripts" / "seed-misp.sh"
+
+
+def test_existing_event_in_misp_response_envelope_is_reused(tmp_path):
+    """MISP's restSearch response is an object containing ``response``."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    call_log = tmp_path / "curl-calls"
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+args = sys.argv[1:]
+method = args[args.index("-X") + 1]
+url = args[-1]
+with pathlib.Path(os.environ["APTL_TEST_CURL_LOG"]).open("a") as log:
+    log.write(f"{method} {url}\\n")
+
+if url.endswith("/events/restSearch"):
+    print(json.dumps({"response": [{"Event": {"id": "42", "uuid": "event-42"}}]}))
+elif "/attributes/add/42" in url:
+    print(json.dumps({"Attribute": {"id": "1"}}))
+elif url.endswith("/tags/attachTagToObject"):
+    print(json.dumps({"success": "Event tagged successfully"}))
+elif url.endswith("/events"):
+    print(json.dumps({"Event": {"id": "99", "uuid": "unexpected-new-event"}}))
+else:
+    raise SystemExit(2)
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "APTL_TEST_CURL_LOG": str(call_log),
+        "MISP_API_KEY": "test-key",
+        "MISP_URL": "https://misp.invalid",
+        "MISP_CACERT": str(tmp_path / "missing-ca.pem"),
+    }
+
+    result = subprocess.run(
+        [SEED_SCRIPT],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Event already exists (id: 42" in result.stdout
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "POST https://misp.invalid/events" not in calls


### PR DESCRIPTION
## Problem

MISP's `/events/restSearch` endpoint returns an object containing a `response` array. The seed script expected a bare array, treated every existing-event lookup as empty, and created a duplicate threat-intelligence event on every lab start.

## Fix

Parse both the current response envelope and a legacy bare-array response. Add a behavioral fake-API test proving an existing event is reused and the event-creation endpoint is not called.

## Validation

- `pytest tests/test_seed_misp_script.py -q`
- `bash -n scripts/seed-misp.sh`
- full pre-commit gate (2,220 passed, 91 skipped)