### PR TITLE
fix: document Linux Buildx prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ aptl kill -c      # emergency: kill MCP processes AND all lab containers
 
 ## Requirements
 
-- Docker + Docker Compose
+- Docker + Docker Compose + Docker Buildx
 - Python 3.11+
 - RAM: 8 GB runs the smaller curated scenarios; the full `techvault-operational` stack needs more than 20 GB
 - 20 GB+ disk

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,7 +40,7 @@ Edit `aptl.json` to enable/disable containers:
 
 ```bash
 # Check requirements
-docker --version && docker compose version
+docker --version && docker compose version && docker buildx version
 sysctl vm.max_map_count  # Native Linux Docker Engine only; should be >= 262144
 netstat -tlnp | grep -E "(443|2027|8443|9000|9001|9200|55000)"  # Ports must be free
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -44,7 +44,7 @@ Four isolated Docker networks:
 
 ## Prerequisites
 
-- Docker with Compose
+- Docker with Compose and Buildx
 - 8GB RAM for the curated scenarios; more than 20GB for the full `techvault-operational` stack
 - Native Linux Docker Engine: `vm.max_map_count >= 262144`
 - Docker Desktop on macOS, Windows, or WSL2: `aptl lab start` skips the host

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -6,6 +6,7 @@
 - 20GB+ disk
 - Docker Engine 20.10+ on native Linux, or Docker Desktop on macOS, Windows, or Linux
 - Docker Compose 2.0+ (`docker compose version`)
+- Docker Buildx (`docker buildx version`)
 - Python 3.11+ (for the CLI)
 - Node.js 18+ and npm (for the MCP servers, the AI-agent control plane that
   `aptl lab start` builds via `mcp/build-all-mcps.sh`; without them the lab
@@ -21,6 +22,15 @@ sudo usermod -aG docker $USER
 ```
 
 Sign out and back in after changing Docker group membership.
+
+The official Docker installer above includes Compose and Buildx. If you use
+Ubuntu's distribution packages instead, install all three explicitly:
+
+```bash
+sudo apt install docker.io docker-compose-v2 docker-buildx
+```
+
+Docker CE repositories name the last package `docker-buildx-plugin` instead.
 
 **macOS (Docker Desktop):** Install Docker Desktop and allocate enough memory
 in Settings -> Resources. The full `techvault-operational` stack needs more
@@ -135,5 +145,6 @@ using `aptl`.
 ```bash
 docker --version
 docker compose version
+docker buildx version
 docker ps
 ```

--- a/src/aptl/core/sysreqs.py
+++ b/src/aptl/core/sysreqs.py
@@ -118,8 +118,10 @@ def _docker_buildx_install_hint() -> str:
             "`docker buildx version` from the same shell that runs aptl."
         ),
         hostenv.OS_LINUX: (
-            "Install the Docker Buildx plugin, for example your distro's "
-            "docker-buildx-plugin package, then verify `docker buildx version`."
+            "Install the Docker Buildx plugin (`sudo apt install docker-buildx` "
+            "for Ubuntu's docker.io packages, or `sudo apt install "
+            "docker-buildx-plugin` for Docker CE), then verify "
+            "`docker buildx version`."
         ),
     }
     return hints.get(

--- a/tests/test_sysreqs.py
+++ b/tests/test_sysreqs.py
@@ -319,7 +319,7 @@ class TestCheckDockerBuildx:
         assert "~/.docker/cli-plugins/docker-buildx" in result.install_hint
 
     def test_fails_with_linux_plugin_hint(self, mocker):
-        """Linux users should get distro-plugin guidance."""
+        """Linux users should get guidance for Ubuntu and Docker CE packages."""
         from aptl.core import hostenv
         from aptl.core.sysreqs import check_docker_buildx
 
@@ -335,6 +335,7 @@ class TestCheckDockerBuildx:
         result = check_docker_buildx()
 
         assert result.passed is False
+        assert "apt install docker-buildx`" in result.install_hint
         assert "docker-buildx-plugin" in result.install_hint
 
     def test_fails_when_docker_cli_is_missing(self, mocker):


### PR DESCRIPTION
## Summary

- list Docker Buildx as a required host tool
- document the correct Ubuntu package for distro-provided Docker
- retain the Docker CE plugin package name in startup recovery guidance
- verify Buildx alongside Docker Engine and Compose

## Validation

- `pytest tests/test_sysreqs.py -q`
- `pre-commit run --all-files`
- reproduced on a fresh Ubuntu 24.04 EC2 host using distro Docker packages
