### PR TITLE
fix: scope SOC seed and retry to the scenario's selected profiles

### DIFF
--- a/docs/aces/techvault-curated-live-validation-gate.md
+++ b/docs/aces/techvault-curated-live-validation-gate.md
@@ -151,3 +151,14 @@ aptl lab stop -v -y
 - Variants that omit `kali` or the SOC stack are intentionally not subject to the
   full gate's Kali reachability and Suricata telemetry probes. Their absence is
   part of the reduced surface, not an ambiguous startup failure.
+- The `techvault-observability-core`, `techvault-defensive-min`, and
+  `techvault-enterprise-web` recorded rows above pass `--skip-seed` in their
+  `command` field. That predates issue #550's fix, which scopes the SOC seed
+  step (and the SOC compose-retry watchdog) to the scenario's realized
+  `selected_profiles` instead of the global `config.containers.soc` flag; before
+  that fix, `aptl lab start` for these `soc`-less variants would otherwise
+  attempt to run `scripts/seed-prime.sh` against a stack that never started SOC.
+  `--skip-seed` is no longer required for these (or any other) reduced variants
+  — none of them select `soc`, so the seed step is now an intentional no-op
+  regardless of the flag. The evidence rows are not re-recorded here because
+  reproducing them needs live infrastructure; see "Reproducing the proof" above.

