### PR TITLE
fix: make SEM-218 realization disclosure non-vacuous

### DIFF
--- a/changelog.d/692.fixed.md
+++ b/changelog.d/692.fixed.md
@@ -1,0 +1,1 @@
+SEM-218 realization disclosure now reads content filesystem kinds from project-scoped backend state and rejects exact content or node concerns when runtime evidence is missing, mismatched, or belongs to another Compose project.

--- a/docs/adrs/adr-046-dynamic-aces-scenario-realization.md
+++ b/docs/adrs/adr-046-dynamic-aces-scenario-realization.md
@@ -332,15 +332,45 @@ and attaches `RealizationProvenanceEntry` values to the returned
 reimplement phase ordering and provenance attachment.
 
 The provisioner's returned `RuntimeSnapshot` must describe backend-observed
-realization. `snapshot_after_apply()` currently copies provisioning resource
-payloads from the declared plan and marks them ready; that is suitable only as
-an interim reconciliation helper and is not evidence that a container, service,
-healthcheck, network attachment, or port binding exists. A resource may enter
-the successful snapshot only after the deployment backend has started and
-inspected the concrete project-scoped resource and verified every concern the
-snapshot claims. Backend inspection continues through typed
-`DeploymentBackend` inventory methods; the ACES adapter must not call Docker or
-parse Compose output directly.
+realization. `snapshot_after_apply()` is only the snapshot assembler; neither a
+planned resource payload, a successful lowering, nor a successful materializer
+call is evidence of runtime state. A resource may enter the successful snapshot
+only after the deployment backend has started and inspected the concrete
+project-scoped resource and verified every concern the snapshot claims. Backend
+inspection continues through typed `DeploymentBackend` operations; the ACES
+adapter must not call Docker or parse Compose output directly.
+
+Issue #692 makes that rule explicit for every SEM-218 concern in
+`aces_processor.semantics.realization.CONCERN_PAYLOAD_PATH`. The existing
+`aptl.backends.aces_observation.observe_realization()` boundary owns the
+translation from backend evidence to concern values; APTL must not copy the
+registry, derive a second concern schema, or read a concern back from the plan:
+
+- `node-type` is disclosed only after a concrete, project-owned backend object
+  of the corresponding kind is observed: a project-labelled container for
+  `vm`, or a project-scoped network for `switch`. Resource routing or a planned
+  `node_type` value is not evidence.
+- `os-family` comes from the inspected project-owned container platform and is
+  normalized into the ACES vocabulary. A missing, malformed, or unsupported
+  platform is omitted; it is never guessed from an image name, Compose service,
+  host OS, or planned `os_family`.
+- `content-type` requires read-back of the realized destination's actual
+  filesystem kind after materialization. A successful seed, a running target
+  container, `DeploymentContentRealization.source_kind`, and the planned
+  `spec.type` are expectations or prerequisites, not observed type. Read-back
+  consumes the existing typed `DeploymentContentRealization` and resolves the
+  project-scoped target/volume through `DeploymentBackend`; it returns only the
+  ACES kind, never content bytes or command output.
+
+An absent object, wrong project label, ambiguous binding, malformed inspection
+shape, non-zero probe result, timeout, or backend I/O error produces no observed
+concern. It does not fall back to the plan. For an `EXACT` requirement that
+omission or mismatch is rejected by ACES as
+`runtime.backend-contract-invalid`; non-exact concerns remain undisclosed
+rather than being fabricated. Snapshot assembly may preserve non-concern fields
+only where the ACES reconciliation contract requires them. In particular, probe
+stdout/stderr and sensitive inline content must not enter `RuntimeSnapshot`,
+`ApplyResult.details`, logs, API errors, telemetry, or run records.
 
 Service concepts must remain distinct while they pass through the existing
 `AptlRealization` to `DeploymentRealizationSpec` seam:
@@ -576,6 +606,7 @@ bundles under `docs/aces/inventory/` were deleted in the PR that closes #690
 | --- | --- |
 | ACES parser and compiler gate | Authored scenarios enter through `aces_sdl.parse_sdl_file` and compile through the ACES compiler and planner. APTL does not structurally revalidate ACES SDL or recompile the `RuntimeModel` with local models. |
 | Realization requirement gate | SEM-218 open and closed semantics are enforced by the ACES planner's `realization_support_diagnostics` against APTL's `RealizationSupportDeclaration`. APTL reads `realization_requirements`; it does not re-derive explicitness classes locally. |
+| Runtime observation gate | `observe_realization()` emits concern values only from project-scoped backend read-back, using ACES's `CONCERN_PAYLOAD_PATH`. Missing, malformed, timed-out, or mismatched evidence omits the concern and lets `RuntimeManager.apply()` fail an exact requirement closed; it never falls back to planned payload values. |
 | Deployment boundary gate | The curated compatibility path may still drive `DeploymentBackend.start_lab` with profiles. The paper scenario drives typed `DeploymentBackend` realization methods. No ACES adapter code calls raw Docker, `docker compose`, or parses compose output directly (ADR-037). |
 | Image trust gate | Node image pull/build decisions are made from ACES `Source` / `source.build` payloads and pass an APTL image policy before backend side effects. Untrusted or insufficient image inputs fail closed through ACES diagnostics without echoing raw image refs, build args, credentials, Dockerfile text, or backend stderr. |
 | Network topology gate | Network creation, IPAM, `internal` egress policy, and per-node attachments come from typed realization specs. Backend validation parses CIDR/gateway/static IP values, preserves project scoping, labels backend-created networks, and fails closed before side effects when authored exact/constrained values cannot be honored. |
