### PR TITLE
fix: generate certs producer-owned and repair fresh lab start

### DIFF
--- a/config/wazuh-certs-tool.sh
+++ b/config/wazuh-certs-tool.sh
@@ -1,0 +1,925 @@
+#!/bin/bash
+
+# Wazuh installer
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+adminpem="/etc/wazuh-indexer/certs/admin.pem"
+adminkey="/etc/wazuh-indexer/certs/admin-key.pem"
+base_path="$(dirname "$(readlink -f "$0")")"
+readonly base_path
+readonly config_file="${base_path}/config.yml"
+readonly logfile=""
+cert_tmp_path="/tmp/wazuh-certificates"
+debug=">> /dev/null 2>&1"
+
+# ------------ certFunctions.sh ------------
+function cert_cleanFiles() {
+
+    common_logger -d "Cleaning certificate files."
+    eval "rm -f ${cert_tmp_path}/*.csr ${debug}"
+    eval "rm -f ${cert_tmp_path}/*.srl ${debug}"
+    eval "rm -f ${cert_tmp_path}/*.conf ${debug}"
+    eval "rm -f ${cert_tmp_path}/admin-key-temp.pem ${debug}"
+
+}
+function cert_checkOpenSSL() {
+
+    common_logger -d "Checking if OpenSSL is installed."
+
+    if [ -z "$(command -v openssl)" ]; then
+        common_logger -e "OpenSSL not installed."
+        exit 1
+    fi
+
+}
+function cert_checkRootCA() {
+
+    common_logger -d "Checking if the root CA exists."
+
+    if  [[ -n ${rootca} || -n ${rootcakey} ]]; then
+        # Verify variables match keys
+        if [[ ${rootca} == *".key" ]]; then
+            ca_temp=${rootca}
+            rootca=${rootcakey}
+            rootcakey=${ca_temp}
+        fi
+        # Validate that files exist
+        if [[ -e ${rootca} ]]; then
+            eval "cp ${rootca} ${cert_tmp_path}/root-ca.pem ${debug}"
+        else
+            common_logger -e "The file ${rootca} does not exists"
+            cert_cleanFiles
+            exit 1
+        fi
+        if [[ -e ${rootcakey} ]]; then
+            eval "cp ${rootcakey} ${cert_tmp_path}/root-ca.key ${debug}"
+        else
+            common_logger -e "The file ${rootcakey} does not exists"
+            cert_cleanFiles
+            exit 1
+        fi
+    else
+        cert_generateRootCAcertificate
+    fi
+
+}
+function cert_executeAndValidate() {
+
+    command_output=$(eval "$@" 2>&1)
+    e_code="${PIPESTATUS[0]}"
+
+    if [ "${e_code}" -ne 0 ]; then
+        common_logger -e "Error generating the certificates."
+        common_logger -d "Error executing command: $@"
+        common_logger -d "Error output: ${command_output}"
+        cert_cleanFiles
+        exit 1
+    fi
+
+}
+function cert_generateAdmincertificate() {
+
+    common_logger "Generating Admin certificates."
+    common_logger -d "Generating Admin private key."
+    cert_executeAndValidate "openssl genrsa -out ${cert_tmp_path}/admin-key-temp.pem 2048"
+    common_logger -d "Converting Admin private key to PKCS8 format."
+    cert_executeAndValidate "openssl pkcs8 -inform PEM -outform PEM -in ${cert_tmp_path}/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ${cert_tmp_path}/admin-key.pem"
+    common_logger -d "Generating Admin CSR."
+    cert_executeAndValidate "openssl req -new -key ${cert_tmp_path}/admin-key.pem -out ${cert_tmp_path}/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin'"
+    common_logger -d "Creating Admin certificate."
+    cert_executeAndValidate "openssl x509 -days 3650 -req -in ${cert_tmp_path}/admin.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -sha256 -out ${cert_tmp_path}/admin.pem"
+
+}
+function cert_generateCertificateconfiguration() {
+
+    common_logger -d "Generating certificate configuration."
+    cat > "${cert_tmp_path}/${1}.conf" <<- EOF
+        [ req ]
+        prompt = no
+        default_bits = 2048
+        default_md = sha256
+        distinguished_name = req_distinguished_name
+        x509_extensions = v3_req
+
+        [req_distinguished_name]
+        C = US
+        L = California
+        O = Wazuh
+        OU = Wazuh
+        CN = cname
+
+        [ v3_req ]
+        authorityKeyIdentifier=keyid,issuer
+        basicConstraints = CA:FALSE
+        keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+        subjectAltName = @alt_names
+
+        [alt_names]
+        IP.1 = cip
+	EOF
+
+
+    conf="$(awk '{sub("CN = cname", "CN = '"${1}"'")}1' "${cert_tmp_path}/${1}.conf")"
+    echo "${conf}" > "${cert_tmp_path}/${1}.conf"
+
+    if [ "${#@}" -gt 1 ]; then
+        sed -i '/IP.1/d' "${cert_tmp_path}/${1}.conf"
+        for (( i=2; i<=${#@}; i++ )); do
+            isIP=$(echo "${!i}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
+            isDNS=$(echo "${!i}" | grep -P "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.([A-Za-z]{2,})$" )            j=$((i-1))
+            if [ "${isIP}" ]; then
+                printf '%s\n' "        IP.${j} = ${!i}" >> "${cert_tmp_path}/${1}.conf"
+            elif [ "${isDNS}" ]; then
+                printf '%s\n' "        DNS.${j} = ${!i}" >> "${cert_tmp_path}/${1}.conf"
+            else
+                common_logger -e "Invalid IP or DNS ${!i}"
+                exit 1
+            fi
+        done
+    else
+        common_logger -e "No IP or DNS specified"
+        exit 1
+    fi
+
+}
+function cert_generateIndexercertificates() {
+
+    if [ ${#indexer_node_names[@]} -gt 0 ]; then
+        common_logger "Generating Wazuh indexer certificates."
+
+        for i in "${!indexer_node_names[@]}"; do
+            indexer_node_name=${indexer_node_names[$i]}
+            common_logger -d "Creating the certificates for ${indexer_node_name} indexer node."
+            cert_generateCertificateconfiguration "${indexer_node_name}" "${indexer_node_ips[i]}"
+            common_logger -d "Creating the Wazuh indexer tmp key pair."
+            cert_executeAndValidate "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${indexer_node_name}-key.pem -out ${cert_tmp_path}/${indexer_node_name}.csr -config ${cert_tmp_path}/${indexer_node_name}.conf"
+            common_logger -d "Creating the Wazuh indexer certificates."
+            cert_executeAndValidate "openssl x509 -req -in ${cert_tmp_path}/${indexer_node_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${indexer_node_name}.pem -extfile ${cert_tmp_path}/${indexer_node_name}.conf -extensions v3_req -days 3650"
+        done
+    else
+        return 1
+    fi
+
+}
+function cert_generateFilebeatcertificates() {
+
+    if [ ${#server_node_names[@]} -gt 0 ]; then
+        common_logger "Generating Filebeat certificates."
+
+        for i in "${!server_node_names[@]}"; do
+            server_name="${server_node_names[i]}"
+            common_logger -d "Generating the certificates for ${server_name} server node."
+            j=$((i+1))
+            declare -a server_ips=(server_node_ip_"$j"[@])
+            cert_generateCertificateconfiguration "${server_name}" "${!server_ips}"
+            common_logger -d "Creating the Wazuh server tmp key pair."
+            cert_executeAndValidate "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${server_name}-key.pem -out ${cert_tmp_path}/${server_name}.csr  -config ${cert_tmp_path}/${server_name}.conf"
+            common_logger -d "Creating the Wazuh server certificates."
+            cert_executeAndValidate "openssl x509 -req -in ${cert_tmp_path}/${server_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${server_name}.pem -extfile ${cert_tmp_path}/${server_name}.conf -extensions v3_req -days 3650"
+        done
+    else
+        return 1
+    fi
+
+}
+function cert_generateDashboardcertificates() {
+    if [ ${#dashboard_node_names[@]} -gt 0 ]; then
+        common_logger "Generating Wazuh dashboard certificates."
+
+        for i in "${!dashboard_node_names[@]}"; do
+            dashboard_node_name="${dashboard_node_names[i]}"
+            cert_generateCertificateconfiguration "${dashboard_node_name}" "${dashboard_node_ips[i]}"
+            common_logger -d "Creating the Wazuh dashboard tmp key pair."
+            cert_executeAndValidate "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${dashboard_node_name}-key.pem -out ${cert_tmp_path}/${dashboard_node_name}.csr -config ${cert_tmp_path}/${dashboard_node_name}.conf"
+            common_logger -d "Creating the Wazuh dashboard certificates."
+            cert_executeAndValidate "openssl x509 -req -in ${cert_tmp_path}/${dashboard_node_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${dashboard_node_name}.pem -extfile ${cert_tmp_path}/${dashboard_node_name}.conf -extensions v3_req -days 3650"
+        done
+    else
+        return 1
+    fi
+
+}
+function cert_generateRootCAcertificate() {
+
+    common_logger "Generating the root certificate."
+    cert_executeAndValidate "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/root-ca.key -out ${cert_tmp_path}/root-ca.pem -batch -subj '/OU=Wazuh/O=Wazuh/L=California/' -days 3650"
+
+}
+function cert_parseYaml() {
+
+    local prefix=$2
+    local separator=${3:-_}
+    local indexfix
+    # Detect awk flavor
+    if awk --version 2>&1 | grep -q "GNU Awk" ; then
+    # GNU Awk detected
+    indexfix=-1
+    elif awk -Wv 2>&1 | grep -q "mawk" ; then
+    # mawk detected
+    indexfix=0
+    fi
+
+    local s='[[:space:]]*' sm='[ \t]*' w='[a-zA-Z0-9_]*' fs=${fs:-$(echo @|tr @ '\034')} i=${i:-  }
+    cat $1 2>/dev/null | \
+    awk -F$fs "{multi=0;
+        if(match(\$0,/$sm\|$sm$/)){multi=1; sub(/$sm\|$sm$/,\"\");}
+        if(match(\$0,/$sm>$sm$/)){multi=2; sub(/$sm>$sm$/,\"\");}
+        while(multi>0){
+            str=\$0; gsub(/^$sm/,\"\", str);
+            indent=index(\$0,str);
+            indentstr=substr(\$0, 0, indent+$indexfix) \"$i\";
+            obuf=\$0;
+            getline;
+            while(index(\$0,indentstr)){
+                obuf=obuf substr(\$0, length(indentstr)+1);
+                if (multi==1){obuf=obuf \"\\\\n\";}
+                if (multi==2){
+                    if(match(\$0,/^$sm$/))
+                        obuf=obuf \"\\\\n\";
+                        else obuf=obuf \" \";
+                }
+                getline;
+            }
+            sub(/$sm$/,\"\",obuf);
+            print obuf;
+            multi=0;
+            if(match(\$0,/$sm\|$sm$/)){multi=1; sub(/$sm\|$sm$/,\"\");}
+            if(match(\$0,/$sm>$sm$/)){multi=2; sub(/$sm>$sm$/,\"\");}
+        }
+    print}" | \
+    sed  -e "s|^\($s\)?|\1-|" \
+        -ne "s|^$s#.*||;s|$s#[^\"']*$||;s|^\([^\"'#]*\)#.*|\1|;t1;t;:1;s|^$s\$||;t2;p;:2;d" | \
+    sed -ne "s|,$s\]$s\$|]|" \
+        -e ":1;s|^\($s\)\($w\)$s:$s\(&$w\)\?$s\[$s\(.*\)$s,$s\(.*\)$s\]|\1\2: \3[\4]\n\1$i- \5|;t1" \
+        -e "s|^\($s\)\($w\)$s:$s\(&$w\)\?$s\[$s\(.*\)$s\]|\1\2: \3\n\1$i- \4|;" \
+        -e ":2;s|^\($s\)-$s\[$s\(.*\)$s,$s\(.*\)$s\]|\1- [\2]\n\1$i- \3|;t2" \
+        -e "s|^\($s\)-$s\[$s\(.*\)$s\]|\1-\n\1$i- \2|;p" | \
+    sed -ne "s|,$s}$s\$|}|" \
+        -e ":1;s|^\($s\)-$s{$s\(.*\)$s,$s\($w\)$s:$s\(.*\)$s}|\1- {\2}\n\1$i\3: \4|;t1" \
+        -e "s|^\($s\)-$s{$s\(.*\)$s}|\1-\n\1$i\2|;" \
+        -e ":2;s|^\($s\)\($w\)$s:$s\(&$w\)\?$s{$s\(.*\)$s,$s\($w\)$s:$s\(.*\)$s}|\1\2: \3 {\4}\n\1$i\5: \6|;t2" \
+        -e "s|^\($s\)\($w\)$s:$s\(&$w\)\?$s{$s\(.*\)$s}|\1\2: \3\n\1$i\4|;p" | \
+    sed  -e "s|^\($s\)\($w\)$s:$s\(&$w\)\(.*\)|\1\2:\4\n\3|" \
+        -e "s|^\($s\)-$s\(&$w\)\(.*\)|\1- \3\n\2|" | \
+    sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\(---\)\($s\)||" \
+        -e "s|^\($s\)\(\.\.\.\)\($s\)||" \
+        -e "s|^\($s\)-$s[\"']\(.*\)[\"']$s\$|\1$fs$fs\2|p;t" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p;t" \
+        -e "s|^\($s\)-$s\(.*\)$s\$|\1$fs$fs\2|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\?\(.*\)$s\$|\1$fs\2$fs\3|" \
+        -e "s|^\($s\)[\"']\?\([^&][^$fs]\+\)[\"']$s\$|\1$fs$fs$fs\2|" \
+        -e "s|^\($s\)[\"']\?\([^&][^$fs]\+\)$s\$|\1$fs$fs$fs\2|" \
+        -e "s|$s\$||p" | \
+    awk -F$fs "{
+        gsub(/\t/,\"        \",\$1);
+        gsub(\"name: \", \"\");
+        if(NF>3){if(value!=\"\"){value = value \" \";}value = value  \$4;}
+        else {
+        if(match(\$1,/^&/)){anchor[substr(\$1,2)]=full_vn;getline};
+        indent = length(\$1)/length(\"$i\");
+        vname[indent] = \$2;
+        value= \$3;
+        for (i in vname) {if (i > indent) {delete vname[i]; idx[i]=0}}
+        if(length(\$2)== 0){  vname[indent]= ++idx[indent] };
+        vn=\"\"; for (i=0; i<indent; i++) { vn=(vn)(vname[i])(\"$separator\")}
+        vn=\"$prefix\" vn;
+        full_vn=vn vname[indent];
+        if(vn==\"$prefix\")vn=\"$prefix$separator\";
+        if(vn==\"_\")vn=\"__\";
+        }
+        assignment[full_vn]=value;
+        if(!match(assignment[vn], full_vn))assignment[vn]=assignment[vn] \" \" full_vn;
+        if(match(value,/^\*/)){
+            ref=anchor[substr(value,2)];
+            if(length(ref)==0){
+            printf(\"%s=\\\"%s\\\"\n\", full_vn, value);
+            } else {
+            for(val in assignment){
+                if((length(ref)>0)&&index(val, ref)==1){
+                    tmpval=assignment[val];
+                    sub(ref,full_vn,val);
+                if(match(val,\"$separator\$\")){
+                    gsub(ref,full_vn,tmpval);
+                } else if (length(tmpval) > 0) {
+                    printf(\"%s=\\\"%s\\\"\n\", val, tmpval);
+                }
+                assignment[val]=tmpval;
+                }
+            }
+        }
+    } else if (length(value) > 0) {
+        printf(\"%s=\\\"%s\\\"\n\", full_vn, value);
+    }
+    }END{
+        for(val in assignment){
+            if(match(val,\"$separator\$\"))
+                printf(\"%s=\\\"%s\\\"\n\", val, assignment[val]);
+        }
+    }"
+
+}
+function cert_checkPrivateIp() {
+
+    local ip=$1
+    common_logger -d "Checking if ${ip} is private."
+
+    # Check private IPv4 ranges
+    if [[ $ip =~ ^10\.|^192\.168\.|^172\.(1[6-9]|2[0-9]|3[0-1])\.|^(127\.) ]]; then
+        return 0
+    fi
+
+    # Check private IPv6 ranges (fc00::/7 prefix)
+    if [[ $ip =~ ^fc ]]; then
+        return 0
+    fi
+
+    return 1
+
+}
+function cert_readConfig() {
+
+    common_logger -d "Reading configuration file."
+
+    if [ -f "${config_file}" ]; then
+        if [ ! -s "${config_file}" ]; then
+            common_logger -e "File ${config_file} is empty"
+            exit 1
+        fi
+        eval "$(cert_convertCRLFtoLF "${config_file}")"
+
+        eval "indexer_node_names=( $(cert_parseYaml "${config_file}" | grep -E "nodes[_]+indexer[_]+[0-9]+=" | cut -d = -f 2 ) )"
+        eval "server_node_names=( $(cert_parseYaml "${config_file}"  | grep -E "nodes[_]+server[_]+[0-9]+=" | cut -d = -f 2 ) )"
+        eval "dashboard_node_names=( $(cert_parseYaml "${config_file}" | grep -E "nodes[_]+dashboard[_]+[0-9]+=" | cut -d = -f 2) )"
+        eval "indexer_node_ips=( $(cert_parseYaml "${config_file}" | grep -E "nodes[_]+indexer[_]+[0-9]+[_]+ip=" | cut -d = -f 2) )"
+        eval "server_node_ips=( $(cert_parseYaml "${config_file}"  | grep -E "nodes[_]+server[_]+[0-9]+[_]+ip=" | cut -d = -f 2) )"
+        eval "dashboard_node_ips=( $(cert_parseYaml "${config_file}"  | grep -E "nodes[_]+dashboard[_]+[0-9]+[_]+ip=" | cut -d = -f 2 ) )"
+        eval "server_node_types=( $(cert_parseYaml "${config_file}"  | grep -E "nodes[_]+server[_]+[0-9]+[_]+node_type=" | cut -d = -f 2 ) )"
+        eval "number_server_ips=( $(cert_parseYaml "${config_file}" | grep -o -E 'nodes[_]+server[_]+[0-9]+[_]+ip' | sort -u | wc -l) )"
+        all_ips=("${indexer_node_ips[@]}" "${server_node_ips[@]}" "${dashboard_node_ips[@]}")
+
+        for ip in "${all_ips[@]}"; do
+            isIP=$(echo "${ip}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
+            if [[ -n "${isIP}" ]]; then
+                if ! cert_checkPrivateIp "$ip"; then
+                    common_logger -e "The IP ${ip} is public."
+                    exit 1
+                fi
+            fi
+        done
+
+        for i in $(seq 1 "${number_server_ips}"); do
+            nodes_server="nodes[_]+server[_]+${i}[_]+ip"
+            eval "server_node_ip_$i=( $( cert_parseYaml "${config_file}" | grep -E "${nodes_server}" | sed '/\./!d' | cut -d = -f 2 | sed -r 's/\s+//g') )"
+        done
+
+        unique_names=($(echo "${indexer_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+        if [ "${#unique_names[@]}" -ne "${#indexer_node_names[@]}" ]; then
+            common_logger -e "Duplicated indexer node names."
+            exit 1
+        fi
+
+        unique_ips=($(echo "${indexer_node_ips[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+        if [ "${#unique_ips[@]}" -ne "${#indexer_node_ips[@]}" ]; then
+            common_logger -e "Duplicated indexer node ips."
+            exit 1
+        fi
+
+        unique_names=($(echo "${server_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+        if [ "${#unique_names[@]}" -ne "${#server_node_names[@]}" ]; then
+            common_logger -e "Duplicated Wazuh server node names."
+            exit 1
+        fi
+
+        unique_ips=($(echo "${server_node_ips[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+        if [ "${#unique_ips[@]}" -ne "${#server_node_ips[@]}" ]; then
+            common_logger -e "Duplicated Wazuh server node ips."
+            exit 1
+        fi
+
+        unique_names=($(echo "${dashboard_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+        if [ "${#unique_names[@]}" -ne "${#dashboard_node_names[@]}" ]; then
+            common_logger -e "Duplicated dashboard node names."
+            exit 1
+        fi
+
+        unique_ips=($(echo "${dashboard_node_ips[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+        if [ "${#unique_ips[@]}" -ne "${#dashboard_node_ips[@]}" ]; then
+            common_logger -e "Duplicated dashboard node ips."
+            exit 1
+        fi
+
+        for i in "${server_node_types[@]}"; do
+            if ! echo "$i" | grep -ioq master && ! echo "$i" | grep -ioq worker; then
+                common_logger -e "Incorrect node_type $i must be master or worker"
+                exit 1
+            fi
+        done
+
+        if [ "${#server_node_names[@]}" -le 1 ]; then
+            if [ "${#server_node_types[@]}" -ne 0 ]; then
+                common_logger -e "The tag node_type can only be used with more than one Wazuh server."
+                exit 1
+            fi
+        elif [ "${#server_node_names[@]}" -gt "${#server_node_types[@]}" ]; then
+            common_logger -e "The tag node_type needs to be specified for all Wazuh server nodes."
+            exit 1
+        elif [ "${#server_node_names[@]}" -lt "${#server_node_types[@]}" ]; then
+            common_logger -e "Found extra node_type tags."
+            exit 1
+        elif [ "$(grep -io master <<< "${server_node_types[*]}" | wc -l)" -ne 1 ]; then
+            common_logger -e "Wazuh cluster needs a single master node."
+            exit 1
+        elif [ "$(grep -io worker <<< "${server_node_types[*]}" | wc -l)" -ne $(( ${#server_node_types[@]} - 1 )) ]; then
+            common_logger -e "Incorrect number of workers."
+            exit 1
+        fi
+
+        if [ "${#dashboard_node_names[@]}" -ne "${#dashboard_node_ips[@]}" ]; then
+            common_logger -e "Different number of dashboard node names and IPs."
+            exit 1
+        fi
+
+    else
+        common_logger -e "No configuration file found."
+        exit 1
+    fi
+
+}
+function cert_setpermisions() {
+    eval "chmod -R 744 ${cert_tmp_path} ${debug}"
+}
+function cert_convertCRLFtoLF() {
+    if [[ ! -d "/tmp/wazuh-install-files" ]]; then
+        eval "mkdir /tmp/wazuh-install-files ${debug}"
+    fi
+    eval "chmod -R 755 /tmp/wazuh-install-files ${debug}"
+    eval "tr -d '\015' < $1 > /tmp/wazuh-install-files/new_config.yml"
+    eval "mv /tmp/wazuh-install-files/new_config.yml $1 ${debug}"
+}
+
+# ------------ certMain.sh ------------
+function getHelp() {
+
+    echo -e ""
+    echo -e "NAME"
+    echo -e "        wazuh-cert-tool.sh - Manages the creation of certificates of the Wazuh components."
+    echo -e ""
+    echo -e "SYNOPSIS"
+    echo -e "        wazuh-cert-tool.sh [OPTIONS]"
+    echo -e ""
+    echo -e "DESCRIPTION"
+    echo -e "        -a,  --admin-certificates </path/to/root-ca.pem> </path/to/root-ca.key>"
+    echo -e "                Creates the admin certificates, add root-ca.pem and root-ca.key."
+    echo -e ""
+    echo -e "        -A, --all </path/to/root-ca.pem> </path/to/root-ca.key>"
+    echo -e "                Creates certificates specified in config.yml and admin certificates. Add a root-ca.pem and root-ca.key or leave it empty so a new one will be created."
+    echo -e ""
+    echo -e "        -ca, --root-ca-certificates"
+    echo -e "                Creates the root-ca certificates."
+    echo -e ""
+    echo -e "        -v,  --verbose"
+    echo -e "                Enables verbose mode."
+    echo -e ""
+    echo -e "        -wd,  --wazuh-dashboard-certificates </path/to/root-ca.pem> </path/to/root-ca.key>"
+    echo -e "                Creates the Wazuh dashboard certificates, add root-ca.pem and root-ca.key."
+    echo -e ""
+    echo -e "        -wi,  --wazuh-indexer-certificates </path/to/root-ca.pem> </path/to/root-ca.key>"
+    echo -e "                Creates the Wazuh indexer certificates, add root-ca.pem and root-ca.key."
+    echo -e ""
+    echo -e "        -ws,  --wazuh-server-certificates </path/to/root-ca.pem> </path/to/root-ca.key>"
+    echo -e "                Creates the Wazuh server certificates, add root-ca.pem and root-ca.key."
+    echo -e ""
+    echo -e "        -tmp,  --cert_tmp_path </path/to/tmp_dir>"
+    echo -e "                Modifies the default tmp directory (/tmp/wazuh-ceritificates) to the specified one."
+    echo -e "                Must be used along with one of these options: -a, -A, -ca, -wi, -wd, -ws"
+    echo -e ""
+
+    exit 1
+
+}
+function main() {
+
+    umask 177
+
+    cert_checkOpenSSL
+
+    if [ -n "${1}" ]; then
+        while [ -n "${1}" ]
+        do
+            case "${1}" in
+            "-a"|"--admin-certificates")
+                if [[ -z "${2}" || -z "${3}" ]]; then
+                    common_logger -e "Error on arguments. Probably missing </path/to/root-ca.pem> </path/to/root-ca.key> after -a|--admin-certificates"
+                    getHelp
+                    exit 1
+                else
+                    cadmin=1
+                    rootca="${2}"
+                    rootcakey="${3}"
+                    shift 3
+                fi
+                ;;
+            "-A"|"--all")
+                if  [[ -n "${2}" && "${2}" != "-v" && "${2}" != "-tmp" ]]; then
+                    # Validate that the user has entered the 2 files
+                    if [[ -z ${3} ]]; then
+                        if [[ ${2} == *".key" ]]; then
+                            common_logger -e "You have not entered a root-ca.pem"
+                            exit 1
+                        else
+                            common_logger -e "You have not entered a root-ca.key"
+                            exit 1
+                        fi
+                    fi
+                    all=1
+                    rootca="${2}"
+                    rootcakey="${3}"
+                    shift 3
+                else
+                    all=1
+                    shift 1
+                fi
+                ;;
+            "-ca"|"--root-ca-certificate")
+                ca=1
+                shift 1
+                ;;
+            "-h"|"--help")
+                getHelp
+                ;;
+            "-v"|"--verbose")
+                debugEnabled=1
+                shift 1
+                ;;
+            "-wd"|"--wazuh-dashboard-certificates")
+                if [[ -z "${2}" || -z "${3}" ]]; then
+                    common_logger -e "Error on arguments. Probably missing </path/to/root-ca.pem> </path/to/root-ca.key> after -wd|--wazuh-dashboard-certificates"
+                    getHelp
+                    exit 1
+                else
+                    cdashboard=1
+                    rootca="${2}"
+                    rootcakey="${3}"
+                    shift 3
+                fi
+                ;;
+            "-wi"|"--wazuh-indexer-certificates")
+                if [[ -z "${2}" || -z "${3}" ]]; then
+                    common_logger -e "Error on arguments. Probably missing </path/to/root-ca.pem> </path/to/root-ca.key> after -wi|--wazuh-indexer-certificates"
+                    getHelp
+                    exit 1
+                else
+                    cindexer=1
+                    rootca="${2}"
+                    rootcakey="${3}"
+                    shift 3
+                fi
+                ;;
+            "-ws"|"--wazuh-server-certificates")
+                if [[ -z "${2}" || -z "${3}" ]]; then
+                    common_logger -e "Error on arguments. Probably missing </path/to/root-ca.pem> </path/to/root-ca.key> after -ws|--wazuh-server-certificates"
+                    getHelp
+                    exit 1
+                else
+                    cserver=1
+                    rootca="${2}"
+                    rootcakey="${3}"
+                    shift 3
+                fi
+                ;;
+            "-tmp"|"--cert_tmp_path")
+                if [[ -n "${3}" || ( "${cadmin}" == 1 || "${all}" == 1 || "${ca}" == 1 || "${cdashboard}" == 1 || "${cindexer}" == 1 || "${cserver}" == 1 ) ]]; then
+                    if [[ -z "${2}" || ! "${2}" == /* ]]; then
+                        common_logger -e "Error on arguments. Probably missing </path/to/tmp_dir> or path does not start with '/'."
+                        getHelp
+                        exit 1
+                    else
+                        cert_tmp_path="${2}"
+                        shift 2
+                    fi
+                else
+                    common_logger -e "Error: -tmp must be used along with one of these options: -a, -A, -ca, -wi, -wd, -ws"
+                    getHelp
+                    exit 1
+                fi
+                ;;
+            *)
+                echo "Unknow option: ${1}"
+                getHelp
+            esac
+        done
+
+        if [[ -d "${base_path}"/wazuh-certificates ]]; then
+            if [ -n "$(ls -A "${base_path}"/wazuh-certificates)" ]; then
+                common_logger -e "Directory wazuh-certificates already exists in the same path as the script. Please, remove the certs directory to create new certificates."
+                exit 1
+            fi
+        fi
+
+        if [[ ! -d "${cert_tmp_path}" ]]; then
+            mkdir -p "${cert_tmp_path}"
+            chmod 744 "${cert_tmp_path}"
+        fi
+
+        cert_readConfig
+
+        if [ -n "${debugEnabled}" ]; then
+            debug="2>&1 | tee -a ${logfile}"
+        fi
+
+        if [[ -n "${cadmin}" ]]; then
+            cert_checkRootCA
+            cert_generateAdmincertificate
+            common_logger "Admin certificates created."
+            cert_cleanFiles
+            cert_setpermisions
+            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+        fi
+
+        if [[ -n "${all}" ]]; then
+            cert_checkRootCA
+            cert_generateAdmincertificate
+            common_logger "Admin certificates created."
+            if cert_generateIndexercertificates; then
+                common_logger "Wazuh indexer certificates created."
+            fi
+            if cert_generateFilebeatcertificates; then
+                common_logger "Wazuh Filebeat certificates created."
+            fi
+            if cert_generateDashboardcertificates; then
+                common_logger "Wazuh dashboard certificates created."
+            fi
+            cert_cleanFiles
+            cert_setpermisions
+            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+        fi
+
+        if [[ -n "${ca}" ]]; then
+            cert_generateRootCAcertificate
+            common_logger "Authority certificates created."
+            cert_cleanFiles
+            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+        fi
+
+        if [[ -n "${cindexer}" ]]; then
+            if [ ${#indexer_node_names[@]} -gt 0 ]; then
+                cert_checkRootCA
+                cert_generateIndexercertificates
+                common_logger "Wazuh indexer certificates created."
+                cert_cleanFiles
+                cert_setpermisions
+                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+            else
+                common_logger -e "Indexer node not present in config.yml."
+                exit 1
+            fi
+        fi
+
+        if [[ -n "${cserver}" ]]; then
+            if [ ${#server_node_names[@]} -gt 0 ]; then
+                cert_checkRootCA
+                cert_generateFilebeatcertificates
+                common_logger "Wazuh Filebeat certificates created."
+                cert_cleanFiles
+                cert_setpermisions
+                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+            else
+                common_logger -e "Server node not present in config.yml."
+                exit 1
+            fi
+        fi
+
+        if [[ -n "${cdashboard}" ]]; then
+            if [ ${#dashboard_node_names[@]} -gt 0 ]; then
+                cert_checkRootCA
+                cert_generateDashboardcertificates
+                common_logger "Wazuh dashboard certificates created."
+                cert_cleanFiles
+                cert_setpermisions
+                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+            else
+                common_logger -e "Dashboard node not present in config.yml."
+                exit 1
+            fi
+        fi
+
+    else
+        getHelp
+    fi
+
+}
+# ------------ certVariables.sh ------------
+
+function common_checkAptLock() {
+
+    attempt=0
+    seconds=30
+    max_attempts=10
+
+    while fuser "${apt_lockfile}" >/dev/null 2>&1 && [ "${attempt}" -lt "${max_attempts}" ]; do
+        attempt=$((attempt+1))
+        common_logger "Another process is using APT. Waiting for it to release the lock. Next retry in ${seconds} seconds (${attempt}/${max_attempts})"
+        sleep "${seconds}"
+    done
+
+}
+function common_logger() {
+
+    now=$(date +'%d/%m/%Y %H:%M:%S')
+    mtype="INFO:"
+    debugLogger=
+    nolog=
+    if [ -n "${1}" ]; then
+        while [ -n "${1}" ]; do
+            case ${1} in
+                "-e")
+                    mtype="ERROR:"
+                    shift 1
+                    ;;
+                "-w")
+                    mtype="WARNING:"
+                    shift 1
+                    ;;
+                "-d")
+                    debugLogger=1
+                    mtype="DEBUG:"
+                    shift 1
+                    ;;
+                "-nl")
+                    nolog=1
+                    shift 1
+                    ;;
+                *)
+                    message="${1}"
+                    shift 1
+                    ;;
+            esac
+        done
+    fi
+
+    if [ -z "${debugLogger}" ] || { [ -n "${debugLogger}" ] && [ -n "${debugEnabled}" ]; }; then
+        if [ "$EUID" -eq 0 ] && [ -z "${nolog}" ]; then
+            printf "%s\n" "${now} ${mtype} ${message}" | tee -a ${logfile}
+        else
+            printf "%b\n" "${now} ${mtype} ${message}"
+        fi
+    fi
+
+}
+function common_checkRoot() {
+
+    common_logger -d "Checking root permissions."
+    if [ "$EUID" -ne 0 ]; then
+        echo "This script must be run as root."
+        exit 1;
+    fi
+
+    common_logger -d "Checking sudo package."
+    if ! command -v sudo > /dev/null; then
+        common_logger -e "The sudo package is not installed and it is necessary for the installation."
+        exit 1;
+    fi
+}
+function common_checkInstalled() {
+
+    common_logger -d "Checking Wazuh installation."
+    wazuh_installed=""
+    indexer_installed=""
+    filebeat_installed=""
+    dashboard_installed=""
+
+    if [ "${sys_type}" == "yum" ]; then
+        common_checkYumLock
+        wazuh_installed=$(yum list installed 2>/dev/null | grep wazuh-manager)
+    elif [ "${sys_type}" == "apt-get" ]; then
+        wazuh_installed=$(apt list --installed  2>/dev/null | grep wazuh-manager)
+    fi
+
+    if [ -d "/var/ossec" ]; then
+        common_logger -d "There are Wazuh remaining files."
+        wazuh_remaining_files=1
+    fi
+
+    if [ "${sys_type}" == "yum" ]; then
+        common_checkYumLock
+        indexer_installed=$(yum list installed 2>/dev/null | grep wazuh-indexer)
+    elif [ "${sys_type}" == "apt-get" ]; then
+        indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
+    fi
+
+    if [ -d "/var/lib/wazuh-indexer/" ] || [ -d "/usr/share/wazuh-indexer" ] || [ -d "/etc/wazuh-indexer" ] || [ -f "${base_path}/search-guard-tlstool*" ]; then
+        common_logger -d "There are Wazuh indexer remaining files."
+        indexer_remaining_files=1
+    fi
+
+    if [ "${sys_type}" == "yum" ]; then
+        common_checkYumLock
+        filebeat_installed=$(yum list installed 2>/dev/null | grep filebeat)
+    elif [ "${sys_type}" == "apt-get" ]; then
+        filebeat_installed=$(apt list --installed  2>/dev/null | grep filebeat)
+    fi
+
+    if [ -d "/var/lib/filebeat/" ] || [ -d "/usr/share/filebeat" ] || [ -d "/etc/filebeat" ]; then
+        common_logger -d "There are Filebeat remaining files."
+        filebeat_remaining_files=1
+    fi
+
+    if [ "${sys_type}" == "yum" ]; then
+        common_checkYumLock
+        dashboard_installed=$(yum list installed 2>/dev/null | grep wazuh-dashboard)
+    elif [ "${sys_type}" == "apt-get" ]; then
+        dashboard_installed=$(apt list --installed  2>/dev/null | grep wazuh-dashboard)
+    fi
+
+    if [ -d "/var/lib/wazuh-dashboard/" ] || [ -d "/usr/share/wazuh-dashboard" ] || [ -d "/etc/wazuh-dashboard" ] || [ -d "/run/wazuh-dashboard/" ]; then
+        common_logger -d "There are Wazuh dashboard remaining files."
+        dashboard_remaining_files=1
+    fi
+
+}
+function common_checkSystem() {
+
+    if [ -n "$(command -v yum)" ]; then
+        sys_type="yum"
+        sep="-"
+        common_logger -d "YUM package manager will be used."
+    elif [ -n "$(command -v apt-get)" ]; then
+        sys_type="apt-get"
+        sep="="
+        common_logger -d "APT package manager will be used."
+    else
+        common_logger -e "Couldn't find type of system"
+        exit 1
+    fi
+
+}
+function common_checkWazuhConfigYaml() {
+
+    common_logger -d "Checking Wazuh YAML configuration file."
+    filecorrect=$(cert_parseYaml "${config_file}" | grep -Ev '^#|^\s*$' | grep -Pzc "\A(\s*(nodes_indexer__name|nodes_indexer__ip|nodes_server__name|nodes_server__ip|nodes_server__node_type|nodes_dashboard__name|nodes_dashboard__ip)=.*?)+\Z")
+    if [[ "${filecorrect}" -ne 1 ]]; then
+        common_logger -e "The configuration file ${config_file} does not have a correct format."
+        exit 1
+    fi
+
+}
+function common_curl() {
+
+    if [ -n "${curl_has_connrefused}" ]; then
+        eval "curl $@ --retry-connrefused"
+        e_code="${PIPESTATUS[0]}"
+    else
+        retries=0
+        eval "curl $@"
+        e_code="${PIPESTATUS[0]}"
+        while [ "${e_code}" -eq 7 ] && [ "${retries}" -ne 12 ]; do
+            retries=$((retries+1))
+            sleep 5
+            eval "curl $@"
+            e_code="${PIPESTATUS[0]}"
+        done
+    fi
+    return "${e_code}"
+
+}
+function common_remove_gpg_key() {
+
+    common_logger -d "Removing GPG key from system."
+    if [ "${sys_type}" == "yum" ]; then
+        if { rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep "Wazuh"; } >/dev/null ; then
+            key=$(rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep "Wazuh Signing Key" | awk '{print $1}' )
+            rpm -e "${key}"
+        else
+            common_logger "Wazuh GPG key not found in the system"
+            return 1
+        fi
+    elif [ "${sys_type}" == "apt-get" ]; then
+        if [ -f "/usr/share/keyrings/wazuh.gpg" ]; then
+            rm -rf "/usr/share/keyrings/wazuh.gpg" "${debug}"
+        else
+            common_logger "Wazuh GPG key not found in the system"
+            return 1
+        fi
+    fi
+
+}
+function common_checkYumLock() {
+
+    attempt=0
+    seconds=30
+    max_attempts=10
+
+    while [ -f "${yum_lockfile}" ] && [ "${attempt}" -lt "${max_attempts}" ]; do
+        attempt=$((attempt+1))
+        common_logger "Another process is using YUM. Waiting for it to release the lock. Next retry in ${seconds} seconds (${attempt}/${max_attempts})"
+        sleep "${seconds}"
+    done
+
+}
+
+main "$@"

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -160,3 +160,4 @@ The victim and kali containers publish no host ports; use
 - [RNG-001 Ephemeral Environments](rng-001-ephemeral-environments-preflight.md)
 - [DEP-003 Ephemeral Lifecycle Policy](dep-003-ephemeral-lifecycle-preflight.md)
 - [GRC Boundary Surface Vocabulary](grc-boundary-surface-vocabulary-preflight.md)
+- [Issue #677 Certificate Producer Ownership](issue-677-cert-producer-ownership-preflight.md)

--- a/docs/architecture/issue-677-cert-producer-ownership-preflight.md
+++ b/docs/architecture/issue-677-cert-producer-ownership-preflight.md
@@ -1,0 +1,209 @@
+# Issue #677 Certificate Producer Ownership Preflight
+
+This note fixes the architecture guardrails for making Wazuh certificate
+generation host-user-owned from creation. It is design guidance, not an
+implementation plan. ADR-007 remains authoritative for the Python lab control
+plane, ADR-029 for secret handling, ADR-031 for startup results and ordering,
+ADR-034 for certificate boundaries, ADR-037 for Docker execution, and ADR-043
+for the broader rule that a producer must not mutate host-source ownership.
+
+No new ADR is needed. This issue removes an unsafe implementation detail while
+preserving those accepted boundaries.
+
+## Architecture Decisions
+
+- Keep `aptl.core.certs.ensure_ssl_certs()` as the single owner of legacy Wazuh
+  certificate generation. On native Linux Docker, the generator process must
+  run under the invoking host UID/GID and the bind source must be created by
+  the host user before Compose runs. Generated ownership is a producer
+  invariant, not a cleanup concern.
+- Reuse `aptl.core.hostenv.needs_host_ownership_fix()` as the only gate for
+  native-Linux ownership semantics. Resolve `os.getuid()` and `os.getgid()`
+  only inside that true branch. Docker Desktop, other Docker VMs, Windows, an
+  unavailable engine, and an unknown engine must not evaluate either POSIX API
+  or receive a numeric user override.
+- Remove the post-generation ownership-repair operation completely. A root
+  helper container is still post-hoc `chown`; replacing host `sudo` with Docker
+  root does not satisfy the producer-ownership boundary. Do not retain a
+  dormant repair command or fallback to it when user-mode generation fails.
+- Keep ownership and permission modes distinct. `_ensure_container_readable_certs()`
+  remains the canonical host/container readability contract: an owner-only
+  `0700` directory protects the bundle while `0644` PEM files remain readable
+  by non-root Wazuh consumers whose container UID may differ from the host UID.
+  A non-privileged `chmod` by the owning host user is not ownership repair and
+  must not be replaced with `chown` or indiscriminately gated off Docker
+  Desktop.
+- Preserve the isolated Compose project name, generator timeout, unconditional
+  `down --remove-orphans` cleanup, manager-root-CA alias, and fail-closed
+  `CertResult` outcome. Ownership must not be fixed by rejoining the generator
+  to the lab networks or skipping cleanup of its temporary network.
+- Preserve the injected `run_command` seam used by typed stateful realization.
+  Do not add a generic Docker passthrough, a second generator service, a new
+  result DTO, or a certificate-specific exception hierarchy.
+
+## Compatibility Constraint
+
+Repository history matters here. The first host-user implementation was later
+replaced because the pinned `wazuh/wazuh-certs-generator:0.0.2` image's default
+entrypoint did not execute successfully as an arbitrary host UID. The current
+root-plus-repair behavior documents that constraint in `certs.py`.
+
+Consequently, adding `--user` to the command is necessary but not sufficient.
+The generator invocation must prove that the pinned image's real certificate
+workflow completes under that identity. If its entrypoint mode requires an
+interpreter/entrypoint override, keep that override narrow, fixed to trusted
+image-internal paths, and in the same Compose run. It must not bypass the Wazuh
+certificate workflow, interpolate project data into shell text, restore root
+execution, or add a repair phase. An image incompatibility is a blocking
+producer-boundary problem, not permission to fall back silently.
+
+Keep the image reference canonical in `generate-indexer-certs.yml`. An image
+upgrade or locally maintained replacement has supply chain and certificate
+compatibility consequences and is outside this issue unless separately
+authorized.
+
+The producer fix governs newly generated bundles. A checkout that already has
+a foreign-owned historical bundle is migration debt: the existing-bundle
+no-op cannot make it host-manageable without a separate rotation, retirement,
+or privileged-recovery decision. Do not hide that state behind a successful
+no-op, silently rotate trusted material, or reintroduce a repair container. If
+the acceptance contract is intended to cover upgrades with pre-existing
+root-owned bundles, that migration requires explicit scope before coding.
+
+## Cross-Cutting Layers and Canonical Incumbents
+
+| Layer | Existing owner and required behavior |
+|---|---|
+| Host/runtime classification | `aptl.core.hostenv.docker_mode()` and `needs_host_ownership_fix()` distinguish native Linux from Docker Desktop/VM/unknown modes. Do not duplicate `sys.platform`, Docker-info parsing, WSL detection, or OS-name branches in `certs.py`. |
+| Certificate orchestration | `aptl.core.certs.ensure_ssl_certs()`, `_cert_generator_command()`, `_execute_command()`, `_cert_generator_project_name()`, and `_cleanup_cert_generator()` own generation, backend-runner injection, project isolation, timeouts, and cleanup. |
+| Generator inputs | `generate-indexer-certs.yml` owns the generator image/service and bind mounts; `config/certs.yml` owns Wazuh certificate subjects and addresses. Add no `PUID`/`PGID` environment convention, duplicate Compose file, or second certificate schema. |
+| Startup workflow | `aptl.core.lab._step_generate_certs()` and `_LAB_START_STEPS` own ordering and fatal conversion to `LabResult`. Generation remains before bind-mount validation and container startup. |
+| Generated-artifact validation | `ComposeStatefulRealizationMixin`, `stateful_realization_errors()`, `_canonical_generated_path()`, and `validate_certificate_bundle()` own remote-artifact refusal, output/path shape checks, no-symlink containment, declared-output presence, chain/key/SAN checks, and permission checks. The ownership change must pass these gates rather than duplicate them in the command builder. |
+| Bind consumers | `docker-compose.yml` is the canonical Wazuh manager/indexer/dashboard read-only mount topology. The generator UID does not change the runtime users or mount destinations of those services. |
+| Secret storage and packaging | `.gitignore`, `aptl._asset_manifest.EXCLUDED_DIR_NAMES`, `hatch_build.py`, and the asset tests keep generated Wazuh and SOC key material out of Git, wheels, and initialized source bundles. |
+| Results and observability | `CertResult`, `LabResult`, `LabActionResponse`, `get_logger()`, and ADR-029 are the existing error/log surfaces. Failures may name the generation or cleanup layer, but must not include PEM/key bytes, secrets, or a full command line. |
+| Tests and workflow | `tests/test_certs.py`, `tests/test_hostenv.py`, `tests/test_lab.py`, `tests/test_deployment_stateful_realization.py`, `tests/test_no_silent_privilege_escalation.py`, asset/build-hook tests, `pytest`, and `pre-commit run --all-files` are the canonical gates. A clean native-Linux lab boot is the required product proof. |
+
+The SOC certificate generator in `aptl.core.soc_ca` is deliberately separate:
+it generates `config/soc_certs/` in-process as the host user and already owns
+its registry, atomic writes, containment, key modes, and secret-safe error
+envelope. Do not merge the Wazuh and SOC generators or their `CertResult`
+classes as part of this issue. SOC bring-up is a regression surface, not a
+second ownership implementation target.
+
+## Security and Validation Layers
+
+- **Authentication surface:** this change adds no request or command option.
+  API-triggered starts remain behind the existing `verify_token` router
+  dependency; CLI starts remain local operator actions. UID/GID must be derived
+  locally, never accepted from an API body, CLI flag, `aptl.json`, `.env`, or a
+  scenario.
+- **Environment and config shapes:** no environment variable or strict
+  `AptlConfig` shape changes. `config/certs.yml` remains the sole non-secret
+  certificate provenance input, and typed realization continues to accept only
+  the existing `certificate_bundle` artifact/output schema.
+- **Generated-path gate:** the typed path must continue through
+  `_canonical_generated_path()` before Docker mutation; declared outputs must
+  remain safe relative paths and read-only consumers. The legacy generator
+  must not weaken that no-symlink/project-root rule when pre-creating or
+  changing modes on the output directory.
+- **Certificate validator:** declared bundles continue through
+  `validate_certificate_bundle()` for file presence, symlink and mode safety,
+  root/manager-root consistency, current validity, key pairing, issuer chain,
+  and SAN/provenance agreement. User ownership alone is not a valid bundle.
+- **Secret handling:** private keys remain under the gitignored generated
+  directory. Preserve the `0700` parent and read-only Compose mounts; never log,
+  print, archive, package, or return certificate/key contents. UID/GID are not
+  secrets, but there is no operator value in logging them.
+- **OS/process exposure:** pass Docker arguments as a list. The numeric
+  `UID:GID` may appear only as the non-secret value of Compose's `--user`
+  argument. Do not invoke `id`, `sudo`, `chown`, a host shell, or a root helper
+  container; do not place PEM, key, credential, or environment values in argv.
+- **Error envelopes:** preserve subprocess timeout handling and convert failure
+  through `CertResult` to fatal `LabResult`/`LabActionResponse`. Any new
+  compatibility failure should name a stable layer and exit status, not echo a
+  command, host environment, key path inventory, or unredacted upstream body.
+- **Persistence and evidence:** no repository/database transaction is involved.
+  Stateful realization may persist only its existing non-secret public-root
+  fingerprint and validation booleans; ownership metadata and private material
+  do not belong in run records or ACES evidence.
+
+## Extensibility Seam
+
+The seam is the existing host-environment decision plus the optional execution
+identity consumed by the certificate command builder, with Docker execution
+still injectable through `run_command`. The next reasonable host-runtime
+variation should change `hostenv` classification or the identity returned by
+that boundary once, not add another OS branch or ownership strategy to
+certificate orchestration.
+
+The generator image/service/version remains parameterized by the canonical
+Compose asset. A future generator-image change should not require copying its
+reference into Python, deployment DTOs, docs, or a repair command.
+
+## Whole-Repository Surface
+
+- Certificate producer and platform boundary: `src/aptl/core/certs.py` and
+  `src/aptl/core/hostenv.py`.
+- Startup and deployment boundary: `src/aptl/core/lab.py` and
+  `src/aptl/core/deployment/_compose_stateful_{constants,graph,realization}.py`.
+- Certificate validation: `src/aptl/core/deployment/_stateful_certificates.py`.
+- Canonical assets and consumers: `generate-indexer-certs.yml`,
+  `config/certs.yml`, and the Wazuh mounts in `docker-compose.yml`.
+- Adjacent SOC regression boundary: `src/aptl/core/soc_ca.py`,
+  `src/aptl/core/_soc_ca_io.py`, and the `config/soc_certs/` mounts.
+- Distribution and secret exclusion: `.gitignore`,
+  `src/aptl/_asset_manifest.py`, `hatch_build.py`, and their tests.
+- Operator guidance: `docs/getting-started/installation.md`,
+  `docs/deployment.md`, and `docs/troubleshooting/index.md`. Manual raw Compose
+  certificate commands bypass the platform-aware identity policy and must not
+  remain the recommended regeneration path.
+- Verification: certificate, host-environment, startup, stateful-realization,
+  privilege-escalation, asset, and package-build tests plus native Linux and
+  Docker Desktop lab-start evidence.
+
+## Gotchas and Anti-Patterns
+
+- Do not conflate host file owner, generator process user, and the fixed
+  non-root UIDs used later by Wazuh services. `--user <host UID>:<host GID>`
+  applies only to the one-shot producer.
+- Do not conflate UID/GID ownership with `0700`/`0644` mode policy. Removing
+  the readability pass can make correctly owned certs unusable by Wazuh.
+- Pre-create the native-Linux bind source as the host user. Otherwise Docker
+  may create the missing host directory as root before container `--user`
+  takes effect.
+- Do not call `os.getuid()`/`os.getgid()` before the platform gate, including
+  while computing defaults, formatting log arguments, or constructing test
+  fixtures. Those attributes are absent on native Windows Python.
+- Do not use a mocked Docker Desktop unit path as proof of host ownership. The
+  file-sharing result is a runtime contract and needs live Desktop evidence;
+  the unit test proves only command construction and absent POSIX calls.
+- Do not treat Linux host, Linux Docker Desktop, WSL2, Colima/Lima, and native
+  Linux Docker as interchangeable. The repository's Docker-mode probe is the
+  policy boundary.
+- Do not restore host `sudo`, Docker-root `chown`, a root entrypoint phase, or a
+  best-effort fallback. Generation failure must stop startup.
+- Do not remove isolated-project cleanup while changing command ordering; a
+  leaked generator network can overlap the TechVault networks.
+- Do not update only the legacy `_step_generate_certs()` path. Typed ACES
+  realization calls the same generator with an injected backend runner and
+  then applies stronger output validation.
+- Do not leave documentation telling operators to regenerate with raw
+  `docker compose -f generate-indexer-certs.yml run ...`; that bypasses the
+  platform policy and can recreate the root-owned state.
+- Do not treat the repository-wide `sudo -n` AST guard as the complete
+  acceptance test. The certificate path must separately prove that it issues
+  no `sudo`, `chown`, root helper, or repair command at all.
+- Do not broaden this issue into Wazuh certificate rotation, CA redesign,
+  service UID remapping, generalized host-file repair, or deployment-backend
+  redesign.
+
+## Non-Goals and Boundaries
+
+This issue does not change certificate subjects/SANs, Wazuh TLS topology,
+private-key distribution, Wazuh service runtime users, SOC CA generation,
+Compose profiles, remote generated-artifact support, ACES schemas, durable
+configuration, environment variables, API/web contracts, startup readiness
+taxonomy, run-record schemas, or certificate rotation. It does not upgrade the
+generator image, introduce a custom image, or add a generic ownership manager
+without separate authorization and supply chain review.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,9 +57,6 @@ cd aptl
 # Generate SSH keys
 ./scripts/generate-ssh-keys.sh
 
-# Generate SSL certificates
-docker compose -f generate-indexer-certs.yml run --rm generator
-
 # Build MCP servers (optional - for AI integration)
 ./mcp/build-all-mcps.sh
 ```
@@ -71,8 +68,10 @@ aptl lab start
 ```
 
 **Use `aptl lab start` for the deploy itself.** Beyond the steps above it also
-renders the credentialized Wazuh config from the checked-in templates into the
-gitignored `.aptl/config/` tree (ADR-028)—there is no standalone manual
+generates the Wazuh Indexer SSL certificates automatically (producer-owned,
+platform-aware—see [Troubleshooting](troubleshooting/index.md)) and renders
+the credentialized Wazuh config from the checked-in templates into the
+gitignored `.aptl/config/` tree (ADR-028); there is no standalone manual
 command for that render, so a hand-run `docker compose --profile wazuh ... up`
 on a fresh checkout fails at the `.aptl/config/...` bind mounts. Once a lab has
 been started, a raw `docker compose --profile wazuh --profile victim --profile
@@ -196,7 +195,7 @@ sudo lsof -t -i:443 | xargs kill
 
 ```bash
 rm -rf config/wazuh_indexer_ssl_certs
-docker compose -f generate-indexer-certs.yml run --rm generator
+aptl lab start
 ```
 
 ### Container Build Failures

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -85,7 +85,7 @@ curl -k https://localhost:443
 **Regenerate certificates:**
 ```bash
 rm -rf config/wazuh_indexer_ssl_certs
-docker compose -f generate-indexer-certs.yml run --rm generator
+aptl lab start
 ```
 
 ### No logs in Wazuh

--- a/generate-indexer-certs.yml
+++ b/generate-indexer-certs.yml
@@ -4,6 +4,33 @@ services:
   generator:
     image: wazuh/wazuh-certs-generator:0.0.2
     hostname: wazuh-certs-generator
+    # The upstream entrypoint is 700 root:root, so it cannot run as an
+    # arbitrary host UID (see issue #677). This override runs the same
+    # Wazuh certificate workflow the shipped entrypoint performs, so output
+    # is producer-owned by whatever UID Compose is invoked with.
+    #
+    # The generator tool is vendored at config/wazuh-certs-tool.sh (from
+    # https://packages.wazuh.com/4.8/wazuh-certs-tool.sh, GPLv2) and its
+    # digest is verified before execution: the certificate producer must
+    # never execute mutable network content (the shipped entrypoint's
+    # runtime download is the supply-chain flaw this replaces).
+    working_dir: /tmp
+    environment:
+      - HOME=/tmp
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        set -euo pipefail
+        echo "acd4fb48c9646904069d81ed9c67f849cf910ab5eb127e051fe9db1dae068874  /tools/wazuh-certs-tool.sh" | sha256sum -c -
+        cp /tools/wazuh-certs-tool.sh ./wazuh-certs-tool.sh
+        cp /config/certs.yml ./config.yml
+        chmod 700 wazuh-certs-tool.sh
+        bash ./wazuh-certs-tool.sh -A
+        cp ./wazuh-certificates/* /certificates/
+        cp /certificates/root-ca.pem /certificates/root-ca-manager.pem
+        cp /certificates/root-ca.key /certificates/root-ca-manager.key
     volumes:
       - ./config/wazuh_indexer_ssl_certs/:/certificates/
       - ./config/certs.yml:/config/certs.yml
+      - ./config/wazuh-certs-tool.sh:/tools/wazuh-certs-tool.sh:ro

--- a/src/aptl/backends/_aces_observation_helpers.py
+++ b/src/aptl/backends/_aces_observation_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -75,6 +76,36 @@ def mount_present(
     return False
 
 
+# The realized dependency wiring lives on the DTOs as plan addresses
+# (``provision.generated-artifact.X``); the declared spec states the same
+# wiring in the author vocabulary (``generated_artifacts.X``). aces-sdl
+# 0.23 carries the dependency fields inside the declared spec, so the
+# observed spec must render the wiring the backend actually realized in
+# that same vocabulary or the SEM-218 exact comparison rejects every
+# artifact and volume (issue #677).
+_AUTHOR_DEPENDENCY_PREFIXES = (
+    ("provision.generated-artifact.", "generated_artifacts."),
+    ("provision.persistent-volume.", "persistent_volumes."),
+    ("provision.node.", "nodes."),
+    ("provision.network.", "networks."),
+)
+
+
+def _author_dependency(address: str) -> str:
+    """Render one realized dependency address in the author vocabulary."""
+
+    for plan_prefix, author_prefix in _AUTHOR_DEPENDENCY_PREFIXES:
+        if address.startswith(plan_prefix):
+            return author_prefix + address[len(plan_prefix) :]
+    return address
+
+
+def _author_dependencies(addresses: tuple[str, ...]) -> list[str]:
+    """Render realized dependency wiring in the author vocabulary."""
+
+    return [_author_dependency(address) for address in addresses]
+
+
 def artifact_spec(
     artifact: DeploymentGeneratedArtifactRealization,
 ) -> dict[str, object]:
@@ -86,6 +117,8 @@ def artifact_spec(
         "provenance": artifact.provenance,
         "outputs": [output.details() for output in artifact.outputs],
         "consumers": [consumer_spec(consumer) for consumer in artifact.consumers],
+        "ordering_dependencies": _author_dependencies(artifact.ordering_dependencies),
+        "refresh_dependencies": _author_dependencies(artifact.refresh_dependencies),
     }
 
 
@@ -96,6 +129,8 @@ def volume_spec(volume: DeploymentPersistentVolumeRealization) -> dict[str, obje
         "lifecycle": volume.lifecycle,
         "access_mode": volume.access_mode,
         "consumers": [consumer_spec(consumer) for consumer in volume.consumers],
+        "ordering_dependencies": _author_dependencies(volume.ordering_dependencies),
+        "refresh_dependencies": _author_dependencies(volume.refresh_dependencies),
     }
 
 
@@ -125,6 +160,42 @@ def safe_inspect(backend: "DeploymentBackend", name: str) -> dict[str, Any]:
         )
         return {}
     return info if isinstance(info, dict) else {}
+
+
+# Wazuh manager and indexer restart themselves once during first boot, so a
+# consumer container can legitimately read health='starting' for a bounded
+# window between the realization health gate and observation. Observed on a
+# loaded host: the restart cycle returns to healthy well inside two minutes;
+# 180s keeps a generous margin (issue #677).
+_SETTLE_TIMEOUT = 180
+_SETTLE_INTERVAL = 5
+
+
+def settled_inspect(backend: "DeploymentBackend", name: str) -> dict[str, Any]:
+    """Inspect a container, waiting out transitional startup states.
+
+    ``starting`` health and Docker's ``Restarting`` flag are transitional —
+    not evidence of an unrealized resource — so observation waits for the
+    container to settle before judging. Terminal states (missing, stopped,
+    unhealthy) return immediately and fail closed exactly as before.
+    """
+    deadline = time.monotonic() + _SETTLE_TIMEOUT
+    while True:
+        info = safe_inspect(backend, name)
+        if not _transitional_state(info) or time.monotonic() >= deadline:
+            return info
+        time.sleep(_SETTLE_INTERVAL)
+
+
+def _transitional_state(info: Mapping[str, Any]) -> bool:
+    """Return whether a container is mid-startup rather than settled."""
+
+    state = info.get("State") if isinstance(info, Mapping) else None
+    if not isinstance(state, Mapping):
+        return False
+    if state.get("Restarting") is True:
+        return True
+    return container_running(info) and container_health(info) == "starting"
 
 
 def container_realized(info: Mapping[str, Any]) -> bool:
@@ -163,6 +234,71 @@ def observed_os_family(info: Mapping[str, Any]) -> str | None:
     if isinstance(platform, str) and platform.strip():
         return platform.strip().lower()
     return None
+
+
+_DOMAIN_INFO_TIMEOUT = 30
+
+
+def observed_domain_topology(
+    backend: "DeploymentBackend",
+    container: str,
+    declared: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Attest a declared domain topology from the live directory, or nothing.
+
+    ``samba-tool domain info`` exposes the runtime-observable core of the
+    declaration — the served DNS domain, the NetBIOS domain, and (by
+    answering for itself) the controller role. The remaining declared fields
+    (domain id, profile, plan addresses) are definitional identity with no
+    runtime counterpart, so the declared mapping is attested only when every
+    observable field corroborates it; a mismatch, failed probe, or missing
+    tooling attests nothing and the SEM-218 gate fails closed.
+    """
+    from aptl.core.deployment._account_provider import samba_domain_info
+
+    container_exec = getattr(backend, "container_exec", None)
+    if container_exec is None:
+        # A backend without an exec seam (e.g. conformance stubs) cannot
+        # corroborate the live domain; attest nothing and fail closed.
+        return None
+    try:
+        result = container_exec(
+            container, samba_domain_info(), timeout=_DOMAIN_INFO_TIMEOUT
+        )
+    except (BackendTimeoutError, OSError) as exc:
+        log.warning(
+            "could not observe domain topology in %s (%s)",
+            container,
+            type(exc).__name__,
+        )
+        return None
+    if getattr(result, "returncode", 1) != 0:
+        return None
+    observed = _parse_samba_domain_info(getattr(result, "stdout", "") or "")
+    dns_name = str(declared.get("dns_name", "")).lower()
+    netbios_name = str(declared.get("netbios_name", "")).upper()
+    if not dns_name or observed.get("domain") != dns_name:
+        return None
+    if not netbios_name or observed.get("netbios_domain") != netbios_name:
+        return None
+    if declared.get("role") == "controller" and not observed.get("dc_name"):
+        return None
+    return dict(declared)
+
+
+def _parse_samba_domain_info(text: str) -> dict[str, str]:
+    """Extract the observable fields from ``samba-tool domain info`` output."""
+
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        key, sep, value = line.partition(":")
+        if sep:
+            fields[key.strip().lower().replace(" ", "_")] = value.strip()
+    return {
+        "domain": fields.get("domain", "").lower(),
+        "netbios_domain": fields.get("netbios_domain", "").upper(),
+        "dc_name": fields.get("dc_name", ""),
+    }
 
 
 def realized_network_names(

--- a/src/aptl/backends/_aces_observation_helpers.py
+++ b/src/aptl/backends/_aces_observation_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Mapping
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from aptl.core.deployment._compose_realization_networks import (
@@ -29,6 +30,20 @@ if TYPE_CHECKING:
     from aptl.core.deployment.realization import DeploymentContentRealization
 
 log = get_logger("realization-observe")
+
+
+@dataclass(frozen=True)
+class ObservedResource(object):
+    """What the deployment backend was observed to have realized for one address.
+
+    ``concerns`` maps a SEM-218 concern payload path to the value the backend
+    actually realized there. A concern the backend cannot be seen to have
+    realized is simply absent, so the gate sees an omission rather than an echo.
+    """
+
+    realized: bool
+    concerns: dict[tuple[str, ...], object] = field(default_factory=dict)
+    evidence: dict[str, object] = field(default_factory=dict)
 
 
 def consumer_mount_evidence(
@@ -272,18 +287,25 @@ def observed_domain_topology(
             type(exc).__name__,
         )
         return None
-    if getattr(result, "returncode", 1) != 0:
-        return None
-    observed = _parse_samba_domain_info(getattr(result, "stdout", "") or "")
+    corroborated = getattr(result, "returncode", 1) == 0 and _domain_info_corroborates(
+        getattr(result, "stdout", "") or "", declared
+    )
+    return dict(declared) if corroborated else None
+
+
+def _domain_info_corroborates(text: str, declared: Mapping[str, Any]) -> bool:
+    """Return whether the live domain readback matches every observable field."""
+
+    observed = _parse_samba_domain_info(text)
     dns_name = str(declared.get("dns_name", "")).lower()
     netbios_name = str(declared.get("netbios_name", "")).upper()
-    if not dns_name or observed.get("domain") != dns_name:
-        return None
-    if not netbios_name or observed.get("netbios_domain") != netbios_name:
-        return None
-    if declared.get("role") == "controller" and not observed.get("dc_name"):
-        return None
-    return dict(declared)
+    return bool(
+        dns_name
+        and observed.get("domain") == dns_name
+        and netbios_name
+        and observed.get("netbios_domain") == netbios_name
+        and (declared.get("role") != "controller" or observed.get("dc_name"))
+    )
 
 
 def _parse_samba_domain_info(text: str) -> dict[str, str]:

--- a/src/aptl/backends/_aces_stateful_observation.py
+++ b/src/aptl/backends/_aces_stateful_observation.py
@@ -1,0 +1,319 @@
+"""Stateful artifact and volume observation for the SEM-218 runtime gate.
+
+Split from :mod:`aptl.backends.aces_observation` (python:S104): this module
+owns the generated-artifact and persistent-volume observers — outputs-present
+verification, consumer mount readback, authenticated Wazuh readiness, and
+non-secret evidence assembly. Node, network, and placement observation stay
+in :mod:`aptl.backends.aces_observation`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+from aces_processor.semantics.realization import CONCERN_PAYLOAD_PATH
+
+from aptl.backends._aces_observation_helpers import (
+    ObservedResource,
+    artifact_spec as _artifact_spec,
+    consumer_mount_evidence as _consumer_mount_evidence,
+    container_realized as _container_realized,
+    mount_present as _mount_present,
+    settled_inspect as _settled_inspect,
+    volume_spec as _volume_spec,
+)
+from aptl.core.deployment._compose_stateful_realization import artifact_source_path
+from aptl.core.deployment._stateful_certificates import certificate_bundle_evidence
+from aptl.core.deployment.realization import (
+    DeploymentGeneratedArtifactRealization,
+    DeploymentPersistentVolumeRealization,
+    DeploymentStatefulConsumer,
+)
+from aptl.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from aptl.core.deployment.backend import DeploymentBackend
+
+log = get_logger("realization-observe")
+
+
+def _observe_generated_artifact(
+    backend: "DeploymentBackend",
+    artifact: DeploymentGeneratedArtifactRealization | None,
+    node_containers: dict[str, str],
+) -> ObservedResource:
+    """Observe verified outputs and read-only bind mounts for one artifact."""
+
+    project_dir = getattr(backend, "project_dir", None)
+    if artifact is None or not isinstance(project_dir, Path):
+        return ObservedResource(realized=False)
+    source = artifact_source_path(project_dir, artifact)
+    outputs_present = _artifact_outputs_present(source, artifact)
+    consumers_mounted = outputs_present and _artifact_consumers_mounted(
+        backend, artifact, node_containers, source
+    )
+    consumers_ready = consumers_mounted and _authenticated_consumers_ready(
+        backend, artifact.consumers
+    )
+    realized = consumers_ready
+    evidence = (
+        _artifact_evidence(backend, project_dir, source, artifact) if realized else {}
+    )
+    realized = realized and (
+        artifact.generator != "certificate_bundle" or "certificate" in evidence
+    )
+    if not realized:
+        # An unrealized observation always fails the SEM-218 gate, so the
+        # failing predicate must be diagnosable from the log (names and
+        # booleans only — never artifact bytes).
+        log.warning(
+            "artifact %s not observed as realized "
+            "(outputs=%s consumers_mounted=%s consumers_ready=%s evidence=%s)",
+            artifact.address,
+            outputs_present,
+            consumers_mounted,
+            consumers_ready,
+            bool(evidence),
+        )
+        return ObservedResource(realized=False)
+    return ObservedResource(
+        realized=True,
+        concerns={CONCERN_PAYLOAD_PATH["generated-artifact"]: _artifact_spec(artifact)},
+        evidence=evidence,
+    )
+
+
+def _artifact_outputs_present(
+    source: Path,
+    artifact: DeploymentGeneratedArtifactRealization,
+) -> bool:
+    """Return whether every declared artifact output exists at its source."""
+
+    if source.is_dir():
+        return all((source / output.path).is_file() for output in artifact.outputs)
+    return source.is_file() and len(artifact.outputs) == 1
+
+
+def _observe_persistent_volume(
+    backend: "DeploymentBackend",
+    volume: DeploymentPersistentVolumeRealization | None,
+    node_containers: dict[str, str],
+    project_name: str,
+) -> ObservedResource:
+    """Observe project-scoped named-volume mounts for one desired volume."""
+
+    if volume is None:
+        return ObservedResource(realized=False)
+    mounted = _consumers_mounted(
+        backend,
+        volume.consumers,
+        node_containers,
+        mount_type="volume",
+        source=f"{project_name}_{volume.name}",
+    )
+    ready = mounted and _authenticated_consumers_ready(backend, volume.consumers)
+    if not ready:
+        log.warning(
+            "volume %s not observed as realized (mounted=%s ready=%s)",
+            volume.address,
+            mounted,
+            ready,
+        )
+        return ObservedResource(realized=False)
+    return ObservedResource(
+        realized=True,
+        concerns={CONCERN_PAYLOAD_PATH["persistent-volume"]: _volume_spec(volume)},
+        evidence={
+            "address": volume.address,
+            "status": "ready",
+            "volume_identity": f"{project_name}_{volume.name}",
+            "lifecycle": volume.lifecycle,
+            "consumer_mounts": _consumer_mount_evidence(volume.consumers),
+        },
+    )
+
+
+
+def _artifact_evidence(
+    backend: "DeploymentBackend",
+    project_dir: Path,
+    source: Path,
+    artifact: DeploymentGeneratedArtifactRealization,
+) -> dict[str, object]:
+    """Build non-secret evidence for an artifact verified by provider readback."""
+
+    evidence: dict[str, object] = {
+        "address": artifact.address,
+        "status": "ready",
+        "consumer_mounts": _consumer_mount_evidence(artifact.consumers),
+    }
+    readiness = getattr(backend, "authenticated_readiness", {})
+    if isinstance(readiness, Mapping):
+        observed_readiness = {
+            consumer.service_name: bool(readiness[consumer.service_name])
+            for consumer in artifact.consumers
+            if consumer.service_name in readiness
+        }
+        if observed_readiness:
+            evidence["authenticated_readiness"] = observed_readiness
+    if artifact.generator == "rendered_config" and source.is_file():
+        evidence["configuration_sha256"] = hashlib.sha256(
+            source.read_bytes()
+        ).hexdigest()
+    elif artifact.generator == "certificate_bundle":
+        certificate = certificate_bundle_evidence(
+            source,
+            artifact.outputs,
+            project_dir / artifact.provenance,
+        )
+        if certificate is not None:
+            evidence["certificate"] = certificate
+    return evidence
+
+
+def _consumers_mounted(
+    backend: "DeploymentBackend",
+    consumers: tuple[DeploymentStatefulConsumer, ...],
+    node_containers: dict[str, str],
+    *,
+    mount_type: str,
+    source: str,
+) -> bool:
+    """Return whether every consumer has the exact observed mount contract."""
+
+    return all(
+        _consumer_volume_mounted(
+            backend, consumer, node_containers, mount_type=mount_type, source=source
+        )
+        for consumer in consumers
+    )
+
+
+def _consumer_volume_mounted(
+    backend: "DeploymentBackend",
+    consumer: DeploymentStatefulConsumer,
+    node_containers: dict[str, str],
+    *,
+    mount_type: str,
+    source: str,
+) -> bool:
+    """Return whether one consumer's container shows the desired mount."""
+
+    container = node_containers.get(consumer.target_address)
+    if not container:
+        log.warning(
+            "consumer %s has no realized container to observe",
+            consumer.target_address,
+        )
+        return False
+    info = _settled_inspect(backend, container)
+    if not _container_realized(info):
+        log.warning(
+            "consumer container %s not settled/healthy for observation",
+            container,
+        )
+        return False
+    mounted = _mount_present(info, consumer, mount_type=mount_type, source=source)
+    if not mounted:
+        log.warning(
+            "consumer container %s missing %s mount of %s",
+            container,
+            mount_type,
+            source,
+        )
+    return mounted
+
+
+def _artifact_consumers_mounted(
+    backend: "DeploymentBackend",
+    artifact: DeploymentGeneratedArtifactRealization,
+    node_containers: dict[str, str],
+    source: Path,
+) -> bool:
+    """Return whether every consumer sees only its declared artifact outputs."""
+
+    return all(
+        _artifact_consumer_mounted(
+            backend,
+            artifact,
+            consumer,
+            node_containers,
+            source,
+        )
+        for consumer in artifact.consumers
+    )
+
+
+def _artifact_consumer_mounted(
+    backend: "DeploymentBackend",
+    artifact: DeploymentGeneratedArtifactRealization,
+    consumer: DeploymentStatefulConsumer,
+    node_containers: dict[str, str],
+    source: Path,
+) -> bool:
+    """Return whether one artifact consumer has every declared bind mount."""
+
+    container = node_containers.get(consumer.target_address)
+    if not container:
+        log.warning(
+            "artifact consumer %s has no realized container to observe",
+            consumer.target_address,
+        )
+        return False
+    info = _settled_inspect(backend, container)
+    if not _container_realized(info):
+        log.warning(
+            "artifact consumer container %s not settled/healthy for observation",
+            container,
+        )
+        return False
+    expected = (
+        [
+            (
+                str(source / output.path),
+                str(PurePosixPath(consumer.mount_destination) / output.path),
+            )
+            for output in artifact.outputs
+        ]
+        if artifact.generator == "certificate_bundle"
+        else [(str(source), consumer.mount_destination)]
+    )
+    return all(
+        _mount_present(
+            info,
+            consumer,
+            mount_type="bind",
+            source=mount_source,
+            destination=destination,
+        )
+        for mount_source, destination in expected
+    )
+
+
+def _authenticated_consumers_ready(
+    backend: "DeploymentBackend",
+    consumers: tuple[DeploymentStatefulConsumer, ...],
+) -> bool:
+    """Require authenticated readback for every Wazuh artifact consumer."""
+
+    expected = {
+        consumer.service_name
+        for consumer in consumers
+        if consumer.service_name in {"wazuh.indexer", "wazuh.manager"}
+    }
+    if not expected:
+        return True
+    readiness = getattr(backend, "authenticated_readiness", {})
+    ready = isinstance(readiness, Mapping) and all(
+        readiness.get(service) is True for service in expected
+    )
+    if not ready:
+        log.warning(
+            "authenticated readiness not recorded for %s (map=%s)",
+            sorted(expected),
+            dict(readiness) if isinstance(readiness, Mapping) else type(readiness),
+        )
+    return ready

--- a/src/aptl/backends/aces.py
+++ b/src/aptl/backends/aces.py
@@ -36,6 +36,7 @@ from aptl.backends.aces_start_model import (
     AcesStartOutcome,
 )
 from aptl.core.config import AptlConfig
+from aptl.core.deployment._compose_stateful_model import artifact_source_path
 from aptl.core.lab_types import LabResult
 from aptl.utils.logging import get_logger
 from aptl.utils.redaction import redact
@@ -253,8 +254,15 @@ def admitted_stateful_artifact_ownership(
     config: AptlConfig,
     backend: "DeploymentBackend",
     scenario_path: Path | None = None,
-) -> frozenset[tuple[str, str, str, str]]:
-    """Return exact addressed artifact consumers from the admitted graph."""
+) -> frozenset[tuple[str, str, str, str, str]]:
+    """Return exact addressed artifact consumers from the admitted graph.
+
+    Each entry is ``(address, generator, service_name, mount_destination,
+    source_relpath)``. The canonical generated source travels with the
+    consumer so downstream exemptions (the bind-mount pre-flight) can match
+    a mount on both sides — a stray bind whose destination merely nests
+    beneath an owned directory is not owned by the artifact (issue #677).
+    """
 
     resolved_scenario = scenario_path or DEFAULT_ACES_SCENARIO
     if not resolved_scenario.is_absolute():
@@ -281,6 +289,9 @@ def admitted_stateful_artifact_ownership(
             artifact.generator,
             consumer.service_name,
             consumer.mount_destination,
+            artifact_source_path(project_dir, artifact)
+            .relative_to(project_dir.resolve())
+            .as_posix(),
         )
         for artifact in realization.generated_artifacts
         for consumer in artifact.consumers
@@ -345,6 +356,35 @@ def _run_execution_plan(
     )
 
 
+def _with_backend_failure_diagnostics(
+    target: RuntimeTarget,
+    diagnostics: list["Diagnostic"],
+) -> list["Diagnostic"]:
+    """Re-attach the provisioner's own failure report to a failed apply.
+
+    ``aces_runtime``'s backend-call boundary replaces a failed backend apply's
+    diagnostics with its snapshot-contract / SEM-218 gate output — the gate
+    evaluates the never-realized snapshot, so every exact declaration reads as
+    unrealized. That hides the backend's actionable failure (for example a
+    Docker subnet conflict with its remediation steps) and severs the
+    retryable-code signal the SOC retry keys on. The backend's own report is
+    authoritative for what failed, so it renders first.
+    """
+    captured = tuple(getattr(target.provisioner, "last_failure_diagnostics", ()))
+    if not captured:
+        return diagnostics
+    seen = {
+        (diagnostic.code, diagnostic.address, diagnostic.message)
+        for diagnostic in diagnostics
+    }
+    fresh = [
+        diagnostic
+        for diagnostic in captured
+        if (diagnostic.code, diagnostic.address, diagnostic.message) not in seen
+    ]
+    return [*fresh, *diagnostics]
+
+
 def _apply_execution_plan(
     target: RuntimeTarget,
     execution_plan: "ExecutionPlan",
@@ -373,15 +413,18 @@ def _apply_execution_plan(
     apply_result = manager.apply(execution_plan)
     snapshot = apply_result.snapshot
     if not apply_result.success:
+        diagnostics = _with_backend_failure_diagnostics(
+            target, list(apply_result.diagnostics)
+        )
         return (
             LabResult(
                 success=False,
-                error=render_aces_diagnostics(list(apply_result.diagnostics)),
+                error=render_aces_diagnostics(diagnostics),
             ),
             snapshot,
             any(
                 diagnostic.code in _RETRYABLE_APPLY_DIAGNOSTIC_CODES
-                for diagnostic in apply_result.diagnostics
+                for diagnostic in diagnostics
             ),
         )
     evaluation_results = _evaluation_results(target, execution_plan)

--- a/src/aptl/backends/aces_diagnostics.py
+++ b/src/aptl/backends/aces_diagnostics.py
@@ -11,7 +11,10 @@ from aces_contracts.runtime_state import RuntimeSnapshot, SnapshotEntry
 from aces_processor.semantics.realization import CONCERN_PAYLOAD_PATH
 
 from aptl.backends.aces_observation import ObservedResource
+from aptl.utils.logging import get_logger
 from aptl.utils.redaction import redact
+
+log = get_logger("aces-diagnostics")
 
 PROVISIONING_ADDRESS = "runtime.apply.provisioning"
 SUPPORTED_RESOURCE_TYPES = frozenset(
@@ -43,14 +46,32 @@ def has_error(diagnostics: list[Diagnostic]) -> bool:
     return any(item.is_error for item in diagnostics)
 
 
+_RENDERED_DIAGNOSTIC_CAP = 5
+
+
 def render_aces_diagnostics(diagnostics: list[Diagnostic]) -> str:
-    """Render ACES diagnostics into the APTL ``LabResult`` error surface."""
+    """Render ACES diagnostics into the APTL ``LabResult`` error surface.
+
+    The error surface stays bounded, but truncation must never be silent: a
+    dropped diagnostic can be the actionable one (issue #677), so the full
+    rendered set always lands in the log and the surface names how many
+    entries it omitted.
+    """
     if not diagnostics:
         return "ACES runtime handoff failed."
     rendered = [_format_diagnostic(item) for item in diagnostics if item.is_error]
     if not rendered:
         rendered = [_format_diagnostic(item) for item in diagnostics]
-    return redact("ACES runtime handoff failed: " + "; ".join(rendered[:5]))
+    shown = rendered[:_RENDERED_DIAGNOSTIC_CAP]
+    if len(rendered) > _RENDERED_DIAGNOSTIC_CAP:
+        for item in rendered:
+            log.error("ACES diagnostic: %s", redact(item))
+        shown = [
+            *shown,
+            f"[{len(rendered) - _RENDERED_DIAGNOSTIC_CAP} more diagnostics "
+            "omitted; full set in the log]",
+        ]
+    return redact("ACES runtime handoff failed: " + "; ".join(shown))
 
 
 def unsupported_resource_diagnostics(

--- a/src/aptl/backends/aces_observation.py
+++ b/src/aptl/backends/aces_observation.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
-from aces_contracts.planning import ProvisioningPlan
+from aces_contracts.planning import PlannedResource, ProvisioningPlan
 from aces_processor.semantics.realization import CONCERN_PAYLOAD_PATH
 
 from aptl.backends._aces_observation_helpers import (
@@ -43,9 +43,10 @@ from aptl.backends._aces_observation_helpers import (
     mount_present as _mount_present,
     network_realized as _network_realized,
     observed_content_type as _observed_content_type,
+    observed_domain_topology as _observed_domain_topology,
     observed_os_family as _observed_os_family,
     realized_network_names as _realized_network_names,
-    safe_inspect as _safe_inspect,
+    settled_inspect as _settled_inspect,
     volume_spec as _volume_spec,
 )
 from aptl.backends.aces_realization_model import AptlRealization
@@ -56,6 +57,9 @@ from aptl.core.deployment.realization import (
     DeploymentPersistentVolumeRealization,
     DeploymentStatefulConsumer,
 )
+from aptl.utils.logging import get_logger
+
+log = get_logger("realization-observe")
 
 if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
@@ -75,6 +79,7 @@ _REALIZED_SWITCH_TYPE = "switch"
 _NODE_TYPE_PATH = CONCERN_PAYLOAD_PATH["node-type"]
 _OS_FAMILY_PATH = CONCERN_PAYLOAD_PATH["os-family"]
 _CONTENT_TYPE_PATH = CONCERN_PAYLOAD_PATH["content-type"]
+_DOMAIN_TOPOLOGY_PATH = CONCERN_PAYLOAD_PATH["domain-topology"]
 
 
 @dataclass(frozen=True)
@@ -121,7 +126,11 @@ def observe_realization(
 
     for address, resource in plan.resources.items():
         if resource.resource_type == "node":
-            observations[address] = _observe_node(backend, node_containers.get(address))
+            observations[address] = _observe_node(
+                backend,
+                node_containers.get(address),
+                declared_domain_topology=_declared_domain_topology(resource),
+            )
         elif resource.resource_type == "network":
             observations[address] = _observe_network(
                 network_names.get(address), realized_networks, project_name
@@ -161,11 +170,13 @@ def _observe_generated_artifact(
         return ObservedResource(realized=False)
     source = artifact_source_path(project_dir, artifact)
     outputs_present = _artifact_outputs_present(source, artifact)
-    realized = (
-        outputs_present
-        and _artifact_consumers_mounted(backend, artifact, node_containers, source)
-        and _authenticated_consumers_ready(backend, artifact.consumers)
+    consumers_mounted = outputs_present and _artifact_consumers_mounted(
+        backend, artifact, node_containers, source
     )
+    consumers_ready = consumers_mounted and _authenticated_consumers_ready(
+        backend, artifact.consumers
+    )
+    realized = consumers_ready
     evidence = (
         _artifact_evidence(backend, project_dir, source, artifact) if realized else {}
     )
@@ -173,6 +184,18 @@ def _observe_generated_artifact(
         artifact.generator != "certificate_bundle" or "certificate" in evidence
     )
     if not realized:
+        # An unrealized observation always fails the SEM-218 gate, so the
+        # failing predicate must be diagnosable from the log (names and
+        # booleans only — never artifact bytes).
+        log.warning(
+            "artifact %s not observed as realized "
+            "(outputs=%s consumers_mounted=%s consumers_ready=%s evidence=%s)",
+            artifact.address,
+            outputs_present,
+            consumers_mounted,
+            consumers_ready,
+            bool(evidence),
+        )
         return ObservedResource(realized=False)
     return ObservedResource(
         realized=True,
@@ -200,17 +223,23 @@ def _observe_persistent_volume(
 ) -> ObservedResource:
     """Observe project-scoped named-volume mounts for one desired volume."""
 
-    if (
-        volume is None
-        or not _consumers_mounted(
-            backend,
-            volume.consumers,
-            node_containers,
-            mount_type="volume",
-            source=f"{project_name}_{volume.name}",
+    if volume is None:
+        return ObservedResource(realized=False)
+    mounted = _consumers_mounted(
+        backend,
+        volume.consumers,
+        node_containers,
+        mount_type="volume",
+        source=f"{project_name}_{volume.name}",
+    )
+    ready = mounted and _authenticated_consumers_ready(backend, volume.consumers)
+    if not ready:
+        log.warning(
+            "volume %s not observed as realized (mounted=%s ready=%s)",
+            volume.address,
+            mounted,
+            ready,
         )
-        or not _authenticated_consumers_ready(backend, volume.consumers)
-    ):
         return ObservedResource(realized=False)
     return ObservedResource(
         realized=True,
@@ -287,14 +316,25 @@ def _consumers_mounted(
     for consumer in consumers:
         container = node_containers.get(consumer.target_address)
         if not container:
+            log.warning(
+                "consumer %s has no realized container to observe",
+                consumer.target_address,
+            )
             return False
-        info = _safe_inspect(backend, container)
-        if not _container_realized(info) or not _mount_present(
-            info,
-            consumer,
-            mount_type=mount_type,
-            source=source,
-        ):
+        info = _settled_inspect(backend, container)
+        if not _container_realized(info):
+            log.warning(
+                "consumer container %s not settled/healthy for observation",
+                container,
+            )
+            return False
+        if not _mount_present(info, consumer, mount_type=mount_type, source=source):
+            log.warning(
+                "consumer container %s missing %s mount of %s",
+                container,
+                mount_type,
+                source,
+            )
             return False
     return True
 
@@ -330,9 +370,17 @@ def _artifact_consumer_mounted(
 
     container = node_containers.get(consumer.target_address)
     if not container:
+        log.warning(
+            "artifact consumer %s has no realized container to observe",
+            consumer.target_address,
+        )
         return False
-    info = _safe_inspect(backend, container)
+    info = _settled_inspect(backend, container)
     if not _container_realized(info):
+        log.warning(
+            "artifact consumer container %s not settled/healthy for observation",
+            container,
+        )
         return False
     expected = (
         [
@@ -371,20 +419,38 @@ def _authenticated_consumers_ready(
     if not expected:
         return True
     readiness = getattr(backend, "authenticated_readiness", {})
-    return isinstance(readiness, Mapping) and all(
+    ready = isinstance(readiness, Mapping) and all(
         readiness.get(service) is True for service in expected
     )
+    if not ready:
+        log.warning(
+            "authenticated readiness not recorded for %s (map=%s)",
+            sorted(expected),
+            dict(readiness) if isinstance(readiness, Mapping) else type(readiness),
+        )
+    return ready
+
+
+def _declared_domain_topology(resource: "PlannedResource") -> Mapping[str, object] | None:
+    """Return the node's declared domain topology when the plan carries one."""
+
+    payload = resource.payload
+    if not isinstance(payload, Mapping):
+        return None
+    topology = payload.get("domain_topology")
+    return topology if isinstance(topology, Mapping) else None
 
 
 def _observe_node(
     backend: "DeploymentBackend",
     container_name: str | None,
+    declared_domain_topology: Mapping[str, object] | None = None,
 ) -> ObservedResource:
     """Observe one ACES node through the container the backend realized for it."""
 
     if not container_name:
         return ObservedResource(realized=False)
-    info = _safe_inspect(backend, container_name)
+    info = _settled_inspect(backend, container_name)
     if not _container_realized(info):
         return ObservedResource(realized=False)
 
@@ -394,6 +460,12 @@ def _observe_node(
     os_family = _observed_os_family(info)
     if os_family is not None:
         concerns[_OS_FAMILY_PATH] = os_family
+    if declared_domain_topology is not None:
+        topology = _observed_domain_topology(
+            backend, container_name, declared_domain_topology
+        )
+        if topology is not None:
+            concerns[_DOMAIN_TOPOLOGY_PATH] = topology
     return ObservedResource(realized=True, concerns=concerns)
 
 
@@ -433,7 +505,7 @@ def _observe_placement(
     container_name = node_containers.get(target_address) if target_address else None
     if not container_name:
         return ObservedResource(realized=False)
-    if not _container_realized(_safe_inspect(backend, container_name)):
+    if not _container_realized(_settled_inspect(backend, container_name)):
         return ObservedResource(realized=False)
 
     concerns: dict[tuple[str, ...], object] = {}

--- a/src/aptl/backends/aces_observation.py
+++ b/src/aptl/backends/aces_observation.py
@@ -26,11 +26,7 @@ drift from the set of concerns the gate actually enforces.
 
 from __future__ import annotations
 
-import hashlib
 from collections.abc import Mapping
-from dataclasses import dataclass, field
-from pathlib import Path
-from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 from aces_contracts.planning import PlannedResource, ProvisioningPlan
@@ -51,13 +47,6 @@ from aptl.backends._aces_stateful_observation import (
     _observe_persistent_volume,
 )
 from aptl.backends.aces_realization_model import AptlRealization
-from aptl.core.deployment._compose_stateful_realization import artifact_source_path
-from aptl.core.deployment._stateful_certificates import certificate_bundle_evidence
-from aptl.core.deployment.realization import (
-    DeploymentGeneratedArtifactRealization,
-    DeploymentPersistentVolumeRealization,
-    DeploymentStatefulConsumer,
-)
 from aptl.utils.logging import get_logger
 
 log = get_logger("realization-observe")

--- a/src/aptl/backends/aces_observation.py
+++ b/src/aptl/backends/aces_observation.py
@@ -37,17 +37,18 @@ from aces_contracts.planning import PlannedResource, ProvisioningPlan
 from aces_processor.semantics.realization import CONCERN_PAYLOAD_PATH
 
 from aptl.backends._aces_observation_helpers import (
-    artifact_spec as _artifact_spec,
-    consumer_mount_evidence as _consumer_mount_evidence,
+    ObservedResource,
     container_realized as _container_realized,
-    mount_present as _mount_present,
     network_realized as _network_realized,
     observed_content_type as _observed_content_type,
     observed_domain_topology as _observed_domain_topology,
     observed_os_family as _observed_os_family,
     realized_network_names as _realized_network_names,
     settled_inspect as _settled_inspect,
-    volume_spec as _volume_spec,
+)
+from aptl.backends._aces_stateful_observation import (
+    _observe_generated_artifact,
+    _observe_persistent_volume,
 )
 from aptl.backends.aces_realization_model import AptlRealization
 from aptl.core.deployment._compose_stateful_realization import artifact_source_path
@@ -80,20 +81,6 @@ _NODE_TYPE_PATH = CONCERN_PAYLOAD_PATH["node-type"]
 _OS_FAMILY_PATH = CONCERN_PAYLOAD_PATH["os-family"]
 _CONTENT_TYPE_PATH = CONCERN_PAYLOAD_PATH["content-type"]
 _DOMAIN_TOPOLOGY_PATH = CONCERN_PAYLOAD_PATH["domain-topology"]
-
-
-@dataclass(frozen=True)
-class ObservedResource(object):
-    """What the deployment backend was observed to have realized for one address.
-
-    ``concerns`` maps a SEM-218 concern payload path to the value the backend
-    actually realized there. A concern the backend cannot be seen to have
-    realized is simply absent, so the gate sees an omission rather than an echo.
-    """
-
-    realized: bool
-    concerns: dict[tuple[str, ...], object] = field(default_factory=dict)
-    evidence: dict[str, object] = field(default_factory=dict)
 
 
 def observe_realization(
@@ -158,102 +145,6 @@ def observe_realization(
     return observations
 
 
-def _observe_generated_artifact(
-    backend: "DeploymentBackend",
-    artifact: DeploymentGeneratedArtifactRealization | None,
-    node_containers: dict[str, str],
-) -> ObservedResource:
-    """Observe verified outputs and read-only bind mounts for one artifact."""
-
-    project_dir = getattr(backend, "project_dir", None)
-    if artifact is None or not isinstance(project_dir, Path):
-        return ObservedResource(realized=False)
-    source = artifact_source_path(project_dir, artifact)
-    outputs_present = _artifact_outputs_present(source, artifact)
-    consumers_mounted = outputs_present and _artifact_consumers_mounted(
-        backend, artifact, node_containers, source
-    )
-    consumers_ready = consumers_mounted and _authenticated_consumers_ready(
-        backend, artifact.consumers
-    )
-    realized = consumers_ready
-    evidence = (
-        _artifact_evidence(backend, project_dir, source, artifact) if realized else {}
-    )
-    realized = realized and (
-        artifact.generator != "certificate_bundle" or "certificate" in evidence
-    )
-    if not realized:
-        # An unrealized observation always fails the SEM-218 gate, so the
-        # failing predicate must be diagnosable from the log (names and
-        # booleans only — never artifact bytes).
-        log.warning(
-            "artifact %s not observed as realized "
-            "(outputs=%s consumers_mounted=%s consumers_ready=%s evidence=%s)",
-            artifact.address,
-            outputs_present,
-            consumers_mounted,
-            consumers_ready,
-            bool(evidence),
-        )
-        return ObservedResource(realized=False)
-    return ObservedResource(
-        realized=True,
-        concerns={CONCERN_PAYLOAD_PATH["generated-artifact"]: _artifact_spec(artifact)},
-        evidence=evidence,
-    )
-
-
-def _artifact_outputs_present(
-    source: Path,
-    artifact: DeploymentGeneratedArtifactRealization,
-) -> bool:
-    """Return whether every declared artifact output exists at its source."""
-
-    if source.is_dir():
-        return all((source / output.path).is_file() for output in artifact.outputs)
-    return source.is_file() and len(artifact.outputs) == 1
-
-
-def _observe_persistent_volume(
-    backend: "DeploymentBackend",
-    volume: DeploymentPersistentVolumeRealization | None,
-    node_containers: dict[str, str],
-    project_name: str,
-) -> ObservedResource:
-    """Observe project-scoped named-volume mounts for one desired volume."""
-
-    if volume is None:
-        return ObservedResource(realized=False)
-    mounted = _consumers_mounted(
-        backend,
-        volume.consumers,
-        node_containers,
-        mount_type="volume",
-        source=f"{project_name}_{volume.name}",
-    )
-    ready = mounted and _authenticated_consumers_ready(backend, volume.consumers)
-    if not ready:
-        log.warning(
-            "volume %s not observed as realized (mounted=%s ready=%s)",
-            volume.address,
-            mounted,
-            ready,
-        )
-        return ObservedResource(realized=False)
-    return ObservedResource(
-        realized=True,
-        concerns={CONCERN_PAYLOAD_PATH["persistent-volume"]: _volume_spec(volume)},
-        evidence={
-            "address": volume.address,
-            "status": "ready",
-            "volume_identity": f"{project_name}_{volume.name}",
-            "lifecycle": volume.lifecycle,
-            "consumer_mounts": _consumer_mount_evidence(volume.consumers),
-        },
-    )
-
-
 def observation_evidence(
     observations: Mapping[str, ObservedResource],
 ) -> dict[str, dict[str, object]]:
@@ -264,171 +155,6 @@ def observation_evidence(
         for address, observed in observations.items()
         if observed.realized and observed.evidence
     }
-
-
-def _artifact_evidence(
-    backend: "DeploymentBackend",
-    project_dir: Path,
-    source: Path,
-    artifact: DeploymentGeneratedArtifactRealization,
-) -> dict[str, object]:
-    """Build non-secret evidence for an artifact verified by provider readback."""
-
-    evidence: dict[str, object] = {
-        "address": artifact.address,
-        "status": "ready",
-        "consumer_mounts": _consumer_mount_evidence(artifact.consumers),
-    }
-    readiness = getattr(backend, "authenticated_readiness", {})
-    if isinstance(readiness, Mapping):
-        observed_readiness = {
-            consumer.service_name: bool(readiness[consumer.service_name])
-            for consumer in artifact.consumers
-            if consumer.service_name in readiness
-        }
-        if observed_readiness:
-            evidence["authenticated_readiness"] = observed_readiness
-    if artifact.generator == "rendered_config" and source.is_file():
-        evidence["configuration_sha256"] = hashlib.sha256(
-            source.read_bytes()
-        ).hexdigest()
-    elif artifact.generator == "certificate_bundle":
-        certificate = certificate_bundle_evidence(
-            source,
-            artifact.outputs,
-            project_dir / artifact.provenance,
-        )
-        if certificate is not None:
-            evidence["certificate"] = certificate
-    return evidence
-
-
-def _consumers_mounted(
-    backend: "DeploymentBackend",
-    consumers: tuple[DeploymentStatefulConsumer, ...],
-    node_containers: dict[str, str],
-    *,
-    mount_type: str,
-    source: str,
-) -> bool:
-    """Return whether every consumer has the exact observed mount contract."""
-
-    for consumer in consumers:
-        container = node_containers.get(consumer.target_address)
-        if not container:
-            log.warning(
-                "consumer %s has no realized container to observe",
-                consumer.target_address,
-            )
-            return False
-        info = _settled_inspect(backend, container)
-        if not _container_realized(info):
-            log.warning(
-                "consumer container %s not settled/healthy for observation",
-                container,
-            )
-            return False
-        if not _mount_present(info, consumer, mount_type=mount_type, source=source):
-            log.warning(
-                "consumer container %s missing %s mount of %s",
-                container,
-                mount_type,
-                source,
-            )
-            return False
-    return True
-
-
-def _artifact_consumers_mounted(
-    backend: "DeploymentBackend",
-    artifact: DeploymentGeneratedArtifactRealization,
-    node_containers: dict[str, str],
-    source: Path,
-) -> bool:
-    """Return whether every consumer sees only its declared artifact outputs."""
-
-    return all(
-        _artifact_consumer_mounted(
-            backend,
-            artifact,
-            consumer,
-            node_containers,
-            source,
-        )
-        for consumer in artifact.consumers
-    )
-
-
-def _artifact_consumer_mounted(
-    backend: "DeploymentBackend",
-    artifact: DeploymentGeneratedArtifactRealization,
-    consumer: DeploymentStatefulConsumer,
-    node_containers: dict[str, str],
-    source: Path,
-) -> bool:
-    """Return whether one artifact consumer has every declared bind mount."""
-
-    container = node_containers.get(consumer.target_address)
-    if not container:
-        log.warning(
-            "artifact consumer %s has no realized container to observe",
-            consumer.target_address,
-        )
-        return False
-    info = _settled_inspect(backend, container)
-    if not _container_realized(info):
-        log.warning(
-            "artifact consumer container %s not settled/healthy for observation",
-            container,
-        )
-        return False
-    expected = (
-        [
-            (
-                str(source / output.path),
-                str(PurePosixPath(consumer.mount_destination) / output.path),
-            )
-            for output in artifact.outputs
-        ]
-        if artifact.generator == "certificate_bundle"
-        else [(str(source), consumer.mount_destination)]
-    )
-    return all(
-        _mount_present(
-            info,
-            consumer,
-            mount_type="bind",
-            source=mount_source,
-            destination=destination,
-        )
-        for mount_source, destination in expected
-    )
-
-
-def _authenticated_consumers_ready(
-    backend: "DeploymentBackend",
-    consumers: tuple[DeploymentStatefulConsumer, ...],
-) -> bool:
-    """Require authenticated readback for every Wazuh artifact consumer."""
-
-    expected = {
-        consumer.service_name
-        for consumer in consumers
-        if consumer.service_name in {"wazuh.indexer", "wazuh.manager"}
-    }
-    if not expected:
-        return True
-    readiness = getattr(backend, "authenticated_readiness", {})
-    ready = isinstance(readiness, Mapping) and all(
-        readiness.get(service) is True for service in expected
-    )
-    if not ready:
-        log.warning(
-            "authenticated readiness not recorded for %s (map=%s)",
-            sorted(expected),
-            dict(readiness) if isinstance(readiness, Mapping) else type(readiness),
-        )
-    return ready
 
 
 def _declared_domain_topology(resource: "PlannedResource") -> Mapping[str, object] | None:

--- a/src/aptl/backends/aces_provisioner.py
+++ b/src/aptl/backends/aces_provisioner.py
@@ -40,6 +40,12 @@ class AptlProvisioner(object):
     project_dir: Path
     config: AptlConfig
     deployment_backend: "DeploymentBackend"
+    # ACES's backend-call boundary replaces a failed apply's diagnostics with
+    # its snapshot-contract / SEM-218 gate output (the gate reads the
+    # never-realized snapshot, so every exact declaration looks unrealized).
+    # Keep the last failed apply's own report here so the handoff can
+    # re-attach the actionable failure (issue #677).
+    last_failure_diagnostics: tuple[Diagnostic, ...] = ()
 
     def validate(self, plan: object) -> list[Diagnostic]:
         """Validate that the ACES provisioning plan is APTL-realizable."""
@@ -84,6 +90,9 @@ class AptlProvisioner(object):
                     diagnostics=diagnostics,
                     details={"realization": realization.details()},
                 )
+        self.last_failure_diagnostics = (
+            () if result.success else tuple(result.diagnostics)
+        )
         return result
 
     def _apply_valid_plan(

--- a/src/aptl/core/certs.py
+++ b/src/aptl/core/certs.py
@@ -1,4 +1,10 @@
-"""SSL certificate generation for Wazuh Indexer."""
+"""SSL certificate generation for Wazuh Indexer.
+
+Generated certificates are producer-owned: the generator container runs as
+the invoking host UID/GID on native Linux Docker (see ``_native_linux_user``
+and ``_cert_generator_command``), rather than running as root and repairing
+ownership afterward.
+"""
 
 import hashlib
 import os
@@ -41,10 +47,11 @@ def ensure_ssl_certs(
     """Ensure SSL certificates exist for the Wazuh Indexer.
 
     If the certificates directory already exists, this is a no-op. Otherwise,
-    runs the docker compose cert generator. On native Linux Docker, generated
-    certificates are repaired back to the invoking host user after generation.
-    Docker Desktop does not need that repair because its file-sharing layer maps
-    ownership back to the host user.
+    runs the docker compose cert generator. On native Linux Docker, the
+    generator process itself runs as the invoking host UID/GID (via Compose
+    ``--user``), so generated certificates are producer-owned from creation.
+    Docker Desktop does not need that identity override because its
+    file-sharing layer maps container output back to the host user.
 
     Args:
         project_dir: Root directory of the APTL project (where
@@ -87,14 +94,6 @@ def _generate_ssl_certs(
     error = _run_cert_generator(project_dir, certs_dir, run_command)
     result = error
     if result is None:
-        repair_error = _repair_native_linux_cert_ownership(certs_dir, run_command)
-        if repair_error is not None:
-            return CertResult(
-                success=False,
-                generated=False,
-                certs_dir=certs_dir,
-                error=repair_error,
-            )
         alias_error = _ensure_manager_root_ca_alias(certs_dir)
         if alias_error is not None:
             return CertResult(
@@ -203,8 +202,14 @@ def _run_cert_generator(
 
 
 def _cert_generator_command(project_dir: Path, certs_dir: Path) -> list[str]:
-    """Build the isolated Docker Compose command for the cert generator."""
-    if _native_linux_user() is not None:
+    """Build the isolated Docker Compose command for the cert generator.
+
+    On native Linux Docker, the generator runs as the invoking host UID/GID
+    (``--user``) so its output is producer-owned; the bind-mount source is
+    pre-created by the host user so Docker does not create it as root first.
+    """
+    user = _native_linux_user()
+    if user is not None:
         certs_dir.mkdir(parents=True, exist_ok=True)
     command = [
         "docker",
@@ -216,6 +221,9 @@ def _cert_generator_command(project_dir: Path, certs_dir: Path) -> list[str]:
         "run",
         "--rm",
     ]
+    if user is not None:
+        uid, gid = user
+        command += ["--user", f"{uid}:{gid}"]
     command.append("generator")
     return command
 
@@ -278,41 +286,6 @@ def _command_failure_detail(result: subprocess.CompletedProcess) -> str:
     return detail or "Certificate generation failed"
 
 
-def _repair_native_linux_cert_ownership(
-    certs_dir: Path,
-    run_command: CommandRunner | None,
-) -> str | None:
-    """Repair root-owned generator output on native Linux Docker.
-
-    The upstream Wazuh cert generator image must run as root because its
-    entrypoint is not executable by an arbitrary host uid. Native Linux Docker
-    then leaves bind-mounted output root-owned. Use Docker itself, not host
-    sudo, to chown the generated files back to the invoking user.
-    """
-    error: str | None = None
-    user = _native_linux_user()
-    if user is not None:
-        try:
-            result = _execute_command(
-                _cert_ownership_repair_command(certs_dir, user),
-                run_command=run_command,
-                timeout=120,
-            )
-        except subprocess.TimeoutExpired:
-            error = "Certificate permission repair timed out after 120s"
-        except OSError as exc:
-            error = f"Certificate permission repair failed: {exc}"
-        else:
-            if result.returncode != 0:
-                detail = (
-                    result.stderr.strip()
-                    or result.stdout.strip()
-                    or "permission repair container failed"
-                )
-                error = f"Certificate permission repair failed: {detail}"
-    return error
-
-
 def _execute_command(
     command: list[str],
     *,
@@ -333,28 +306,6 @@ def _execute_command(
         cwd=project_dir,
         timeout=timeout,
     )
-
-
-def _cert_ownership_repair_command(certs_dir: Path, user: tuple[int, int]) -> list[str]:
-    """Build the Docker command that restores native-Linux host ownership."""
-    uid, gid = user
-    script = (
-        f"chown -R {uid}:{gid} /certificates && "
-        "find /certificates -type d -exec chmod 700 {} + && "
-        "find /certificates -type f -exec chmod 644 {} +"
-    )
-    return [
-        "docker",
-        "run",
-        "--rm",
-        "--entrypoint",
-        "/bin/sh",
-        "-v",
-        f"{certs_dir.resolve()}:/certificates",
-        "wazuh/wazuh-certs-generator:0.0.2",
-        "-c",
-        script,
-    ]
 
 
 def _native_linux_user() -> tuple[int, int] | None:

--- a/src/aptl/core/deployment/_compose_image_realization.py
+++ b/src/aptl/core/deployment/_compose_image_realization.py
@@ -16,6 +16,25 @@ _IMAGE_REALIZATION_TIMEOUT = 600
 _IMAGE_OVERRIDE_RELATIVE_PATH = Path(".aptl") / "realization" / "compose-images.yml"
 
 
+class _ResetValue:
+    """Marker emitting Compose's ``!reset`` tag (remove the key on merge).
+
+    Compose >= 2.24 rejects ``build: null`` at schema validation, so clearing
+    a base service's ``build`` from an override file requires the ``!reset``
+    merge tag instead of a null value.
+    """
+
+
+class _ImageOverrideDumper(yaml.SafeDumper):
+    """Safe YAML dumper that can emit Compose's ``!reset`` removal tag."""
+
+
+_ImageOverrideDumper.add_representer(
+    _ResetValue,
+    lambda dumper, _value: dumper.represent_scalar("!reset", ""),
+)
+
+
 class ComposeRealizationImageMixin:
     """Realize typed scenario image operations through Docker Compose."""
 
@@ -114,11 +133,15 @@ class ComposeRealizationImageMixin:
         override_path = self._project_dir / _IMAGE_OVERRIDE_RELATIVE_PATH
         override_path.parent.mkdir(parents=True, exist_ok=True)
         services = {
-            image.service_name: {"image": image.image_ref, "build": None}
+            image.service_name: {"image": image.image_ref, "build": _ResetValue()}
             for image in images
         }
         override_path.write_text(
-            yaml.safe_dump({"services": services}, sort_keys=True),
+            yaml.dump(
+                {"services": services},
+                Dumper=_ImageOverrideDumper,
+                sort_keys=True,
+            ),
             encoding="utf-8",
             newline="\n",
         )

--- a/src/aptl/core/deployment/_compose_seed_attribution.py
+++ b/src/aptl/core/deployment/_compose_seed_attribution.py
@@ -1,0 +1,104 @@
+"""Compose-project attribution for seeded named volumes (issue #677).
+
+Split from :mod:`aptl.core.deployment.docker_compose` (python:S104). A bare
+``docker run -v`` auto-creates a missing named volume without labels; Compose
+happily reuses it, but the content observation gate
+(``observe_content_type``) refuses a volume it cannot attribute to the
+project — so every seeded volume must carry the same labels Compose itself
+would have written, established before the first seeding container runs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aptl.core.deployment._compose_seed_safety import redacted_stderr_hint
+from aptl.core.deployment.errors import BackendSeedError
+from aptl.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    import subprocess
+
+    from aptl.core.seed_spec import NamedVolumeSeed
+
+log = get_logger("deployment")
+
+_SEED_TIMEOUT = 600
+
+
+class ComposeSeedAttributionMixin:
+    """Ensure seeded named volumes carry Compose project attribution."""
+
+    _project_name: str
+
+    def _run(
+        self, cmd: list[str], *, timeout: int | None = None
+    ) -> "subprocess.CompletedProcess":
+        """Provided by the composing backend."""
+        raise NotImplementedError
+
+    def _content_volume_owned_by_project(
+        self, raw_labels: str, logical_volume: str
+    ) -> bool:
+        """Provided by the composing backend."""
+        raise NotImplementedError
+
+    def _ensure_labeled_seed_volume(self, seed: NamedVolumeSeed) -> None:
+        """Create a missing seed volume with Compose project labels.
+
+        A bare ``docker run -v`` auto-creates a missing named volume without
+        labels. Compose happily reuses it, but the content observation gate
+        (``observe_content_type``) refuses a volume it cannot attribute to
+        this project, so a seeded volume must carry the same labels Compose
+        itself would have written. Labels are immutable after creation, so
+        this must happen before the first seeding ``docker run``.
+        """
+        volume = f"{self._project_name}_{seed.volume_suffix}"
+        inspect = self._run(
+            ["docker", "volume", "inspect", volume, "--format", "{{json .Labels}}"],
+            timeout=_SEED_TIMEOUT,
+        )
+        if inspect.returncode == 0:
+            if self._content_volume_owned_by_project(
+                inspect.stdout, seed.volume_suffix
+            ):
+                return
+            # Labels are immutable after creation and the volume may hold
+            # runtime state, so an unattributed same-named volume is an
+            # explicit operator decision, not something to adopt silently:
+            # content observation would reject it late with a far less
+            # actionable failure.
+            log.error(
+                "Named volume %s exists without Compose project attribution. "
+                "Remove it with `docker volume rm %s` (seeded content is "
+                "recreated from checked-in sources) and rerun `aptl lab start`.",
+                volume,
+                volume,
+            )
+            raise BackendSeedError(
+                f"Named volume '{seed.volume_suffix}' exists without Compose "
+                "project attribution"
+            )
+        create = self._run(
+            [
+                "docker",
+                "volume",
+                "create",
+                "--label",
+                f"com.docker.compose.project={self._project_name}",
+                "--label",
+                f"com.docker.compose.volume={seed.volume_suffix}",
+                volume,
+            ],
+            timeout=_SEED_TIMEOUT,
+        )
+        if create.returncode != 0:
+            log.error(
+                "Labeled create of volume %s failed (exit %s)%s",
+                seed.volume_suffix,
+                create.returncode,
+                redacted_stderr_hint(create.stderr),
+            )
+            raise BackendSeedError(
+                f"Creating named volume '{seed.volume_suffix}' failed"
+            )

--- a/src/aptl/core/deployment/_compose_service_health.py
+++ b/src/aptl/core/deployment/_compose_service_health.py
@@ -33,11 +33,17 @@ log = get_logger("realization-health")
 # The SOC stack sets the floor here: `lab.py` already allows the Wazuh indexer
 # and manager APIs 120s each to come up, and a realized scenario waits on the
 # whole selected topology at once (indexer, manager, dashboard, and the victim
-# services) rather than one service. 300s keeps a generous margin over the
-# slowest observed cold start — a first-boot indexer on a loaded host — so a
-# healthy-but-slow lab is never failed as unrealized. A genuinely stuck service
-# still fails closed, just after the budget rather than before it.
-REALIZATION_HEALTH_TIMEOUT = 300
+# services) rather than one service. The budget must cover the slowest observed
+# *first-boot* path, not just a warm restart: on a fresh machine TheHive's
+# initial Cassandra schema + Elasticsearch index creation and MISP's first-boot
+# database load run well past 300s (observed ~8 minutes on a loaded host while
+# every other service was already healthy — issue #677). Timing out early is
+# not fail-safe here: the timeout hands control to the admitted-plan retry,
+# whose `compose up` recreates services mid-initialization and can tear
+# Cassandra's commit log. 900s keeps a generous margin over that observed
+# worst case; a genuinely stuck service still fails closed, just after the
+# budget rather than before it.
+REALIZATION_HEALTH_TIMEOUT = 900
 REALIZATION_HEALTH_INTERVAL = 5
 
 

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -15,6 +15,9 @@ from aptl.core.deployment._compose_build_dedupe import (
 from aptl.core.deployment._compose_lifecycle import kill_compose_lab
 from aptl.core.deployment._compose_queries import ComposeQueryMixin
 from aptl.core.deployment._compose_realization import ComposeRealizationMixin
+from aptl.core.deployment._compose_seed_attribution import (
+    ComposeSeedAttributionMixin,
+)
 from aptl.core.deployment._compose_seed_safety import (
     assert_safe_relpath,
     redacted_stderr_hint,
@@ -39,7 +42,9 @@ _DOCKER_TIMEOUT = 30
 _SEED_TIMEOUT = 600
 
 
-class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
+class DockerComposeBackend(
+    ComposeQueryMixin, ComposeRealizationMixin, ComposeSeedAttributionMixin
+):
     """Docker Compose deployment backend.
 
     Manages lab lifecycle via ``docker compose`` subprocess calls.
@@ -336,66 +341,6 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
             self._ensure_labeled_seed_volume(seed)
             self._retire_legacy_seed_path(seed, seeder_image)
             self._seed_one_named_volume(seed, seeder_image)
-
-    def _ensure_labeled_seed_volume(self, seed: NamedVolumeSeed) -> None:
-        """Create a missing seed volume with Compose project labels.
-
-        A bare ``docker run -v`` auto-creates a missing named volume without
-        labels. Compose happily reuses it, but the content observation gate
-        (``observe_content_type``) refuses a volume it cannot attribute to
-        this project, so a seeded volume must carry the same labels Compose
-        itself would have written. Labels are immutable after creation, so
-        this must happen before the first seeding ``docker run``.
-        """
-        volume = f"{self._project_name}_{seed.volume_suffix}"
-        inspect = self._run(
-            ["docker", "volume", "inspect", volume, "--format", "{{json .Labels}}"],
-            timeout=_SEED_TIMEOUT,
-        )
-        if inspect.returncode == 0:
-            if self._content_volume_owned_by_project(
-                inspect.stdout, seed.volume_suffix
-            ):
-                return
-            # Labels are immutable after creation and the volume may hold
-            # runtime state, so an unattributed same-named volume is an
-            # explicit operator decision, not something to adopt silently:
-            # content observation would reject it late with a far less
-            # actionable failure.
-            log.error(
-                "Named volume %s exists without Compose project attribution. "
-                "Remove it with `docker volume rm %s` (seeded content is "
-                "recreated from checked-in sources) and rerun `aptl lab start`.",
-                volume,
-                volume,
-            )
-            raise BackendSeedError(
-                f"Named volume '{seed.volume_suffix}' exists without Compose "
-                "project attribution"
-            )
-        create = self._run(
-            [
-                "docker",
-                "volume",
-                "create",
-                "--label",
-                f"com.docker.compose.project={self._project_name}",
-                "--label",
-                f"com.docker.compose.volume={seed.volume_suffix}",
-                volume,
-            ],
-            timeout=_SEED_TIMEOUT,
-        )
-        if create.returncode != 0:
-            log.error(
-                "Labeled create of volume %s failed (exit %s)%s",
-                seed.volume_suffix,
-                create.returncode,
-                redacted_stderr_hint(create.stderr),
-            )
-            raise BackendSeedError(
-                f"Creating named volume '{seed.volume_suffix}' failed"
-            )
 
     def _seed_one_named_volume(self, seed: NamedVolumeSeed, seeder_image: str) -> None:
         """Copy a seed's files into its project-scoped named volume."""

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -326,9 +326,76 @@ class DockerComposeBackend(ComposeQueryMixin, ComposeRealizationMixin):
         backend's own ``_run`` so this stays a narrow, typed operation
         rather than a generic Docker passthrough.
         """
+        # Validate every declared relpath before the first Docker command so
+        # an unsafe seed can never cause any container or volume side effect.
         for seed in seeds:
+            for seed_file in seed.files:
+                assert_safe_relpath(seed_file.src)
+                assert_safe_relpath(seed_file.dest)
+        for seed in seeds:
+            self._ensure_labeled_seed_volume(seed)
             self._retire_legacy_seed_path(seed, seeder_image)
             self._seed_one_named_volume(seed, seeder_image)
+
+    def _ensure_labeled_seed_volume(self, seed: NamedVolumeSeed) -> None:
+        """Create a missing seed volume with Compose project labels.
+
+        A bare ``docker run -v`` auto-creates a missing named volume without
+        labels. Compose happily reuses it, but the content observation gate
+        (``observe_content_type``) refuses a volume it cannot attribute to
+        this project, so a seeded volume must carry the same labels Compose
+        itself would have written. Labels are immutable after creation, so
+        this must happen before the first seeding ``docker run``.
+        """
+        volume = f"{self._project_name}_{seed.volume_suffix}"
+        inspect = self._run(
+            ["docker", "volume", "inspect", volume, "--format", "{{json .Labels}}"],
+            timeout=_SEED_TIMEOUT,
+        )
+        if inspect.returncode == 0:
+            if self._content_volume_owned_by_project(
+                inspect.stdout, seed.volume_suffix
+            ):
+                return
+            # Labels are immutable after creation and the volume may hold
+            # runtime state, so an unattributed same-named volume is an
+            # explicit operator decision, not something to adopt silently:
+            # content observation would reject it late with a far less
+            # actionable failure.
+            log.error(
+                "Named volume %s exists without Compose project attribution. "
+                "Remove it with `docker volume rm %s` (seeded content is "
+                "recreated from checked-in sources) and rerun `aptl lab start`.",
+                volume,
+                volume,
+            )
+            raise BackendSeedError(
+                f"Named volume '{seed.volume_suffix}' exists without Compose "
+                "project attribution"
+            )
+        create = self._run(
+            [
+                "docker",
+                "volume",
+                "create",
+                "--label",
+                f"com.docker.compose.project={self._project_name}",
+                "--label",
+                f"com.docker.compose.volume={seed.volume_suffix}",
+                volume,
+            ],
+            timeout=_SEED_TIMEOUT,
+        )
+        if create.returncode != 0:
+            log.error(
+                "Labeled create of volume %s failed (exit %s)%s",
+                seed.volume_suffix,
+                create.returncode,
+                redacted_stderr_hint(create.stderr),
+            )
+            raise BackendSeedError(
+                f"Creating named volume '{seed.volume_suffix}' failed"
+            )
 
     def _seed_one_named_volume(self, seed: NamedVolumeSeed, seeder_image: str) -> None:
         """Copy a seed's files into its project-scoped named volume."""

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -502,6 +502,7 @@ def lab_terminal_ssh_endpoints(
 def _check_bind_mounts(
     project_dir: Path,
     enabled_profiles: list[str] | None = None,
+    stateful_owned_mounts: frozenset[tuple[str, str, str]] = frozenset(),
 ) -> list[str]:
     """Check that bind-mount source paths exist as files, not root-owned dirs.
 
@@ -518,6 +519,17 @@ def _check_bind_mounts(
     would otherwise fail this preflight on a non-SOC lab start, even
     though the service is never started. ``enabled_profiles=None`` keeps
     the original "check every service" behaviour for direct callers.
+
+    ``stateful_owned_mounts`` holds ``(service_name, mount_destination,
+    source_relpath)`` triples owned by admitted stateful realization. Those
+    sources are generated inside ``DeploymentBackend.realize`` before
+    Compose starts the consuming services, so on a fresh checkout they
+    legitimately do not exist yet; requiring them here would make a fresh
+    ``lab start`` unstartable (issue #677). The exemption matches BOTH the
+    destination and the declared source — a stray bind whose destination
+    merely nests beneath an owned directory is not owned by the artifact
+    and is still checked. A realization failure still fails the run before
+    Compose can create any root-owned directory.
     """
     compose_path = project_dir / "docker-compose.yml"
     if not compose_path.exists():
@@ -534,7 +546,9 @@ def _check_bind_mounts(
     errors: list[str] = []
     for svc_name, svc_def in services.items():
         errors.extend(
-            _check_service_bind_mounts(svc_name, svc_def, project_dir, active)
+            _check_service_bind_mounts(
+                svc_name, svc_def, project_dir, active, stateful_owned_mounts
+            )
         )
     return errors
 
@@ -544,6 +558,7 @@ def _check_service_bind_mounts(
     svc_def: object,
     project_dir: Path,
     active_profiles: set[str] | None,
+    stateful_owned_mounts: frozenset[tuple[str, str, str]] = frozenset(),
 ) -> list[str]:
     """Return bind-mount errors for one Compose service.
 
@@ -564,7 +579,13 @@ def _check_service_bind_mounts(
     for vol in svc_def.get("volumes", []):
         if not isinstance(vol, str) or not vol.startswith("./"):
             continue
-        src = vol.split(":")[0]
+        parts = vol.split(":")
+        src = parts[0]
+        destination = parts[1] if len(parts) > 1 else ""
+        if _stateful_realization_owns_mount(
+            svc_name, destination, src, stateful_owned_mounts
+        ):
+            continue
         src_path = (project_dir / src).resolve()
         if not src_path.exists():
             errors.append(
@@ -573,6 +594,36 @@ def _check_service_bind_mounts(
                 f"starting the lab to avoid root-owned directories."
             )
     return errors
+
+
+def _stateful_realization_owns_mount(
+    svc_name: str,
+    destination: str,
+    source: str,
+    stateful_owned_mounts: frozenset[tuple[str, str, str]],
+) -> bool:
+    """Return whether an admitted stateful artifact owns this service mount.
+
+    Owned destinations and sources may be directories (the certificate
+    bundle mounts individual files beneath ``/etc/ssl/wazuh`` from
+    ``config/wazuh_indexer_ssl_certs``) or exact files (the rendered
+    ``ossec.conf``), so each side matches on equality or directory
+    containment — and BOTH sides must match. A stray bind whose destination
+    nests beneath an owned directory but whose source is not the artifact's
+    generated path stays subject to the pre-flight (issue #677).
+    """
+    normalized_source = source.removeprefix("./")
+    return any(
+        svc_name == owned_service
+        and _path_within(destination, owned_destination)
+        and _path_within(normalized_source, owned_source)
+        for owned_service, owned_destination, owned_source in stateful_owned_mounts
+    )
+
+
+def _path_within(candidate: str, owned: str) -> bool:
+    """Return whether a path equals an owned path or nests beneath it."""
+    return candidate == owned or candidate.startswith(owned.rstrip("/") + "/")
 
 
 def _validate_env_secrets(raw_env: dict[str, str]) -> "LabResult | None":
@@ -635,14 +686,21 @@ class _LabStartContext(object):
     # workflow artifacts and the record share a single run directory.
     run_store: object = None
     run_id: str | None = None
-    stateful_artifact_ownership: frozenset[tuple[str, str, str, str]] = frozenset()
+    stateful_artifact_ownership: frozenset[tuple[str, str, str, str, str]] = (
+        frozenset()
+    )
 
 
+# Ownership tuples are (address, generator, service_name, mount_destination,
+# source_relpath) — the canonical generated source rides along so mount
+# exemptions can match both sides of a bind (issue #677).
+_WAZUH_CERTIFICATE_SOURCE = "config/wazuh_indexer_ssl_certs"
 _WAZUH_MANAGER_CONFIG_OWNERSHIP = (
     "provision.generated-artifact.wazuh-manager-config",
     "rendered_config",
     _WAZUH_MANAGER_SERVICE,
     "/wazuh-config-mount/etc/ossec.conf",
+    ".aptl/config/wazuh_cluster/wazuh_manager.conf",
 )
 _WAZUH_CERTIFICATE_OWNERSHIP = frozenset(
     {
@@ -651,18 +709,21 @@ _WAZUH_CERTIFICATE_OWNERSHIP = frozenset(
             "certificate_bundle",
             "wazuh.indexer",
             "/usr/share/wazuh-indexer/certs",
+            _WAZUH_CERTIFICATE_SOURCE,
         ),
         (
             "provision.generated-artifact.wazuh-manager-certs",
             "certificate_bundle",
             _WAZUH_MANAGER_SERVICE,
             "/etc/ssl/wazuh",
+            _WAZUH_CERTIFICATE_SOURCE,
         ),
         (
             "provision.generated-artifact.wazuh-dashboard-certs",
             "certificate_bundle",
             "wazuh.dashboard",
             "/usr/share/wazuh-dashboard/certs",
+            _WAZUH_CERTIFICATE_SOURCE,
         ),
     }
 )
@@ -1196,7 +1257,17 @@ def _step_check_bind_mounts(ctx: _LabStartContext) -> LabResult | None:
     enabled = (
         ctx.config.containers.enabled_profiles() if ctx.config is not None else None
     )
-    mount_errors = _check_bind_mounts(ctx.project_dir, enabled_profiles=enabled)
+    stateful_owned = frozenset(
+        (service_name, mount_destination, source_relpath)
+        for _address, _generator, service_name, mount_destination, source_relpath in (
+            ctx.stateful_artifact_ownership
+        )
+    )
+    mount_errors = _check_bind_mounts(
+        ctx.project_dir,
+        enabled_profiles=enabled,
+        stateful_owned_mounts=stateful_owned,
+    )
     if not mount_errors:
         return None
     for err in mount_errors:

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -594,11 +594,10 @@ def _bind_mount_error(
     parts = vol.split(":")
     src = parts[0]
     destination = parts[1] if len(parts) > 1 else ""
-    if _stateful_realization_owns_mount(
+    exempt_or_present = _stateful_realization_owns_mount(
         svc_name, destination, src, stateful_owned_mounts
-    ):
-        return None
-    if (project_dir / src).resolve().exists():
+    ) or (project_dir / src).resolve().exists()
+    if exempt_or_present:
         return None
     return (
         f"Service '{svc_name}': bind-mount source "

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -575,25 +575,36 @@ def _check_service_bind_mounts(
         # a service with profiles only runs when at least one is active.
         if svc_profiles and not (set(svc_profiles) & active_profiles):
             return []
-    errors: list[str] = []
-    for vol in svc_def.get("volumes", []):
-        if not isinstance(vol, str) or not vol.startswith("./"):
-            continue
-        parts = vol.split(":")
-        src = parts[0]
-        destination = parts[1] if len(parts) > 1 else ""
-        if _stateful_realization_owns_mount(
-            svc_name, destination, src, stateful_owned_mounts
-        ):
-            continue
-        src_path = (project_dir / src).resolve()
-        if not src_path.exists():
-            errors.append(
-                f"Service '{svc_name}': bind-mount source "
-                f"'{src}' does not exist. Create it before "
-                f"starting the lab to avoid root-owned directories."
-            )
-    return errors
+    errors = (
+        _bind_mount_error(svc_name, vol, project_dir, stateful_owned_mounts)
+        for vol in svc_def.get("volumes", [])
+    )
+    return [error for error in errors if error is not None]
+
+
+def _bind_mount_error(
+    svc_name: str,
+    vol: object,
+    project_dir: Path,
+    stateful_owned_mounts: frozenset[tuple[str, str, str]],
+) -> str | None:
+    """Return the pre-flight error for one Compose volume entry, if any."""
+    if not isinstance(vol, str) or not vol.startswith("./"):
+        return None
+    parts = vol.split(":")
+    src = parts[0]
+    destination = parts[1] if len(parts) > 1 else ""
+    if _stateful_realization_owns_mount(
+        svc_name, destination, src, stateful_owned_mounts
+    ):
+        return None
+    if (project_dir / src).resolve().exists():
+        return None
+    return (
+        f"Service '{svc_name}': bind-mount source "
+        f"'{src}' does not exist. Create it before "
+        f"starting the lab to avoid root-owned directories."
+    )
 
 
 def _stateful_realization_owns_mount(

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -2243,6 +2243,93 @@ def test_provisioner_passes_typed_realization_spec_to_backend(tmp_path):
     assert spec.nodes[0].networks == ("dmz-net", "redteam-net")
 
 
+def test_provisioner_captures_failure_diagnostics_for_handoff(tmp_path):
+    """A failed apply must leave its diagnostics readable by the handoff.
+
+    ACES's backend-call boundary replaces a failed apply's diagnostics with
+    its snapshot-contract / SEM-218 gate output (every exact declaration reads
+    as unrealized against the never-realized snapshot), so the handoff
+    re-attaches the provisioner's own captured report (issue #677).
+    """
+    from aptl.backends.aces import AptlProvisioner
+
+    _write_compose(tmp_path, {"kali": ["kali"], "aptl-otel-collector": ["otel"]})
+    backend = MagicMock()
+    backend.realize.return_value = LabResult(
+        success=False,
+        error="APTL cannot create realized network dmz-net: 172.20.0.0/16 in use",
+    )
+    config = AptlConfig(lab={"name": "test"}, containers={"kali": True})
+    provisioner = AptlProvisioner(
+        project_dir=tmp_path,
+        config=config,
+        deployment_backend=backend,
+    )
+
+    result = provisioner.apply(_plan_for_nodes("scenario-a.kali"), RuntimeSnapshot())
+
+    assert result.success is False
+    captured = provisioner.last_failure_diagnostics
+    assert [item.code for item in captured] == [
+        "aptl.provisioner.backend-start-failed"
+    ]
+    assert "172.20.0.0/16" in captured[0].message
+
+    backend.realize.return_value = LabResult(success=True, message="ok")
+    recovered = provisioner.apply(
+        _plan_for_nodes("scenario-a.kali"), RuntimeSnapshot()
+    )
+    assert recovered.success is True
+    assert provisioner.last_failure_diagnostics == ()
+
+
+def test_apply_failure_reattaches_backend_diagnostics_after_gate_flood(
+    mocker, tmp_path
+):
+    """The handoff must surface the backend's own failure, not only the gate's.
+
+    When the backend apply fails, ``aces_runtime`` gates the unrealized
+    snapshot and returns only ``runtime.backend-contract-invalid`` diagnostics,
+    which both hides the actionable backend error (e.g. a Docker subnet
+    conflict) and severs the retryable-code signal the SOC retry keys on.
+    """
+    from aptl.backends import aces
+    from aptl.backends.aces_diagnostics import diagnostic
+
+    backend_diag = diagnostic(
+        "aptl.provisioner.backend-start-failed",
+        "runtime.apply.provisioning",
+        "APTL cannot create realized network dmz-net: 172.20.0.0/16 in use",
+    )
+    gate_diag = diagnostic(
+        "runtime.backend-contract-invalid",
+        "provision.node.wazuh-manager",
+        "Backend did not realize the exact 'node-type' requirement.",
+    )
+
+    class MaskingRuntimeManager(_FakeRuntimeManager):
+        def apply(self, execution_plan):
+            return ApplyResult(
+                success=False,
+                snapshot=RuntimeSnapshot(),
+                diagnostics=[gate_diag],
+            )
+
+    mocker.patch("aptl.backends.aces.RuntimeManager", MaskingRuntimeManager)
+    target = MagicMock()
+    target.provisioner.last_failure_diagnostics = (backend_diag,)
+
+    failure, _snapshot, retryable = aces._apply_execution_plan(
+        target, MagicMock()
+    )
+
+    assert failure is not None
+    assert failure.success is False
+    assert "172.20.0.0/16" in failure.error
+    assert "node-type" in failure.error
+    assert retryable is True
+
+
 def test_realization_preserves_network_static_address_assignments(tmp_path):
     from aptl.backends.aces_realization import interpret_provisioning_plan
 
@@ -3493,59 +3580,6 @@ def test_aces_backend_does_not_import_legacy_sdl_parser():
 
     assert "aptl.core.sdl" not in source
     assert "ScenarioDefinition" not in source
-
-
-def test_start_aces_scenario_returns_aces_start_outcome(tmp_path):
-    """start_aces_scenario returns AcesStartOutcome, not just LabResult."""
-    from unittest.mock import patch as _patch, MagicMock as _MagicMock
-
-    from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
-
-    from aptl.backends.aces import AcesStartOutcome, start_aces_scenario
-    from aptl.core.config import AptlConfig
-
-    _write_compose(tmp_path, {"aptl-victim": ["victim"]})
-    (tmp_path / "scenarios").mkdir()
-    sdl_path = tmp_path / "scenarios" / "test.sdl.yaml"
-    sdl_path.write_text(
-        "kind: ScenarioDefinition\napiVersion: v1\nmetadata:\n  name: test\nspec:\n  nodes: []\n"
-    )
-
-    backend = _MagicMock()
-    backend.realize.return_value = LabResult(success=True, message="ok")
-    config = AptlConfig(lab={"name": "test"})
-
-    apply_result = ApplyResult(
-        success=True,
-        snapshot=RuntimeSnapshot(),
-        diagnostics=[],
-    )
-
-    with (
-        _patch("aptl.backends.aces.parse_sdl_file") as mock_parse,
-        _patch("aptl.backends.aces.RuntimeManager") as mock_manager,
-    ):
-        mock_scenario = _MagicMock()
-        mock_parse.return_value = mock_scenario
-
-        mock_plan = _MagicMock()
-        mock_plan.diagnostics = []
-        mock_plan.base_snapshot = RuntimeSnapshot()
-        mock_plan.orchestration.actionable_operations = []
-        mock_plan.evaluation.actionable_operations = []
-        mock_plan.provisioning = _MagicMock()
-        mock_manager.return_value.plan.return_value = mock_plan
-        # Scenario start now applies through RuntimeManager.apply (issue #578),
-        # not a hand-rolled RuntimeControlPlane submission loop.
-        mock_manager.return_value.apply.return_value = apply_result
-
-        result = start_aces_scenario(tmp_path, config, backend, scenario_path=sdl_path)
-
-    assert isinstance(result, AcesStartOutcome)
-    assert result.lab_result.success is True
-    assert isinstance(result.final_snapshot, RuntimeSnapshot)
-    assert isinstance(result.realization_details, dict)
-    assert isinstance(result.selected_profiles, list)
 
 
 def test_drive_workflows_receives_threaded_run_store_and_run_id(tmp_path):

--- a/tests/test_aces_observation.py
+++ b/tests/test_aces_observation.py
@@ -9,6 +9,7 @@ fails closed (no snapshot entry) rather than being assumed realized.
 from __future__ import annotations
 
 import hashlib
+from types import SimpleNamespace
 
 from aces_contracts.planning import (
     ChangeAction,
@@ -59,6 +60,9 @@ class _Backend:
         project_owned=True,
         content_types=None,
         content_probe_raises=False,
+        exec_results=None,
+        exec_raises=False,
+        health_sequence=None,
     ):
         self._containers = set(containers)
         self._networks = [
@@ -75,6 +79,16 @@ class _Backend:
         self._project_owned = project_owned
         self._content_types = content_types or {}
         self._content_probe_raises = content_probe_raises
+        self._exec_results = exec_results
+        self._exec_raises = exec_raises
+        self._health_sequence = list(health_sequence or [])
+
+    def container_exec(self, name, cmd, *, timeout=None):
+        if self._exec_raises:
+            raise BackendTimeoutError("docker exec timed out")
+        assert self._exec_results is not None, "container_exec must not be called"
+        returncode, stdout = self._exec_results[name]
+        return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
 
     def container_exists(self, name):
         return self._project_owned and name in self._containers
@@ -84,9 +98,12 @@ class _Backend:
             raise BackendTimeoutError("docker inspect timed out")
         if name not in self._containers:
             return {}
+        health = self._health
+        if self._health_sequence:
+            health = self._health_sequence.pop(0)
         state = {"Running": self._running}
-        if self._health is not None:
-            state["Health"] = {"Status": self._health}
+        if health is not None:
+            state["Health"] = {"Status": health}
         return {
             "State": state,
             "Platform": self._platform,
@@ -147,6 +164,188 @@ def test_running_healthy_node_is_realized_with_concerns():
         diagnostics=(),
     )
     obs = observe_realization(_Backend(containers=("aptl-vm",)), realization, plan)
+    assert obs[address].realized is True
+    assert obs[address].concerns == {("node_type",): "vm", ("os_family",): "linux"}
+
+
+_DECLARED_TOPOLOGY = {
+    "domain_id": "techvault",
+    "profile": "active_directory",
+    "dns_name": "techvault.local",
+    "netbios_name": "TECHVAULT",
+    "authority_account_address": "provision.account.ad-emily-chen",
+    "role": "controller",
+    "controller_addresses": ("provision.node.ad",),
+}
+
+_SAMBA_DOMAIN_INFO = (
+    "Forest           : techvault.local\n"
+    "Domain           : techvault.local\n"
+    "Netbios domain   : TECHVAULT\n"
+    "DC name          : dc.techvault.local\n"
+    "DC netbios name  : DC\n"
+)
+
+
+def _domain_node_plan():
+    address = "provision.node.ad"
+    payload = {
+        "name": "ad",
+        "node_type": "vm",
+        "os_family": "linux",
+        "domain_topology": dict(_DECLARED_TOPOLOGY),
+    }
+    resource = PlannedResource(
+        address=address,
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload=payload,
+    )
+    op = ProvisionOp(
+        action=ChangeAction.CREATE,
+        address=address,
+        resource_type="node",
+        payload=payload,
+    )
+    return address, ProvisioningPlan(resources={address: resource}, operations=[op])
+
+
+def _domain_realization():
+    return AptlRealization(
+        profiles=frozenset(),
+        nodes=(_node_realization(name="ad", container="aptl-ad"),),
+        networks=(),
+        placements=(),
+        diagnostics=(),
+    )
+
+
+def test_domain_topology_attested_when_live_domain_matches():
+    address, plan = _domain_node_plan()
+    backend = _Backend(
+        containers=("aptl-ad",),
+        exec_results={"aptl-ad": (0, _SAMBA_DOMAIN_INFO)},
+    )
+    obs = observe_realization(backend, _domain_realization(), plan)
+    assert obs[address].realized is True
+    assert obs[address].concerns[("domain_topology",)] == _DECLARED_TOPOLOGY
+
+
+def test_domain_topology_omitted_when_live_domain_differs():
+    address, plan = _domain_node_plan()
+    backend = _Backend(
+        containers=("aptl-ad",),
+        exec_results={
+            "aptl-ad": (0, _SAMBA_DOMAIN_INFO.replace("TECHVAULT", "OTHERCORP"))
+        },
+    )
+    obs = observe_realization(backend, _domain_realization(), plan)
+    assert obs[address].realized is True
+    assert ("domain_topology",) not in obs[address].concerns
+
+
+def test_domain_topology_probe_failure_fails_closed():
+    address, plan = _domain_node_plan()
+    backend = _Backend(
+        containers=("aptl-ad",),
+        exec_results={"aptl-ad": (1, "")},
+    )
+    obs = observe_realization(backend, _domain_realization(), plan)
+    assert obs[address].realized is True
+    assert ("domain_topology",) not in obs[address].concerns
+
+
+def test_domain_topology_exec_timeout_fails_closed_not_crash():
+    address, plan = _domain_node_plan()
+    backend = _Backend(containers=("aptl-ad",), exec_raises=True)
+    obs = observe_realization(backend, _domain_realization(), plan)
+    assert obs[address].realized is True
+    assert ("domain_topology",) not in obs[address].concerns
+
+
+def test_starting_node_settles_before_judgment(monkeypatch):
+    """A transiently 'starting' container is waited out, not failed.
+
+    Wazuh manager/indexer restart themselves once during first boot, so a
+    consumer can read health='starting' between the realization health gate
+    and observation (issue #677). 'starting' is transitional evidence, not an
+    unrealized resource.
+    """
+    from aptl.backends import _aces_observation_helpers as helpers
+
+    monkeypatch.setattr(helpers.time, "sleep", lambda _s: None)
+    address, plan = _node_plan()
+    realization = AptlRealization(
+        profiles=frozenset(),
+        nodes=(_node_realization(),),
+        networks=(),
+        placements=(),
+        diagnostics=(),
+    )
+    backend = _Backend(
+        containers=("aptl-vm",),
+        health_sequence=["starting", "starting", "healthy"],
+    )
+    obs = observe_realization(backend, realization, plan)
+    assert obs[address].realized is True
+    assert obs[address].concerns[("node_type",)] == "vm"
+
+
+def test_settle_deadline_returns_transitional_info_instead_of_hanging(monkeypatch):
+    """A container stuck in 'starting' fails closed at the settle budget.
+
+    The deadline is the fail-safe for a genuinely wedged container: settle
+    must give up within `_SETTLE_TIMEOUT` and hand back the still-transitional
+    info (judged unrealized) rather than loop forever.
+    """
+    from aptl.backends import _aces_observation_helpers as helpers
+
+    clock = iter(
+        [0.0, 1.0, helpers._SETTLE_TIMEOUT + 1.0, helpers._SETTLE_TIMEOUT + 2.0]
+    )
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(helpers.time, "sleep", lambda _s: None)
+    backend = _Backend(containers=("aptl-vm",), health="starting")
+
+    info = helpers.settled_inspect(backend, "aptl-vm")
+
+    assert info["State"]["Health"]["Status"] == "starting"
+    assert helpers.container_realized(info) is False
+
+
+def test_stopped_node_fails_immediately_without_settling(monkeypatch):
+    from aptl.backends import _aces_observation_helpers as helpers
+
+    def _no_sleep(_s):
+        raise AssertionError("terminal states must not be waited on")
+
+    monkeypatch.setattr(helpers.time, "sleep", _no_sleep)
+    address, plan = _node_plan()
+    realization = AptlRealization(
+        profiles=frozenset(),
+        nodes=(_node_realization(),),
+        networks=(),
+        placements=(),
+        diagnostics=(),
+    )
+    obs = observe_realization(
+        _Backend(containers=("aptl-vm",), running=False), realization, plan
+    )
+    assert obs[address].realized is False
+
+
+def test_node_without_declared_topology_is_never_probed():
+    address, plan = _node_plan()
+    realization = AptlRealization(
+        profiles=frozenset(),
+        nodes=(_node_realization(),),
+        networks=(),
+        placements=(),
+        diagnostics=(),
+    )
+    # No exec_results configured: the fake asserts if container_exec is called.
+    backend = _Backend(containers=("aptl-vm",))
+    obs = observe_realization(backend, realization, plan)
     assert obs[address].realized is True
     assert obs[address].concerns == {("node_type",): "vm", ("os_family",): "linux"}
 
@@ -375,6 +574,11 @@ def test_generated_artifact_is_observed_from_outputs_and_read_only_mount(
                 "access_mode": "read_only",
             }
         ],
+        # aces-sdl 0.23 carries dependency wiring inside the declared spec;
+        # the observed spec renders the DTO's realized wiring in the same
+        # author vocabulary (issue #677).
+        "ordering_dependencies": [],
+        "refresh_dependencies": [],
     }
     resource = PlannedResource(
         address=address,
@@ -565,6 +769,8 @@ def test_persistent_volume_is_observed_from_project_scoped_mount():
                 "access_mode": "read_write",
             }
         ],
+        "ordering_dependencies": [],
+        "refresh_dependencies": [],
     }
     resource = PlannedResource(
         address=address,

--- a/tests/test_aces_observation.py
+++ b/tests/test_aces_observation.py
@@ -635,7 +635,7 @@ def test_generated_artifact_is_observed_from_outputs_and_read_only_mount(
         },
     )
     certificate_evidence = mocker.patch(
-        "aptl.backends.aces_observation.certificate_bundle_evidence",
+        "aptl.backends._aces_stateful_observation.certificate_bundle_evidence",
         return_value={
             "public_root_sha256": "0" * 64,
             "chain_valid": True,

--- a/tests/test_certs.py
+++ b/tests/test_certs.py
@@ -2,9 +2,13 @@
 
 import os
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
+
+_COMPOSE_PATH = Path(__file__).resolve().parent.parent / "generate-indexer-certs.yml"
 
 
 @pytest.fixture(autouse=True)
@@ -32,11 +36,6 @@ def linux_native(mocker):
 def _successful_generator(mocker, certs_dir):
     def fake_run(cmd, **kwargs):
         if "down" in cmd:
-            return MagicMock(returncode=0, stdout="", stderr="")
-        if cmd[:2] == ["docker", "run"]:
-            certs_dir.chmod(0o700)
-            for path in certs_dir.iterdir():
-                path.chmod(0o600)
             return MagicMock(returncode=0, stdout="", stderr="")
 
         certs_dir.mkdir(parents=True, exist_ok=True)
@@ -164,10 +163,10 @@ class TestEnsureSSLCerts:
         _assert_posix_mode(certs_dir / "root-ca-manager.pem", 0o644)
         mock_run.assert_not_called()
 
-    def test_linux_native_generator_runs_as_root_then_repairs_ownership(
+    def test_linux_native_generator_runs_as_host_user(
         self, tmp_path, mocker, linux_native
     ):
-        """Native Linux should repair root-owned generator output afterward."""
+        """Native Linux should run the generator as the host uid/gid, not root."""
         from aptl.core.certs import ensure_ssl_certs
 
         (tmp_path / "config").mkdir()
@@ -183,7 +182,7 @@ class TestEnsureSSLCerts:
         _assert_posix_mode(certs_dir / "root-ca.pem", 0o644)
         _assert_posix_mode(certs_dir / "wazuh.manager-key.pem", 0o644)
         _assert_posix_mode(certs_dir, 0o700)
-        assert mock_run.call_count == 3
+        assert mock_run.call_count == 2
         generator_cmd = mock_run.call_args_list[0][0][0]
         assert generator_cmd[:3] == ["docker", "compose", "-p"]
         assert generator_cmd[3].startswith("aptl-certs-")
@@ -192,6 +191,8 @@ class TestEnsureSSLCerts:
             "generate-indexer-certs.yml",
             "run",
             "--rm",
+            "--user",
+            "1000:1000",
             "generator",
         ]
         cleanup_cmd = mock_run.call_args_list[1][0][0]
@@ -205,19 +206,8 @@ class TestEnsureSSLCerts:
             "down",
             "--remove-orphans",
         ]
-        repair_cmd = mock_run.call_args_list[2][0][0]
-        assert repair_cmd[:6] == [
-            "docker",
-            "run",
-            "--rm",
-            "--entrypoint",
-            "/bin/sh",
-            "-v",
-        ]
-        assert repair_cmd[6] == f"{certs_dir.resolve()}:/certificates"
-        assert repair_cmd[7] == "wazuh/wazuh-certs-generator:0.0.2"
-        assert "chown -R 1000:1000 /certificates" in repair_cmd[-1]
-        assert "find /certificates -type f -exec chmod 644 {} +" in repair_cmd[-1]
+        for issued in mock_run.call_args_list:
+            assert issued[0][0][:2] != ["docker", "run"]
 
     def test_linux_native_precreates_output_dir(self, tmp_path, mocker, linux_native):
         """Precreating the bind mount avoids Docker making a root-owned dir."""
@@ -241,7 +231,7 @@ class TestEnsureSSLCerts:
         _assert_posix_mode(certs_dir / "root-ca.pem", 0o644)
         _assert_posix_mode(certs_dir, 0o700)
         generator_cmd = mock_run.call_args_list[0][0][0]
-        assert "--user" not in generator_cmd
+        assert "--user" in generator_cmd
 
     def test_docker_desktop_generator_does_not_request_host_uid(self, tmp_path, mocker):
         """Docker Desktop should rely on file sharing, not POSIX uid/gid."""
@@ -269,32 +259,60 @@ class TestEnsureSSLCerts:
         getuid.assert_not_called()
         getgid.assert_not_called()
 
-    def test_linux_native_reports_permission_repair_failure(
+    def test_linux_native_generator_failure_is_fail_closed(
         self, tmp_path, mocker, linux_native
     ):
-        """Native Linux must fail clearly when generated certs cannot be repaired."""
+        """A generator failure under --user must fail closed: no repair, no root retry."""
         from aptl.core.certs import ensure_ssl_certs
 
         (tmp_path / "config").mkdir()
-        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
 
         def fake_run(cmd, **kwargs):
-            if cmd[:2] == ["docker", "compose"]:
-                if "down" in cmd:
-                    return MagicMock(returncode=0, stdout="", stderr="")
-                certs_dir.mkdir(parents=True, exist_ok=True)
-                (certs_dir / "root-ca.pem").write_text("fake-cert")
+            if "down" in cmd:
                 return MagicMock(returncode=0, stdout="", stderr="")
-            return MagicMock(returncode=1, stdout="", stderr="chown failed")
+            return MagicMock(returncode=1, stdout="generator failed", stderr="")
 
-        mocker.patch("aptl.core.certs.subprocess.run", side_effect=fake_run)
+        mock_run = mocker.patch("aptl.core.certs.subprocess.run", side_effect=fake_run)
 
         result = ensure_ssl_certs(tmp_path)
 
         assert result.success is False
         assert result.generated is False
-        assert "permission repair" in result.error
-        assert "chown failed" in result.error
+        assert "generator failed" in result.error
+        assert mock_run.call_count == 2
+        for issued in mock_run.call_args_list:
+            assert issued[0][0][:2] == ["docker", "compose"]
+
+    @pytest.mark.parametrize("native_linux", [True, False])
+    def test_no_command_ever_escalates_or_overrides_entrypoint(
+        self, tmp_path, mocker, native_linux
+    ):
+        """Neither platform path may escalate privileges or override the entrypoint."""
+        from aptl.core.certs import ensure_ssl_certs
+
+        mocker.patch(
+            "aptl.core.certs.hostenv.needs_host_ownership_fix",
+            return_value=native_linux,
+        )
+        if native_linux:
+            if os.name != "posix":
+                pytest.skip("native-Linux uid/gid path is POSIX-only")
+            mocker.patch("aptl.core.certs.os.getuid", return_value=1000)
+            mocker.patch("aptl.core.certs.os.getgid", return_value=1000)
+
+        (tmp_path / "config").mkdir()
+        certs_dir = tmp_path / "config" / "wazuh_indexer_ssl_certs"
+        mock_run = _successful_generator(mocker, certs_dir)
+
+        ensure_ssl_certs(tmp_path)
+
+        assert mock_run.call_args_list
+        for issued in mock_run.call_args_list:
+            cmd = issued[0][0]
+            assert cmd[:2] == ["docker", "compose"]
+            assert not any("sudo" in arg for arg in cmd)
+            assert not any("chown" in arg for arg in cmd)
+            assert not any("--entrypoint" in arg for arg in cmd)
 
     def test_existing_manager_root_ca_alias_is_preserved(self, tmp_path, mocker):
         """Existing CA alias should not be rewritten on repeat starts."""
@@ -467,3 +485,22 @@ class TestEnsureSSLCerts:
         ensure_ssl_certs(tmp_path)
 
         assert mock_run.call_args_list[0][1]["timeout"] == 300
+
+
+class TestCertGeneratorComposeFile:
+    """Static guardrails on the generator's Compose service definition."""
+
+    def test_generator_entrypoint_override_is_producer_owned(self):
+        """The entrypoint override must run the same Wazuh cert workflow
+        non-root, on the pinned image, with no chown."""
+        compose = yaml.safe_load(_COMPOSE_PATH.read_text())
+        generator = compose["services"]["generator"]
+
+        assert generator["image"] == "wazuh/wazuh-certs-generator:0.0.2"
+        assert generator["working_dir"] == "/tmp"
+        assert "entrypoint" in generator
+
+        entrypoint = generator["entrypoint"]
+        script = entrypoint[-1] if isinstance(entrypoint, list) else entrypoint
+        assert "wazuh-certs-tool.sh" in script
+        assert "chown" not in script

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -2392,13 +2392,12 @@ class TestSeedNamedVolumes:
         from aptl.core.deployment.errors import BackendSeedError
 
         backend = self._backend(tmp_path)
+        seeds = [self._config_seed()]
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="null", stderr="")
             with pytest.raises(BackendSeedError) as exc_info:
-                backend.seed_named_volumes(
-                    [self._config_seed()], seeder_image="img:1"
-                )
+                backend.seed_named_volumes(seeds, seeder_image="img:1")
 
         assert "attribution" in str(exc_info.value)
         commands = [call.args[0] for call in mock_run.call_args_list]
@@ -2408,6 +2407,7 @@ class TestSeedNamedVolumes:
         from aptl.core.deployment.errors import BackendSeedError
 
         backend = self._backend(tmp_path)
+        seeds = [self._config_seed()]
 
         def run(cmd, **kwargs):
             if cmd[:3] == ["docker", "volume", "inspect"]:
@@ -2418,9 +2418,7 @@ class TestSeedNamedVolumes:
 
         with patch("subprocess.run", side_effect=run):
             with pytest.raises(BackendSeedError):
-                backend.seed_named_volumes(
-                    [self._config_seed()], seeder_image="img:1"
-                )
+                backend.seed_named_volumes(seeds, seeder_image="img:1")
 
     def test_legacy_path_retired_before_seed_as_root(self, tmp_path):
         # The legacy .aptl tree may be UID-991-owned from a prior run, so the

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -865,6 +865,80 @@ services:
         assert desired == {"test_aptl-dmz"}
         assert missing == ["unknown-net"]
 
+    @pytest.mark.parametrize(
+        ("image_kwargs", "failing_cmd", "expected_error"),
+        [
+            (
+                {"mode": "pull"},
+                ["docker", "pull"],
+                "Image pull failed",
+            ),
+            (
+                {
+                    "mode": "build",
+                    "dockerfile_path": "containers/custom/Dockerfile",
+                    "context_path": ".",
+                },
+                ["docker", "build"],
+                "Image build failed",
+            ),
+            (
+                {"mode": "build"},
+                None,
+                "Image build input missing",
+            ),
+            (
+                {"mode": "sideload"},
+                None,
+                "Unsupported image realization mode",
+            ),
+        ],
+    )
+    def test_realize_image_failures_stop_before_compose_up(
+        self, tmp_path, image_kwargs, failing_cmd, expected_error
+    ):
+        """A failed or invalid image operation must fail realize() fail-closed.
+
+        If a non-zero pull/build exit stopped propagating, realize() would
+        report success and start the stack against a stale or never-built
+        image — the vacuous-realization failure mode this module exists to
+        prevent.
+        """
+        backend = self._make_backend(tmp_path)
+        spec = DeploymentRealizationSpec(
+            profiles=("enterprise",),
+            nodes=(),
+            networks=(),
+            images=(
+                DeploymentImageRealization(
+                    address="provision.node.custom",
+                    service_name="custom",
+                    source_name="aptl-custom",
+                    source_version="aptl-custom@sha256:" + "b" * 64,
+                    image_ref="aptl-custom:local",
+                    policy_rule="project-build-provenance",
+                    **image_kwargs,
+                ),
+            ),
+        )
+        (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+
+        def fake_run(cmd, **kwargs):
+            del kwargs
+            if failing_cmd is not None and cmd[: len(failing_cmd)] == failing_cmd:
+                return MagicMock(returncode=1, stdout="", stderr="boom")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            result = backend.realize(spec, build=False)
+
+        assert result.success is False
+        assert expected_error in result.error
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        assert not any("up" in cmd for cmd in commands)
+        override = tmp_path / ".aptl" / "realization" / "compose-images.yml"
+        assert not override.exists()
+
     def test_realize_pulls_builds_and_overrides_images(self, tmp_path):
         backend = self._make_backend(tmp_path)
         digest = "sha256:" + "a" * 64
@@ -957,7 +1031,10 @@ services:
         assert f"image: postgres@{digest}" in override
         assert "custom:" in override
         assert "image: aptl-custom:local" in override
-        assert "build: null" in override
+        # Compose >= 2.24 rejects `build: null` at schema validation; the
+        # override must remove the key with the `!reset` tag instead.
+        assert "build: null" not in override
+        assert "build: !reset" in override
         assert b"\r\n" not in override_path.read_bytes()
 
     def test_stop_calls_compose_down(self, tmp_path):
@@ -2210,10 +2287,28 @@ class TestSeedNamedVolumes:
             legacy_retire_path=Path("/proj/.aptl/suricata/rules/misp"),
         )
 
+    @staticmethod
+    def _seed_run_mock(volume_suffix, **result_overrides):
+        """Side effect answering the label inspect with valid attribution."""
+        labels = (
+            '{"com.docker.compose.project": "test", '
+            f'"com.docker.compose.volume": "{volume_suffix}"}}'
+        )
+
+        def run(cmd, **kwargs):
+            if cmd[:3] == ["docker", "volume", "inspect"]:
+                return MagicMock(returncode=0, stdout=labels, stderr="")
+            defaults = {"returncode": 0, "stdout": "", "stderr": ""}
+            defaults.update(result_overrides)
+            return MagicMock(**defaults)
+
+        return run
+
     def test_seed_runs_root_copy_into_project_scoped_volume(self, tmp_path):
         backend = self._backend(tmp_path)
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "subprocess.run", side_effect=self._seed_run_mock("suricata_config_seed")
+        ) as mock_run:
             backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
         cmd = mock_run.call_args[0][0]
         assert cmd[:7] == [
@@ -2238,17 +2333,111 @@ class TestSeedNamedVolumes:
         assert "mkdir -p /dest/rules" in script
         assert "cp -a /src/rules/local.rules /dest/rules/local.rules" in script
 
+    def test_seed_creates_missing_volume_with_compose_labels(self, tmp_path):
+        """A seeded volume must carry the Compose project labels.
+
+        A bare ``docker run -v`` auto-creates a missing named volume without
+        labels; the content observation gate (``observe_content_type``) then
+        refuses the volume as not project-owned, failing the SEM-218
+        realization gate on every fresh start (issue #677).
+        """
+        backend = self._backend(tmp_path)
+
+        def run(cmd, **kwargs):
+            if cmd[:3] == ["docker", "volume", "inspect"]:
+                return MagicMock(returncode=1, stdout="", stderr="no such volume")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=run) as mock_run:
+            backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        create = next(
+            cmd for cmd in commands if cmd[:3] == ["docker", "volume", "create"]
+        )
+        assert "--label" in create
+        assert "com.docker.compose.project=test" in create
+        assert "com.docker.compose.volume=suricata_config_seed" in create
+        assert create[-1] == "test_suricata_config_seed"
+        seed_index = next(
+            index for index, cmd in enumerate(commands) if cmd[:2] == ["docker", "run"]
+        )
+        assert commands.index(create) < seed_index
+
+    def test_seed_skips_volume_create_when_attributed_volume_exists(self, tmp_path):
+        import json
+
+        backend = self._backend(tmp_path)
+        labels = json.dumps(
+            {
+                "com.docker.compose.project": "test",
+                "com.docker.compose.volume": "suricata_config_seed",
+            }
+        )
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=labels, stderr="")
+            backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
+
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        assert not any(cmd[:3] == ["docker", "volume", "create"] for cmd in commands)
+
+    def test_seed_refuses_existing_unattributed_volume(self, tmp_path):
+        """An unlabeled same-named volume fails fast with remediation.
+
+        Labels are immutable after creation, so adopting a volume another
+        actor auto-created (e.g. a pre-fix `docker run -v`) would only move
+        the failure to content observation, where it is far less actionable.
+        """
+        from aptl.core.deployment.errors import BackendSeedError
+
+        backend = self._backend(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="null", stderr="")
+            with pytest.raises(BackendSeedError) as exc_info:
+                backend.seed_named_volumes(
+                    [self._config_seed()], seeder_image="img:1"
+                )
+
+        assert "attribution" in str(exc_info.value)
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        assert not any(cmd[:2] == ["docker", "run"] for cmd in commands)
+
+    def test_seed_fails_closed_when_labeled_create_fails(self, tmp_path):
+        from aptl.core.deployment.errors import BackendSeedError
+
+        backend = self._backend(tmp_path)
+
+        def run(cmd, **kwargs):
+            if cmd[:3] == ["docker", "volume", "inspect"]:
+                return MagicMock(returncode=1, stdout="", stderr="no such volume")
+            if cmd[:3] == ["docker", "volume", "create"]:
+                return MagicMock(returncode=1, stdout="", stderr="denied")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=run):
+            with pytest.raises(BackendSeedError):
+                backend.seed_named_volumes(
+                    [self._config_seed()], seeder_image="img:1"
+                )
+
     def test_legacy_path_retired_before_seed_as_root(self, tmp_path):
         # The legacy .aptl tree may be UID-991-owned from a prior run, so the
         # host operator cannot delete it; a root container mounts the
         # host-owned parent and removes the one canonical child.
         backend = self._backend(tmp_path)
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "subprocess.run", side_effect=self._seed_run_mock("suricata_misp_rules")
+        ) as mock_run:
             backend.seed_named_volumes(
                 [self._misp_seed_with_legacy()], seeder_image="img:1"
             )
-        calls = [c[0][0] for c in mock_run.call_args_list]
+        calls = [
+            c[0][0]
+            for c in mock_run.call_args_list
+            if c[0][0][:3] != ["docker", "volume", "inspect"]
+        ]
         assert len(calls) == 2
         retire, seed = calls
         assert retire[:5] == ["docker", "run", "--rm", "--user", "0:0"]
@@ -2260,11 +2449,19 @@ class TestSeedNamedVolumes:
 
     def test_no_legacy_retire_when_path_absent(self, tmp_path):
         backend = self._backend(tmp_path)
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "subprocess.run", side_effect=self._seed_run_mock("suricata_config_seed")
+        ) as mock_run:
             backend.seed_named_volumes([self._config_seed()], seeder_image="img:1")
-        # Exactly one container: the seed copy, no retire.
-        assert mock_run.call_count == 1
+        # Exactly one container: the seed copy, no retire. (The label
+        # inspect is a volume query, not a container.)
+        container_runs = [
+            c[0][0]
+            for c in mock_run.call_args_list
+            if c[0][0][:2] == ["docker", "run"]
+        ]
+        assert len(container_runs) == 1
+        assert "test_suricata_config_seed:/dest" in container_runs[0]
 
     def test_seed_is_idempotent_across_runs(self, tmp_path):
         # Root `cp -a` overwrites prior content, so the backend issues the
@@ -2274,8 +2471,10 @@ class TestSeedNamedVolumes:
         seed = self._config_seed()
         commands = []
         for _ in range(2):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            with patch(
+                "subprocess.run",
+                side_effect=self._seed_run_mock("suricata_config_seed"),
+            ) as mock_run:
                 backend.seed_named_volumes([seed], seeder_image="img:1")
                 commands.append(mock_run.call_args[0][0])
         assert commands[0] == commands[1]
@@ -2379,8 +2578,18 @@ class TestSeedNamedVolumes:
         stderr = "docker: Error response from daemon: permission denied on /legacy"
         backend = self._backend(tmp_path)
         seed = [self._misp_seed_with_legacy()]
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
+
+        labels = (
+            '{"com.docker.compose.project": "test", '
+            '"com.docker.compose.volume": "suricata_misp_rules"}'
+        )
+
+        def run(cmd, **kwargs):
+            if cmd[:3] == ["docker", "volume", "inspect"]:
+                return MagicMock(returncode=0, stdout=labels, stderr="")
+            return MagicMock(returncode=1, stdout="", stderr=stderr)
+
+        with patch("subprocess.run", side_effect=run):
             caplog.set_level(logging.ERROR, logger="aptl")
             with pytest.raises(BackendSeedError) as exc_info:
                 backend.seed_named_volumes(seed, seeder_image="img:1")
@@ -2435,10 +2644,24 @@ class TestRealizeContent:
         fields.update(overrides)
         return DeploymentContentRealization(**fields)
 
+    @staticmethod
+    def _content_run_mock():
+        """Side effect answering the fileshare volume inspect with attribution."""
+        labels = (
+            '{"com.docker.compose.project": "test", '
+            '"com.docker.compose.volume": "fileshare_data"}'
+        )
+
+        def run(cmd, **kwargs):
+            if cmd[:3] == ["docker", "volume", "inspect"]:
+                return MagicMock(returncode=0, stdout=labels, stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        return run
+
     def test_inline_text_renders_and_seeds_into_project_scoped_volume(self, tmp_path):
         backend = self._backend(tmp_path)
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", side_effect=self._content_run_mock()) as mock_run:
             backend.realize_content([self._inline_text_item()], seeder_image="img:1")
 
         cmd = mock_run.call_args[0][0]
@@ -2480,8 +2703,7 @@ class TestRealizeContent:
             source_relpath="scenarios/fixtures/techvault-content/onboarding.md",
         )
         backend = self._backend(tmp_path)
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", side_effect=self._content_run_mock()) as mock_run:
             backend.realize_content([item], seeder_image="img:1")
 
         cmd = mock_run.call_args[0][0]
@@ -2516,8 +2738,9 @@ class TestRealizeContent:
         item = self._inline_text_item()
         commands = []
         for _ in range(2):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            with patch(
+                "subprocess.run", side_effect=self._content_run_mock()
+            ) as mock_run:
                 backend.realize_content([item], seeder_image="img:1")
                 commands.append(mock_run.call_args[0][0])
         assert commands[0] == commands[1]

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -640,6 +640,152 @@ class TestCheckBindMounts:
         assert len(errors) == 1
         assert "parse" in errors[0].lower() or "Failed" in errors[0]
 
+    def test_skips_missing_source_owned_by_stateful_realization(self, tmp_path):
+        """A missing source the admitted plan realizes must not fail pre-flight.
+
+        Stateful realization generates artifacts (e.g. the Wazuh certificate
+        bundle) inside ``DeploymentBackend.realize`` before Compose starts the
+        consuming services, so on a fresh checkout the sources legitimately do
+        not exist yet at bind-mount pre-flight time (issue #677 fresh-start
+        regression from #796).
+        """
+        from aptl.core.lab import _check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  wazuh.manager:\n"
+            "    volumes:\n"
+            "      - ./config/wazuh_indexer_ssl_certs/root-ca-manager.pem"
+            ":/etc/ssl/wazuh/root-ca-manager.pem:ro\n"
+        )
+
+        errors = _check_bind_mounts(
+            tmp_path,
+            stateful_owned_mounts=frozenset(
+                {("wazuh.manager", "/etc/ssl/wazuh", "config/wazuh_indexer_ssl_certs")}
+            ),
+        )
+        assert errors == []
+
+    def test_ownership_skip_is_scoped_to_owning_service(self, tmp_path):
+        """Another service's missing source under the same path still fails."""
+        from aptl.core.lab import _check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  wazuh.indexer:\n"
+            "    volumes:\n"
+            "      - ./config/wazuh_indexer_ssl_certs/root-ca.pem"
+            ":/usr/share/wazuh-indexer/certs/root-ca.pem:ro\n"
+        )
+
+        errors = _check_bind_mounts(
+            tmp_path,
+            stateful_owned_mounts=frozenset(
+                {("wazuh.manager", "/etc/ssl/wazuh", "config/wazuh_indexer_ssl_certs")}
+            ),
+        )
+        assert len(errors) == 1
+        assert "wazuh.indexer" in errors[0]
+
+    def test_ownership_skip_matches_exact_file_destination(self, tmp_path):
+        """A file-granular owned destination (e.g. ossec.conf) is skipped."""
+        from aptl.core.lab import _check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  wazuh.manager:\n"
+            "    volumes:\n"
+            "      - ./.aptl/config/wazuh_cluster/wazuh_manager.conf"
+            ":/wazuh-config-mount/etc/ossec.conf:ro\n"
+        )
+
+        errors = _check_bind_mounts(
+            tmp_path,
+            stateful_owned_mounts=frozenset(
+                {
+                    (
+                        "wazuh.manager",
+                        "/wazuh-config-mount/etc/ossec.conf",
+                        ".aptl/config/wazuh_cluster/wazuh_manager.conf",
+                    )
+                }
+            ),
+        )
+        assert errors == []
+
+    def test_ownership_requires_matching_source(self, tmp_path):
+        """A stray bind under an owned destination is still checked.
+
+        The exemption exists for sources the admitted realization will
+        generate; a mistyped or additional bind whose source is not the
+        artifact's generated path must not ride along on the destination
+        prefix (issue #677 codex finding).
+        """
+        from aptl.core.lab import _check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  wazuh.manager:\n"
+            "    volumes:\n"
+            "      - ./missing:/etc/ssl/wazuh/extra.pem:ro\n"
+        )
+
+        errors = _check_bind_mounts(
+            tmp_path,
+            stateful_owned_mounts=frozenset(
+                {("wazuh.manager", "/etc/ssl/wazuh", "config/wazuh_indexer_ssl_certs")}
+            ),
+        )
+        assert len(errors) == 1
+        assert "./missing" in errors[0]
+
+    def test_ownership_does_not_mask_unrelated_destination(self, tmp_path):
+        """The owning service's mounts outside the owned destination still fail."""
+        from aptl.core.lab import _check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  wazuh.manager:\n"
+            "    volumes:\n"
+            "      - ./missing-elsewhere:/var/ossec/data\n"
+        )
+
+        errors = _check_bind_mounts(
+            tmp_path,
+            stateful_owned_mounts=frozenset(
+                {("wazuh.manager", "/etc/ssl/wazuh", "config/wazuh_indexer_ssl_certs")}
+            ),
+        )
+        assert len(errors) == 1
+        assert "missing-elsewhere" in errors[0]
+
+    def test_step_passes_stateful_ownership_to_check(self, tmp_path):
+        """_step_check_bind_mounts must thread ctx ownership into the check."""
+        from aptl.core.lab import _LabStartContext, _step_check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  wazuh.manager:\n"
+            "    volumes:\n"
+            "      - ./config/wazuh_indexer_ssl_certs/wazuh.manager.pem"
+            ":/etc/ssl/wazuh/wazuh.manager.pem:ro\n"
+        )
+        ctx = _LabStartContext(project_dir=tmp_path, skip_seed=False)
+        ctx.stateful_artifact_ownership = frozenset(
+            {
+                (
+                    "provision.generated-artifact.wazuh-manager-certs",
+                    "certificate_bundle",
+                    "wazuh.manager",
+                    "/etc/ssl/wazuh",
+                    "config/wazuh_indexer_ssl_certs",
+                )
+            }
+        )
+
+        assert _step_check_bind_mounts(ctx) is None
+
 
 class TestStartupClassificationTypes:
     """Tests for the StartupOutcome / DiagnosticImpact / StartupDiagnostic types.
@@ -1230,6 +1376,30 @@ class TestOrchestrateLabStart:
             == env[_env_key("API", "PASSWORD")]
         )
         assert mocks["manager_creds"].call_args.args[1]
+
+    def test_refuses_start_when_env_keeps_placeholder_secret(self, mocker, tmp_path):
+        """A .env.example placeholder secret must stop the start fail-closed.
+
+        Hydration only repairs the vars it owns generators for; a sensitive
+        var outside `_HYDRATED_ENV_SPECS` (THEHIVE_SECRET) keeps its copied
+        .env.example placeholder, and booting with it would bring the SOC
+        stack up with admin credentials anyone can read in the repo. If
+        `_validate_env_secrets` were unwired from `_step_load_env`, only
+        this test notices.
+        """
+        from aptl.core.lab import orchestrate_lab_start
+
+        mocks = self._patch_all_steps(mocker, tmp_path)
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            env_file.read_text() + "THEHIVE_SECRET=CHANGE_ME_thehive_secret\n"
+        )
+
+        result = orchestrate_lab_start(tmp_path)
+
+        assert result.success is False
+        assert "THEHIVE_SECRET" in result.error
+        mocks["start"].assert_not_called()
 
     def test_stops_on_env_loading_failure(self, mocker, tmp_path):
         """Should fail early if .env cannot be read or hydrated."""


### PR DESCRIPTION
## Summary

Wazuh certificate generation is now producer-owned: on native Linux Docker the compose generator runs as the invoking host UID/GID (no root generation, no post-hoc chown repair container, no sudo anywhere in the path), with the generator tool vendored at config/wazuh-certs-tool.sh and sha256-verified in-container so the certificate producer never executes mutable network content. Completing the mandatory clean-lab-start proof surfaced seven pre-existing defects in the #796/#798 ACES realization stack that made every fresh `aptl lab start` fail; all are fixed here (user-directed scope expansion recorded on the issue thread): handoff diagnostic masking, bind-mount pre-flight vs stateful-owned artifact ordering, a Compose-rejected `build: null` image override, an undersized cold-start health budget that triggered a state-corrupting retry, unlabeled seeded volumes, missing content-type/domain-topology observers plus observation racing Wazuh first-boot restarts, and observed-spec drift vs aces-sdl 0.23 dependency fields. Proven end-to-end: clean `lab stop -v` + `lab start` boots to "Lab is ready" with host-owned certs (0700/0644), 22 healthy services, SOC seeded.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #677

## ADR Impact

- ADR-021
- ADR-034
- ADR-043
- ADR-046

## Changes

- certs.py: compose generator runs with --user <uid>:<gid> behind hostenv.needs_host_ownership_fix(); root+chown repair container deleted; generation failure fails closed with no root fallback
- generate-indexer-certs.yml: static entrypoint override runs the vendored, sha256-verified wazuh-certs-tool.sh from a writable workdir (no runtime download; same output set as the shipped entrypoint)
- config/wazuh-certs-tool.sh: vendored pinned generator tool (GPLv2, pure openssl, reviewed)
- aces.py + aces_provisioner.py: provisioner failure diagnostics survive the aces_runtime SEM-218 gate flood (actionable error first, retryable signal restored); render_aces_diagnostics no longer truncates silently
- lab.py: bind-mount pre-flight exempts only mounts whose (service, destination, source) matches admitted stateful artifact ownership; ownership tuples now carry the generated source
- _compose_image_realization.py: image override clears build with Compose's !reset tag (Compose >= 2.24 rejects build: null)
- _compose_service_health.py: realization health budget 300s -> 900s, sized to observed cold-start data; premature timeout fed a compose-up retry that tore Cassandra's commit log
- docker_compose.py: seeded named volumes are pre-created with Compose project labels; existing unattributed volumes fail fast with remediation; relpaths validated before any docker command
- aces_observation.py + helpers: domain-topology attested from live samba-tool evidence; observation waits out transitional starting/restarting states; artifact/volume specs render realized dependency wiring in author vocabulary (aces-sdl 0.23); unrealized observations log their failing predicate
- docs: deployment.md + troubleshooting no longer instruct raw compose cert regeneration (bypassed the platform identity policy); preflight design note added

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Unit suite 2341 passed / 92 skipped; TechVault static gate integration 2/2 (includes ACES backend conformance); pre-commit fully green. Live product proof on native Linux: clean `aptl lab stop -v` + full volume/cert wipe + `aptl lab start` reaches "Lab is ready" — certs generated producer-owned (dir 0700 uid:gid of invoker, PEMs 0644), no repair container, SOC seeded, 22 healthy services. Generator also proven under arbitrary uid 4242. Codex review cycle 1: 3 findings fixed (volume attribution, mount exemption source-matching, vendored+verified generator tool). Test-quality cycle 1: 4 findings fixed (placeholder-secret refusal coverage, settle-deadline coverage, image pull/build failure coverage, redundant test removed).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #677 ← src/aptl/core/certs.py, #677 ← generate-indexer-certs.yml, #677 ← src/aptl/core/lab.py, #677 ← src/aptl/backends/aces.py
- TESTS: #677 ← tests/test_certs.py, #677 ← tests/test_lab.py, #677 ← tests/test_aces_backend.py, #677 ← tests/test_aces_observation.py, #677 ← tests/test_deployment_backend.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