--- a/docs/architecture/issue-550-soc-selected-profile-preflight.md
+++ b/docs/architecture/issue-550-soc-selected-profile-preflight.md
@@ -1,0 +1,170 @@
+# Issue #550: SOC selected-profile scoping preflight
+
+This note records architecture guardrails for scoping SOC startup recovery and
+prime seeding to the ACES scenario's realized Compose profiles. It is design
+guidance, not an implementation plan. No new ADR is needed: the change applies
+ADR-005, ADR-030, ADR-031, ADR-044, and ADR-046 to a remaining lab-start path.
+
+## Decision
+
+Keep these two profile concepts distinct:
+
+- `AptlConfig.containers.enabled_profiles()` and
+  `public_start_profiles(config)` are the operator-configured capability ceiling.
+- `AcesStartOutcome.selected_profiles` and its orchestration cache,
+  `_LabStartContext.selected_profiles`, are the scenario-realized runtime
+  surface after `select_backend_profiles()` intersects that ceiling with the
+  ACES realization (plus core profiles).
+
+Scenario-dependent work and recovery must use the realized runtime surface.
+Consequently:
+
+- A failed first container start receives the attempt's selected profiles before
+  deciding whether the SOC-specific wait/restart/retry path applies. The ACES
+  handoff computes `AcesStartOutcome.selected_profiles` before backend apply, so
+  a Compose/apply failure can still carry the authoritative set. A literal
+  `"soc" in ctx.selected_profiles` replacement while the context is populated
+  only after success would silently disable the full-scenario retry.
+- After each handoff attempt, derive the context cache from the returned
+  `AcesStartOutcome`; do not independently parse/plan a second time when the
+  outcome already carries the answer. The existing no-side-effect
+  `selected_profiles_for_scenario()` remains the compatibility/best-effort seam,
+  not a second source of truth.
+- SOC seeding is an intentional no-op, with no degradation diagnostic, when
+  `soc` is absent from the selected set. Never fall back to the global config
+  flag when selected-profile resolution is empty or unavailable; side effects
+  fail closed.
+- Prime seed eligibility and the missing-profile diagnostic compare
+  `_PRIME_REQUIRED_PROFILES` with the selected set. If `soc` is selected but the
+  rest of the prime surface is not, retain the existing non-fatal
+  `CAPABILITY`/`WARNING` classification and name the profiles missing from the
+  selected surface. Operator guidance must account for both causes: a profile
+  can be disabled in `aptl.json` or intentionally omitted by the scenario.
+- `required_profiles_enabled()` remains a config-bound contract predicate. Do
+  not broaden it to accept either an `AptlConfig` or an arbitrary collection;
+  that would conflate configured capability with runtime selection. At this
+  boundary, ordinary set containment against `_PRIME_REQUIRED_PROFILES` is the
+  clearer incumbent.
+
+The full `techvault-operational` scenario selects the complete prime profile
+set under the default config and therefore retains its existing SOC retry and
+seed behavior. Reduced scenarios inherit no scenario-name branches: their ACES
+content and the existing profile selector determine behavior.
+
+## Canonical incumbents
+
+- Repository inputs: `aptl.json` for the configured profile ceiling,
+  `scenarios/catalog.json` plus the selected `scenarios/*.sdl.yaml` for scenario
+  identity/content, `docker-compose.yml` for profile-to-service topology, `.env`
+  for runtime secrets, and `scripts/seed-prime.sh` for the existing seed action.
+  None receives a new shape in this issue.
+- Scenario selection and containment: `resolve_scenario_selection()`, the
+  strict `ScenarioCatalog` models, `_resolve_project_file()`, and the ACES SDL
+  parser.
+- Planning and profile authority: `RuntimeManager.plan()`,
+  `interpret_provisioning_plan()`, `select_backend_profiles()`,
+  `public_start_profiles()`, `ComposeProfileIndex`, and
+  `AcesStartOutcome.selected_profiles`.
+- Startup workflow: `_LabStartContext`, `_step_start_containers()`,
+  `_step_seed_soc()`, `_emit_missing_prime_profiles()`, and the ordered
+  `_LAB_START_STEPS` short-circuit convention.
+- Result and observability surfaces: `LabResult`, `StartupOutcome`,
+  `StartupDiagnostic`, `_emit_diagnostic()`, `get_logger()`, and `redact()`.
+- Side-effect boundaries: `DeploymentBackend` for container operations and
+  `run_shell_script()` for the cross-platform seed script invocation.
+- Persistence: `AcesStartOutcome` plus the ADR-044 reproducibility record and
+  `LocalRunStore` redacting structured writes. Selected profiles are already
+  persisted as backend realization evidence; no seed-specific schema is needed.
+- Test conventions: extend `tests/test_lab.py` for orchestration/diagnostic
+  behavior and retain `tests/test_techvault_curated_variants.py` as the
+  content-driven selected-profile contract. Do not create a parallel startup
+  harness.
+
+Do not add a profile DTO, a second ACES parser/realizer, a scenario-name table,
+a seed service/repository, a new exception hierarchy, or a parallel diagnostic
+shape for this change.
+
+## Cross-cutting and security layers
+
+- **CLI/catalog/path validation:** `--scenario` continues through the strict
+  catalog, project-root containment, and ACES parse validation. Profile gates
+  consume the validated/planned result, never raw CLI strings or catalog data.
+- **Config validation:** `aptl.json` continues through strict Pydantic
+  `AptlConfig` / `ContainerSettings`; `select_backend_profiles()` continues to
+  enforce the configured upper bound. This change adds no config key and does
+  not weaken `extra="forbid"`.
+- **ACES validation:** parse, planning diagnostics, provisioning realization,
+  dependency closure, and backend conformance remain ACES/APTL adapter-owned.
+  Do not locally shape-check `selected_profiles` beyond normalizing the outcome's
+  existing list into the context set.
+- **Environment and secret binding:** `.env` remains owned by
+  `hydrate_dotenv()`, `load_dotenv()`, `env_vars_from_dict()`, and placeholder
+  rejection. The seed receives secrets in the child environment through
+  `run_shell_script()`, not in process argv; profile names and scenario paths are
+  non-secret.
+- **Deployment and host boundary:** the SOC retry watchdog continues through
+  `DeploymentBackend`; no raw `docker`, SSH, or Compose subprocess is introduced.
+  The seed command argv contains only the script/shell path. Local and
+  SSH-Compose behavior outside the existing recovery boundary is unchanged.
+- **Auth surface:** no API route or request shape changes. API-triggered default
+  starts remain protected by `verify_token` through the router dependency; the
+  CLI path remains a local operator action.
+- **Errors and diagnostics:** preserve `LabResult` and ADR-030 diagnostics.
+  Intentional omission of `soc` is neither a warning nor degraded readiness.
+  Missing prime profiles are a narrow capability diagnostic, while fatal ACES
+  or backend failures retain the existing redacted error envelopes.
+- **Logging and OS exposure:** log selected profile names or counts only; never
+  env values, argv with credentials, or raw seed output. In particular,
+  `_execute_seed_soc_script()` currently logs `seed_result.stderr` directly and
+  `aptl.utils.logging` has no automatic redaction filter. That adjacent
+  ADR-029 hazard is not a pattern to copy or rely on; any touched logging must
+  use a narrow status or explicit `redact()` and diagnostics must continue
+  through `_emit_diagnostic()`.
+- **Persistence:** no database/repository transaction is involved. Do not add a
+  seed-attempt field or another profile copy to the run record; the outcome's
+  selected profiles remain the persisted realization evidence.
+
+## Extensibility seam
+
+The seam is the selected-profile collection carried by the ACES start outcome
+and cached on the startup context, plus the parameterized
+`_PRIME_REQUIRED_PROFILES` set. A future scenario or another scenario-scoped
+post-start capability should consume that same collection rather than add a
+config-flag or scenario-id branch.
+
+If a later issue scopes pre-start work such as certificate generation, image
+pulling, bind-mount checks, or host-port planning, resolve the selected surface
+once in an explicit pre-start boundary after config/backend initialization and
+reuse it. Do not scatter extra parse/plan calls across those steps. That broader
+pre-start refactor is not required for issue #550.
+
+## Verification contracts
+
+- With global `soc: true` and a selected set without `soc`, no seed script,
+  seed-failure diagnostic, SOC wait, Wazuh restart, or second start attempt is
+  attributable to the SOC path.
+- With `soc` selected and the prime set incomplete, the diagnostic is derived
+  from selected profiles and remains non-fatal.
+- With the full prime selected set, the existing seed subprocess, timeout,
+  redaction, and diagnostic behavior is preserved.
+- Retry coverage must use an `AcesStartOutcome` carrying selected profiles on a
+  failed first apply, proving the ordering contract rather than pre-populating a
+  test-only context accidentally.
+- Existing readiness-scoping tests remain the model: selected profiles override
+  permissive global flags. Curated variant tests continue to prove selection is
+  content-driven rather than catalog-name-driven.
+
+## Non-goals and anti-patterns
+
+- Do not redesign Compose profiles, ACES realization, startup ordering as a
+  whole, the seed script, SOC TLS, generated credentials, MCP config sync,
+  deployment backends, run records, API/web contracts, or readiness taxonomy.
+- Do not scope unrelated pre-start preparation steps in this issue.
+- Do not interpret `skip_seed` as profile selection; it remains an explicit
+  operator override after selection.
+- Do not emit a missing-prime warning for a scenario that intentionally omits
+  `soc`, and do not tell an operator merely to edit `aptl.json` when the selected
+  scenario itself omits a required profile.
+- Do not use an empty/unresolved selected set as permission to seed or retry.
+- Do not duplicate the profile intersection, hardcode TechVault catalog ids, or
+  scrape CLI/log text to infer what started.

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -1902,7 +1902,7 @@ def _step_seed_soc(ctx: _LabStartContext) -> LabResult | None:
         assert ctx.config is not None
         if "soc" not in ctx.selected_profiles:
             log.debug("SOC profile not selected by this scenario, skipping seed")