@@ -598,6 +629,9 @@ The canonical incumbents this decision builds on are:
   not the paper-scenario topology driver.
 - `src/aptl/backends/aces_diagnostics.py` for the supported-resource-type set
   and diagnostics.
+- `src/aptl/backends/aces_observation.py` for backend evidence-to-concern
+  translation, using the ACES-owned concern path registry rather than an
+  APTL-local schema.
 - `src/aptl/backends/aces_manifest.py` for the realization support declaration.
 - `aces_backend_protocols.account_features.provisioner_account_features` for
   the governed account-spec-to-feature mapping; do not copy that decision table
@@ -659,6 +693,14 @@ account fixture, or provider backend is used without editing TechVault-only
 code. Future account deletion/replacement reuses ACES `ChangeAction`; it must
 not add an APTL-only lifecycle enum.
 
+For runtime disclosure, the parameterized seam remains
+`observe_realization(DeploymentBackend, AptlRealization, ProvisioningPlan)` and
+the existing typed realization records. A new backend or a new ACES concern
+adds provider-owned read-back behind `DeploymentBackend` and maps only the
+observed value at this boundary. The ACES concern kind/path registry, runtime
+gate, snapshot DTO, and provenance vocabulary remain upstream-owned and are not
+extended with APTL mirrors.
+
 ## Consequences
 
 ### Positive
@@ -691,6 +733,18 @@ not add an APTL-only lifecycle enum.
 - Manifest capability text can drift ahead of backend behavior. The static
   lowering tests and clean-start live gate must catch claims that are parsed
   and counted but never passed to a typed backend operation.
+- `RuntimeSnapshot.payload` participates in ACES reconciliation as well as
+  disclosure. Removing non-concern fields blindly can force perpetual updates,
+  while copying a sensitive planned payload can leak it into the run record.
+  Preserve only contract-required reconciliation state and keep sensitive
+  content and probe output outside the snapshot; a broader split between
+  desired-state fingerprints and observed evidence belongs in ACES, not an
+  APTL-only snapshot schema.
+- Disclosure failure happens after backend side effects. It rejects the apply
+  and restores the baseline control-plane snapshot, but it is not transactional
+  rollback of already-created containers, networks, or volumes. Do not report
+  failed observations in `changed_addresses`; cleanup remains the established
+  lab stop/kill workflow unless ACES adds an apply rollback contract.
 
 ## Non-Goals
 
@@ -707,6 +761,9 @@ not add an APTL-only lifecycle enum.
   RBAC, secrets management, or a general directory-service API. It does not
   delete accounts/groups absent from the scenario or migrate the additional
   baseline fixtures in `provision-users.sh`.
+- Issue #692 does not add a second disclosure gate, a new runtime snapshot or
+  evidence schema, an API surface, operator-configurable probe commands, content
+  equality/integrity attestation, or transactional provisioning rollback.
 
 ## Anti-Patterns
 
@@ -733,6 +790,9 @@ not add an APTL-only lifecycle enum.
   the operational TechVault SDL.
 - Treating `content-placement` or `account-placement` resource counts as proof
   of realization when no typed backend operation consumes the placement.
+- Treating a successful seed, a running/healthy target container, the typed
+  placement's source kind, or `spec.type` as read-back proof of the realized
+  content type.
 - Treating a matching line in `provision-users.sh`, a successful create command,
   or an existing username as proof that groups and declared attributes were
   realized; backend success requires non-secret read-after-write verification.
@@ -758,6 +818,9 @@ not add an APTL-only lifecycle enum.
   API responses, or run records.
 - Re-evaluating SEM-218 explicitness classes with a local model rather than
   consuming `realization_requirements` and the planner gate.
+- Copying gated concern values from a `ProvisioningPlan`, or falling back to
+  them when inspection is unavailable; accepting a same-named container without
+  the configured Compose project label; or logging raw probe output.
 - Adding a second topology authority, a duplicate compose parser, or a local
   `RuntimeModel` mirror.
 - Writing realization evidence to a new record type instead of `LocalRunStore`
