### PR TITLE
fix: surface required prime seed failures

### DIFF
--- a/scripts/seed-prime.sh
+++ b/scripts/seed-prime.sh
@@ -19,6 +19,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENV_FILE="$PROJECT_DIR/.env"
+SEED_FAILURES=()
+
+record_seed_failure() {
+    local component="$1"
+    local message="$2"
+    echo "  ERROR: $message"
+    SEED_FAILURES+=("$component")
+}
 
 ensure_env_file() {
     if [ ! -f "$ENV_FILE" ]; then
@@ -98,8 +106,8 @@ echo ""
 echo "[1/7] Provisioning TheHive API key..."
 
 if [ -x "$SCRIPT_DIR/thehive-apikey.sh" ]; then
-    THEHIVE_API_KEY=$("$SCRIPT_DIR/thehive-apikey.sh" 2>/dev/null) || true
-    if [ -n "$THEHIVE_API_KEY" ]; then
+    if THEHIVE_API_KEY=$("$SCRIPT_DIR/thehive-apikey.sh" 2>/dev/null) && \
+        [ -n "$THEHIVE_API_KEY" ]; then
         export THEHIVE_API_KEY
         echo "  TheHive API key provisioned: ${THEHIVE_API_KEY:0:8}..."
 
@@ -116,10 +124,10 @@ if [ -x "$SCRIPT_DIR/thehive-apikey.sh" ]; then
         update_env_var SHUFFLE_API_KEY "${SHUFFLE_API_KEY:-31a211c4-ea5c-4a49-b022-5e2434e758a7}"
         echo "  TheHive/MISP/Shuffle API keys written to .env (mode 600)"
     else
-        echo "  WARNING: Could not provision TheHive API key (non-fatal)"
+        record_seed_failure "TheHive API key" "Could not provision TheHive API key"
     fi
 else
-    echo "  SKIP: thehive-apikey.sh not found"
+    record_seed_failure "TheHive API key" "thehive-apikey.sh not found"
 fi
 
 # ---------------------------------------------------------------------------
@@ -129,16 +137,16 @@ echo ""
 echo "[2/7] Provisioning Cortex API key..."
 
 if [ -x "$SCRIPT_DIR/cortex-apikey.sh" ]; then
-    CORTEX_API_KEY=$("$SCRIPT_DIR/cortex-apikey.sh") || true
-    if [ -n "$CORTEX_API_KEY" ]; then
+    if CORTEX_API_KEY=$("$SCRIPT_DIR/cortex-apikey.sh") && \
+        [ -n "$CORTEX_API_KEY" ]; then
         export CORTEX_API_KEY
         update_env_var CORTEX_API_KEY "$CORTEX_API_KEY"
         echo "  Cortex API key provisioned and written to .env (mode 600)"
     else
-        echo "  WARNING: Could not provision Cortex API key (non-fatal)"
+        record_seed_failure "Cortex API key" "Could not provision Cortex API key"
     fi
 else
-    echo "  SKIP: cortex-apikey.sh not found"
+    record_seed_failure "Cortex API key" "cortex-apikey.sh not found"
 fi
 
 # ---------------------------------------------------------------------------
@@ -172,7 +180,9 @@ while [ $elapsed -lt $max_wait ]; do
 done
 
 if [ $elapsed -ge $max_wait ]; then
-    echo "  WARNING: Indexer may not be ready after ${max_wait}s, continuing anyway..."
+    record_seed_failure \
+        "Wazuh Indexer" \
+        "Indexer was not ready after ${max_wait}s"
 fi
 
 # ---------------------------------------------------------------------------
@@ -182,9 +192,11 @@ echo ""
 echo "[4/7] Seeding MISP with lab threat intelligence..."
 
 if [ -x "$SCRIPT_DIR/seed-misp.sh" ]; then
-    "$SCRIPT_DIR/seed-misp.sh" || echo "  WARNING: MISP seeding failed (non-fatal)"
+    if ! "$SCRIPT_DIR/seed-misp.sh"; then
+        record_seed_failure "MISP" "MISP seeding failed"
+    fi
 else
-    echo "  SKIP: seed-misp.sh not found or not executable"
+    record_seed_failure "MISP" "seed-misp.sh not found or not executable"
 fi
 
 # ---------------------------------------------------------------------------
@@ -194,9 +206,11 @@ echo ""
 echo "[5/7] Seeding Shuffle with SOAR workflows..."
 
 if [ -x "$SCRIPT_DIR/seed-shuffle.sh" ]; then
-    "$SCRIPT_DIR/seed-shuffle.sh" || echo "  WARNING: Shuffle seeding failed (non-fatal)"
+    if ! "$SCRIPT_DIR/seed-shuffle.sh"; then
+        record_seed_failure "Shuffle" "Shuffle seeding failed"
+    fi
 else
-    echo "  SKIP: seed-shuffle.sh not found or not executable"
+    record_seed_failure "Shuffle" "seed-shuffle.sh not found or not executable"
 fi
 
 # ---------------------------------------------------------------------------
@@ -205,14 +219,21 @@ fi
 echo ""
 echo "[6/7] Configuring Wazuh -> Shuffle integration..."
 
-WEBHOOK_FILE="/tmp/aptl_shuffle_webhook_url"
+WEBHOOK_FILE="${APTL_SHUFFLE_WEBHOOK_FILE:-/tmp/aptl_shuffle_webhook_url}"
 if [ -f "$WEBHOOK_FILE" ]; then
     WEBHOOK_URL=$(cat "$WEBHOOK_FILE")
-    docker exec aptl-wazuh-manager bash -c \
-        "echo '${WEBHOOK_URL}' > /var/ossec/etc/shuffle_webhook_url"
-    echo "  Webhook URL written to Wazuh manager: ${WEBHOOK_URL}"
+    if docker exec aptl-wazuh-manager bash -c \
+        "echo '${WEBHOOK_URL}' > /var/ossec/etc/shuffle_webhook_url"; then
+        echo "  Webhook URL written to Wazuh manager: ${WEBHOOK_URL}"
+    else
+        record_seed_failure \
+            "Wazuh to Shuffle" \
+            "Could not write the Shuffle webhook URL to Wazuh"
+    fi
 else
-    echo "  WARNING: No webhook URL from Shuffle seed (non-fatal)"
+    record_seed_failure \
+        "Wazuh to Shuffle" \
+        "Shuffle seed did not produce a webhook URL"
 fi
 
 # ---------------------------------------------------------------------------
@@ -236,13 +257,27 @@ if [ -n "$ws_pubkey" ]; then
         echo "  Workstation key already present in victim authorized_keys"
     fi
 else
-    echo "  WARNING: Could not read workstation SSH public key"
+    record_seed_failure \
+        "Workstation to victim" \
+        "Could not read workstation SSH public key"
 fi
 
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
+if [ ${#SEED_FAILURES[@]} -gt 0 ]; then
+    echo "============================================="
+    echo "  Prime Scenario Seed Incomplete"
+    echo "============================================="
+    echo ""
+    echo "Required seed steps failed:"
+    printf '  - %s\n' "${SEED_FAILURES[@]}"
+    echo ""
+    echo "Resolve the errors above and re-run scripts/seed-prime.sh."
+    exit 1
+fi
+
 echo "============================================="
 echo "  Prime Scenario Seed Complete"
 echo "============================================="

--- a/tests/test_seed_prime_failures.py
+++ b/tests/test_seed_prime_failures.py
@@ -24,6 +24,9 @@ def test_required_seed_failure_returns_nonzero_and_names_component(tmp_path):
     fake_bin.mkdir()
     shutil.copy2(PROJECT_ROOT / "scripts" / "seed-prime.sh", scripts)
     (scripts / "seed-prime.sh").chmod(0o755)
+    env_helper = PROJECT_ROOT / "scripts" / "aptl-env.sh"
+    if env_helper.exists():
+        shutil.copy2(env_helper, scripts)
 
     _write_executable(scripts / "thehive-apikey.sh", "#!/bin/sh\nexit 1\n")
     _write_executable(

--- a/tests/test_seed_prime_failures.py
+++ b/tests/test_seed_prime_failures.py
@@ -1,0 +1,73 @@
+"""Failure reporting for the full TechVault prime seed."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_required_seed_failure_returns_nonzero_and_names_component(tmp_path):
+    project = tmp_path / "project"
+    scripts = project / "scripts"
+    fake_bin = tmp_path / "bin"
+    scripts.mkdir(parents=True)
+    fake_bin.mkdir()
+    shutil.copy2(PROJECT_ROOT / "scripts" / "seed-prime.sh", scripts)
+    (scripts / "seed-prime.sh").chmod(0o755)
+
+    _write_executable(scripts / "thehive-apikey.sh", "#!/bin/sh\nexit 1\n")
+    _write_executable(
+        scripts / "cortex-apikey.sh",
+        "#!/bin/sh\nprintf 'cortex-test-key\\n'\n",
+    )
+    _write_executable(scripts / "seed-misp.sh", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        scripts / "seed-shuffle.sh",
+        "#!/bin/sh\nprintf 'http://shuffle.invalid/hook' > "
+        '"$APTL_SHUFFLE_WEBHOOK_FILE"\n',
+    )
+    _write_executable(
+        fake_bin / "docker",
+        """#!/bin/sh
+if [ "$1" = inspect ]; then
+    printf 'healthy\n'
+elif [ "$1 $2 $3" = "exec aptl-workstation cat" ]; then
+    printf 'ssh-rsa AAAATEST participant@workstation\n'
+elif [ "$1 $2 $3" = "exec aptl-victim grep" ]; then
+    printf '1\n'
+fi
+""",
+    )
+    _write_executable(
+        fake_bin / "curl",
+        "#!/bin/sh\nprintf '{\"status\":\"green\"}\\n'\n",
+    )
+    webhook_file = tmp_path / "shuffle-webhook"
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "APTL_SHUFFLE_WEBHOOK_FILE": str(webhook_file),
+    }
+
+    result = subprocess.run(
+        [scripts / "seed-prime.sh"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 1
+    assert "Prime Scenario Seed Incomplete" in result.stdout
+    assert "- TheHive API key" in result.stdout
+    assert "Prime Scenario Seed Complete" not in result.stdout


### PR DESCRIPTION
## Problem

The full TechVault seed treated required TheHive, Cortex, MISP, Shuffle, webhook, indexer, and workstation-trust failures as non-fatal, then printed `Prime Scenario Seed Complete`. Because `aptl lab start` uses the script's exit status to derive its structured readiness outcome, a broken SOC integration could be reported as fully ready.

## Fix

Collect failures for required prime seed components, print an actionable incomplete summary, and return nonzero. This lets the existing startup diagnostic path report `degraded_unusable` instead of a false ready state. The successful path is unchanged.

## Validation

- behavioral test with a failed TheHive provisioner verifies exit 1, named component, and no success headline
- `bash -n scripts/seed-prime.sh`
- full pre-commit gate (2,220 passed, 91 skipped)