-        elif not _PRIME_REQUIRED_PROFILES <= ctx.selected_profiles:
+        elif not _PRIME_REQUIRED_PROFILES.issubset(ctx.selected_profiles):
             _emit_missing_prime_profiles(ctx)
         else:
             _run_seed_soc_script(ctx)

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -26,7 +26,6 @@ from aptl.core.contracts import (
     backend_is_initialized,
     config_is_loaded,
     env_is_loaded,
-    required_profiles_enabled,
     ssh_key_is_ready,
 )
 from aptl.core.credentials import (
@@ -1227,6 +1226,45 @@ def _restart_wazuh_manager_if_stuck(ctx: _LabStartContext) -> None:
         log.warning("wazuh-manager restart attempt failed: %s", exc)
 
 
+def _selected_profiles_after_attempt(
+    ctx: _LabStartContext, outcome: object
+) -> set[str]:
+    """Return the selected-profile set to cache on ``ctx`` after a handoff attempt.
+
+    Called from ``_step_start_containers`` after EVERY
+    ``start_aces_scenario`` attempt — including a failed first attempt,
+    not only on success. ACES computes ``AcesStartOutcome.selected_profiles``
+    before the backend apply and returns it on both the failure and
+    success branches (aces.py), so a failed attempt's outcome already
+    carries the authoritative answer. That ordering is what lets the SOC
+    retry gate see the real selected set instead of the empty default a
+    "populate the cache only on success" approach would leave behind
+    (issue #550).
+
+    ``profiles is not None`` is the load-bearing branch: an outcome that
+    explicitly carries ``[]`` (a planner-blocked failure) must fail
+    closed — no seed, no retry, per the guardrail that an
+    empty/unresolved selected set is never permission to act. An outcome
+    with no ``selected_profiles`` attribute at all — a bare ``LabResult``,
+    the shape ``start_aces_scenario`` returns when the ACES import itself
+    fails — falls back to the no-side-effect
+    ``selected_profiles_for_scenario`` resolver, kept as the
+    compatibility/best-effort seam rather than a second source of truth.
+    """
+    # Caller (`_step_start_containers`) is icontract-guarded so config/backend
+    # are not None — narrowing only, no new behavior.
+    assert ctx.config is not None and ctx.backend is not None
+    profiles = getattr(outcome, "selected_profiles", None)
+    if profiles is not None:
+        return set(_safe_list(profiles))
+    return selected_profiles_for_scenario(
+        ctx.project_dir,
+        ctx.config,
+        ctx.backend,
+        scenario_path=ctx.scenario_path,
+    )
+
+
 @_runtime_require(
     lambda ctx: config_is_loaded(ctx.config),
     description="config_is_loaded(ctx.config)",
@@ -1253,7 +1291,14 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
         run_id=ctx.run_id,
     )
     lab_result = outcome.lab_result if hasattr(outcome, "lab_result") else outcome
-    if not lab_result.success and ctx.config.containers.soc:
+    # Cache the realized profile set from THIS attempt before the retry gate
+    # below reads it. ACES computes selected_profiles before the backend
+    # apply and returns it on both branches (aces.py), so a failed first
+    # attempt can still carry the authoritative set — populating the cache
+    # only in the success branch below would read an empty set here and
+    # silently disable the full-scenario SOC retry (issue #550).
+    ctx.selected_profiles = _selected_profiles_after_attempt(ctx, outcome)
+    if not lab_result.success and "soc" in ctx.selected_profiles:
         log.warning(
             "Initial compose up failed (SOC dependencies may still be "
             "initializing). Waiting 60s and retrying..."
@@ -1278,19 +1323,13 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
             run_id=ctx.run_id,
         )
         lab_result = outcome.lab_result if hasattr(outcome, "lab_result") else outcome
+        ctx.selected_profiles = _selected_profiles_after_attempt(ctx, outcome)
     if lab_result.success:
         # Store the ACES start outcome for the run record step (REP-001).
+        # ctx.selected_profiles is already populated from this attempt's
+        # outcome above; re-resolving it here would re-parse and re-plan
+        # the scenario a second time for an answer already in hand.
         ctx.aces_outcome = outcome
-        # Scope the post-start readiness checks to the profiles this scenario
-        # actually started, not the global config flags. A curated bounded
-        # scenario starts a subset, so a config-flag gate would wait on (and
-        # fail) services it never launched.
-        ctx.selected_profiles = selected_profiles_for_scenario(
-            ctx.project_dir,
-            ctx.config,
-            ctx.backend,
-            scenario_path=ctx.scenario_path,
-        )
         return None
     log.error("Lab start failed: %s", lab_result.error)
     return LabResult(
@@ -1833,11 +1872,13 @@ def _step_build_mcps(ctx: _LabStartContext) -> LabResult | None:
 # without fileshare), so a missing prime profile must NOT fatally refuse
 # lab startup — it just means the prime seed cannot meaningfully run, and
 # the lab should come up with SOC empty plus a CAPABILITY diagnostic.
-# Kept module-level so the reusable `required_profiles_enabled` predicate
-# from `aptl.core.contracts` has a stable constant to read, and so a
-# future operation (e.g. an explicit `aptl scenario prime start`
-# entrypoint) can wire the same set into a hard `_runtime_require` at
-# *that* boundary without redefining it.
+# Kept module-level as a stable constant: the seed gate below diffs it
+# directly against `ctx.selected_profiles`, the scenario-realized surface
+# (issue #550 — not the config ceiling), and a future operation (e.g. an
+# explicit `aptl scenario prime start` entrypoint) can still wire the same
+# set into a hard `_runtime_require` via the config-bound
+# `required_profiles_enabled` predicate in `aptl.core.contracts` without
+# redefining it.
 _PRIME_REQUIRED_PROFILES = frozenset(
     {"wazuh", "enterprise", "victim", "kali", "fileshare", "soc"}
 )
@@ -1859,9 +1900,9 @@ def _step_seed_soc(ctx: _LabStartContext) -> LabResult | None:
         log.info("Step 13: Seeding SOC tools...")
         # Runtime guard above.
         assert ctx.config is not None
-        if not ctx.config.containers.soc:
-            log.debug("SOC profile not enabled, skipping seed")
-        elif not required_profiles_enabled(ctx.config, _PRIME_REQUIRED_PROFILES):
+        if "soc" not in ctx.selected_profiles:
+            log.debug("SOC profile not selected by this scenario, skipping seed")
+        elif not _PRIME_REQUIRED_PROFILES <= ctx.selected_profiles:
             _emit_missing_prime_profiles(ctx)
         else:
             _run_seed_soc_script(ctx)
@@ -1869,11 +1910,15 @@ def _step_seed_soc(ctx: _LabStartContext) -> LabResult | None:
 
 
 def _emit_missing_prime_profiles(ctx: _LabStartContext) -> None:
-    """Emit the non-fatal diagnostic for partial prime profile sets."""
-    assert ctx.config is not None
-    missing = sorted(
-        _PRIME_REQUIRED_PROFILES - set(ctx.config.containers.enabled_profiles())
-    )
+    """Emit the non-fatal diagnostic for a selected-but-incomplete prime set.
+
+    Diffs against ``ctx.selected_profiles`` — the scenario-realized
+    surface — not the config ceiling: a profile can be missing here
+    because the selected scenario never included it, not only because it
+    is disabled in ``aptl.json`` (issue #550), so the operator guidance
+    below must name both possible causes.
+    """
+    missing = sorted(_PRIME_REQUIRED_PROFILES - ctx.selected_profiles)
     _emit_diagnostic(
         ctx,
         step="seed_soc",
@@ -1884,9 +1929,11 @@ def _emit_missing_prime_profiles(ctx: _LabStartContext) -> None:
             f"missing: {', '.join(missing)}. SOC tools will start empty."
         ),
         operator_action=(
-            "Enable the missing prime profiles in aptl.json and "
-            "re-run `aptl lab start`, or run `scripts/seed-prime.sh` "
-            "manually once the prime stack is up."
+            "Enable the missing prime profiles in aptl.json if they are "
+            "disabled, or start a scenario that selects them — the "
+            "current scenario may intentionally omit them. Alternatively "
+            "run `scripts/seed-prime.sh` manually once the prime stack "
+            "is up."
         ),
     )
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -2875,6 +2875,45 @@ class TestStartupClassificationWiring:
 
         assert ctx.diagnostics == []
 
+    def test_seed_soc_skipped_when_soc_not_in_selected_profiles(self, tmp_path):
+        """A scenario that never selects `soc` (e.g. a curated reduced
+        variant) must skip seeding even though the global config flag is
+        on — the gate is the scenario-realized profile surface, not the
+        config ceiling (issue #550). A real seed script that would fail
+        loudly if invoked (rather than a mock assertion) proves the skip:
+        if the gate regressed to reading the config flag, this script
+        would run and its `exit 1` would surface as a diagnostic."""
+        from aptl.core.config import AptlConfig
+        from aptl.core.lab import _step_seed_soc
+
+        ctx = self._ctx(
+            tmp_path,
+            config=AptlConfig(
+                lab={"name": "test-lab"},
+                containers={
+                    "wazuh": True,
+                    "enterprise": True,
+                    "victim": True,
+                    "kali": True,
+                    "fileshare": True,
+                    "soc": True,
+                },
+            ),
+            # soc (and the rest of the prime set) is enabled in config, but
+            # the scenario this run started never selected it.
+            selected_profiles={"wazuh", "victim", "kali", "otel"},
+        )
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        seed_script = scripts_dir / "seed-prime.sh"
+        seed_script.write_text("#!/bin/bash\nexit 1\n")
+        seed_script.chmod(0o755)
+
+        result = _step_seed_soc(ctx)
+        assert result is None
+
+        assert ctx.diagnostics == []
+
     # -- mcp_config_sync (capability) ----------------------------------
 
     def test_mcp_config_sync_exception_emits_capability_warning(self, tmp_path, mocker):
@@ -3020,6 +3059,27 @@ class TestLabOrchestrationContracts:
         defaults.update(container_overrides)
         return AptlConfig(lab={"name": "test-lab"}, containers=defaults)
 
+    def _outcome(self, *, success, selected_profiles, error="", message="ok"):
+        """Build a real `AcesStartOutcome` — the shape `start_aces_scenario`
+        actually returns on a successful ACES import. ACES computes
+        `selected_profiles` before the backend apply and returns it on
+        BOTH the failure and success branches (aces.py:181-216), so the
+        SOC retry-gate tests below must prove the ordering contract
+        against this shape, not a bare `LabResult` (which carries no
+        `selected_profiles` attribute at all) — issue #550."""
+        from aces_contracts.runtime_state import RuntimeSnapshot
+
+        from aptl.backends.aces import AcesStartOutcome
+        from aptl.core.lab import LabResult
+
+        return AcesStartOutcome(
+            lab_result=LabResult(success=success, error=error, message=message),
+            final_snapshot=RuntimeSnapshot(),
+            realization_details={},
+            selected_profiles=sorted(selected_profiles),
+            scenario_path=None,
+        )
+
     # -- env_is_loaded ------------------------------------------------
 
     def test_sync_credentials_without_env_raises_violation(self, tmp_path):
@@ -3137,10 +3197,114 @@ class TestLabOrchestrationContracts:
         assert ctx.run_store is not None
         assert ctx.run_id
 
+    # -- SOC retry gate reads the attempt's own selected profiles -----
+
+    def test_start_containers_retries_when_outcome_carries_soc_selected(
+        self, mocker, tmp_path
+    ):
+        """The SOC retry gate must read the FAILED attempt's own selected
+        profiles, not a config flag and not a cache populated only on
+        success. ACES computes `selected_profiles` before the backend
+        apply and returns it on the failure branch too
+        (aces.py:199-206) — a failed first apply whose outcome carries
+        "soc" must still trigger the retry. This is issue #550's central
+        ordering-contract regression: a naive `"soc" in
+        ctx.selected_profiles` swap on a cache populated only after
+        success would read an empty set here and silently disable the
+        full-scenario SOC retry."""
+        from aptl.core.lab import _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        # Config itself disables soc: proves the retry decision comes
+        # from the outcome's selected profiles, not ctx.config.
+        ctx.config = self._full_config(soc=False)
+        ctx.backend = MagicMock()
+        start_aces = mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=[
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+                self._outcome(
+                    success=True,
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+            ],
+        )
+        mocker.patch("time.sleep")
+
+        result = _step_start_containers(ctx)
+
+        assert result is None
+        assert start_aces.call_count == 2
+
+    def test_start_containers_skips_retry_when_outcome_omits_soc(
+        self, mocker, tmp_path
+    ):
+        """A failed first apply whose outcome does NOT select "soc" must
+        not wait, must not probe/restart wazuh-manager, and must not
+        retry — even though the global config flag is on. A bounded
+        scenario that never selects SOC gets no SOC-specific recovery
+        (issue #550)."""
+        from aptl.core.lab import _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        backend = MagicMock()
+        ctx.backend = backend
+        start_aces = mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            return_value=self._outcome(
+                success=False,
+                error="compose still starting",
+                selected_profiles={"wazuh", "victim", "kali"},
+            ),
+        )
+        sleep = mocker.patch("time.sleep")
+
+        result = _step_start_containers(ctx)
+
+        assert result is not None
+        assert result.success is False
+        start_aces.assert_called_once()
+        sleep.assert_not_called()
+        backend.container_restart.assert_not_called()
+
+    def test_start_containers_fails_closed_on_planner_blocked_outcome(
+        self, mocker, tmp_path
+    ):
+        """A planner-blocked failure returns `selected_profiles=[]`
+        (explicitly empty, not absent) — waiting 60s never fixes a
+        planner error, and an empty/unresolved selected set is never
+        permission to retry (issue #550 fail-closed guardrail)."""
+        from aptl.core.lab import _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        ctx.backend = MagicMock()
+        start_aces = mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            return_value=self._outcome(
+                success=False,
+                error="planner blocked: unresolved dependency",
+                selected_profiles=[],
+            ),
+        )
+        sleep = mocker.patch("time.sleep")
+
+        result = _step_start_containers(ctx)
+
+        assert result is not None
+        assert result.success is False
+        start_aces.assert_called_once()
+        sleep.assert_not_called()
+
     def test_start_containers_preserves_scenario_path_on_soc_retry(
         self, mocker, tmp_path
     ):
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3150,8 +3314,15 @@ class TestLabOrchestrationContracts:
         start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
             side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+                self._outcome(
+                    success=True,
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
             ],
         )
         mocker.patch("time.sleep")