@@ -794,6 +857,7 @@ not add an APTL-only lifecycle enum.
   [#575](https://github.com/Brad-Edwards/aptl/issues/575),
   [#576](https://github.com/Brad-Edwards/aptl/issues/576),
   [#689](https://github.com/Brad-Edwards/aptl/issues/689),
+  [#692](https://github.com/Brad-Edwards/aptl/issues/692),
   [aces#598](https://github.com/Brad-Edwards/aces/issues/598), and
   [aces#600](https://github.com/Brad-Edwards/aces/issues/600); DSL-008 /
   [#422](https://github.com/Brad-Edwards/aptl/issues/422).

--- a/src/aptl/backends/aces_observation.py
+++ b/src/aptl/backends/aces_observation.py
@@ -39,11 +39,12 @@ from aptl.core.deployment._compose_service_health import (
     container_health,
     container_running,
 )
-from aptl.core.deployment.errors import BackendTimeoutError
+from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
 from aptl.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
+    from aptl.core.deployment.realization import DeploymentContentRealization
 
 # Compose defaults the project name to "aptl"; a backend that scopes to a
 # different project exposes its own ``project_name``.
@@ -94,6 +95,11 @@ def observe_realization(
         placement.address: placement.target_address
         for placement in realization.placements
     }
+    placement_content = {
+        placement.address: placement.content
+        for placement in realization.placements
+        if placement.content is not None
+    }
     project_name = getattr(backend, "project_name", _DEFAULT_PROJECT_NAME)
     realized_networks = _realized_network_names(backend, project_name)
 
@@ -109,15 +115,15 @@ def observe_realization(
         else:
             observations[address] = _observe_placement(
                 backend,
-                resource.payload,
                 node_containers,
                 placement_targets.get(address),
+                placement_content.get(address),
             )
     return observations
 
 
 def _safe_inspect(backend: "DeploymentBackend", name: str) -> dict[str, Any]:
-    """Inspect a container, treating a transient backend error as "absent".
+    """Inspect a project-owned container, treating uncertainty as "absent".
 
     A ``docker inspect`` that times out or errors leaves the container's state
     unknown, and an unobservable resource must fail closed — read as not
@@ -127,9 +133,15 @@ def _safe_inspect(backend: "DeploymentBackend", name: str) -> dict[str, Any]:
     """
 
     try:
+        if not backend.container_exists(name):
+            return {}
         info = backend.container_inspect(name)
     except (BackendTimeoutError, OSError) as exc:
-        log.warning("could not inspect container %s: %s", name, exc)
+        log.warning(
+            "could not inspect project container %s (%s)",
+            name,
+            type(exc).__name__,
+        )
         return {}
     return info if isinstance(info, dict) else {}
 
@@ -174,9 +186,9 @@ def _observe_network(
 
 def _observe_placement(
     backend: "DeploymentBackend",
-    payload: Mapping[str, Any],
     node_containers: dict[str, str],
     target_address: str | None,
+    content: "DeploymentContentRealization | None",
 ) -> ObservedResource:
     """Observe a node-scoped placement through the node that received it.
 
@@ -195,7 +207,7 @@ def _observe_placement(
         return ObservedResource(realized=False)
 
     concerns: dict[tuple[str, ...], object] = {}
-    content_type = _declared_content_type(payload)
+    content_type = _observed_content_type(backend, content)
     if content_type is not None:
         concerns[_CONTENT_TYPE_PATH] = content_type
     return ObservedResource(realized=True, concerns=concerns)
@@ -210,20 +222,24 @@ def _container_realized(info: Mapping[str, Any]) -> bool:
     return not health or health == "healthy"
 
 
-def _declared_content_type(payload: Mapping[str, Any]) -> object | None:
-    """Return the content type the backend realized for a content placement.
+def _observed_content_type(
+    backend: "DeploymentBackend",
+    content: "DeploymentContentRealization | None",
+) -> str | None:
+    """Return the destination kind observed by the deployment provider."""
 
-    APTL materializes content exactly as the compiled spec types it (a file, a
-    directory, a dataset) — the seeder fails closed rather than substituting a
-    different kind — so the realized type is the spec's type, reported only
-    because the target container was observed running.
-    """
-
-    spec = payload.get("spec")
-    if not isinstance(spec, Mapping):
+    if content is None:
         return None
-    content_type = spec.get("type")
-    return content_type if content_type is not None else None
+    try:
+        observed = backend.observe_content_type(content)
+    except (BackendSeedError, BackendTimeoutError, OSError) as exc:
+        log.warning(
+            "could not observe content type for %s (%s)",
+            content.address,
+            type(exc).__name__,
+        )
+        return None
+    return observed if observed in ("file", "directory") else None
 
 
 def _observed_os_family(info: Mapping[str, Any]) -> str | None:
@@ -255,7 +271,7 @@ def _realized_network_names(
     try:
         names = backend.host_list_lab_networks(project_name)
     except (BackendTimeoutError, OSError) as exc:
-        log.warning("could not list realized networks: %s", exc)
+        log.warning("could not list realized networks (%s)", type(exc).__name__)
         return set()
     return set(names) if isinstance(names, list | tuple | set) else set()
 

--- a/src/aptl/backends/aces_observation.py
+++ b/src/aptl/backends/aces_observation.py
@@ -224,7 +224,7 @@ def _container_realized(info: Mapping[str, Any]) -> bool:
 
 def _observed_content_type(
     backend: "DeploymentBackend",
-    content: "DeploymentContentRealization | None",
+    content: DeploymentContentRealization | None,
 ) -> str | None:
     """Return the destination kind observed by the deployment provider."""
 

--- a/src/aptl/core/deployment/_compose_content_realization.py
+++ b/src/aptl/core/deployment/_compose_content_realization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 
 from aptl.core.content_seed import build_content_volume_seeds
@@ -13,6 +14,18 @@ from aptl.core.deployment.realization import DeploymentContentRealization
 # lab's supply chain"). The image only needs `/bin/sh`, `mkdir`, and `cp`,
 # which this Alpine-based image provides.
 CONTENT_SEEDER_IMAGE = "jasonish/suricata:7.0"
+
+# Content read-back is a short metadata probe against a local/remote Docker
+# daemon. Keep it independently bounded so an unhealthy daemon cannot stall the
+# SEM-218 disclosure gate after provisioning side effects have completed.
+_CONTENT_PROBE_TIMEOUT = 30
+
+# The probe communicates only a filesystem-kind class through its return code.
+# stdout/stderr are deliberately ignored so content and backend output cannot
+# enter snapshots, diagnostics, or logs.
+_CONTENT_FILE_EXIT = 10
+_CONTENT_DIRECTORY_EXIT = 11
+_CONTENT_MISSING_EXIT = 12
 
 
 class ComposeRealizationContentMixin:
@@ -30,3 +43,83 @@ class ComposeRealizationContentMixin:
             return
         seeds = build_content_volume_seeds(self._project_dir, content)
         self.seed_named_volumes(seeds, seeder_image=seeder_image)
+
+    def observe_content_type(
+        self,
+        content: DeploymentContentRealization,
+    ) -> str | None:
+        """Read back a content destination's realized filesystem kind.
+
+        The named volume is first inspected so Docker cannot create an empty
+        volume as a side effect of observation. The actual probe mounts that
+        project-owned volume read-only and returns a fixed exit-code class; it
+        never reads or returns the destination's bytes.
+        """
+
+        self._assert_safe_relpath(content.dest_relpath)
+        volume = f"{self._project_name}_{content.volume_suffix}"
+        volume_result = self._run(
+            [
+                "docker",
+                "volume",
+                "inspect",
+                volume,
+                "--format",
+                "{{json .Labels}}",
+            ],
+            timeout=_CONTENT_PROBE_TIMEOUT,
+        )
+        if volume_result.returncode != 0 or not self._content_volume_owned_by_project(
+            volume_result.stdout,
+            content.volume_suffix,
+        ):
+            return None
+
+        destination = f"/dest/{content.dest_relpath}"
+        script = (
+            f'if [ -f "$1" ]; then exit {_CONTENT_FILE_EXIT}; fi; '
+            f'if [ -d "$1" ]; then exit {_CONTENT_DIRECTORY_EXIT}; fi; '
+            f"exit {_CONTENT_MISSING_EXIT}"
+        )
+        result = self._run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--user",
+                "0:0",
+                "--network",
+                "none",
+                "--entrypoint",
+                "/bin/sh",
+                "-v",
+                f"{volume}:/dest:ro",
+                CONTENT_SEEDER_IMAGE,
+                "-c",
+                script,
+                "aptl-content-probe",
+                destination,
+            ],
+            timeout=_CONTENT_PROBE_TIMEOUT,
+        )
+        return {
+            _CONTENT_FILE_EXIT: "file",
+            _CONTENT_DIRECTORY_EXIT: "directory",
+        }.get(result.returncode)
+
+    def _content_volume_owned_by_project(
+        self,
+        raw_labels: str,
+        logical_volume: str,
+    ) -> bool:
+        """Return whether volume labels bind it to this Compose project."""
+
+        try:
+            labels = json.loads(raw_labels)
+        except (json.JSONDecodeError, TypeError):
+            return False
+        return (
+            isinstance(labels, dict)
+            and labels.get("com.docker.compose.project") == self._project_name
+            and labels.get("com.docker.compose.volume") == logical_volume
+        )

--- a/src/aptl/core/deployment/backend.py
+++ b/src/aptl/core/deployment/backend.py
@@ -218,6 +218,19 @@ class DeploymentBackend(Protocol):
         """
         ...
 
+    def observe_content_type(
+        self,
+        content: DeploymentContentRealization,
+    ) -> str | None:
+        """Read back the realized filesystem kind for one content placement.
+
+        Implementations inspect the project-scoped realized destination and
+        return only the governed ACES kind (``file`` or ``directory``). Missing,
+        ambiguous, or failed observations return ``None``. Content bytes and raw
+        probe output must never cross this boundary.
+        """
+        ...
+
     def realize_accounts(
         self,
         accounts: Sequence[DeploymentAccountRealization],

--- a/src/aptl/validation/_gate_checks.py
+++ b/src/aptl/validation/_gate_checks.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
 from aces_conformance.conformance import run_target_conformance
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
     from aces_contracts.diagnostics import Diagnostic
 
     from aptl.core.config import AptlConfig
+    from aptl.core.deployment.realization import DeploymentContentRealization
 
 # `aces conformance backend` is ~2s. `aces sdl verify-imports` re-resolves and
 # re-parses a scenario's whole module tree, which scales with that tree rather
@@ -69,6 +71,8 @@ class _NoStartBackend(object):
     def __init__(self) -> None:
         self._container_names: set[str] = set()
         self._network_names: list[str] = []
+        self._content_root: TemporaryDirectory[str] | None = None
+        self._content_paths: dict[str, Path] = {}
 
     def realize(self, realization: object, *, build: bool = True) -> LabResult:
         """Record the typed realization as realized without starting Docker."""
@@ -87,7 +91,41 @@ class _NoStartBackend(object):
             for network in getattr(realization, "networks", ())
             if getattr(network, "name", None)
         ]
+        self._materialize_content_shapes(getattr(realization, "content", ()))
         return LabResult(success=True, message="Static validation realization accepted")
+
+    def _materialize_content_shapes(self, content: Sequence[object]) -> None:
+        """Create empty filesystem shapes for offline content observation.
+
+        The static gate never copies inline or project content. It creates only
+        an empty file/directory per typed realization, then the same observation
+        boundary reads that filesystem state back. This keeps the offline
+        simulation non-secret and non-vacuous without starting Docker.
+        """
+
+        if self._content_root is not None:
+            self._content_root.cleanup()
+        self._content_root = TemporaryDirectory(prefix="aptl-static-conformance-")
+        root = Path(self._content_root.name)
+        self._content_paths = {}
+        for index, item in enumerate(content):
+            address = getattr(item, "address", None)
+            source_kind = getattr(item, "source_kind", None)
+            if not isinstance(address, str):
+                continue
+            path = root / f"content-{index}"
+            if source_kind in ("project-directory", "empty-directory"):
+                path.mkdir()
+            elif source_kind in ("inline-text", "project-file"):
+                path.touch()
+            else:
+                continue
+            self._content_paths[address] = path
+
+    def container_exists(self, name: str) -> bool:
+        """Return whether the simulated project realized this container."""
+
+        return name in self._container_names
 
     def container_inspect(self, name: str) -> dict[str, object]:
         """Report a declared node container as running and healthy.
@@ -117,6 +155,21 @@ class _NoStartBackend(object):
         honours the same project scoping the observer relies on.
         """
         return [name for name in self._network_names if name_prefix in name]
+
+    def observe_content_type(
+        self,
+        content: "DeploymentContentRealization",
+    ) -> str | None:
+        """Read the filesystem kind materialized by the offline simulation."""
+
+        path = self._content_paths.get(content.address)
+        if path is None:
+            return None
+        if path.is_file():
+            return "file"
+        if path.is_dir():
+            return "directory"
+        return None
 
     @staticmethod
     def start(profiles: list[str], *, build: bool = True) -> LabResult:

--- a/src/aptl/validation/_gate_checks.py
+++ b/src/aptl/validation/_gate_checks.py
@@ -163,13 +163,13 @@ class _NoStartBackend(object):
         """Read the filesystem kind materialized by the offline simulation."""
 
         path = self._content_paths.get(content.address)
-        if path is None:
-            return None
-        if path.is_file():
-            return "file"
-        if path.is_dir():
-            return "directory"
-        return None
+        observed: str | None = None
+        if path is not None:
+            if path.is_file():
+                observed = "file"
+            elif path.is_dir():
+                observed = "directory"
+        return observed
 
     @staticmethod
     def start(profiles: list[str], *, build: bool = True) -> LabResult:

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -159,6 +159,7 @@ class _RealizedBackend(MagicMock):
         platform: str = "linux",
         health: str | None = None,
         running: bool = True,
+        content_types: dict[str, str] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -173,7 +174,11 @@ class _RealizedBackend(MagicMock):
         self._platform = platform
         self._health = health
         self._running = running
+        self._content_types = content_types or {}
         self.realize.return_value = LabResult(success=True, message="ok")
+
+    def container_exists(self, name: str) -> bool:
+        return name in self._containers
 
     def container_inspect(self, name: str) -> dict:
         if name not in self._containers:
@@ -189,6 +194,9 @@ class _RealizedBackend(MagicMock):
 
     def host_list_lab_networks(self, name_prefix: str) -> list[str]:
         return list(self._networks)
+
+    def observe_content_type(self, content) -> str | None:
+        return self._content_types.get(content.address)
 
     def _get_child_mock(self, /, **kw):
         # ``NonCallableMock.__new__`` gives every mock instance its own
@@ -284,6 +292,41 @@ def _execution_plan_with_derived_realization_requirements():
                 type: vm
                 os: ${node_os}
                 resources: {ram: 1 gib, cpu: 1}
+            """
+        )
+    )
+    return plan(
+        compile_runtime_model(scenario),
+        create_aptl_manifest(),
+        target_name=APTL_ACES_TARGET_NAME,
+    )
+
+
+def _execution_plan_with_content_realization_requirement():
+    """Compile an EXACT file content concern through ACES's public planner."""
+    from textwrap import dedent
+
+    from aces_processor.compiler import compile_runtime_model
+    from aces_processor.planner import plan
+    from aces_sdl.parser import parse_sdl
+
+    from aptl.backends.aces_manifest import APTL_ACES_TARGET_NAME, create_aptl_manifest
+
+    scenario = parse_sdl(
+        dedent(
+            """
+            name: disclosure-content
+            nodes:
+              fileshare:
+                type: vm
+                os: linux
+                resources: {ram: 1 gib, cpu: 1}
+            content:
+              notice:
+                type: file
+                target: fileshare
+                path: public/notice.txt
+                text: hello
             """
         )
     )
@@ -3349,6 +3392,30 @@ def _apply_disclosure_scenario(tmp_path, backend, execution_plan=None):
     return manager.apply(execution_plan)
 
 
+def _apply_content_disclosure_scenario(tmp_path, observed_content_type):
+    """Apply an exact content concern with a controlled backend observation."""
+    from aces_runtime.manager import RuntimeManager
+
+    from aptl.backends.aces import create_aptl_runtime_target
+    from aptl.core.config import AptlConfig
+
+    execution_plan = _execution_plan_with_content_realization_requirement()
+    content_address = "provision.content.notice"
+    backend = _RealizedBackend(
+        containers=("fileshare",),
+        content_types={content_address: observed_content_type},
+    )
+    _write_compose(tmp_path, {"fileshare": ["otel"]})
+    target = create_aptl_runtime_target(
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "test"}),
+        backend=backend,
+    )
+    return RuntimeManager(
+        target, initial_snapshot=execution_plan.base_snapshot
+    ).apply(execution_plan)
+
+
 def test_apply_provisioning_populates_realization_and_profiles(tmp_path):
     """A scenario that realizes nodes reports non-empty realization details."""
     from unittest.mock import MagicMock as _MagicMock
@@ -3405,6 +3472,26 @@ def test_apply_provisioning_rejects_exact_concern_realized_differently(tmp_path)
     assert result.success is False
     codes = {diagnostic.code for diagnostic in result.diagnostics}
     assert "runtime.backend-contract-invalid" in codes
+
+
+def test_apply_provisioning_rejects_exact_content_type_probe_mismatch(tmp_path):
+    """The disclosure gate rejects a real directory where a file was authored."""
+    result = _apply_content_disclosure_scenario(tmp_path, "directory")
+
+    assert result.success is False
+    assert "runtime.backend-contract-invalid" in {
+        diagnostic.code for diagnostic in result.diagnostics
+    }
+
+
+def test_apply_provisioning_records_content_type_provenance_when_honored(tmp_path):
+    """A matching content probe succeeds and reaches the provenance ledger."""
+    result = _apply_content_disclosure_scenario(tmp_path, "file")
+
+    assert result.success is True, [d.message for d in result.diagnostics]
+    assert "content-type" in {
+        entry.requirement_kind for entry in result.snapshot.realization_provenance
+    }
 
 
 def test_apply_provisioning_rejects_node_that_never_became_healthy(tmp_path):

--- a/tests/test_aces_observation.py
+++ b/tests/test_aces_observation.py
@@ -23,6 +23,7 @@ from aptl.backends.aces_realization_model import (
     NodeRealization,
     PlacementRealization,
 )
+from aptl.core.deployment.realization import DeploymentContentRealization
 from aptl.core.deployment._compose_realization_networks import _concrete_network_name
 from aptl.core.deployment.errors import BackendTimeoutError
 
@@ -44,6 +45,9 @@ class _Backend:
         running=True,
         inspect_raises=False,
         networks_raise=False,
+        project_owned=True,
+        content_types=None,
+        content_probe_raises=False,
     ):
         self._containers = set(containers)
         self._networks = [_concrete_network_name(n, self.project_name) for n in networks]
@@ -52,6 +56,12 @@ class _Backend:
         self._running = running
         self._inspect_raises = inspect_raises
         self._networks_raise = networks_raise
+        self._project_owned = project_owned
+        self._content_types = content_types or {}
+        self._content_probe_raises = content_probe_raises
+
+    def container_exists(self, name):
+        return self._project_owned and name in self._containers
 
     def container_inspect(self, name):
         if self._inspect_raises:
@@ -71,6 +81,11 @@ class _Backend:
         if self._networks_raise:
             raise BackendTimeoutError("docker network ls timed out")
         return [n for n in self._networks if name_prefix in n]
+
+    def observe_content_type(self, content):
+        if self._content_probe_raises:
+            raise BackendTimeoutError("content probe timed out")
+        return self._content_types.get(content.address)
 
 
 def _node_plan(name="vm"):
@@ -157,6 +172,21 @@ def test_inspect_timeout_fails_closed_not_crash():
     )
     backend = _Backend(containers=("aptl-vm",), inspect_raises=True)
     # Must not raise, and the unobservable node must not be reported realized.
+    assert observe_realization(backend, realization, plan)[address].realized is False
+
+
+def test_same_named_container_from_another_project_is_not_realized():
+    """A foreign container name cannot satisfy this project's node concern."""
+    address, plan = _node_plan()
+    realization = AptlRealization(
+        profiles=frozenset(),
+        nodes=(_node_realization(),),
+        networks=(),
+        placements=(),
+        diagnostics=(),
+    )
+    backend = _Backend(containers=("aptl-vm",), project_owned=False)
+
     assert observe_realization(backend, realization, plan)[address].realized is False
 
 
@@ -301,3 +331,79 @@ def test_placement_on_down_target_is_not_realized():
     assert observe_realization(_Backend(containers=()), realization, plan)[
         address
     ].realized is False
+
+
+def _content_placement_fixture():
+    address = "provision.content.notice"
+    target_address = "provision.node.vm"
+    resource = PlannedResource(
+        address=address,
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="content-placement",
+        payload={
+            "name": "notice",
+            "target_address": target_address,
+            "spec": {"type": "file", "path": "public/notice.txt"},
+        },
+    )
+    plan = ProvisioningPlan(
+        resources={address: resource},
+        operations=[
+            ProvisionOp(
+                action=ChangeAction.CREATE,
+                address=address,
+                resource_type=resource.resource_type,
+                payload=resource.payload,
+            )
+        ],
+    )
+    content = DeploymentContentRealization(
+        address=address,
+        target_address=target_address,
+        content_name="notice",
+        volume_suffix="fileshare_data",
+        dest_relpath="public/notice.txt",
+        source_kind="inline-text",
+        inline_text="hello",
+    )
+    placement = PlacementRealization(
+        address=address,
+        resource_type="content-placement",
+        name="notice",
+        target_address=target_address,
+        target_node="vm",
+        content=content,
+    )
+    realization = AptlRealization(
+        profiles=frozenset(),
+        nodes=(_node_realization(),),
+        networks=(),
+        placements=(placement,),
+        diagnostics=(),
+    )
+    return address, plan, realization
+
+
+def test_content_type_comes_from_backend_probe_not_declared_payload():
+    """A realized directory must not be echoed back as the planned file."""
+    address, plan, realization = _content_placement_fixture()
+    backend = _Backend(
+        containers=("aptl-vm",),
+        content_types={address: "directory"},
+    )
+
+    observation = observe_realization(backend, realization, plan)[address]
+
+    assert observation.realized is True
+    assert observation.concerns == {("spec", "type"): "directory"}
+
+
+def test_content_probe_timeout_omits_concern_without_echoing_plan():
+    """Unobservable exact content fails closed instead of becoming a file."""
+    address, plan, realization = _content_placement_fixture()
+    backend = _Backend(containers=("aptl-vm",), content_probe_raises=True)
+
+    observation = observe_realization(backend, realization, plan)[address]
+
+    assert observation.realized is True
+    assert observation.concerns == {}

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -2521,9 +2521,9 @@ class TestObserveContentType:
         cmd = run.call_args_list[1].args[0]
         assert "test_fileshare_data:/dest:ro" in cmd
         assert cmd[:3] == ["docker", "run", "--rm"]
-        assert ["--user", "0:0"] == cmd[3:5]
-        assert ["--network", "none"] == cmd[5:7]
-        assert ["--entrypoint", "/bin/sh"] == cmd[7:9]
+        assert cmd[3:5] == ["--user", "0:0"]
+        assert cmd[5:7] == ["--network", "none"]
+        assert cmd[7:9] == ["--entrypoint", "/bin/sh"]
         assert "secret payload" not in " ".join(cmd)
         assert "/dest/public/notice.txt" not in cmd[-3]
         assert '"$1"' in cmd[-3]
@@ -2589,11 +2589,10 @@ class TestObserveContentType:
 
     def test_unsafe_destination_never_runs_probe(self, tmp_path):
         backend = DockerComposeBackend(project_dir=tmp_path, project_name="test")
+        item = self._item(dest_relpath="../../outside", inline_text=None)
         with patch.object(backend, "_run") as run:
             with pytest.raises(BackendSeedError):
-                backend.observe_content_type(
-                    self._item(dest_relpath="../../outside", inline_text=None)
-                )
+                backend.observe_content_type(item)
         run.assert_not_called()
 
 

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -31,7 +31,7 @@ from aptl.core.deployment._compose_realization import (
     _resolve_realization_networks,
 )
 from aptl.core.deployment._compose_queries import _select_shell
-from aptl.core.deployment.errors import BackendTimeoutError
+from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
 from aptl.core.lab import LabResult, LabStatus
 
 # SSHComposeBackend validates the *local* ssh identity path with
@@ -2460,6 +2460,141 @@ class TestRealizeContent:
                 backend.realize_content(content, seeder_image="img:1")
         assert "fileshare_data" in str(exc_info.value)
         assert "secret docker stderr" not in str(exc_info.value)
+
+
+class TestObserveContentType:
+    """Read back the realized filesystem kind without reading its content."""
+
+    def _item(self, **overrides):
+        from aptl.core.deployment.realization import DeploymentContentRealization
+
+        fields = {
+            "address": "provision.content-placement.notice",
+            "target_address": "provision.node.fileshare",
+            "content_name": "notice",
+            "volume_suffix": "fileshare_data",
+            "dest_relpath": "public/notice.txt",
+            "source_kind": "inline-text",
+            "inline_text": "secret payload",
+        }
+        fields.update(overrides)
+        return DeploymentContentRealization(**fields)
+
+    @pytest.mark.parametrize(
+        ("returncode", "expected"),
+        [(10, "file"), (11, "directory"), (12, None), (1, None)],
+    )
+    def test_classifies_project_scoped_volume_destination(
+        self, tmp_path, returncode, expected
+    ):
+        backend = DockerComposeBackend(project_dir=tmp_path, project_name="test")
+        with patch.object(backend, "_run") as run:
+            run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        {
+                            "com.docker.compose.project": "test",
+                            "com.docker.compose.volume": "fileshare_data",
+                        }
+                    ),
+                    stderr="",
+                ),
+                MagicMock(
+                    returncode=returncode,
+                    stdout="must-not-be-consumed",
+                    stderr="must-not-be-consumed",
+                ),
+            ]
+
+            observed = backend.observe_content_type(self._item())
+
+        assert observed == expected
+        assert run.call_args_list[0].args[0] == [
+            "docker",
+            "volume",
+            "inspect",
+            "test_fileshare_data",
+            "--format",
+            "{{json .Labels}}",
+        ]
+        cmd = run.call_args_list[1].args[0]
+        assert "test_fileshare_data:/dest:ro" in cmd
+        assert cmd[:3] == ["docker", "run", "--rm"]
+        assert ["--user", "0:0"] == cmd[3:5]
+        assert ["--network", "none"] == cmd[5:7]
+        assert ["--entrypoint", "/bin/sh"] == cmd[7:9]
+        assert "secret payload" not in " ".join(cmd)
+        assert "/dest/public/notice.txt" not in cmd[-3]
+        assert '"$1"' in cmd[-3]
+        assert cmd[-2:] == ["aptl-content-probe", "/dest/public/notice.txt"]
+        assert all(call.kwargs["timeout"] > 0 for call in run.call_args_list)
+
+    def test_missing_project_volume_is_not_created_by_probe(self, tmp_path):
+        backend = DockerComposeBackend(project_dir=tmp_path, project_name="test")
+        with patch.object(backend, "_run") as run:
+            run.return_value = MagicMock(returncode=1, stdout="", stderr="secret")
+
+            assert backend.observe_content_type(self._item()) is None
+
+        assert run.call_args.args[0] == [
+            "docker",
+            "volume",
+            "inspect",
+            "test_fileshare_data",
+            "--format",
+            "{{json .Labels}}",
+        ]
+        assert run.call_args.kwargs["timeout"] > 0
+
+    @pytest.mark.parametrize(
+        "labels",
+        [
+            {},
+            {
+                "com.docker.compose.project": "other",
+                "com.docker.compose.volume": "fileshare_data",
+            },
+            {
+                "com.docker.compose.project": "test",
+                "com.docker.compose.volume": "other_data",
+            },
+        ],
+    )
+    def test_same_named_foreign_or_unlabelled_volume_is_not_probed(
+        self, tmp_path, labels
+    ):
+        backend = DockerComposeBackend(project_dir=tmp_path, project_name="test")
+        with patch.object(backend, "_run") as run:
+            run.side_effect = [
+                MagicMock(returncode=0, stdout=json.dumps(labels), stderr=""),
+                MagicMock(returncode=10, stdout="", stderr=""),
+            ]
+
+            assert backend.observe_content_type(self._item()) is None
+
+        assert run.call_count == 1
+
+    def test_malformed_volume_labels_are_not_probed(self, tmp_path):
+        backend = DockerComposeBackend(project_dir=tmp_path, project_name="test")
+        with patch.object(backend, "_run") as run:
+            run.side_effect = [
+                MagicMock(returncode=0, stdout="not-json", stderr=""),
+                MagicMock(returncode=10, stdout="", stderr=""),
+            ]
+
+            assert backend.observe_content_type(self._item()) is None
+
+        assert run.call_count == 1
+
+    def test_unsafe_destination_never_runs_probe(self, tmp_path):
+        backend = DockerComposeBackend(project_dir=tmp_path, project_name="test")
+        with patch.object(backend, "_run") as run:
+            with pytest.raises(BackendSeedError):
+                backend.observe_content_type(
+                    self._item(dest_relpath="../../outside", inline_text=None)
+                )
+        run.assert_not_called()
 
 
 class TestComposeRealizeContentStep:

