### PR TITLE
feat: consume ACES runtime-substituted plans

### DIFF
--- a/docs/aces/dsl-003-runtime-substitution-preflight.md
+++ b/docs/aces/dsl-003-runtime-substitution-preflight.md
@@ -1,0 +1,217 @@
+# DSL-003 Runtime Variable Backend Consumption Preflight
+
+This note is the architecture preflight for issue #432. It is guidance, not an
+implementation plan. The variable and substitution contract is owned by ACES
+(upstream issue Brad-Edwards/aces#655). ADR-035 remains the schema/adoption
+boundary, ADR-044 owns run evidence, and ADR-046 owns dynamic realization and
+provider safety.
+
+## Architecture Decisions
+
+- ACES remains the sole authority for variable declarations, defaults, types,
+  allowed values, selected profiles, substitution, provenance, unresolved
+  reference detection, and post-substitution semantic validation. APTL passes
+  an explicit typed binding mapping to `RuntimeManager.plan(parameters=...)`
+  or consumes an ACES-admitted plan; it does not mutate YAML, interpolate
+  strings, coerce values, or define a local variable DTO.
+- A lab-start attempt has exactly one substitution/planning authority. The
+  resulting `ExecutionPlan` and its `RuntimeModel` are the concrete scenario
+  consumed by realization, participant-action projection, selected-profile
+  reporting, evidence, and apply. No downstream path may reparse or recompile
+  the raw `Scenario` to rediscover those facts.
+- Keep the lifecycle types distinct: authored `Scenario`, ACES
+  `InstantiatedScenario`, `RuntimeModel`, `ExecutionPlan`, APTL
+  `AptlRealization`, provider `DeploymentRealizationSpec`, observed
+  `RuntimeSnapshot`, and persisted `RangeSnapshot`. A parameter bag is input to
+  admission, not a realization model, deployment configuration, or snapshot.
+- Substitution failure is fatal and occurs before provider side effects.
+  Missing required values, undeclared names, type mismatches, allowed-value
+  failures, unresolved references, and post-substitution validation failures
+  must not reach `DeploymentBackend`. They are deterministic contract failures,
+  not SOC readiness failures, and must not take the current delayed retry path.
+- `SDLInstantiationError` is the upstream failure owner. Project it once into
+  the existing redacted `LabResult`/startup/API envelope. Do not create a local
+  exception hierarchy, reproduce upstream checks, or classify failures by
+  scraping English exception text.
+- The selected `aces-sdl` 0.21.x surface exposes instantiation details as free
+  text rather than stable value-free diagnostic records. Raw rendering is not
+  safe because details may contain provided or derived values. A bounded
+  generic failure is the safe fallback. Per-mode actionable projection requires
+  an upstream code, variable path/name, and value-free detail contract; advance
+  the ACES dependency rather than introducing duplicate APTL validation or an
+  English-message parser.
+- Runtime bindings are explicit per-run inputs. They do not come implicitly
+  from `os.environ`, `.env`, `EnvVars`, `AptlConfig`, Compose interpolation, or
+  scenario-name defaults. The same immutable input must be retained across a
+  legitimate clean-boot/retry attempt and handed to ACES unchanged.
+- SDL variables are not a secret transport. Do not persist the raw mapping or
+  expose it in logs, traces, errors, CLI output, API responses, process argv, or
+  provider environment. A future secret-capable contract needs explicit
+  sensitivity and delivery semantics; existing `.env`/generated-credential
+  owners remain the only secret surface.
+
+## Required Cross-Cutting Concerns
+
+- **ACES contract and validation:** `aces_sdl.parse_sdl_file`, source/import
+  constraints, semantic validation, ACES instantiation, `RuntimeManager.plan()`,
+  planner diagnostics, `ExecutionPlan`, `RuntimeModel`, instantiation
+  provenance, backend manifest validation, and `RuntimeManager.apply()`.
+- **APTL admission and lowering:** `start_aces_scenario()`,
+  `create_aptl_runtime_target()`, `interpret_provisioning_plan()`,
+  `AptlProvisioner.validate()`, typed `AptlRealization`, and
+  `_apply_execution_plan()`. SEM-218 and provider support remain plan/apply
+  gates after successful substitution.
+- **Single-model consumers:** `participant_action_specs_from_runtime_model()`,
+  the selected profiles already returned in `AcesStartOutcome`, realization
+  details, manifest payload, and ACES run evidence. The best-effort
+  `participant_action_specs_for_scenario()` compiler and
+  `selected_profiles_for_scenario()` must not create a second model during the
+  same start attempt.
+- **Provider safety:** `DeploymentBackend`, `DockerComposeBackend`,
+  `SSHComposeBackend`, typed argv calls, project-name/Compose-label scoping,
+  timeouts, image source/digest/build-path checks, content source/destination
+  containment, network/address checks, exact port conflict checks, loopback
+  publishing defaults, account validation, and participant binding validation.
+- **Configuration and secrets:** strict `AptlConfig`, `.env`/`EnvVars`,
+  placeholder rejection, generated credential/config owners, `redact()`, and
+  ADR-025/ADR-029. These are adjacent controls, not alternate variable binding
+  systems.
+- **Errors and observability:** ACES `Diagnostic` for plan/apply failures,
+  `aces_diagnostics`, `render_aces_diagnostics()`, `LabResult`,
+  `StartupDiagnostic`, `AcesStartOutcome`, `get_logger()`, existing telemetry,
+  and authenticated API projections. Substitution is a pre-plan failure and
+  must not be mislabeled as provisioning or degraded readiness.
+- **Evidence and persistence:** `LocalRunStore` redacting JSON/JSONL methods,
+  `aces_repro`, `RuntimeSnapshot`, and `RangeSnapshot.to_dict()`. Preserve an
+  upstream instantiated artifact identity and value-free binding metadata when
+  available; do not create an APTL parameter record or persist raw provenance
+  values by default.
+- **Workflow conventions:** `orchestrate_lab_start()`, `_LabStartContext`,
+  `_step_start_containers()`, clean boot, static/live ACES gates, `pytest`, and
+  `pre-commit run --all-files` under `.gc/plan-rules.md`.
+
+## Cross-Cutting Layers The Design Must Pass
+
+| Layer | Required behavior |
+| --- | --- |
+| Scenario selection | Continue through `resolve_scenario_selection()` and project-file containment. A runtime binding must never become a path or import bypass. |
+| ACES parse and semantic admission | Let the selected ACES package parse, shape-check, resolve imports, and validate authored SDL. Do not add an APTL schema or placeholder scanner. |
+| ACES instantiation | Pass one explicit mapping with ACES-supported scalar types to `RuntimeManager.plan(parameters=...)`. ACES owns required/default, undeclared, type, constraint, selected-profile, unresolved-reference, and post-substitution checks. |
+| Plan and manifest | Fail planner diagnostics before side effects and preserve the planned manifest, provenance, canonical addresses, and SEM-218 requirements. Do not synthesize a plan from substituted dictionaries. |
+| APTL lowering | Interpret only the admitted plan/model into `AptlRealization`. A remaining `${...}` token or malformed concrete value is a contract failure, not a value to drop, default, or substitute locally. |
+| Provider policy | Re-run all existing image, content, network, port, account, participant-binding, and backend capability checks on concrete values. Successful ACES substitution does not waive provider safety policy. |
+| Deployment and OS exposure | Use `DeploymentBackend` and discrete argv. Never forward the binding mapping wholesale to Compose environment, container environment, subprocess argv, or shell. Participant-action values still pass governed binding validation; bindings must not carry secrets because container argv may be inspectable. |
+| Config and environment shape | Keep durable non-secret configuration in strict `AptlConfig` and control-plane secrets in `.env`/`EnvVars` and generated config. No ambient environment lookup or string-to-scalar coercion is permitted. |
+| Auth and ingress | Issue #432 adds no HTTP or CLI variable-authoring surface. Existing lab start remains behind `verify_token` and BFF host/CSRF/session gates. A later ingress must use an authenticated strict Pydantic body or protected typed file that preserves scalar types, never query parameters or secret-bearing command-line flags; validation projections must omit raw input values. |
+| Retry and side-effect boundary | Instantiation and planner failures are non-retryable and return immediately. If orchestration needs a signal, carry a narrow stage/retryability classification on the existing start outcome; do not infer it from message text. A legitimate provider retry reuses the same admitted inputs. |
+| Error envelope | Return a fatal redacted `LabResult` before deployment. Expose stable upstream codes, variable identifiers/paths, and value-free remediation only when the upstream contract supplies them; otherwise use a bounded generic message. Do not echo the mapping, raw exception, scenario, or plan. |
+| Logging and telemetry | Log only stage, stable code, safe variable identifier, and counts. Never attach values, the binding mapping, raw plan/model, exception payload, or rendered scenario to logs or span attributes. `redact()` is defense in depth, not proof that arbitrary values are safe. |
+| Persistence and export | Use existing runstore paths and redaction. Raw binding values and upstream provenance containing them stay out of snapshots, run JSON, archives, CLI/API projections, and exports unless a later sensitivity-aware contract explicitly admits them. Export remains packaging-only. |
+
+## Extensibility Seam
+
+The required seam is the existing ACES planning call, parameterized by:
+
+`(Scenario, explicit per-run bindings, selected ACES profile, prior
+RuntimeSnapshot, RuntimeTarget) -> ExecutionPlan`.
+
+The bindings are handed to ACES exactly once. Every later concern receives the
+admitted `ExecutionPlan` or its `RuntimeModel`, never the raw mapping. This
+allows the next reasonable variation -- a different authenticated binding
+carrier, another backend, or an upstream-admitted instantiated artifact -- to
+replace only the input/admission edge while leaving realization, participant
+projection, apply, provider validation, and evidence handling unchanged.
+
+The error-projection seam is an upstream structured instantiation diagnostic:
+stable code, variable address/name, phase, and value-free remediation. APTL may
+map that to its existing envelopes, but must not define the semantic taxonomy.
+If orchestration needs retry control, stage/retryability belongs on the existing
+start outcome, not in a second exception tree.
+
+## Whole-Repo Surface
+
+- Contract authority: `pyproject.toml`, `uv.lock`, the selected `aces-sdl`
+  parser/instantiator/runtime APIs, ACES diagnostics, manifest, conformance
+  corpus, and upstream contract tests.
+- Runtime path: `src/aptl/backends/aces.py`, `aces_start_model.py`,
+  `aces_participant_actions.py`, `aces_participant_bindings.py`,
+  `aces_realization.py`, `aces_realization_model.py`,
+  `aces_realization_values.py`, `aces_profiles.py`, `aces_provisioner.py`, and
+  `aces_diagnostics.py`.
+- Provider/security path: `aces_image_realization.py`,
+  `aces_content_realization.py`, `aces_realization_networks.py`,
+  `aces_account_realization.py`, `src/aptl/core/deployment/`, host-port checks,
+  Docker/SSH Compose process boundaries, project labels, and host binding.
+- Lifecycle/output path: `src/aptl/core/lab.py`, `lab_types.py`, `runstore.py`,
+  `snapshot.py`, `src/aptl/backends/aces_repro.py`, CLI lab output,
+  `src/aptl/api/routers/lab.py`, API schemas, BFF/auth middleware, logs, traces,
+  run archives, and exports.
+- Config/secret path: `src/aptl/core/config.py`, `env.py`, `.env`, generated
+  config/credentials, `AptlConfig`, `EnvVars`, `redact()`, ADR-025, ADR-029,
+  ADR-035, ADR-039, ADR-044, and ADR-046.
+- Validation path: `src/aptl/validation/_gate_checks.py`,
+  `_live_gate_probes.py`, and `curated_live_proof.py`. Required-variable
+  scenarios need an explicit representative binding input; do not add
+  scenario-name parameter maps to make gates pass.
+- Test path: `tests/test_aces_backend.py`,
+  `tests/test_aces_realization_service_ports.py`,
+  `tests/test_aces_repro.py`, `tests/test_lab.py`, CLI/API tests, target
+  conformance, static scenario gates, and the bounded live gate.
+
+## Gotchas And Anti-Patterns
+
+- `participant_action_specs_for_scenario()` currently recompiles the raw
+  scenario and swallows failure. Runtime-substituted participant bindings must
+  instead come from the already planned `execution_plan.model` through
+  `participant_action_specs_from_runtime_model()`.
+- Lab start currently calls `selected_profiles_for_scenario()` after a
+  successful ACES start, causing a second raw parse/plan. Use
+  `AcesStartOutcome.selected_profiles`; otherwise required bindings disappear
+  or defaults may diverge from the executed plan.
+- The SOC startup path currently retries any ACES failure after a delay.
+  Substitution, parse, planner, and provider-policy failures are deterministic
+  and must not be delayed or retried as readiness failures.
+- `aces_realization_values` currently drops unsubstituted port tokens, and tests
+  pin that defensive behavior. In the admitted runtime path, unresolved tokens
+  are impossible by contract; if one arrives, fail closed before side effects
+  rather than silently omitting a declaration. Do not add a repo-wide duplicate
+  placeholder validator.
+- `aces_repro` currently records `scenario_parameters: null` and a note that no
+  parameter surface exists. That statement becomes stale, but replacing it
+  with raw ACES binding provenance would create a secret/data leakage surface.
+- Do not use local regex replacement, recursive dictionary walkers, YAML
+  mutation, local Pydantic variable models, string coercion, or duplicate
+  required/type/allowed-value checks.
+- Do not conflate ACES `${variable}` semantics with Compose interpolation,
+  `.env.example` placeholder detection, participant `{{...}}` templates,
+  generated credentials, shell variables, or service environment variables.
+- Do not reparse/replan for profiles, participant actions, evidence, retries, or
+  validation; do not branch on scenario name or hardcode a parameter map for a
+  curated scenario.
+- Do not parse `SDLInstantiationError` prose, blindly render it, hash low-entropy
+  values as a substitute for secrecy, or rely on `redact()` to discover
+  arbitrary user-provided values.
+- Do not treat a substitution failure as an ACES provisioning diagnostic,
+  backend execution failure, degraded startup diagnostic, or successful lab
+  with omitted fields.
+
+## Non-Goals And Boundaries
+
+- Do not implement issue #432 in this preflight.
+- Do not define or change SDL variable syntax, scope, precedence, types,
+  defaults, allowed-value semantics, profile semantics, substitution order, or
+  provenance in APTL; the upstream ACES contract is authoritative.
+- Do not add an API, UI, CLI flag, environment convention, config property, or
+  persistence schema for authoring/storing bindings in this issue.
+- Do not make SDL variables a secret manager or migrate existing service
+  credentials, generated config, TLS/SSH material, tokens, or `.env` values into
+  the SDL variable surface.
+- Do not redesign `DeploymentBackend`, Compose topology, startup readiness,
+  provider validation, participant templates, run archives, snapshots,
+  exporter packaging, authentication, or observability.
+- Do not accept arbitrary externally serialized plans unless the selected ACES
+  contract supplies an admission/integrity path. An in-process `ExecutionPlan`
+  from the canonical planner is not a general remote-plan API.
+- Do not weaken downstream provider validation because substitution succeeded,
+  and do not broaden live gates beyond one representative valid concrete
+  binding plus fast contract/failure coverage.

--- a/docs/sdl/runtime-architecture.md
+++ b/docs/sdl/runtime-architecture.md
@@ -8,8 +8,24 @@ The supported runtime handoff is now:
 
 1. Resolve the curated catalog ID or explicit project-contained SDL path.
 2. Validate the selected file with `aces_sdl.parse_sdl_file`.
-3. Plan through `aces_runtime.manager.RuntimeManager`.
-4. Start the lab through `aptl.backends.aces.start_aces_scenario()`.
+3. Pass any explicit per-run runtime bindings to
+   `aces_runtime.manager.RuntimeManager.plan(parameters=...)`. ACES owns
+   substitution, type and constraint validation, unresolved-reference checks,
+   and post-substitution semantic validation.
+4. Consume the resulting `ExecutionPlan` and its concrete `RuntimeModel`
+   throughout realization, participant actions, selected-profile reporting,
+   evidence, and apply. The start path does not recompile the authored scenario.
+5. Start the lab through `aptl.backends.aces.start_aces_scenario()`.
+
+If the deployment backend returns its existing retryable start diagnostic, the
+SOC recovery hook runs and APTL applies that same admitted `ExecutionPlan` one
+more time. It does not parse the SDL or invoke the planner again.
+
+Runtime bindings are an in-process admission input, not APTL configuration or
+secrets. APTL does not source them from the environment, forward them to
+Compose or process arguments, or persist them in run records. Instantiation
+failures stop before backend side effects and return bounded, value-free
+remediation rather than rendering the upstream exception.
 
 APTL still keeps `aptl.core.runtime.workflow_engine` as an implementation
 helper for the ACES orchestrator's workflow result/history records. It is not a

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -30,7 +30,11 @@ from aptl.backends.aces_realization import (
 from aptl.backends.aces_profiles import (
     select_backend_profiles,
 )
-from aptl.backends.aces_start_model import DEFAULT_ACES_SCENARIO, AcesStartOutcome
+from aptl.backends.aces_start_model import (
+    DEFAULT_ACES_SCENARIO,
+    AcesRunTarget,
+    AcesStartOutcome,
+)
 from aptl.core.config import AptlConfig
 from aptl.core.lab_types import LabResult
 from aptl.utils.logging import get_logger
@@ -91,18 +95,17 @@ def start_aces_scenario(
     backend: "DeploymentBackend",
     scenario_path: Path | None = None,
     *,
-    run_store: RunStorageBackend | None = None,
-    run_id: str | None = None,
+    run_target: AcesRunTarget | None = None,
     parameters: Mapping[str, object] | None = None,
     before_backend_retry: Callable[[], None] | None = None,
 ) -> AcesStartOutcome:
     """Start an APTL lab by compiling and applying an ACES SDL scenario.
 
-    ``run_store`` and ``run_id`` (resolved once for the whole lab-start run,
-    REP-001 / GAP 4) are threaded into orchestration so workflow result and
-    history artifacts persist under the same run directory the reproducibility
-    record is written to. ``parameters`` is the explicit per-run ACES binding
-    mapping; only the planner sees it, and APTL neither logs nor persists it.
+    ``run_target`` (resolved once for the whole lab-start run, REP-001 / GAP 4)
+    is threaded into orchestration so workflow result and history artifacts
+    persist under the same run directory the reproducibility record is written
+    to. ``parameters`` is the explicit per-run ACES binding mapping; only the
+    planner sees it, and APTL neither logs nor persists it.
     """
 
     resolved_scenario = scenario_path or DEFAULT_ACES_SCENARIO
@@ -138,8 +141,8 @@ def start_aces_scenario(
             target,
             execution_plan,
             resolved_scenario,
-            run_store=run_store,
-            run_id=run_id,
+            run_store=run_target.run_store if run_target is not None else None,
+            run_id=run_target.run_id if run_target is not None else None,
         )
         if (
             outcome.retryable
@@ -151,8 +154,8 @@ def start_aces_scenario(
                 target,
                 execution_plan,
                 resolved_scenario,
-                run_store=run_store,
-                run_id=run_id,
+                run_store=run_target.run_store if run_target is not None else None,
+                run_id=run_target.run_id if run_target is not None else None,
             )
         return outcome
     except SDLInstantiationError:

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from aces_contracts.runtime_state import RuntimeSnapshot
 from aces_runtime.manager import RuntimeManager
 from aces_runtime.registry import RuntimeTarget
-from aces_sdl import SDLError, parse_sdl_file
+from aces_sdl import SDLError, SDLInstantiationError, parse_sdl_file
 
 from aptl.backends.aces_diagnostics import (
     render_aces_diagnostics,
@@ -20,7 +20,7 @@ from aptl.backends.aces_orchestrator import AptlOrchestrator
 from aptl.backends.aces_participant_actions import (
     DEFAULT_PARTICIPANT_ACTIONS,
     ParticipantActionSpec,
-    participant_action_specs_for_scenario,
+    participant_action_specs_from_runtime_model,
 )
 from aptl.backends.aces_participant_runtime import AptlParticipantRuntime
 from aptl.backends.aces_provisioner import AptlProvisioner
@@ -43,6 +43,14 @@ if TYPE_CHECKING:
     from aptl.core.runstore import RunStorageBackend
 
 log = get_logger("aces-backend")
+
+_INSTANTIATION_FAILURE_MESSAGE = (
+    "ACES runtime variable binding failed before deployment. Provide every "
+    "required variable using its declared type and allowed values."
+)
+_RETRYABLE_APPLY_DIAGNOSTIC_CODES = frozenset(
+    {"aptl.provisioner.backend-start-failed"}
+)
 
 
 def create_aptl_runtime_target(
@@ -85,13 +93,16 @@ def start_aces_scenario(
     *,
     run_store: RunStorageBackend | None = None,
     run_id: str | None = None,
+    parameters: Mapping[str, object] | None = None,
+    before_backend_retry: Callable[[], None] | None = None,
 ) -> AcesStartOutcome:
     """Start an APTL lab by compiling and applying an ACES SDL scenario.
 
     ``run_store`` and ``run_id`` (resolved once for the whole lab-start run,
     REP-001 / GAP 4) are threaded into orchestration so workflow result and
     history artifacts persist under the same run directory the reproducibility
-    record is written to.
+    record is written to. ``parameters`` is the explicit per-run ACES binding
+    mapping; only the planner sees it, and APTL neither logs nor persists it.
     """
 
     resolved_scenario = scenario_path or DEFAULT_ACES_SCENARIO
@@ -104,9 +115,14 @@ def start_aces_scenario(
             config=config,
             backend=backend,
         )
-        execution_plan = RuntimeManager(target).plan(scenario)
-        participant_action_specs = participant_action_specs_for_scenario(
-            scenario,
+        manager = RuntimeManager(target)
+        execution_plan = (
+            manager.plan(scenario, parameters=dict(parameters))
+            if parameters is not None
+            else manager.plan(scenario)
+        )
+        participant_action_specs = participant_action_specs_from_runtime_model(
+            execution_plan.model,
             provisioning_plan=execution_plan.provisioning,
             project_dir=project_dir,
             config=config,
@@ -118,12 +134,34 @@ def start_aces_scenario(
                 backend=backend,
                 participant_action_specs=participant_action_specs,
             )
-        return _run_execution_plan(
+        outcome = _run_execution_plan(
             target,
             execution_plan,
             resolved_scenario,
             run_store=run_store,
             run_id=run_id,
+        )
+        if outcome.retryable and before_backend_retry is not None:
+            before_backend_retry()
+            outcome = _run_execution_plan(
+                target,
+                execution_plan,
+                resolved_scenario,
+                run_store=run_store,
+                run_id=run_id,
+            )
+        return outcome
+    except SDLInstantiationError:
+        return AcesStartOutcome(
+            lab_result=LabResult(
+                success=False,
+                error=_INSTANTIATION_FAILURE_MESSAGE,
+            ),
+            final_snapshot=RuntimeSnapshot(),
+            realization_details={},
+            selected_profiles=[],
+            scenario_path=resolved_scenario,
+            retryable=False,
         )
     except (FileNotFoundError, SDLError, TypeError, ValueError) as exc:
         return AcesStartOutcome(
@@ -190,7 +228,7 @@ def _run_execution_plan(
     realization_details, selected_profiles = _interpret_realization(
         target, execution_plan
     )
-    failure, snapshot = _apply_execution_plan(
+    failure, snapshot, retryable = _apply_execution_plan(
         target,
         execution_plan,
         run_store=run_store,
@@ -203,6 +241,7 @@ def _run_execution_plan(
             realization_details=realization_details,
             selected_profiles=selected_profiles,
             scenario_path=scenario_path,
+            retryable=retryable,
         )
     return AcesStartOutcome(
         lab_result=LabResult(
@@ -222,7 +261,7 @@ def _apply_execution_plan(
     *,
     run_store: RunStorageBackend | None = None,
     run_id: str | None = None,
-) -> tuple[LabResult | None, RuntimeSnapshot]:
+) -> tuple[LabResult | None, RuntimeSnapshot, bool]:
     """Apply the plan through ACES's own runtime manager, then drive workflows.
 
     ``RuntimeManager.apply`` is the only path that threads the compiled
@@ -235,7 +274,9 @@ def _apply_execution_plan(
     Going through the manager deletes that parallel path outright: the gate and
     the provenance ledger are ACES's, not APTL's (issue #578, ADR-046).
 
-    Returns ``(failure | None, snapshot)``.
+    Returns ``(failure | None, snapshot, retryable)``. Only the existing
+    deployment-backend start diagnostic is retryable; deterministic admission,
+    planning, provider-policy, and workflow failures are not.
     """
 
     manager = RuntimeManager(target, initial_snapshot=execution_plan.base_snapshot)
@@ -248,6 +289,10 @@ def _apply_execution_plan(
                 error=render_aces_diagnostics(list(apply_result.diagnostics)),
             ),
             snapshot,
+            any(
+                diagnostic.code in _RETRYABLE_APPLY_DIAGNOSTIC_CODES
+                for diagnostic in apply_result.diagnostics
+            ),
         )
     evaluation_results = _evaluation_results(target, execution_plan)
     failure = _drive_orchestrator_workflows(
@@ -256,7 +301,7 @@ def _apply_execution_plan(
         run_store=run_store,
         run_id=run_id,
     )
-    return failure, snapshot
+    return failure, snapshot, False
 
 
 def _evaluation_results(

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -108,56 +108,22 @@ def start_aces_scenario(
     planner sees it, and APTL neither logs nor persists it.
     """
 
-    resolved_scenario = scenario_path or DEFAULT_ACES_SCENARIO
-    if not resolved_scenario.is_absolute():
-        resolved_scenario = project_dir / resolved_scenario
+    resolved_scenario = _resolve_scenario_path(project_dir, scenario_path)
     try:
-        scenario = parse_sdl_file(resolved_scenario)
-        target = create_aptl_runtime_target(
-            project_dir=project_dir,
-            config=config,
-            backend=backend,
+        target, execution_plan = _plan_scenario(
+            project_dir,
+            config,
+            backend,
+            resolved_scenario,
+            parameters,
         )
-        manager = RuntimeManager(target)
-        execution_plan = (
-            manager.plan(scenario, parameters=dict(parameters))
-            if parameters is not None
-            else manager.plan(scenario)
-        )
-        participant_action_specs = participant_action_specs_from_runtime_model(
-            execution_plan.model,
-            provisioning_plan=execution_plan.provisioning,
-            project_dir=project_dir,
-            config=config,
-        )
-        if participant_action_specs:
-            target = create_aptl_runtime_target(
-                project_dir=project_dir,
-                config=config,
-                backend=backend,
-                participant_action_specs=participant_action_specs,
-            )
-        outcome = _run_execution_plan(
+        return _apply_with_backend_retry(
             target,
             execution_plan,
             resolved_scenario,
-            run_store=run_target.run_store if run_target is not None else None,
-            run_id=run_target.run_id if run_target is not None else None,
+            run_target,
+            before_backend_retry,
         )
-        if (
-            outcome.retryable
-            and "soc" in outcome.selected_profiles
-            and before_backend_retry is not None
-        ):
-            before_backend_retry()
-            outcome = _run_execution_plan(
-                target,
-                execution_plan,
-                resolved_scenario,
-                run_store=run_target.run_store if run_target is not None else None,
-                run_id=run_target.run_id if run_target is not None else None,
-            )
-        return outcome
     except SDLInstantiationError:
         return AcesStartOutcome(
             lab_result=LabResult(
@@ -181,6 +147,84 @@ def start_aces_scenario(
             selected_profiles=[],
             scenario_path=resolved_scenario,
         )
+
+
+def _resolve_scenario_path(project_dir: Path, scenario_path: Path | None) -> Path:
+    """Resolve the authored scenario beneath the project when it is relative."""
+
+    resolved = scenario_path or DEFAULT_ACES_SCENARIO
+    return resolved if resolved.is_absolute() else project_dir / resolved
+
+
+def _plan_scenario(
+    project_dir: Path,
+    config: AptlConfig,
+    backend: "DeploymentBackend",
+    scenario_path: Path,
+    parameters: Mapping[str, object] | None,
+) -> tuple[RuntimeTarget, "ExecutionPlan"]:
+    """Build one ACES plan and the target that consumes its concrete model."""
+
+    scenario = parse_sdl_file(scenario_path)
+    target = create_aptl_runtime_target(
+        project_dir=project_dir,
+        config=config,
+        backend=backend,
+    )
+    manager = RuntimeManager(target)
+    execution_plan = (
+        manager.plan(scenario, parameters=dict(parameters))
+        if parameters is not None
+        else manager.plan(scenario)
+    )
+    participant_action_specs = participant_action_specs_from_runtime_model(
+        execution_plan.model,
+        provisioning_plan=execution_plan.provisioning,
+        project_dir=project_dir,
+        config=config,
+    )
+    if participant_action_specs:
+        target = create_aptl_runtime_target(
+            project_dir=project_dir,
+            config=config,
+            backend=backend,
+            participant_action_specs=participant_action_specs,
+        )
+    return target, execution_plan
+
+
+def _apply_with_backend_retry(
+    target: RuntimeTarget,
+    execution_plan: "ExecutionPlan",
+    scenario_path: Path,
+    run_target: AcesRunTarget | None,
+    before_backend_retry: Callable[[], None] | None,
+) -> AcesStartOutcome:
+    """Apply one admitted plan, retrying only its SOC backend-start failure."""
+
+    run_store = run_target.run_store if run_target is not None else None
+    run_id = run_target.run_id if run_target is not None else None
+    outcome = _run_execution_plan(
+        target,
+        execution_plan,
+        scenario_path,
+        run_store=run_store,
+        run_id=run_id,
+    )
+    if (
+        outcome.retryable
+        and "soc" in outcome.selected_profiles
+        and before_backend_retry is not None
+    ):
+        before_backend_retry()
+        return _run_execution_plan(
+            target,
+            execution_plan,
+            scenario_path,
+            run_store=run_store,
+            run_id=run_id,
+        )
+    return outcome
 
 
 def selected_profiles_for_scenario(

--- a/src/aptl/backends/aces_repro.py
+++ b/src/aptl/backends/aces_repro.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
 
 SCHEMA_VERSION = "aptl.run-record/v1"
 
-_SEEDS_ABSENT_NOTE = (
-    "ACES ExecutionPlan does not currently expose a scenario-level "
-    "seed or parameter surface; seeds absent is the honest state."
+_PARAMETERS_OMITTED_NOTE = (
+    "Runtime parameters are intentionally omitted; APTL does not persist raw "
+    "scenario bindings or value-bearing provenance."
 )
 
 
@@ -86,7 +86,7 @@ def build_reproducibility_record(inputs: RunRecordInputs) -> dict[str, Any]:
             "runtime_snapshot": runtime_snapshot_payload,
             "scenario": scenario_section,
             "scenario_parameters": None,
-            "scenario_parameters_note": _SEEDS_ABSENT_NOTE,
+            "scenario_parameters_note": _PARAMETERS_OMITTED_NOTE,
             "realization": inputs.realization_details,
         },
         "backend_evidence": {

--- a/src/aptl/backends/aces_start_model.py
+++ b/src/aptl/backends/aces_start_model.py
@@ -23,3 +23,4 @@ class AcesStartOutcome:
     selected_profiles: list[str]
     scenario_path: Path | None
     manifest_payload: dict[str, Any] = field(default_factory=dict)
+    retryable: bool = False

--- a/src/aptl/backends/aces_start_model.py
+++ b/src/aptl/backends/aces_start_model.py
@@ -13,6 +13,14 @@ from aptl.core.lab_types import LabResult
 DEFAULT_ACES_SCENARIO = Path("scenarios") / "techvault-operational.sdl.yaml"
 
 
+@dataclass(frozen=True)
+class AcesRunTarget:
+    """Resolved archive destination shared by orchestration and run records."""
+
+    run_store: Any
+    run_id: str
+
+
 @dataclass
 class AcesStartOutcome:
     """Reference-holder for start_aces_scenario outputs (REP-001 / ADR-044)."""

--- a/src/aptl/backends/aces_start_model.py
+++ b/src/aptl/backends/aces_start_model.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aces_contracts.runtime_state import RuntimeSnapshot
 
 from aptl.core.lab_types import LabResult
+
+if TYPE_CHECKING:
+    from aptl.core.runstore import RunStorageBackend
 
 DEFAULT_ACES_SCENARIO = Path("scenarios") / "techvault-operational.sdl.yaml"
 
@@ -17,7 +20,7 @@ DEFAULT_ACES_SCENARIO = Path("scenarios") / "techvault-operational.sdl.yaml"
 class AcesRunTarget:
     """Resolved archive destination shared by orchestration and run records."""
 
-    run_store: Any
+    run_store: RunStorageBackend
     run_id: str
 
 

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
     from docker.client import DockerClient
 
     from aptl.backends.aces import AcesStartOutcome
+    from aptl.backends.aces_start_model import AcesRunTarget
     from aptl.core.deployment.backend import DeploymentBackend
 
 log = get_logger("lab")
@@ -119,16 +120,15 @@ def start_aces_scenario(
     backend: "DeploymentBackend",
     scenario_path: Path | None = None,
     *,
-    run_store: object = None,
-    run_id: str | None = None,
+    run_target: AcesRunTarget | None = None,
     parameters: Mapping[str, object] | None = None,
     before_backend_retry: Callable[[], None] | None = None,
 ) -> AcesStartOutcome | LabResult:
     """Lazy ACES handoff import for the public lab-start path.
 
-    ``run_store``/``run_id`` (resolved once per lab-start run, REP-001 / GAP 4)
-    are threaded into the ACES handoff so orchestration persists workflow
-    artifacts under the same run directory the run record is written to.
+    ``run_target`` (resolved once per lab-start run, REP-001 / GAP 4) is
+    threaded into the ACES handoff so orchestration persists workflow artifacts
+    under the same run directory the run record is written to.
     ``before_backend_retry`` lets the lifecycle prepare SOC dependencies while
     the backend retains and reapplies the already admitted execution plan.
     """
@@ -144,8 +144,7 @@ def start_aces_scenario(
         config,
         backend,
         scenario_path=scenario_path,
-        run_store=run_store,
-        run_id=run_id,
+        run_target=run_target,
         parameters=parameters,
         before_backend_retry=before_backend_retry,
     )
@@ -1340,13 +1339,14 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
     # orchestration persists workflow artifacts and the later run-record step
     # write to the same run directory / run_id.
     ctx.run_store, ctx.run_id = _resolve_run_target(ctx)
+    from aptl.backends.aces_start_model import AcesRunTarget
+
     outcome = start_aces_scenario(
         ctx.project_dir,
         ctx.config,
         ctx.backend,
         scenario_path=ctx.scenario_path,
-        run_store=ctx.run_store,
-        run_id=ctx.run_id,
+        run_target=AcesRunTarget(run_store=ctx.run_store, run_id=ctx.run_id),
         # The ACES handoff invokes this only for a retryable backend-start
         # failure whose admitted plan actually selected SOC. Keeping that gate
         # beside the admitted plan avoids both config-flag approximation and a

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
@@ -120,12 +120,16 @@ def start_aces_scenario(
     *,
     run_store: object = None,
     run_id: str | None = None,
+    parameters: Mapping[str, object] | None = None,
+    before_backend_retry: Callable[[], None] | None = None,
 ) -> AcesStartOutcome | LabResult:
     """Lazy ACES handoff import for the public lab-start path.
 
     ``run_store``/``run_id`` (resolved once per lab-start run, REP-001 / GAP 4)
     are threaded into the ACES handoff so orchestration persists workflow
     artifacts under the same run directory the run record is written to.
+    ``before_backend_retry`` lets the lifecycle prepare SOC dependencies while
+    the backend retains and reapplies the already admitted execution plan.
     """
     try:
         from aptl.backends.aces import start_aces_scenario as _start_aces_scenario
@@ -141,6 +145,8 @@ def start_aces_scenario(
         scenario_path=scenario_path,
         run_store=run_store,
         run_id=run_id,
+        parameters=parameters,
+        before_backend_retry=before_backend_retry,
     )
 
 
@@ -150,12 +156,12 @@ def selected_profiles_for_scenario(
     backend: "DeploymentBackend",
     scenario_path: Path | None = None,
 ) -> set[str]:
-    """Lazy ACES import for the scenario's selected Compose profiles.
+    """Inspect a scenario's selected Compose profiles without starting it.
 
-    Returns the profile set the scenario actually starts, so post-start
-    readiness checks scope to it instead of the global config flags. On import
-    failure returns an empty set (the readiness steps then skip rather than
-    falsely waiting on services).
+    This remains an independent validation/inspection surface. The actual lab
+    start path consumes ``AcesStartOutcome.selected_profiles`` from its one
+    admitted execution plan and does not call this helper after deployment.
+    On import or planning failure, return an empty set.
     """
     try:
         from aptl.backends.aces import (
@@ -167,10 +173,8 @@ def selected_profiles_for_scenario(
                 project_dir, config, backend, scenario_path=scenario_path
             )
         )
-    # broad-except: resolving selected profiles is best-effort enrichment for
-    # the readiness steps. The lab already started; any failure (import,
-    # missing/invalid SDL, ACES planning error) must degrade to an empty set so
-    # the readiness steps skip rather than crash the start or falsely wait.
+    # broad-except: resolving profiles is best-effort inspection. Any failure
+    # (import, missing/invalid SDL, ACES planning error) degrades to an empty set.
     except Exception as exc:
         log.warning("Could not resolve selected profiles: %s", redact(str(exc)))
         return set()
@@ -1227,6 +1231,22 @@ def _restart_wazuh_manager_if_stuck(ctx: _LabStartContext) -> None:
         log.warning("wazuh-manager restart attempt failed: %s", exc)
 
 
+def _prepare_aces_backend_retry(ctx: _LabStartContext) -> None:
+    """Wait for SOC dependencies and repair the manager before one apply retry."""
+
+    log.warning(
+        "Initial compose up failed (SOC dependencies may still be "
+        "initializing). Waiting 60s and retrying the admitted plan..."
+    )
+    import time
+
+    time.sleep(60)
+    # Colima on macOS reproducibly leaves the wazuh-manager container in a
+    # state where s6-supervise reports EACCES while the container remains Up.
+    # Repair that state between apply attempts without reparsing or replanning.
+    _restart_wazuh_manager_if_stuck(ctx)
+
+
 @_runtime_require(
     lambda ctx: config_is_loaded(ctx.config),
     description="config_is_loaded(ctx.config)",
@@ -1251,33 +1271,13 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
         scenario_path=ctx.scenario_path,
         run_store=ctx.run_store,
         run_id=ctx.run_id,
+        before_backend_retry=(
+            partial(_prepare_aces_backend_retry, ctx)
+            if ctx.config.containers.soc
+            else None
+        ),
     )
     lab_result = outcome.lab_result if hasattr(outcome, "lab_result") else outcome
-    if not lab_result.success and ctx.config.containers.soc:
-        log.warning(
-            "Initial compose up failed (SOC dependencies may still be "
-            "initializing). Waiting 60s and retrying..."
-        )
-        import time
-
-        time.sleep(60)
-        # Colima on macOS reproducibly leaves the wazuh-manager container
-        # in a state where s6-supervise reports EACCES on the (executable)
-        # `run` scripts and the wazuh daemons never spawn (#732). The
-        # container stays Up so docker's own restart policy never fires,
-        # but no wazuh-* processes exist inside. A single `docker restart`
-        # clears the state; do that before the retry so compose isn't
-        # forced to try running `up` against a broken container instance.
-        _restart_wazuh_manager_if_stuck(ctx)
-        outcome = start_aces_scenario(
-            ctx.project_dir,
-            ctx.config,
-            ctx.backend,
-            scenario_path=ctx.scenario_path,
-            run_store=ctx.run_store,
-            run_id=ctx.run_id,
-        )
-        lab_result = outcome.lab_result if hasattr(outcome, "lab_result") else outcome
     if lab_result.success:
         # Store the ACES start outcome for the run record step (REP-001).
         ctx.aces_outcome = outcome
@@ -1285,12 +1285,7 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
         # actually started, not the global config flags. A curated bounded
         # scenario starts a subset, so a config-flag gate would wait on (and
         # fail) services it never launched.
-        ctx.selected_profiles = selected_profiles_for_scenario(
-            ctx.project_dir,
-            ctx.config,
-            ctx.backend,
-            scenario_path=ctx.scenario_path,
-        )
+        ctx.selected_profiles = set(getattr(outcome, "selected_profiles", ()))
         return None
     log.error("Lab start failed: %s", lab_result.error)
     return LabResult(

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -1612,6 +1612,46 @@ def test_start_aces_scenario_passes_runtime_parameters_to_aces_planner(
     assert calls == {"scenario": scenario, "parameters": parameters}
 
 
+def test_start_aces_scenario_threads_resolved_run_target(mocker, tmp_path):
+    from aptl.backends import aces
+    from aptl.backends.aces_start_model import AcesRunTarget, AcesStartOutcome
+
+    _write_compose(tmp_path, {"aptl-victim": ["victim"]})
+    scenario = object()
+    mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=scenario)
+
+    class FakeRuntimeManager(_FakeRuntimeManager):
+        def plan(self, parsed_scenario):
+            assert parsed_scenario is scenario
+            return _FakeExecutionPlan(_plan_for_nodes("aptl-victim"))
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    mocker.patch(
+        "aptl.backends.aces.participant_action_specs_from_runtime_model",
+        return_value={},
+    )
+    outcome = AcesStartOutcome(
+        lab_result=LabResult(success=True, message="ok"),
+        final_snapshot=RuntimeSnapshot(),
+        realization_details={},
+        selected_profiles=["victim"],
+        scenario_path=None,
+    )
+    run_plan = mocker.patch("aptl.backends.aces._run_execution_plan", return_value=outcome)
+    store = object()
+    run_target = AcesRunTarget(run_store=store, run_id="run-1")
+
+    result = aces.start_aces_scenario(
+        tmp_path,
+        AptlConfig(lab={"name": "test"}, containers={"victim": True}),
+        MagicMock(),
+        run_target=run_target,
+    )
+
+    assert result is outcome
+    assert run_plan.call_args.kwargs == {"run_store": store, "run_id": "run-1"}
+
+
 def test_start_aces_scenario_uses_planned_runtime_model_for_participant_actions(
     mocker, tmp_path
 ):

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -2,7 +2,7 @@
 
 import inspect
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -465,10 +465,12 @@ class _FakeExecutionPlan:
         diagnostics=None,
         orchestration=None,
         evaluation=None,
+        model=None,
     ):
         self.provisioning = provisioning
         self.orchestration = orchestration or OrchestrationPlan()
         self.evaluation = evaluation or EvaluationPlan()
+        self.model = model if model is not None else object()
         self.base_snapshot = RuntimeSnapshot()
         self.is_valid = is_valid
         self.diagnostics = diagnostics or []
@@ -1577,6 +1579,155 @@ def test_start_aces_scenario_uses_selected_scenario_path(mocker, tmp_path):
     parser.assert_called_once_with(selected)
 
 
+def test_start_aces_scenario_passes_runtime_parameters_to_aces_planner(
+    mocker, tmp_path
+):
+    from aptl.backends import aces
+
+    _write_compose(tmp_path, {"aptl-victim": ["victim"]})
+    scenario = object()
+    mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=scenario)
+    calls: dict[str, object] = {}
+
+    class FakeRuntimeManager(_FakeRuntimeManager):
+        def plan(self, parsed_scenario, *, parameters=None):
+            calls["scenario"] = parsed_scenario
+            calls["parameters"] = parameters
+            return _FakeExecutionPlan(_plan_for_nodes("aptl-victim"))
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    backend = MagicMock()
+    backend.realize.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
+    parameters = {"victim_os": "linux", "instance_count": 1}
+
+    result = aces.start_aces_scenario(
+        tmp_path,
+        config,
+        backend,
+        parameters=parameters,
+    )
+
+    assert result.lab_result.success is True
+    assert calls == {"scenario": scenario, "parameters": parameters}
+
+
+def test_start_aces_scenario_uses_planned_runtime_model_for_participant_actions(
+    mocker, tmp_path
+):
+    from aptl.backends import aces
+
+    _write_compose(tmp_path, {"aptl-victim": ["victim"]})
+    scenario = object()
+    planned_model = object()
+    mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=scenario)
+
+    class FakeRuntimeManager(_FakeRuntimeManager):
+        def plan(self, parsed_scenario):
+            assert parsed_scenario is scenario
+            return _FakeExecutionPlan(
+                _plan_for_nodes("aptl-victim"), model=planned_model
+            )
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    planned_specs = mocker.patch.object(
+        aces,
+        "participant_action_specs_from_runtime_model",
+        create=True,
+        return_value={},
+    )
+    backend = MagicMock()
+    backend.realize.return_value = LabResult(success=True, message="ok")
+    config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
+
+    result = aces.start_aces_scenario(tmp_path, config, backend)
+
+    assert result.lab_result.success is True
+    planned_specs.assert_called_once_with(
+        planned_model,
+        provisioning_plan=ANY,
+        project_dir=tmp_path,
+        config=config,
+    )
+
+
+def test_start_aces_scenario_projects_instantiation_failure_without_values(
+    tmp_path,
+):
+    from aptl.backends import aces
+
+    scenario_path = tmp_path / "runtime-variables.sdl.yaml"
+    scenario_path.write_text(
+        "name: runtime-variables\n"
+        "description: Deployment tier ${deployment_tier}\n"
+        "variables:\n"
+        "  deployment_tier:\n"
+        "    type: integer\n"
+        "    required: true\n"
+        "nodes: {}\n"
+    )
+    supplied_value = "private-runtime-value"
+    backend = MagicMock()
+    before_retry = MagicMock()
+
+    result = aces.start_aces_scenario(
+        tmp_path,
+        AptlConfig(lab={"name": "test"}),
+        backend,
+        scenario_path=scenario_path,
+        parameters={"deployment_tier": supplied_value},
+        before_backend_retry=before_retry,
+    )
+
+    assert result.lab_result.success is False
+    assert "runtime variable" in result.lab_result.error.lower()
+    assert supplied_value not in result.lab_result.error
+    assert result.retryable is False
+    backend.realize.assert_not_called()
+    before_retry.assert_not_called()
+
+
+def test_start_aces_scenario_retries_apply_without_replanning(mocker, tmp_path):
+    from aptl.backends import aces
+
+    _write_compose(tmp_path, {"aptl-victim": ["victim"]})
+    scenario = object()
+    mocker.patch("aptl.backends.aces.parse_sdl_file", return_value=scenario)
+    calls = {"plan": 0, "apply": 0}
+
+    class FakeRuntimeManager(_FakeRuntimeManager):
+        def plan(self, parsed_scenario, *, parameters=None):
+            assert parsed_scenario is scenario
+            assert parameters == {"victim_os": "linux"}
+            calls["plan"] += 1
+            return _FakeExecutionPlan(_plan_for_nodes("aptl-victim"))
+
+        def apply(self, execution_plan):
+            calls["apply"] += 1
+            return super().apply(execution_plan)
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", FakeRuntimeManager)
+    backend = MagicMock()
+    backend.realize.side_effect = [
+        LabResult(success=False, error="backend still starting"),
+        LabResult(success=True, message="ok"),
+    ]
+    before_retry = MagicMock()
+
+    result = aces.start_aces_scenario(
+        tmp_path,
+        AptlConfig(lab={"name": "test"}, containers={"victim": True}),
+        backend,
+        parameters={"victim_os": "linux"},
+        before_backend_retry=before_retry,
+    )
+
+    assert result.lab_result.success is True
+    assert calls == {"plan": 1, "apply": 2}
+    assert backend.realize.call_count == 2
+    before_retry.assert_called_once_with()
+
+
 def _workflow_and_evaluation_execution_plan():
     """Compile a minimal workflow+objective scenario into its full ACES plan.
 
@@ -1722,6 +1873,7 @@ def test_start_aces_scenario_fails_when_provisioning_backend_fails(mocker, tmp_p
 
     assert result.lab_result.success is False
     assert result.lab_result.error
+    assert result.retryable is True
 
 
 def test_start_aces_scenario_fails_when_orchestration_fails(mocker, tmp_path):
@@ -1757,11 +1909,20 @@ def test_start_aces_scenario_fails_when_orchestration_fails(mocker, tmp_path):
     backend = MagicMock()
     backend.realize.return_value = LabResult(success=True, message="ok")
     config = AptlConfig(lab={"name": "test"}, containers={"victim": True})
+    before_retry = MagicMock()
 
-    result = aces.start_aces_scenario(tmp_path, config, backend)
+    result = aces.start_aces_scenario(
+        tmp_path,
+        config,
+        backend,
+        before_backend_retry=before_retry,
+    )
 
     assert result.lab_result.success is False
     assert result.lab_result.error
+    assert result.retryable is False
+    before_retry.assert_not_called()
+    backend.realize.assert_called_once()
 
 
 def test_start_aces_scenario_submits_evaluation_for_objective_scenario(

--- a/tests/test_aces_repro.py
+++ b/tests/test_aces_repro.py
@@ -79,11 +79,12 @@ class TestReproRecord:
         assert sentinel_value not in raw
         assert "[REDACTED]" in raw
 
-    def test_seeds_honest_absence(self):
+    def test_runtime_parameters_are_intentionally_omitted(self):
         record = _dummy_record()
         assert record["aces"]["scenario_parameters"] is None
         note = record["aces"]["scenario_parameters_note"]
-        assert isinstance(note, str) and len(note) > 0
+        assert "intentionally omitted" in note
+        assert "raw scenario bindings" in note
 
     def test_image_digest_captured_when_available(self):
         record = _dummy_record(

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -7,7 +7,7 @@ calls are mocked.
 
 import logging
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 from uuid import uuid4
 
 import pytest
@@ -16,6 +16,44 @@ import pytest
 def _env_key(*parts: str) -> str:
     """Build env names for generated test values."""
     return "_".join(parts)
+
+
+def _aces_outcome(
+    *,
+    success: bool,
+    error: str = "",
+    selected_profiles: tuple[str, ...] = (),
+    retryable: bool = False,
+):
+    """Build the concrete outcome returned by the ACES backend handoff."""
+    from aces_contracts.runtime_state import RuntimeSnapshot
+
+    from aptl.backends.aces import AcesStartOutcome
+    from aptl.core.lab_types import LabResult
+
+    return AcesStartOutcome(
+        lab_result=LabResult(
+            success=success,
+            message="Lab started" if success else "",
+            error=error,
+        ),
+        final_snapshot=RuntimeSnapshot(),
+        realization_details={},
+        selected_profiles=list(selected_profiles),
+        scenario_path=None,
+        retryable=retryable,
+    )
+
+
+def _aces_start_after_backend_retry(
+    *_args,
+    before_backend_retry=None,
+    **_kwargs,
+):
+    """Model the backend invoking the lifecycle callback between apply attempts."""
+    assert before_backend_retry is not None
+    before_backend_retry()
+    return _aces_outcome(success=True)
 
 
 class TestLabImportContracts:
@@ -1079,20 +1117,14 @@ class TestOrchestrateLabStart:
             return_value=CertResult(success=True, generated=False, certs_dir=certs_dir),
         )
 
-        # Mock ACES runtime handoff start
-        from aptl.core.lab import LabResult
-
+        # Mock ACES runtime handoff start. The planned profile set is part of
+        # the outcome so the lifecycle does not re-plan the authored scenario.
         mocks["start"] = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            return_value=LabResult(success=True, message="Lab started"),
-        )
-        # Mock the post-start profile resolution so _step_start_containers does
-        # not re-parse a scenario file the test fixture does not provide. The
-        # config above enables wazuh/victim/kali, so the default operational
-        # scenario selects exactly those (+ otel).
-        mocks["selected_profiles"] = mocker.patch(
-            "aptl.core.lab.selected_profiles_for_scenario",
-            return_value={"wazuh", "victim", "kali", "otel"},
+            return_value=_aces_outcome(
+                success=True,
+                selected_profiles=("wazuh", "victim", "kali", "otel"),
+            ),
         )
 
         # Mock service waiting
@@ -3111,14 +3143,14 @@ class TestLabOrchestrationContracts:
             _step_start_containers(ctx)
 
     def test_start_containers_routes_through_aces_handoff(self, mocker, tmp_path):
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config()
         ctx.backend = MagicMock()
         start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            return_value=LabResult(success=True, message="ok"),
+            return_value=_aces_outcome(success=True),
         )
 
         result = _step_start_containers(ctx)
@@ -3133,14 +3165,118 @@ class TestLabOrchestrationContracts:
             scenario_path=None,
             run_store=ctx.run_store,
             run_id=ctx.run_id,
+            before_backend_retry=ANY,
         )
         assert ctx.run_store is not None
         assert ctx.run_id
 
+    def test_start_containers_disables_backend_retry_without_soc(
+        self, mocker, tmp_path
+    ):
+        from aptl.core.lab import _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=False)
+        ctx.backend = MagicMock()
+        start_aces = mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            return_value=_aces_outcome(success=True),
+        )
+
+        result = _step_start_containers(ctx)
+
+        assert result is None
+        start_aces.assert_called_once()
+        assert start_aces.call_args.kwargs["before_backend_retry"] is None
+
+    def test_start_containers_reuses_profiles_from_aces_outcome(
+        self, mocker, tmp_path
+    ):
+        from aces_contracts.runtime_state import RuntimeSnapshot
+
+        from aptl.backends.aces import AcesStartOutcome
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config()
+        ctx.backend = MagicMock()
+        outcome = AcesStartOutcome(
+            lab_result=LabResult(success=True, message="ok"),
+            final_snapshot=RuntimeSnapshot(),
+            realization_details={},
+            selected_profiles=["wazuh", "otel"],
+            scenario_path=None,
+        )
+        mocker.patch("aptl.core.lab.start_aces_scenario", return_value=outcome)
+        replan = mocker.patch(
+            "aptl.core.lab.selected_profiles_for_scenario",
+            side_effect=AssertionError("successful startup must not plan twice"),
+        )
+
+        result = _step_start_containers(ctx)
+
+        assert result is None
+        assert ctx.selected_profiles == {"wazuh", "otel"}
+        replan.assert_not_called()
+
+    def test_start_containers_does_not_retry_nonretryable_aces_failure(
+        self, mocker, tmp_path
+    ):
+        from aces_contracts.runtime_state import RuntimeSnapshot
+
+        from aptl.backends.aces import AcesStartOutcome
+        from aptl.core.lab import LabResult, _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        ctx.backend = MagicMock()
+        outcome = AcesStartOutcome(
+            lab_result=LabResult(
+                success=False,
+                error="ACES runtime variable binding failed.",
+            ),
+            final_snapshot=RuntimeSnapshot(),
+            realization_details={},
+            selected_profiles=[],
+            scenario_path=None,
+            retryable=False,
+        )
+        start_aces = mocker.patch(
+            "aptl.core.lab.start_aces_scenario", return_value=outcome
+        )
+        sleep = mocker.patch("time.sleep")
+
+        result = _step_start_containers(ctx)
+
+        assert result is not None
+        assert result.success is False
+        start_aces.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_start_containers_retries_retryable_backend_start_failure(
+        self, mocker, tmp_path
+    ):
+        from aptl.core.lab import _step_start_containers
+
+        ctx = self._ctx(tmp_path)
+        ctx.config = self._full_config(soc=True)
+        ctx.backend = MagicMock()
+        start_aces = mocker.patch(
+            "aptl.core.lab.start_aces_scenario",
+            side_effect=_aces_start_after_backend_retry,
+        )
+        sleep = mocker.patch("time.sleep")
+
+        result = _step_start_containers(ctx)
+
+        assert result is None
+        start_aces.assert_called_once()
+        sleep.assert_called_once_with(60)
+
     def test_start_containers_preserves_scenario_path_on_soc_retry(
         self, mocker, tmp_path
     ):
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3149,10 +3285,7 @@ class TestLabOrchestrationContracts:
         ctx.scenario_path = selected
         start_aces = mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
-            ],
+            side_effect=_aces_start_after_backend_retry,
         )
         mocker.patch("time.sleep")
 
@@ -3160,7 +3293,6 @@ class TestLabOrchestrationContracts:
 
         assert result is None
         assert [call.kwargs["scenario_path"] for call in start_aces.call_args_list] == [
-            selected,
             selected,
         ]
 
@@ -3172,7 +3304,7 @@ class TestLabOrchestrationContracts:
         with zero wazuh-* daemons alive (#732). One `docker restart`
         clears the state; do it once, before the retry, so compose is
         not asked to `up` against a broken container."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3186,10 +3318,7 @@ class TestLabOrchestrationContracts:
 
         mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
-            ],
+            side_effect=_aces_start_after_backend_retry,
         )
         mocker.patch("time.sleep")
 
@@ -3203,7 +3332,7 @@ class TestLabOrchestrationContracts:
     ):
         """Daemons alive inside the container: the retry is likely
         succeeding for a different reason; do NOT restart wazuh-manager."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3217,10 +3346,7 @@ class TestLabOrchestrationContracts:
 
         mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
-            ],
+            side_effect=_aces_start_after_backend_retry,
         )
         mocker.patch("time.sleep")
 
@@ -3234,7 +3360,7 @@ class TestLabOrchestrationContracts:
         """State.Status != 'running' means the container is gone / dead /
         being recreated by compose itself — restarting would race
         compose. Skip."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3246,10 +3372,7 @@ class TestLabOrchestrationContracts:
 
         mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
-            ],
+            side_effect=_aces_start_after_backend_retry,
         )
         mocker.patch("time.sleep")
 
@@ -3264,7 +3387,7 @@ class TestLabOrchestrationContracts:
         """The watchdog is best-effort: exceptions from container_inspect
         or container_exec must not abort the retry. Also covers the
         `int()` ValueError branch when the /proc walk emits garbage."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3274,10 +3397,7 @@ class TestLabOrchestrationContracts:
 
         mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
-            ],
+            side_effect=_aces_start_after_backend_retry,
         )
         mocker.patch("time.sleep")
 
@@ -3292,7 +3412,7 @@ class TestLabOrchestrationContracts:
         """A nonzero exec probe (or non-int stdout) blocks the restart —
         we do not know the process state, so refuse to restart rather
         than guess wrong."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3305,10 +3425,7 @@ class TestLabOrchestrationContracts:
 
         mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
-            ],
+            side_effect=_aces_start_after_backend_retry,
         )
         mocker.patch("time.sleep")
 
@@ -3320,7 +3437,7 @@ class TestLabOrchestrationContracts:
     ):
         """`container_restart` raising is logged and swallowed — the
         retry proceeds regardless."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3332,10 +3449,7 @@ class TestLabOrchestrationContracts:
 
         mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
-            ],
+            side_effect=_aces_start_after_backend_retry,
         )
         mocker.patch("time.sleep")
 
@@ -3349,7 +3463,7 @@ class TestLabOrchestrationContracts:
     ):
         """If /proc walk returns non-numeric output (e.g. a sh error line),
         the ValueError branch keeps the retry going with no restart."""
-        from aptl.core.lab import LabResult, _step_start_containers
+        from aptl.core.lab import _step_start_containers
 
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config(soc=True)
@@ -3362,10 +3476,7 @@ class TestLabOrchestrationContracts:
 
         mocker.patch(
             "aptl.core.lab.start_aces_scenario",
-            side_effect=[
-                LabResult(success=False, error="compose still starting"),
-                LabResult(success=True, message="ok"),
-            ],
+            side_effect=_aces_start_after_backend_retry,
         )
         mocker.patch("time.sleep")
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -3373,6 +3373,8 @@ class TestLabOrchestrationContracts:
         result = _step_start_containers(ctx)
 
         assert result is None
+        from aptl.backends.aces_start_model import AcesRunTarget
+
         # GAP 4: the handoff is invoked with the single run target resolved
         # once on ctx, so orchestration and the run record share a run_id.
         start_aces.assert_called_once_with(
@@ -3380,8 +3382,7 @@ class TestLabOrchestrationContracts:
             ctx.config,
             ctx.backend,
             scenario_path=None,
-            run_store=ctx.run_store,
-            run_id=ctx.run_id,
+            run_target=AcesRunTarget(run_store=ctx.run_store, run_id=ctx.run_id),
             before_backend_retry=ANY,
         )
         assert ctx.run_store is not None


### PR DESCRIPTION
## Summary

APTL now passes explicit per-run bindings to the ACES planner, consumes the admitted execution plan throughout backend realization, and reports value-free instantiation failures before side effects.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #432

## ADR Impact

- ADR-035
- ADR-044
- ADR-046

## Changes

- Pass typed runtime bindings only to `RuntimeManager.plan()` and build participant actions from the resulting `RuntimeModel`.
- Reuse selected profiles and the admitted `ExecutionPlan`, including one bounded backend-start retry without reparsing or replanning.
- Keep raw bindings out of errors and reproducibility records while documenting the ACES-owned boundary.
- Add regression coverage for substitution, redaction, single-plan retries, retry gating, and profile reuse.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

`pre-commit run --all-files`; 2,275 non-integration tests passed with 92 skipped; 2 TechVault integration-gate tests passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #432 ← src/aptl/backends/aces.py, Issue #432 ← src/aptl/core/lab.py
- TESTS: Issue #432 ← tests/test_aces_backend.py, Issue #432 ← tests/test_lab.py, Issue #432 ← tests/test_aces_repro.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