@@ -3172,7 +3343,7 @@ class TestLabOrchestrationContracts:
         with zero wazuh-* daemons alive (#732). One `docker restart`
         clears the state; do it once, before the retry, so compose is
         not asked to `up` against a broken container."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3184,11 +3355,18 @@ class TestLabOrchestrationContracts:
         backend.container_exec.return_value = MagicMock(returncode=0, stdout="0\n")
         ctx.backend = backend
 
-        mocker.patch(
+        start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
             side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+                self._outcome(
+                    success=True,
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
             ],
         )
         mocker.patch("time.sleep")
@@ -3196,6 +3374,7 @@ class TestLabOrchestrationContracts:
         result = _step_start_containers(ctx)
 
         assert result is None
+        assert start_aces.call_count == 2
         backend.container_restart.assert_called_once_with("aptl-wazuh-manager")
 
     def test_start_containers_skips_restart_when_wazuh_daemons_alive(
@@ -3203,7 +3382,7 @@ class TestLabOrchestrationContracts:
     ):
         """Daemons alive inside the container: the retry is likely
         succeeding for a different reason; do NOT restart wazuh-manager."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3215,17 +3394,25 @@ class TestLabOrchestrationContracts:
         backend.container_exec.return_value = MagicMock(returncode=0, stdout="9\n")
         ctx.backend = backend
 
-        mocker.patch(
+        start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
             side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+                self._outcome(
+                    success=True,
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
             ],
         )
         mocker.patch("time.sleep")
 
         _step_start_containers(ctx)
 
+        assert start_aces.call_count == 2
         backend.container_restart.assert_not_called()
 
     def test_start_containers_skips_restart_when_wazuh_manager_not_running(
@@ -3234,7 +3421,7 @@ class TestLabOrchestrationContracts:
         """State.Status != 'running' means the container is gone / dead /
         being recreated by compose itself — restarting would race
         compose. Skip."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3244,17 +3431,25 @@ class TestLabOrchestrationContracts:
         }
         ctx.backend = backend
 