--- a/tests/test_techvault_static_gate.py
+++ b/tests/test_techvault_static_gate.py
@@ -154,6 +154,47 @@ def test_target_conformance_fails_loudly_on_missing_corpus(tmp_path):
     assert not report.passed
 
 
+def test_no_start_backend_reads_back_simulated_content_kind():
+    """The offline backend observes a materialized shape, not plan payload text."""
+    from aptl.core.deployment.realization import (
+        DeploymentContentRealization,
+        DeploymentRealizationSpec,
+    )
+
+    file_item = DeploymentContentRealization(
+        address="provision.content.notice",
+        target_address="provision.node.fileshare",
+        content_name="notice",
+        volume_suffix="fileshare_data",
+        dest_relpath="public/notice.txt",
+        source_kind="inline-text",
+        inline_text="must not be materialized by the static gate",
+    )
+    directory_item = DeploymentContentRealization(
+        address="provision.content.onboarding",
+        target_address="provision.node.fileshare",
+        content_name="onboarding",
+        volume_suffix="fileshare_data",
+        dest_relpath="onboarding",
+        source_kind="empty-directory",
+    )
+    backend = _NoStartBackend()
+
+    result = backend.realize(
+        DeploymentRealizationSpec(
+            profiles=(),
+            nodes=(),
+            networks=(),
+            content=(file_item, directory_item),
+        )
+    )
+
+    assert result.success is True
+    assert backend.observe_content_type(file_item) == "file"
+    assert backend.observe_content_type(directory_item) == "directory"
+    assert backend.container_exists("unrealized") is False
+
+
 @pytest.mark.integration
 def test_backend_conformance_fails_loudly_on_missing_corpus(tmp_path):
     # Spawns the `aces conformance backend` CLI subprocess via


