### PR TITLE
fix: generate current MCP client configuration

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,69 +1,52 @@
 {
   "mcpServers": {
-    "kali-ssh": {
+    "aptl-red": {
       "command": "node",
       "args": ["./mcp/mcp-red/build/index.js"],
       "env": {
         "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
       }
     },
-    "reverse-sandbox-ssh": {
+    "aptl-indexer": {
       "command": "node",
-      "args": ["./mcp/mcp-reverse/build/index.js"],
+      "args": ["./mcp/mcp-indexer/build/index.js"],
       "env": {
         "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
       }
     },
-    "shuffle": {
+    "aptl-wazuh": {
+      "command": "node",
+      "args": ["./mcp/mcp-wazuh/build/index.js"],
+      "env": {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
+      }
+    },
+    "aptl-network": {
+      "command": "node",
+      "args": ["./mcp/mcp-network/build/index.js"],
+      "env": {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
+      }
+    },
+    "aptl-threatintel": {
+      "command": "node",
+      "args": ["./mcp/mcp-threatintel/build/index.js"],
+      "env": {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
+      }
+    },
+    "aptl-casemgmt": {
+      "command": "node",
+      "args": ["./mcp/mcp-casemgmt/build/index.js"],
+      "env": {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
+      }
+    },
+    "aptl-soar": {
       "command": "node",
       "args": ["./mcp/mcp-soar/build/index.js"],
       "env": {
-        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
-        "SHUFFLE_API_KEY": "<run seed-shuffle.sh or check Shuffle UI>"
-      }
-    },
-    "indexer": {
-      "command": "node",
-      "args": ["./mcp/mcp-indexer/build/index.js"],
-      "env": {
-        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
-        "INDEXER_USERNAME": "admin",
-        "INDEXER_PASSWORD": "SecretPassword",
-        "API_USERNAME": "wazuh-wui",
-        "API_PASSWORD": "WazuhPass123!"
-      }
-    },
-    "wazuh": {
-      "command": "./tools/bin/mcp-server-wazuh",
-      "env": {
-        "WAZUH_API_HOST": "localhost",
-        "WAZUH_API_PORT": "55000",
-        "WAZUH_API_USERNAME": "wazuh-wui",
-        "WAZUH_API_PASSWORD": "WazuhPass123!",
-        "WAZUH_INDEXER_HOST": "localhost",
-        "WAZUH_INDEXER_PORT": "9200",
-        "WAZUH_INDEXER_USERNAME": "admin",
-        "WAZUH_INDEXER_PASSWORD": "SecretPassword",
-        "WAZUH_VERIFY_SSL": "false",
-        "RUST_LOG": "warn"
-      }
-    },
-    "misp": {
-      "command": "./tools/misp-mcp-server/.venv/bin/python",
-      "args": ["./tools/misp-mcp-server/misp_server.py"],
-      "env": {
-        "MISP_URL": "https://localhost:8443",
-        "MISP_API_KEY": "<check MISP UI or .env>",
-        "MISP_VERIFY_SSL": "False"
-      }
-    },
-    "thehive": {
-      "command": "./tools/bin/thehivemcp",
-      "args": ["--transport", "stdio"],
-      "env": {
-        "THEHIVE_URL": "https://localhost:9000",
-        "THEHIVE_API_KEY": "<run scripts/thehive-apikey.sh>",
-        "THEHIVE_ORGANISATION": "APTL"
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -145,13 +145,20 @@ Authoring and selection details: [SDL Reference](docs/sdl/index.md) · [Curated 
 
 ## AI Agents (MCP)
 
-Build the MCP servers:
+`aptl lab start` builds the seven MCP servers for the default scenario and
+creates a private `.mcp.json` client configuration with the generated lab
+credentials. Start your AI client from the project directory so its relative
+entry points resolve correctly.
+
+To rebuild the MCP artifacts without restarting the lab:
 
 ```bash
 ./mcp/build-all-mcps.sh
 ```
 
-Point your AI client (Claude Code, Cursor, Cline) at the entry points under `./mcp/<server>/build/index.js`. Full setup: [MCP Integration](docs/components/mcp-integration.md).
+The repository still builds the optional reverse MCP artifact, but the
+generated default client config omits it because the default SDL has no
+reverse node. Full setup: [MCP Integration](docs/components/mcp-integration.md).
 
 Smoke-test the wiring once the lab is up:
 

--- a/docs/components/mcp-integration.md
+++ b/docs/components/mcp-integration.md
@@ -13,7 +13,6 @@ flowchart TD
     B --> F[mcp-threatintel]
     B --> G[mcp-casemgmt]
     B --> I[mcp-soar]
-    B --> J[mcp-reverse]
     B --> K[mcp-indexer]
 
     C --> L[Kali Container<br/>172.20.4.30]
@@ -23,8 +22,11 @@ flowchart TD
     F --> P[MISP<br/>172.20.0.16]
     G --> Q[TheHive<br/>172.20.0.18]
     I --> R[Shuffle SOAR<br/>172.20.0.20]
-    J --> S[Reverse Engineering<br/>172.20.0.27]
 ```
+
+The optional `mcp-reverse` server is built with the other artifacts but is not
+written to the default client configuration because `techvault-operational`
+does not realize a reverse-engineering node.
 
 ## Common Library
 
@@ -41,23 +43,34 @@ All SSH-based MCPs use `aptl-mcp-common` for session management, connection pool
 | mcp-threatintel | MISP (172.20.0.16) | HTTPS | IOC search, indicator submission |
 | mcp-casemgmt | TheHive (172.20.0.18) | HTTPS | Case management, observables, analyzers |
 | mcp-soar | Shuffle (172.20.0.20) | HTTPS | Workflow triggers, response actions |
-| mcp-reverse | Reverse eng (172.20.0.27) | SSH | Binary analysis, YARA, capa |
 
 ## Setup
 
-Build all MCP servers:
+The normal participant path is automatic:
+
+```bash
+aptl lab start
+```
+
+Startup builds the MCP artifacts, creates `.mcp.json` from the shipped current
+template when it is missing, and injects the generated MISP, TheHive, and
+Shuffle keys. Existing MCP client entries are preserved. Start Claude Code,
+Cursor, Cline, or another project-config-aware client from the project root.
+
+To rebuild all artifacts without restarting the lab:
 
 ```bash
 ./mcp/build-all-mcps.sh
 ```
 
-Or build individually:
+Or rebuild one server:
 
 ```bash
 cd mcp/mcp-red && npm install && npm run build && cd ../..
 ```
 
-Configure your AI client to connect to `./mcp/<server>/build/index.js`.
+The generated config points every enabled server at
+`./mcp/<server>/build/index.js`.
 
 ## Usage
 
@@ -72,4 +85,3 @@ Configure your AI client to connect to `./mcp/<server>/build/index.js`.
 - Search threat intelligence
 - Manage incident cases
 - Trigger SOAR playbooks
-- Run binary analysis

--- a/docs/components/mcp-smoke-test-protocol.md
+++ b/docs/components/mcp-smoke-test-protocol.md
@@ -60,7 +60,9 @@ This protocol is executed by an AI agent with the APTL MCP servers connected. Th
 
 ### MCP Server Architecture
 
-APTL uses 8 custom MCP servers, all Node.js, built from `mcp/`:
+APTL builds 8 custom Node.js MCP servers from `mcp/`. The default operational
+scenario configures the 7 servers whose target nodes are present; the reverse
+server remains an optional build artifact.
 
 | Server (.mcp.json name) | Type | Source |
 |---|---|---|
@@ -75,7 +77,9 @@ APTL uses 8 custom MCP servers, all Node.js, built from `mcp/`:
 
 ### Setup
 
-The agent's MCP client must have all 8 APTL servers configured (see `.mcp.json`). Environment variables required:
+For the default scenario, the agent's MCP client must have the 7 generated
+APTL servers configured in `.mcp.json`. Add `aptl-reverse` only when a selected
+scenario realizes its target node. Environment variables required:
 
 | Variable | Used by | Source |
 |---|---|---|
@@ -216,7 +220,7 @@ when neither automated tests nor agent MCP access are available.
 3. Wait for startup to complete (5-10 min for full SOC stack).
 4. Build MCP servers: `./mcp/build-all-mcps.sh`
 5. Install published MCPs (see `tools/.gitignore` for details).
-6. Configure your MCP client to load all APTL servers (see `.mcp.json`).
+6. Confirm your MCP client loaded the generated APTL servers from `.mcp.json`.
 
 ### 1. Container Health
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -2122,19 +2122,24 @@ def orchestrate_lab_start(
 
 
 def _sync_mcp_config_keys(project_dir: Path) -> None:
-    """Update `.mcp.json` env entries for dynamic API keys from `.env`.
+    """Create or update `.mcp.json` with dynamic API keys from `.env`.
 
-    Idempotent: runs after seed-prime, only touches the three known dynamic
-    server names, only updates keys the seed script defines. If `.mcp.json`
-    does not exist (e.g. fresh checkout, user hasn't configured an MCP
-    client yet) this is a no-op.
+    A fresh lab copies the shipped example so its seven enabled custom MCPs
+    are client-ready without a manual configuration step. Existing client
+    configuration is preserved: only the three known dynamic credential
+    entries are refreshed after seed-prime.
     """
     import json
 
     mcp_path = project_dir / ".mcp.json"
+    example_path = project_dir / ".mcp.json.example"
     env_path = project_dir / ".env"
-    if not mcp_path.exists() or not env_path.exists():
-        log.debug("MCP sync: missing %s or %s, skipping", mcp_path.name, env_path.name)
+    source_path = mcp_path if mcp_path.exists() else example_path
+    if not source_path.exists() or not env_path.exists():
+        log.debug(
+            "MCP sync: missing client template/config or %s, skipping",
+            env_path.name,
+        )
         return
 
     # Use the canonical .env parser so quoted values, `export` prefixes,
@@ -2152,7 +2157,7 @@ def _sync_mcp_config_keys(project_dir: Path) -> None:
         "aptl-soar": ["SHUFFLE_API_KEY"],
     }
 
-    cfg = json.loads(mcp_path.read_text())
+    cfg = json.loads(source_path.read_text())
     servers = cfg.get("mcpServers", {})
     updated = []
     for server_name, keys in SERVER_KEYS.items():
@@ -2165,8 +2170,12 @@ def _sync_mcp_config_keys(project_dir: Path) -> None:
                 spec_env[key] = env_vals[key]
                 updated.append(f"{server_name}.{key}")
 
-    if updated:
+    created = source_path == example_path
+    if updated or created:
         mcp_path.write_text(json.dumps(cfg, indent=2) + "\n")
-        log.info("MCP sync: refreshed %s in %s", ", ".join(updated), mcp_path.name)
+        mcp_path.chmod(0o600)
+        action = "created" if created else "refreshed"
+        details = f" ({', '.join(updated)})" if updated else ""
+        log.info("MCP sync: %s %s%s", action, mcp_path.name, details)
     else:
         log.debug("MCP sync: no changes needed")

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -2121,6 +2121,36 @@ def orchestrate_lab_start(
     )
 
 
+_MCP_SERVER_KEYS = {
+    "aptl-casemgmt": ("THEHIVE_API_KEY",),
+    "aptl-threatintel": ("MISP_API_KEY",),
+    "aptl-soar": ("SHUFFLE_API_KEY",),
+}
+
+
+def _refresh_mcp_server_keys(
+    cfg: dict[str, Any], env_vals: dict[str, str]
+) -> list[str]:
+    """Refresh seeded credentials in MCP server environment blocks."""
+    updated: list[str] = []
+    servers = cfg.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        return updated
+
+    for server_name, keys in _MCP_SERVER_KEYS.items():
+        spec = servers.get(server_name)
+        if not isinstance(spec, dict):
+            continue
+        spec_env = spec.setdefault("env", {})
+        if not isinstance(spec_env, dict):
+            continue
+        for key in keys:
+            if key in env_vals and env_vals[key] != spec_env.get(key):
+                spec_env[key] = env_vals[key]
+                updated.append(f"{server_name}.{key}")
+    return updated
+
+
 def _sync_mcp_config_keys(project_dir: Path) -> None:
     """Create or update `.mcp.json` with dynamic API keys from `.env`.
 
@@ -2150,25 +2180,8 @@ def _sync_mcp_config_keys(project_dir: Path) -> None:
         log.debug("MCP sync: %s vanished between checks; skipping", env_path.name)
         return
 
-    # server name -> env keys it expects
-    SERVER_KEYS = {
-        "aptl-casemgmt": ["THEHIVE_API_KEY"],
-        "aptl-threatintel": ["MISP_API_KEY"],
-        "aptl-soar": ["SHUFFLE_API_KEY"],
-    }
-
     cfg = json.loads(source_path.read_text())
-    servers = cfg.get("mcpServers", {})
-    updated = []
-    for server_name, keys in SERVER_KEYS.items():
-        spec = servers.get(server_name)
-        if not spec:
-            continue
-        spec_env = spec.setdefault("env", {})
-        for key in keys:
-            if key in env_vals and env_vals[key] != spec_env.get(key):
-                spec_env[key] = env_vals[key]
-                updated.append(f"{server_name}.{key}")
+    updated = _refresh_mcp_server_keys(cfg, env_vals)
 
     created = source_path == example_path
     if updated or created:

--- a/tests/test_mcp_config_example.py
+++ b/tests/test_mcp_config_example.py
@@ -1,37 +1,94 @@
-"""Guard for the shipped .mcp.json.example template.
-
-TheHive terminates HTTPS in-container on port 9000 (see the docker-compose
-healthcheck ``curl -ksf https://localhost:9000/api/status``), so a client
-pointed at ``http://localhost:9000`` gets a dead connection. The example MCP
-config is copied verbatim by users, so its TheHive URL must use the same
-scheme the service actually serves.
-"""
+"""Guards for the generated participant MCP client configuration."""
 
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_PATH = REPO_ROOT / ".mcp.json.example"
+EXPECTED_SERVERS = {
+    "aptl-red": "mcp/mcp-red/build/index.js",
+    "aptl-indexer": "mcp/mcp-indexer/build/index.js",
+    "aptl-wazuh": "mcp/mcp-wazuh/build/index.js",
+    "aptl-network": "mcp/mcp-network/build/index.js",
+    "aptl-threatintel": "mcp/mcp-threatintel/build/index.js",
+    "aptl-casemgmt": "mcp/mcp-casemgmt/build/index.js",
+    "aptl-soar": "mcp/mcp-soar/build/index.js",
+}
 
 
-def test_mcp_example_is_valid_json() -> None:
-    data = json.loads((REPO_ROOT / ".mcp.json.example").read_text(encoding="utf-8"))
-    assert "mcpServers" in data
+def _example() -> dict:
+    return json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
 
 
-def test_thehive_example_url_matches_served_scheme() -> None:
-    data = json.loads((REPO_ROOT / ".mcp.json.example").read_text(encoding="utf-8"))
-    url = data["mcpServers"]["thehive"]["env"]["THEHIVE_URL"]
-    assert url.startswith("https://"), (
-        f"TheHive serves HTTPS on 9000, so .mcp.json.example THEHIVE_URL must be "
-        f"https:// (got {url!r})"
+def test_mcp_example_uses_current_enabled_custom_servers() -> None:
+    servers = _example()["mcpServers"]
+
+    assert set(servers) == set(EXPECTED_SERVERS)
+    assert "aptl-reverse" not in servers
+    for name, entrypoint in EXPECTED_SERVERS.items():
+        spec = servers[name]
+        assert spec["command"] == "node"
+        assert spec["args"] == [f"./{entrypoint}"]
+        assert set(spec["env"]) == {"OTEL_EXPORTER_OTLP_ENDPOINT"}
+
+
+def test_mcp_sync_creates_private_config_and_injects_seeded_keys(tmp_path) -> None:
+    from aptl.core.lab import _sync_mcp_config_keys
+
+    (tmp_path / ".mcp.json.example").write_text(
+        EXAMPLE_PATH.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (tmp_path / ".env").write_text(
+        "THEHIVE_API_KEY=thehive-test-key\n"
+        "MISP_API_KEY=misp-test-key\n"
+        "SHUFFLE_API_KEY=shuffle-test-key\n",
+        encoding="utf-8",
     )
 
-    # The compose healthcheck is the source of truth for the served scheme.
-    compose = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
-    assert re.search(r"curl[^\n]*https://localhost:9000/api/status", compose), (
-        "expected the docker-compose TheHive healthcheck to probe "
-        "https://localhost:9000/api/status"
+    _sync_mcp_config_keys(tmp_path)
+
+    generated_path = tmp_path / ".mcp.json"
+    generated = json.loads(generated_path.read_text(encoding="utf-8"))
+    servers = generated["mcpServers"]
+    assert generated_path.stat().st_mode & 0o777 == 0o600
+    assert servers["aptl-casemgmt"]["env"]["THEHIVE_API_KEY"] == (
+        "thehive-test-key"
     )
+    assert servers["aptl-threatintel"]["env"]["MISP_API_KEY"] == (
+        "misp-test-key"
+    )
+    assert servers["aptl-soar"]["env"]["SHUFFLE_API_KEY"] == (
+        "shuffle-test-key"
+    )
+
+
+def test_mcp_sync_preserves_existing_client_entries(tmp_path) -> None:
+    from aptl.core.lab import _sync_mcp_config_keys
+
+    existing = {
+        "mcpServers": {
+            "operator-tool": {"command": "operator-mcp"},
+            "aptl-casemgmt": {
+                "command": "node",
+                "args": ["./custom-casemgmt.js"],
+                "env": {"THEHIVE_API_KEY": "stale"},
+            },
+        }
+    }
+    (tmp_path / ".mcp.json").write_text(json.dumps(existing), encoding="utf-8")
+    (tmp_path / ".env").write_text(
+        "THEHIVE_API_KEY=fresh\n", encoding="utf-8"
+    )
+
+    _sync_mcp_config_keys(tmp_path)
+
+    updated = json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8"))
+    assert updated["mcpServers"]["operator-tool"] == {
+        "command": "operator-mcp"
+    }
+    casemgmt = updated["mcpServers"]["aptl-casemgmt"]
+    assert casemgmt["args"] == ["./custom-casemgmt.js"]
+    assert casemgmt["env"]["THEHIVE_API_KEY"] == "fresh"


### PR DESCRIPTION
## Problem

A fresh participant checkout built the MCP servers but never created `.mcp.json`. The shipped example was also stale: it pointed Wazuh, MISP, and TheHive at retired external binaries, omitted current network coverage, used names the key-sync path did not recognize, and configured the reverse server even though the default SDL has no reverse node.

## Fix

- ship a seven-server template using the current custom Node entrypoints
- create a private `.mcp.json` automatically after successful lab seeding
- inject generated MISP, TheHive, and Shuffle keys while preserving existing client entries
- omit the unavailable reverse server from the default client config
- update participant and MCP validation docs to describe the automatic path

## Validation

- focused MCP config/sync tests (5 passed)
- JSON and Ruff validation
- full pre-commit gate (2,218 passed, 91 skipped)