-        mocker.patch(
+        start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
             side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+                self._outcome(
+                    success=True,
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
             ],
         )
         mocker.patch("time.sleep")
 
         _step_start_containers(ctx)
 
+        assert start_aces.call_count == 2
         backend.container_restart.assert_not_called()
         backend.container_exec.assert_not_called()
 
@@ -3264,7 +3459,7 @@ class TestLabOrchestrationContracts:
         """The watchdog is best-effort: exceptions from container_inspect
         or container_exec must not abort the retry. Also covers the
         `int()` ValueError branch when the /proc walk emits garbage."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3272,11 +3467,18 @@ class TestLabOrchestrationContracts:
         backend.container_inspect.side_effect = RuntimeError("boom")
         ctx.backend = backend
 
-        mocker.patch(
+        start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
             side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+                self._outcome(
+                    success=True,
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
             ],
         )
         mocker.patch("time.sleep")
@@ -3284,6 +3486,7 @@ class TestLabOrchestrationContracts:
         # Should complete without raising; retry still runs.
         result = _step_start_containers(ctx)
         assert result is None
+        assert start_aces.call_count == 2
         backend.container_restart.assert_not_called()
 
     def test_start_containers_watchdog_swallows_exec_failures(
@@ -3292,7 +3495,7 @@ class TestLabOrchestrationContracts:
         """A nonzero exec probe (or non-int stdout) blocks the restart —
         we do not know the process state, so refuse to restart rather
         than guess wrong."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3303,16 +3506,24 @@ class TestLabOrchestrationContracts:
         )
         ctx.backend = backend
 