### PR DESCRIPTION
## Summary

Make SEM-218 realization disclosure compare authored concerns against project-owned runtime observations, including filesystem read-back for content placements, so absent or mismatched exact concerns fail closed instead of passing through echoed plan data.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #692

## ADR Impact

- ADR-046 (amended)

## Changes

- Add typed content-kind observation to the deployment backend and implement a bounded, network-isolated Compose volume probe with canonical ownership-label checks.
- Require project-owned containers and provider-observed content kinds when assembling runtime snapshots; omit unverifiable concerns without exposing probe output.
- Extend the offline conformance backend, ADR-046, changelog, and regression coverage for mismatch rejection, honored provenance, project isolation, and probe safety.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

`pytest -n auto -k "not integration"`: 2,230 passed, 91 skipped. `pytest -n auto tests/test_techvault_static_gate.py -m integration`: 2 passed. `pre-commit run --all-files`: passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #692 ← src/aptl/backends/aces_observation.py, Issue #692 ← src/aptl/core/deployment/_compose_content_realization.py
- TESTS: Issue #692 ← tests/test_aces_observation.py, Issue #692 ← tests/test_deployment_backend.py, Issue #692 ← tests/test_aces_backend.py, Issue #692 ← tests/test_techvault_static_gate.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/692.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed