### PR TITLE
fix(aces): truth up backend manifest

### DIFF
--- a/changelog.d/580.fixed.md
+++ b/changelog.d/580.fixed.md
@@ -1,0 +1,1 @@
+APTL's ACES backend manifest no longer overstates runtime realization support: it now advertises only Linux Docker node realization, file/directory content placements, supported account fields, no ACL support, and the single non-vacuously exercised constrained realization concern (`os-family`).

--- a/docs/aces/techvault-static-validation-gate.md
+++ b/docs/aces/techvault-static-validation-gate.md
@@ -64,15 +64,19 @@ components mean:
 
 | Manifest component | APTL declaration |
 | --- | --- |
-| `provisioner` | Realizes `switch` and `vm` nodes across the declared OS families; `dataset`, `directory`, and `file` content; accounts and ACLs; and the listed account features through typed realization and `DeploymentBackend`. |
+| `provisioner` | Realizes `vm` nodes as Linux Docker containers, `switch` nodes as Docker networks, bounded `file` and `directory` content placements, and accounts with the listed non-secret account features through typed realization and `DeploymentBackend`. It does not claim datasets or ACLs. |
 | `orchestrator` | Drives RTE-001 workflows through `WorkflowEngine`, including decision, parallel-barrier, failure-transition, outcome-matching, condition-reference, and inject-binding surfaces. |
 | `evaluator` | Evaluates conditions and objectives and publishes result/history envelopes. It does not support scoring or the deprecated SDL scoring chain. |
 | `participant_runtime` | Supports the bounded red-participant episode, behavior-history, observation, and shared-state-change surface through `DeploymentBackend.container_exec()`. It does not claim other roles or general multi-party semantics. |
 | `observation` | Is `null`: participant observations are participant-runtime contract data, not a standalone observation component. |
 
-Realization support is constrained to declared-capability matching and the
-listed node, OS, content, and account constraint kinds, with disclosure through
-the manifest, operation-status, and runtime-snapshot contracts. The compatible
+Realization support declares exact `declared-capability-match` coverage and the
+single constrained kind APTL currently exercises non-vacuously: `os-family`.
+Node type and content type are still checked as exact realization concerns when
+authored literally; account placements are realized and verified by the typed
+account provider, but ACES 0.21.0 does not emit an `account-feature`
+runtime-realization concern for the SEM-218 gate. Disclosure flows through the
+manifest, operation-status, and runtime-snapshot contracts. The compatible
 processors, concept-authority bindings, and supported contract versions are
 separate compatibility declarations rather than additional capabilities.
 

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -146,8 +146,8 @@ _PARTICIPANT_RUNTIME = ParticipantRuntimeCapabilities(
 _PROVISIONER = ProvisionerCapabilities(
     name="aptl-docker-compose-provisioner",
     supported_node_types=frozenset({"switch", "vm"}),
-    supported_os_families=frozenset({"freebsd", "linux", "macos", "other", "windows"}),
-    supported_content_types=frozenset({"dataset", "directory", "file"}),
+    supported_os_families=frozenset({"linux"}),
+    supported_content_types=frozenset({"directory", "file"}),
     # Manifest honesty (#577, ADR-046 addendum): advertise only the account
     # features the backend materializes AND verifies by read-after-write — the
     # non-secret fields the typed DeploymentAccountRealization carries. auth_method
@@ -157,20 +157,25 @@ _PROVISIONER = ProvisionerCapabilities(
     supported_account_features=frozenset(
         {"disabled", "groups", "mail", "spn"}
     ),
-    supports_acls=True,
+    supports_acls=False,
     supports_accounts=True,
 )
 
 # What APTL realizes from a provisioning plan, and how. APTL matches declared
 # capabilities against its provisioner support and discloses the result through
-# the backend-manifest / operation-status / runtime-snapshot contracts.
+# the backend-manifest / operation-status / runtime-snapshot contracts. The
+# constrained-kind set is intentionally narrower than the provisioner vocabulary:
+# ACES 0.21.x publishes runtime concern paths for node type, OS family, and
+# content type, but only OS family is currently expressible by APTL's regression
+# scenario as a constrained (processor-derived) requirement. Node/content exact
+# requirements are covered by ``declared-capability-match``; account features are
+# realized through the account provider's typed read-after-write path but are not
+# yet an ACES runtime realization concern.
 _REALIZATION_SUPPORT = (
     RealizationSupportDeclaration(
         domain="runtime-realization",
         support_mode=RealizationSupportMode.CONSTRAINED,
-        supported_constraint_kinds=frozenset(
-            {"account-feature", "content-type", "node-type", "os-family"}
-        ),
+        supported_constraint_kinds=frozenset({"os-family"}),
         supported_exact_requirement_kinds=frozenset({"declared-capability-match"}),
         disclosure_kinds=frozenset(
             {"backend-manifest-v2", "operation-status-v1", "runtime-snapshot-v1"}

--- a/src/aptl/backends/aces_observation.py
+++ b/src/aptl/backends/aces_observation.py
@@ -213,10 +213,11 @@ def _container_realized(info: Mapping[str, Any]) -> bool:
 def _declared_content_type(payload: Mapping[str, Any]) -> object | None:
     """Return the content type the backend realized for a content placement.
 
-    APTL materializes content exactly as the compiled spec types it (a file, a
-    directory, a dataset) — the seeder fails closed rather than substituting a
-    different kind — so the realized type is the spec's type, reported only
-    because the target container was observed running.
+    APTL materializes the content kinds its manifest claims (file and directory)
+    exactly as the compiled spec types them. Unsupported kinds such as datasets
+    fail closed in the realizer before mutation rather than being substituted,
+    so the realized type is the spec's type only after the target container was
+    observed running.
     """
 
     spec = payload.get("spec")

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -536,6 +536,53 @@ def test_create_aptl_manifest_is_canonical_backend_manifest_v2():
     assert payload["capabilities"]["participant_runtime"] is not None
 
 
+def test_manifest_provisioner_declares_only_realized_capabilities():
+    """Issue #580: provisioner vocabulary must match the typed realization path."""
+    from aptl.backends.aces_manifest import create_aptl_manifest
+
+    manifest = create_aptl_manifest()
+    provisioner = manifest.provisioner
+
+    assert provisioner.supported_node_types == frozenset({"switch", "vm"})
+    assert provisioner.supported_os_families == frozenset({"linux"})
+    assert provisioner.supported_content_types == frozenset({"directory", "file"})
+    assert provisioner.supported_account_features == frozenset(
+        {"disabled", "groups", "mail", "spn"}
+    )
+    assert provisioner.supports_accounts is True
+    assert provisioner.supports_acls is False
+
+
+def test_manifest_realization_support_matches_exercised_concerns():
+    """Issue #580: constrained support is limited to a non-vacuous witness."""
+    from aptl.backends.aces_manifest import create_aptl_manifest
+
+    (support,) = create_aptl_manifest().realization_support
+
+    assert support.domain == "runtime-realization"
+    assert support.supported_constraint_kinds == frozenset({"os-family"})
+    assert support.supported_exact_requirement_kinds == frozenset(
+        {"declared-capability-match"}
+    )
+    assert support.disclosure_kinds == frozenset(
+        {"backend-manifest-v2", "operation-status-v1", "runtime-snapshot-v1"}
+    )
+
+
+def test_derived_realization_fixture_exercises_manifest_constrained_claim():
+    """The retained constrained claim has a compiled runtime requirement."""
+    from aces_sdl.explicitness import ExplicitnessClass
+
+    execution_plan = _execution_plan_with_derived_realization_requirements()
+
+    constrained = {
+        requirement.requirement_kind: requirement.field_path
+        for requirement in execution_plan.model.realization_requirements
+        if requirement.explicitness is ExplicitnessClass.CONSTRAINED
+    }
+    assert constrained == {"os-family": "nodes.vm.os"}
+
+
 def test_current_backend_docs_cover_declared_manifest_components():
     from aces_backend_protocols.manifest import backend_manifest_payload
 
@@ -671,6 +718,8 @@ def test_aptl_target_passes_orchestration_evaluation_conformance():
         for case in report.cases
         if not case.passed
     ]
+    case_names = {case.name for case in report.cases}
+    assert {"target-provisioning", "target-snapshot"} <= case_names
 
 
 def test_aptl_target_passes_full_remote_control_plane_conformance():
@@ -703,6 +752,8 @@ def test_aptl_target_passes_full_remote_control_plane_conformance():
         for case in report.cases
         if not case.passed
     ]
+    case_names = {case.name for case in report.cases}
+    assert {"target-provisioning", "target-snapshot"} <= case_names
 
 
 def test_participant_runtime_lifecycle_updates_control_plane_snapshot(tmp_path):
@@ -3465,7 +3516,7 @@ def test_apply_provisioning_discloses_processor_derived_provenance(tmp_path):
     unreachable at the runtime gate, so this test is the regression guard on the
     dependency floor.
     """
-    from aces_sdl.explicitness import ExplicitnessProvenance
+    from aces_sdl.explicitness import ExplicitnessClass, ExplicitnessProvenance
 
     backend = _RealizedBackend(containers=("vm",), platform="linux")
 
@@ -3480,8 +3531,13 @@ def test_apply_provisioning_discloses_processor_derived_provenance(tmp_path):
         entry.requirement_kind: entry.provenance
         for entry in result.snapshot.realization_provenance
     }
+    by_explicitness = {
+        entry.requirement_kind: entry.explicitness
+        for entry in result.snapshot.realization_provenance
+    }
     assert by_kind["os-family"] == ExplicitnessProvenance.PROCESSOR_DERIVED
     assert by_kind["node-type"] == ExplicitnessProvenance.AUTHOR_DECLARED
+    assert by_explicitness["os-family"] is ExplicitnessClass.CONSTRAINED
 
 
 def test_apply_provisioning_accepts_constrained_concern_realized_in_bounds(tmp_path):


### PR DESCRIPTION
## Summary

Truth up APTL's ACES backend manifest so it no longer overstates provisioning capabilities or constrained realization support after the #578 SEM-218 runtime wiring landed.

## Requirement UIDs

- `SCN-010`

## Related Issues

Closes #580

## ADR Impact

- ADR-046

## Changes

- Narrow the provisioner manifest to Linux Docker realization, file/directory content placements, supported account DTO fields, and no ACL support.
- Limit constrained realization support to the non-vacuously exercised `os-family` concern while keeping exact `declared-capability-match` coverage.
- Add manifest and conformance regressions that assert the retained constrained claim has a compiled constrained witness and that ACES target conformance runs target provisioning/snapshot cases.
- Update the static validation gate documentation and content observation docstring to match the truthful manifest.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- `uv run pytest -q tests/test_aces_backend.py tests/test_aces_observation.py`
- `uv run pytest -q tests/test_techvault_static_gate.py -m 'not integration'`
- `uv run pre-commit run --all-files`
- `uv run pytest -n auto tests/test_techvault_static_gate.py -m integration`
- commit hook reran the repo pre-commit subset successfully

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SCN-010 ← src/aptl/backends/aces_manifest.py, SCN-010 ← src/aptl/backends/aces_observation.py, SCN-010 ← docs/aces/techvault-static-validation-gate.md, SCN-010 ← #580
- TESTS: SCN-010 ← tests/test_aces_backend.py, SCN-010 ← tests/test_aces_observation.py, SCN-010 ← tests/test_techvault_static_gate.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/580.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