-        mocker.patch(
+        start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
             side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+                self._outcome(
+                    success=True,
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
             ],
         )
         mocker.patch("time.sleep")
 
         _step_start_containers(ctx)
+        assert start_aces.call_count == 2
         backend.container_restart.assert_not_called()
 
     def test_start_containers_watchdog_swallows_restart_failure(
@@ -3320,7 +3531,7 @@ class TestLabOrchestrationContracts:
     ):
         """`container_restart` raising is logged and swallowed — the
         retry proceeds regardless."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3330,17 +3541,25 @@ class TestLabOrchestrationContracts:
         backend.container_restart.side_effect = RuntimeError("daemon down")
         ctx.backend = backend
 
-        mocker.patch(
+        start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
             side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
+                self._outcome(
+                    success=True,
+                    selected_profiles={"soc", "wazuh", "victim", "kali"},
+                ),
             ],
         )
         mocker.patch("time.sleep")
 
         result = _step_start_containers(ctx)
         assert result is None
+        assert start_aces.call_count == 2
         # We tried, we failed, we did not raise.
         backend.container_restart.assert_called_once_with("aptl-wazuh-manager")
 
@@ -3349,7 +3568,7 @@ class TestLabOrchestrationContracts:
     ):
         """If /proc walk returns non-numeric output (e.g. a sh error line),
         the ValueError branch keeps the retry going with no restart."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3360,16 +3579,25 @@ class TestLabOrchestrationContracts:
         )
         ctx.backend = backend
 
-        mocker.patch(
+        selected = {"soc", "wazuh", "victim", "kali"}
+        start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
             side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
+                self._outcome(
+                    success=False,
+                    error="compose still starting",
+                    selected_profiles=selected,
+                ),
+                self._outcome(success=True, selected_profiles=selected),
             ],
         )
         mocker.patch("time.sleep")
 
         _step_start_containers(ctx)
+        # Without this the test cannot tell "retry ran and the ValueError
+        # branch handled it" from "retry never fired", which is exactly what
+        # a bare LabResult side_effect would silently cause (issue #550).
+        assert start_aces.call_count == 2
         backend.container_restart.assert_not_called()
 
     def test_start_containers_hints_for_stale_realization_networks(
@@ -3629,20 +3857,29 @@ class TestStopLabCleanupIsContractFree:
 
 
 class TestSeedSocPrimeProfileDiagnostic:
-    """Soft check against the reusable `required_profiles_enabled`
-    predicate at the SOC seed boundary. ADR-005 supports selective SOC
-    labs, so a missing prime profile must NOT fatally refuse lab
-    startup — it surfaces as a CAPABILITY diagnostic and the step
-    returns None. The reusable predicate remains available as a hard
-    contract for a future explicit prime-scenario entrypoint."""
+    """Soft check against `_PRIME_REQUIRED_PROFILES`, diffed against
+    `ctx.selected_profiles` (the scenario-realized surface, issue #550) at
+    the SOC seed boundary. ADR-005 supports selective SOC labs, so a
+    missing prime profile must NOT fatally refuse lab startup — it
+    surfaces as a CAPABILITY diagnostic and the step returns None. The
+    config-bound `required_profiles_enabled` predicate in
+    `aptl.core.contracts` remains available as a hard contract for a
+    future explicit prime-scenario entrypoint; this boundary uses plain
+    set containment against the selected surface instead."""
 
-    def _ctx(self, tmp_path: Path, *, soc: bool, **extra):
+    def _ctx(self, tmp_path: Path, *, soc: bool, selected_profiles=None, **extra):
         from aptl.core.config import AptlConfig
         from aptl.core.env import EnvVars
         from aptl.core.lab import _LabStartContext
 
         containers = {"wazuh": True, "victim": True, "kali": True, "soc": soc}
         containers.update(extra)
+        cfg = AptlConfig(lab={"name": "t"}, containers=containers)
+        # Default: the scenario selects exactly what config enables (the
+        # common case where config and selection coincide). Tests proving
+        # the selected-surface distinction pass an explicit subset.
+        if selected_profiles is None:
+            selected_profiles = set(cfg.containers.enabled_profiles())
         return _LabStartContext(
             project_dir=tmp_path,
             skip_seed=False,
@@ -3652,7 +3889,8 @@ class TestSeedSocPrimeProfileDiagnostic:
                 api_username="u",
                 api_password="p",
             ),
-            config=AptlConfig(lab={"name": "t"}, containers=containers),
+            config=cfg,
+            selected_profiles=selected_profiles,
         )
 
     def test_partial_prime_set_emits_capability_diagnostic(self, tmp_path):
@@ -3709,6 +3947,43 @@ class TestSeedSocPrimeProfileDiagnostic:
         result = _step_seed_soc(ctx)
         assert result is None
         assert ctx.diagnostics == []
+
+    def test_scenario_omitted_profile_emits_diagnostic_from_selected_surface(
+        self, tmp_path
+    ):
+        """A profile can be fully enabled in aptl.json yet still land in
+        the diagnostic's `missing` list, because the gate diffs against
+        `ctx.selected_profiles` — the scenario-realized surface — not the
+        config ceiling. Operator guidance must name both possible causes
+        (issue #550): a profile can be disabled in aptl.json, or the
+        selected scenario can intentionally omit it, as this test does."""
+        from aptl.core.lab import _step_seed_soc
+        from aptl.core.lab_types import DiagnosticImpact, DiagnosticSeverity
+
+        ctx = self._ctx(
+            tmp_path,
+            soc=True,
+            enterprise=True,
+            fileshare=True,
+            # Every prime profile is enabled in config, but this run's
+            # scenario only realized a subset of it.
+            selected_profiles={"soc", "wazuh", "victim", "kali"},
+        )
+        result = _step_seed_soc(ctx)
+
+        assert result is None  # non-fatal
+        assert len(ctx.diagnostics) == 1
+        diag = ctx.diagnostics[0]
+        assert diag.step == "seed_soc"
+        assert diag.impact is DiagnosticImpact.CAPABILITY
+        assert diag.severity is DiagnosticSeverity.WARNING
+        assert "enterprise" in diag.message
+        assert "fileshare" in diag.message
+        # Operator guidance must name BOTH causes, not just "edit
+        # aptl.json" — enterprise/fileshare are enabled in config here;
+        # it is the scenario's own selection that omitted them.
+        assert "aptl.json" in diag.operator_action
+        assert "scenario" in diag.operator_action.lower()
 
 
 class TestGenerateSocCertsStep:


### PR DESCRIPTION
## Summary

Scope the SOC seed step, the compose-retry watchdog, and the missing-prime diagnostic to the scenario's realized profile set (`ctx.selected_profiles`) instead of the global `config.containers.soc` flag, mirroring commit 273977a which scoped the post-start readiness checks. A reduced curated scenario booted under a permissive `aptl.json` (`soc: true`) previously attempted SOC seeding for containers it never started, which is why proving those variants required `--skip-seed`. The fix also closes a latent ordering defect: `ctx.selected_profiles` was populated only on a successful start, but the SOC retry gate runs before that on the failure path, so a naive gate swap would have read an empty set and silently disabled the full-scenario retry. The cache is now populated from the returned `AcesStartOutcome` after every ACES handoff attempt (ACES computes the selected set before the backend apply and returns it on both branches); a planner-blocked failure carries an empty set and correctly fails closed.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #550

## ADR Impact

- ADR-021

## Changes

- `_step_start_containers`: cache `ctx.selected_profiles` from each attempt's returned outcome via the new `_selected_profiles_after_attempt(ctx, outcome)` helper, before the retry gate evaluates; the retry gate now reads `"soc" in ctx.selected_profiles`. Removed the now-redundant post-success profile re-resolution (a duplicate parse+plan per start).
- `_step_seed_soc`: gate on `"soc" not in ctx.selected_profiles` (silent no-op, no diagnostic) and on `_PRIME_REQUIRED_PROFILES <= ctx.selected_profiles`, replacing the config-flag gate and the `required_profiles_enabled` config predicate.
- `_emit_missing_prime_profiles`: diff the required prime set against the selected surface, and update operator guidance to name both causes — a profile disabled in `aptl.json` or intentionally omitted by the selected scenario.
- `required_profiles_enabled` stays untouched in `core/contracts.py` as a config-bound predicate; only its now-unused import in `lab.py` was removed.
- Fixed 5 pre-existing SOC-retry/watchdog tests in `tests/test_lab.py` that had gone vacuous (they mocked a bare `LabResult` and asserted only "restart not called", which stayed trivially true even with zero retries once the gate flipped); each now uses a real `AcesStartOutcome` and asserts the retry actually fires.
- Added tests covering: SOC absent from the selected set is a silent no-op; a failed first apply whose outcome carries `soc` still retries; an outcome omitting `soc` skips the retry; a planner-blocked empty-set outcome fails closed; a selected-but-incomplete prime set emits the non-fatal diagnostic from the selected surface.
- Noted in `docs/aces/techvault-curated-live-validation-gate.md` that the recorded `--skip-seed` evidence rows predate this fix and are no longer required for reduced variants.

## Test Plan

Full suite green: 2272 passed, 92 skipped (`pytest -n auto -k "not integration"`); TechVault static integration gate: 2 passed. pre-commit clean including Vale prose lint. Acceptance criterion 3 (a reduced curated variant boots cleanly via `aptl lab start --scenario techvault-defensive-min` without `--skip-seed`) is proven at unit level here; a live `aptl lab start` boot requires real infrastructure and is not run in CI.

## Ground Control Checks

- [x] pre-commit passes (Vale prose lint, ruff/ESLint complexity gates, pytest)
- [x] `gc_assert_quality_gates` passes for this repo-only change
- [x] Codex pre-push review clean; test-quality review finding fixed and recorded on the issue thread

## Traceability

- IMPLEMENTS: #550 ← src/aptl/core/lab.py
- TESTS: #550 ← tests/test_lab.py

## Checklist

- [x] Code follows project coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated (`docs/architecture/issue-550-soc-selected-profile-preflight.md` preflight note; curated-live-validation-gate doc note)
