### PR TITLE
feat: add ACES experiment specification admission and trial planning (EXP-002)

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -68,3 +68,4 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [044](adr-044-aces-aligned-run-reproducibility-record.md) | ACES-Aligned Run Reproducibility Record | accepted | 2026-06-25 |
 | [045](adr-045-ephemeral-lifecycle-policy-enforcement.md) | Ephemeral Lifecycle Policy Enforcement | accepted | 2026-06-28 |
 | [046](adr-046-dynamic-aces-scenario-realization.md) | Dynamic ACES Scenario Realization | accepted | 2026-06-29 |
+| [047](adr-047-aces-experiment-admission-and-trial-plan-boundary.md) | ACES Experiment Admission and Trial-Plan Boundary | accepted | 2026-07-19 |

--- a/docs/adrs/adr-047-aces-experiment-admission-and-trial-plan-boundary.md
+++ b/docs/adrs/adr-047-aces-experiment-admission-and-trial-plan-boundary.md
@@ -1,0 +1,439 @@
+# ADR-047: ACES Experiment Admission and Trial-Plan Boundary
+
+## Status
+
+accepted
+
+## Date
+
+2026-07-19
+
+## Context
+
+EXP-002 makes APTL the execution apparatus for experiments authored through
+ACES `experiment-authoring-input-v1`. The authoring input references an ACES
+`experiment-task-v1`, capture specifications, and scenario material, then asks
+the apparatus to turn a bounded allocation into stable executable trials.
+
+The architectural risk is not the allocation loop. It is creating a second
+experiment language, resolving untrusted references after the lab has already
+changed, or letting an admission-only code path bypass the controls already
+used by scenario startup and run capture.
+
+The repository already owns the relevant boundaries:
+
+- `aces_contracts.experiment_spec.parse_experiment_spec` and the exported ACES
+  contract models own experiment structure and model-level semantic invariants.
+- `aces_sdl.parse_sdl_file`, `RuntimeManager.plan()`, and planner diagnostics
+  own scenario semantics, parameter binding, realization requirements, and the
+  backend capability gate.
+- `create_aptl_manifest()` owns APTL backend identity and runtime capability
+  claims. The ACES reference processor manifest is the corresponding processor
+  identity surface.
+- `start_aces_scenario()`, `AcesRunTarget`, `AcesStartOutcome`, and
+  `_LAB_START_STEPS` own the existing ACES-to-lab handoff.
+- `DeploymentBackend` owns Docker, Compose, host, and container operations.
+- Strict `AptlConfig` owns durable non-secret configuration. `EnvVars`, `.env`
+  hydration, placeholder checks, and generated config own runtime secrets.
+- `LocalRunStore`, `RangeSnapshot.to_dict()`, ADR-044's reproducibility record,
+  and the exporter own persistence, redaction, inventory, and packaging.
+- ACES `Diagnostic`, `render_aces_diagnostics()`, `StartupDiagnostic`,
+  `LabResult`, and the existing CLI/API projections own failure reporting.
+
+Current startup ordering is important. `_LAB_START_STEPS` hydrates `.env`,
+generates keys and certificates, renders service configuration, seeds volumes,
+and pulls images before `_step_start_containers` plans and applies the ACES
+scenario. Experiment admission cannot simply be added inside
+`start_aces_scenario()`: by then APTL has already mutated local apparatus state.
+
+## Decision
+
+### Experiment-controller boundary
+
+Add one experiment-controller composition boundary above lab lifecycle. It has
+two distinct phases:
+
+1. **Admission** reads bounded inputs, resolves and pins every referenced
+   artifact, invokes ACES validation and planning APIs, checks APTL apparatus
+   policy, and produces canonical immutable trial-plan bytes. Admission may use
+   bounded temporary staging and persist its final journal, but it must not
+   hydrate `.env`, generate credentials or certificates, render service config,
+   pull images, invoke collectors, call `DeploymentBackend`, start a session, or
+   otherwise mutate the range.
+2. **Execution** is downstream work. It receives an admitted plan and delegates
+   each trial's scenario to the existing `RuntimeManager` and lab lifecycle. It
+   must not re-resolve references, reinterpret the allocation, or mint a new run
+   identity.
+
+Admission is all-or-nothing across the complete allocation. No trial may start
+when any source, condition, capture requirement, stochastic control, apparatus
+constraint, or planned scenario fails admission. A retry after an operational
+backend failure may reuse the exact admitted bytes; it must not parse or plan a
+new input, matching the existing admitted-plan retry rule in `aces.py`.
+
+The controller is a coordinator, not another runtime manager. Do not split it
+into speculative repository, service, provider, DTO, and policy hierarchies.
+Its dependencies should be explicit inputs: ACES public loaders/models, the
+canonical processor and backend manifests, an authorized artifact resolver,
+an admission policy with resource limits, and the existing
+`RunStorageBackend`. Deployment is not an admission dependency.
+
+### ACES contracts remain authoritative
+
+The admitted graph retains ACES objects and identities directly:
+
+- The root enters through `parse_experiment_spec`; APTL does not define a local
+  authoring-input model.
+- Task and capture payloads validate through the exported
+  `ExperimentTaskModel` and `ExperimentCaptureSpecModel` public surfaces. The
+  installed ACES fixture corpus is the contract test source; fixtures are not
+  copied into an APTL-owned schema corpus.
+- Scenario material enters through `parse_sdl_file`; canonical scenario or
+  instantiated-snapshot identity uses the ACES canonical digest API.
+- Associated-artifact manifests enter through
+  `load_associated_artifact_manifest_json` and
+  `validate_associated_artifact_manifest`, with caller-supplied bounded readers
+  and `AssociatedArtifactValidationLimits`.
+- Each unique condition binding is submitted to `RuntimeManager.plan()` against
+  `create_aptl_manifest()` before admission succeeds. ACES planner diagnostics,
+  realization support, variable typing, and semantic validation are not
+  duplicated locally.
+
+APTL performs only joins and apparatus policy that require multiple already
+validated artifacts: reference identity/version equality, unique resolution,
+task/scenario agreement, capture-scope compatibility, condition parameter
+target resolution, supported allocation/control policy, and conjunction of the
+task's apparatus constraints with the authoring input's apparatus intent.
+These checks must operate on ACES fields; they must not restate those fields in
+local Pydantic or dataclass mirrors.
+
+Contract schema versions and artifact versions are different concepts.
+`schema_version="experiment-task/v1"` selects the ACES contract, while a
+task reference's `ref_version` identifies the authored task revision. Admission
+must validate and record both and must not compare one namespace to the other.
+Likewise, the hyphenated identifiers in manifest
+`supported_contract_versions` are not interchangeable with slash-form schema
+version values.
+
+The backend manifest remains a runtime capability declaration. Do not add
+experiment authoring/task/capture contract identifiers to
+`create_aptl_manifest()` merely to advertise this controller unless ACES's
+backend manifest authority explicitly allows and requires them.
+
+### Authorized artifact resolution
+
+Experiment references are capabilities, not paths or commands. The default
+resolver is offline and project-contained. It accepts only explicitly
+supported locator forms and returns one bounded byte stream plus normalized
+locator metadata; it never returns an executable object or a path to reopen.
+
+For project files, build on the containment rule in
+`scenario_catalog._resolve_project_file`, strengthened for untrusted experiment
+inputs:
+
+- Reject absolute paths, `..` components, NULs, non-files, and every symlinked
+  path component. Resolving a path and checking its prefix is not enough because
+  a symlink can change between check and open.
+- Open once using descriptor-relative, no-follow semantics where the platform
+  provides them. Hash and parse the exact bytes from that open handle so a
+  time-of-check/time-of-use swap cannot change the admitted payload.
+- Enforce per-document, per-artifact, aggregate-byte, reference-count,
+  allocation-size, and nesting/depth limits before expensive parsing or trial
+  expansion. ACES's associated-artifact limits remain the authority where that
+  contract applies.
+- Verify declared size and checksum before parsing or using a payload. Digest
+  mismatch, unsupported digest algorithm, ambiguous/missing resolution, or an
+  undeclared extra binding is fatal.
+- Reject credential userinfo and secret-bearing query fields in every locator,
+  not only associated-artifact manifests. Persist portable references and
+  digests, not host-absolute paths.
+
+Network, OCI, or registry fetching is disabled by default. A future remote
+resolver is a separately authorized implementation of the same narrow
+resolver contract, parameterized by allowed scheme/authority, offline mode,
+timeouts, redirect policy, maximum bytes, authentication source, and digest
+requirement. It must reject redirects to unauthorized authorities and must not
+take credentials from the experiment document. Do not fall back from a failed
+remote resolution to an ambient filesystem search, current working directory,
+`PATH`, environment variable, or package import.
+
+### Apparatus and capture capability admission
+
+Task apparatus constraints and authoring-input apparatus intent are conjunctive;
+the latter cannot weaken the former. Evaluate processor/backend identities,
+manifest references and digests, compatibility declarations, required
+capabilities, and contract versions against the canonical ACES processor
+manifest and `create_aptl_manifest()` payload.
+
+Scenario-specific feasibility remains with `RuntimeManager.plan()`. Docker or
+Compose must not be probed directly during admission, and config flags must not
+be treated as proof of a capability the manifest or planner rejects.
+
+Capture admission needs one code-owned mapping from ACES capture requirement
+terms to existing APTL capture owners (`collectors.py`, MCP/Kali capture,
+runtime snapshots, orchestration/evaluation history). Admission and later
+execution must share that mapping. Unknown capture kinds, channels, media types,
+sealing/redaction requirements, or retention/integrity guarantees fail closed;
+they never become arbitrary collector names, imports, backend method names, or
+shell commands. The mapping describes support only. It does not replace the
+ACES capture-spec model.
+
+Participant implementation/provider selection remains behind the ACES
+participant-runtime boundary and issue #557. Admission may retain and validate
+an ACES red-variant selection, but it cannot resolve `agent_ref` to a Python
+entry point, executable, image, environment variable, or provider method.
+
+### Deterministic immutable trial plan
+
+The trial plan is an APTL internal execution journal, not a portable ACES
+experiment, task, study, run, apparatus, capture, or analysis contract. It may
+carry only the data needed to bind execution back to the admitted ACES graph:
+source identities and digests, canonical condition/factor assignments,
+resolved non-secret scenario parameter bindings, stochastic controls, episode
+controls, capture-spec references, ordering coordinates, and stable planned
+trial IDs. Eventual portable run and apparatus records use ACES contracts; they
+must not serialize this journal as if it were `experiment-run-v1`.
+
+Expansion obeys these rules:
+
+- A flat allocation uses ordinal `0..target_run_count-1`.
+- A condition allocation follows the authored `compared_conditions` order,
+  then an explicit zero-based replication ordinal. Map insertion order,
+  filesystem enumeration, locale, wall clock, and process-global randomness
+  have no effect.
+- An `allocation_method`, stochastic-control role, or ordering behavior is
+  executable only when it maps to a supported, versioned controller policy.
+  Free-form text is never evaluated or silently approximated. Unknown or
+  under-specified controls fail admission.
+- Condition and red-variant parameters may bind only to uniquely declared ACES
+  scenario variables. The ACES planner validates the assembled binding.
+  Missing targets, multiple candidate targets, conflicting values, and unused
+  parameters are fatal.
+- A seed or randomized order is derived with a documented, domain-separated
+  cryptographic hash from canonical source-set identity plus logical trial
+  coordinates and control ID. Do not use Python `hash()`, UUIDs, timestamps,
+  ambient RNG state, or a library PRNG whose algorithm is not part of the
+  policy version.
+- The plan and source-set identities are digests of RFC 8785 canonical JSON
+  projections. Canonical projections exclude admission time, host-absolute
+  paths, temporary paths, log text, and mutable runtime state. They normalize
+  digest case and sort semantically unordered maps/sets. Authored lists whose
+  order is meaningful remain ordered.
+- Planned-trial IDs are a filesystem-safe prefix plus a full or collision-safe
+  cryptographic digest of the versioned identity domain, source-set digest,
+  condition ID (or flat sentinel), and replication ordinal. The same admitted
+  inputs and policy version produce the same IDs on every supported host.
+
+The in-memory plan is immutable after construction. No downstream caller may
+mutate a shared list/dict or replace a referenced artifact. Before execution,
+the persisted plan digest must still match the canonical bytes and every
+trial's plan reference must match it.
+
+The extensibility parameter for allocation is a small versioned ordering and
+stochastic-control policy passed into the pure expander. A future supported
+blocked or seeded-random allocation adds a policy mapping and conformance tests;
+it does not add scenario-name branches or reinterpret old plan bytes.
+
+### Persistence and state model
+
+`RunStorageBackend` remains the only persistence dependency. The controller
+must receive the configured store; it must not hardcode `./runs`,
+`.aptl/runs`, or a third root. Trace-correlated run capture and configured run
+storage currently use both roots in different paths, so EXP-002 must not deepen
+that inconsistency. Callers resolve and inject one store/target, as they already
+do with `AcesRunTarget`.
+
+The existing `LocalRunStore.write_json()` is contained and redacting, but it is
+overwrite-capable and emits presentation JSON rather than canonical bytes.
+Immutability therefore requires a narrow create-once canonical JSON operation
+on the existing run-store protocol, not a second experiment repository. That
+operation redacts first, canonicalizes once, writes atomically with
+create-exclusive semantics, and treats an identical existing payload as an
+idempotent success while rejecting different bytes. `write_file()` and
+`copy_file()` are not acceptable for structured plans because they bypass
+structural redaction.
+
+Persist the full admitted plan once under a controller-owned plan namespace.
+Each planned trial archive stores only the plan identity/digest and its own
+trial projection, then reuses the planned-trial ID as the execution `run_id`.
+Do not call `_resolve_run_target()` to mint a timestamp run ID for an admitted
+trial. The controller journal is explicitly APTL-internal and names the ACES
+source artifacts it derives from; it is not an ACES study or run.
+
+Admission has a one-shot result, not a parallel workflow engine:
+
+- rejected: structured diagnostics and no plan;
+- admitted: immutable canonical plan bytes, plan identity, and trial tuple.
+
+Execution state continues through ACES operation receipt/status, runtime
+snapshot, workflow/evaluation history, `ScenarioSession`, and `LabResult`.
+Do not create `PENDING/RUNNING/FAILED` experiment-controller states that
+duplicate those incumbents.
+
+## Security layers
+
+| Layer | Required behavior |
+| --- | --- |
+| Auth surface | Core admission performs no authentication. A local CLI caller is the current trusted operator boundary. Any future `/api` admission route must inherit the API-wide `verify_token` dependency before resolving paths or reading bodies, use a bounded Pydantic request projection, and never accept credentials in a URL. |
+| Input shape | Bound the root bytes before `parse_experiment_spec`; use ACES closed-world models and validators for all ACES payloads. Reject unknown versions and malformed/duplicate or ambiguous bindings rather than coercing them into a local shape. |
+| Semantic validation | Use ACES model validators, canonical digest APIs, associated-artifact validation, and `RuntimeManager.plan()` diagnostics. Local checks are cross-artifact identity joins and explicit apparatus policy only. |
+| Artifact resolution | Use the injected authorized resolver, no-follow contained opens, one-handle hash/parse, digest and size verification, aggregate limits, offline default, and no ambient lookup. No input controls imports, commands, collectors, backend methods, environment names, or filesystem roots. |
+| Secret handling | Treat the whole experiment graph as untrusted. Reject secret-shaped scalar content and parameter name/value pairs using the canonical `redact()` taxonomy before plan construction; never rely on later redaction to make an executable secret safe. Keep control-plane secrets out of source artifacts and locators. |
+| Config shape | Non-secret admission limits or resolver policy that become durable settings must be strict `AptlConfig` fields with real consumers. The experiment document cannot add config keys or override deployment provider/project identity. |
+| Environment binding | Admission must not call `.env` hydration or construct `EnvVars`. Experiment parameters cannot name or read environment variables. Runtime secrets remain in `EnvVars`, placeholder validation, and generated config after admission succeeds. |
+| Apparatus capability | Compare both task and spec constraints with canonical manifest payloads and ACES planner diagnostics. Unknown contract/capability/capture terms fail closed before `_LAB_START_STEPS`. |
+| OS/process exposure | Default admission uses no subprocess. Do not put parameter values, digests used as credentials, auth headers, or artifact contents in argv, process titles, URLs, or environment. A future resolver uses in-process transport or the existing `curl_safe` boundary without credential-bearing argv. |
+| Range-mutation gate | The complete plan must be admitted and persisted before `.env` hydration, key/cert generation, rendered config, volume seeding, image pulls, session creation, or any `DeploymentBackend` call. Clean boot/teardown is execution and cannot precede admission. |
+| Persistence | Inject `RunStorageBackend`; reuse ID/path containment and shared redaction. Add only create-once canonical structured writes. Exporter packages already-safe records and is never the first sanitizer. |
+| Logs and telemetry | Use `get_logger`; log contract/diagnostic codes, safe identities, counts, and digests only. Raw documents, parameter values, artifact bytes, locators with queries, exception strings, and validation `input` fields never enter logs or OTel attributes. Admission spans may carry plan/trial counts and digests after `redact()`. |
+| Error envelope | Normalize failures into redacted ACES `Diagnostic` values in an experiment-admission domain, then reuse `render_aces_diagnostics`, `StartupDiagnostic`, `LabResult`, Typer exits, and existing API response conventions. Do not expose raw Pydantic errors with `input_value`, YAML excerpts, absolute paths, resolver exceptions, or backend stderr. |
+
+## Canonical incumbents
+
+| Concern | Reuse |
+| --- | --- |
+| Experiment contracts and examples | `aces_contracts.experiment_spec`, exported `aces_contracts.contracts` models, associated-artifact APIs, and the installed ACES fixture corpus |
+| Scenario parsing and parameter semantics | `aces_sdl.parse_sdl_file`, ACES canonical scenario digests, and `RuntimeManager.plan()` |
+| Backend identity and feasibility | `create_aptl_manifest()`, ACES manifest payload/model APIs, planner diagnostics, and existing conformance tests |
+| Runtime handoff | `start_aces_scenario()`, `AcesRunTarget`, `AcesStartOutcome`, and the admitted-plan retry behavior in `aces.py` |
+| Lab lifecycle | `_LAB_START_STEPS`, orchestration contract predicates, `LabResult`, `StartupOutcome`, and `StartupDiagnostic` |
+| Deployment | `DeploymentBackend` and its typed local/SSH Compose implementations |
+| Scenario containment precedent | `scenario_catalog._resolve_project_file`, strengthened to no-follow one-open semantics rather than copied into a second path checker |
+| Config and secrets | `load_config`/`AptlConfig`, `EnvVars`, placeholder checks, ADR-028/029 generated-state rules, and `redact()` |
+| Capture | `collectors.py`, MCP/Kali capture owners, `RuntimeSnapshot`, workflow/evaluation history, and the ADR-033/044 evidence layout |
+| Persistence and export | `RunStorageBackend`/`LocalRunStore`, `RangeSnapshot.to_dict()`, ADR-044 run records, and `exporter.py` |
+| Diagnostics and observability | ACES `Diagnostic`, `render_aces_diagnostics()`, `_emit_diagnostic()`, `get_logger`, and ADR-012 telemetry rules |
+| API exposure if added | API-wide `verify_token`, `WebAuthSettings`, existing router assembly, and narrow Pydantic response projections |
+
+## Extensibility
+
+The primary external extension seam is the authorized artifact resolver. It is
+parameterized by trust roots/authorities, offline mode, limits, redirects,
+timeouts, and digest policy while always returning the same bounded immutable
+byte binding. This permits a future digest-verified OCI or registry resolver
+without changing admission semantics or allowing the experiment to select a
+transport implementation.
+
+The execution-side seam is the versioned allocation/control policy and the
+shared capture-capability mapping. Future ordering methods, stochastic
+controls, or capture owners extend those bounded mappings. They do not edit
+ACES source models, dispatch by scenario name, or add arbitrary plugin loading.
+
+If ACES publishes a portable trial-plan or admission-diagnostic contract later,
+the controller should replace the corresponding internal projection at the
+ACES namespace while keeping APTL-only resolver and persistence evidence under
+the backend journal namespace.
+
+## Testing contract
+
+Implementation must prove the boundary without creating a new test harness:
+
+- ACES package fixtures cover valid and invalid authoring input, task, capture,
+  associated-artifact, manifest, and scenario contracts through public APIs.
+- Unit tests cover cross-artifact identity joins, apparatus/capture capability
+  decisions, exact mutation ordering, redacted diagnostics, canonical bytes,
+  create-once persistence, and stable IDs.
+- Property-based tests under the existing `fuzz` marker cover traversal and
+  symlink inputs, resource limits, secret-shaped values, map/list order,
+  condition/replication counts, digest changes, ID uniqueness, and repeated
+  admission determinism.
+- Contract tests assert that every planned trial resolves to exactly one task,
+  one scenario snapshot, one condition or flat sentinel, one stochastic-control
+  set, one episode-control set, and the admitted capture-spec references.
+- Mutation-spy tests prove that rejected admission makes no
+  `DeploymentBackend`, hydration, credential, certificate, Compose, session,
+  collector, or run-execution call.
+
+Do not weaken these tests by snapshotting APTL-local copies of ACES schemas.
+The project dependency range (`aces-sdl>=0.23.1,<0.24.0`) and `uv.lock` are the
+version authority used by the fixtures and public APIs.
+
+## Gotchas
+
+- Pydantic validation strings can contain the rejected `input_value`; wrapping
+  `str(exc)` in a diagnostic can leak an injected secret. Render only stable
+  error type/location metadata and omit input values and documentation URLs.
+- `parse_experiment_spec` is the public schema loader, but callers still need a
+  byte limit before passing text to it. Do not use `load_experiment_spec` on an
+  unbounded attacker-controlled file.
+- ACES task and capture references deliberately do not carry digest/path fields
+  in their typed reference models. Pin resolved byte digests in the internal
+  admission journal or an ACES associated-artifact binding; do not add forbidden
+  fields or subclass the contracts.
+- A generic scenario reference is not a sealed scenario snapshot. It must
+  resolve to one concrete parsed/instantiated snapshot and canonical digest
+  before planning trials.
+- `target_runs_per_condition` and `target_run_count` have no useful apparatus
+  upper bound in the portable contract. The caller policy must reject expansion
+  beyond configured count/byte limits before allocating a large list.
+- `allocation_method`, `replication_policy`, `stopping_rule`,
+  `termination_rule`, and stochastic descriptions are data, not code. Never
+  evaluate or parse them as shell, Python, templates, expressions, or import
+  names.
+- Current trace capture favors `.aptl/runs`, while configured CLI run storage
+  can point elsewhere. Injection of one resolved `RunStorageBackend` is
+  mandatory; hardcoding either root would split evidence again.
+- `LocalRunStore.write_json` overwrites and is not canonical. Calling it twice
+  is not an immutability guarantee, and bypassing it with `write_file` loses
+  structural redaction.
+- A plan generated with timestamps, absolute paths, Python set/dict traversal,
+  `random`, or UUIDs can look stable in one test process and still drift across
+  hosts or retries.
+- Admission-time Docker probes would make results host-state-dependent and
+  would bypass both the manifest truth surface and the no-mutation boundary.
+
+## Non-goals
+
+- Do not define an APTL experiment DSL or mirror ACES authoring input, task,
+  capture, run, study, apparatus, evidence, protocol, or analysis schemas.
+- Do not execute a trial batch, schedule workers, select participant providers,
+  implement stopping rules, or perform statistical analysis as part of the
+  admission slice.
+- Do not redesign ACES scenario compilation, participant runtime, lab startup,
+  clean boot, collectors, snapshots, run archive layout, exporter, telemetry,
+  web authentication, or deployment backends.
+- Do not add remote fetching by default, a plugin loader, arbitrary URI scheme
+  support, or ambient package/filesystem discovery.
+- Do not make the internal journal a portable ACES artifact or claim that it is
+  an archival `experiment-run-v1` record.
+- Do not weaken redaction so experiment parameters can preserve
+  control-plane/operator secrets. Designed-vulnerable evidence remains governed
+  by ADR-029 at capture time, not by the experiment input.
+
+## Anti-patterns
+
+- Local `ExperimentSpec`, `Task`, `CaptureSpec`, `Study`, `Run`, or protocol
+  models that copy ACES fields.
+- A second YAML/JSON schema validator, semantic-invariant registry, exception
+  hierarchy, diagnostic DTO, readiness taxonomy, or workflow state machine.
+- Resolving references after the first trial starts or reopening a path after
+  hashing it.
+- Treating a digest as optional when bytes can affect execution, or treating an
+  image tag/path/URI as immutable identity.
+- Passing input strings to `getattr`, `importlib`, `subprocess`, shell, Docker,
+  collector dispatch, environment lookup, or backend method selection.
+- Letting condition names or scenario IDs select behavior in `if`/`match`
+  branches instead of using typed ACES fields and bounded policy mappings.
+- Logging raw validation/resolver exceptions or returning them through CLI/API
+  error envelopes.
+- Replanning a trial at execution time and accepting a plan that differs from
+  the persisted digest.
+- Using exporter filtering, file permissions, `.gitignore`, or an offline flag
+  as a substitute for admission-time containment, authorization, and redaction.
+
+## References
+
+- EXP-002 / GitHub issue #438.
+- [ADR-025](adr-025-strict-first-party-config-schema.md): strict APTL config.
+- [ADR-029](adr-029-control-plane-secret-handling.md): secret classification
+  and serialization-boundary redaction.
+- [ADR-031](adr-031-lab-orchestration-contract-guards.md): lifecycle guards and
+  existing error envelopes.
+- [ADR-035](adr-035-aces-sdl-adoption.md): ACES contract authority and adapter
+  boundary.
+- [ADR-039](adr-039-web-control-plane-authentication.md): API auth and error
+  exposure.
+- [ADR-044](adr-044-aces-aligned-run-reproducibility-record.md): portable ACES
+  identity versus APTL backend evidence.
+- [ADR-046](adr-046-dynamic-aces-scenario-realization.md): compiled-plan
+  authority, manifest capability gates, and `DeploymentBackend` realization.

--- a/docs/adrs/adr-047-aces-experiment-admission-and-trial-plan-boundary.md
+++ b/docs/adrs/adr-047-aces-experiment-admission-and-trial-plan-boundary.md
@@ -24,9 +24,9 @@ The repository already owns the relevant boundaries:
 
 - `aces_contracts.experiment_spec.parse_experiment_spec` and the exported ACES
   contract models own experiment structure and model-level semantic invariants.
-- `aces_sdl.parse_sdl_file`, `RuntimeManager.plan()`, and planner diagnostics
-  own scenario semantics, parameter binding, realization requirements, and the
-  backend capability gate.
+- `aces_sdl.parse_sdl` / `parse_sdl_file`, the ACES reference processor, and
+  planner diagnostics own scenario semantics, parameter binding, realization
+  requirements, and the backend capability gate.
 - `create_aptl_manifest()` owns APTL backend identity and runtime capability
   claims. The ACES reference processor manifest is the corresponding processor
   identity surface.
@@ -73,10 +73,10 @@ new input, matching the existing admitted-plan retry rule in `aces.py`.
 
 The controller is a coordinator, not another runtime manager. Do not split it
 into speculative repository, service, provider, DTO, and policy hierarchies.
-Its dependencies should be explicit inputs: ACES public loaders/models, the
-canonical processor and backend manifests, an authorized artifact resolver,
-an admission policy with resource limits, and the existing
-`RunStorageBackend`. Deployment is not an admission dependency.
+Its dependencies should be explicit inputs: ACES public loaders/models and
+reference processor, the canonical processor and backend manifests, an
+authorized artifact resolver, an admission policy with resource limits, and
+the existing `RunStorageBackend`. Deployment is not an admission dependency.
 
 ### ACES contracts remain authoritative
 
@@ -88,16 +88,29 @@ The admitted graph retains ACES objects and identities directly:
   `ExperimentTaskModel` and `ExperimentCaptureSpecModel` public surfaces. The
   installed ACES fixture corpus is the contract test source; fixtures are not
   copied into an APTL-owned schema corpus.
-- Scenario material enters through `parse_sdl_file`; canonical scenario or
-  instantiated-snapshot identity uses the ACES canonical digest API.
+- Import-free scenario material is parsed from the resolver's already bounded
+  UTF-8 bytes with `aces_sdl.parse_sdl`; canonical scenario or
+  instantiated-snapshot identity uses the ACES canonical digest API. Never
+  hand the original untrusted path to `parse_sdl_file`, because doing so
+  reopens it after digest verification.
 - Associated-artifact manifests enter through
   `load_associated_artifact_manifest_json` and
   `validate_associated_artifact_manifest`, with caller-supplied bounded readers
   and `AssociatedArtifactValidationLimits`.
-- Each unique condition binding is submitted to `RuntimeManager.plan()` against
-  `create_aptl_manifest()` before admission succeeds. ACES planner diagnostics,
-  realization support, variable typing, and semantic validation are not
-  duplicated locally.
+- Each unique condition binding is submitted to the public ACES reference
+  processor against `create_aptl_manifest()` before admission succeeds. This is
+  the planning-only seam: it does not require an APTL `RuntimeTarget`,
+  `AptlConfig`, or `DeploymentBackend`. ACES planner diagnostics, realization
+  support, variable typing, and semantic validation are not duplicated locally.
+
+`parse_experiment_spec` currently applies `yaml.safe_load` before the
+closed-world model and therefore does not reject duplicate mapping keys. Bound
+the bytes and perform one narrow duplicate-key/ambiguous-document preflight
+before calling the public loader. This is parser hardening, not a second
+experiment schema: field shape and semantic rules remain exclusively with the
+ACES models. Task and capture artifacts likewise use only their published
+serialization format and exported ACES model; do not silently accept a second
+YAML/JSON dialect.
 
 APTL performs only joins and apparatus policy that require multiple already
 validated artifacts: reference identity/version equality, unique resolution,
@@ -148,6 +161,14 @@ inputs:
   not only associated-artifact manifests. Persist portable references and
   digests, not host-absolute paths.
 
+ACES SDL imports are a second resolver surface. `parse_sdl(content, path=...)`
+delegates imports to ACES file/OCI resolution and reopens local import files.
+Initial admission therefore rejects scenarios with imports unless the
+authorized resolver has first materialized the complete digest-pinned,
+size-bounded transitive graph into a private staging tree and ACES parses only
+that tree with its import lock verified. Never let an admitted root switch from
+the controller resolver to ambient ACES import discovery.
+
 Network, OCI, or registry fetching is disabled by default. A future remote
 resolver is a separately authorized implementation of the same narrow
 resolver contract, parameterized by allowed scheme/authority, offline mode,
@@ -168,6 +189,12 @@ manifest and `create_aptl_manifest()` payload.
 Scenario-specific feasibility remains with `RuntimeManager.plan()`. Docker or
 Compose must not be probed directly during admission, and config flags must not
 be treated as proof of a capability the manifest or planner rejects.
+
+For admission, use the equivalent planning-only ACES reference-processor API.
+`RuntimeManager.plan()` remains the execution-side incumbent, but constructing
+APTL's runtime target pulls in `AptlConfig` and a `DeploymentBackend`, which
+would violate the admission dependency boundary even if a no-op backend were
+passed.
 
 Capture admission needs one code-owned mapping from ACES capture requirement
 terms to existing APTL capture owners (`collectors.py`, MCP/Kali capture,
@@ -243,15 +270,32 @@ storage currently use both roots in different paths, so EXP-002 must not deepen
 that inconsistency. Callers resolve and inject one store/target, as they already
 do with `AcesRunTarget`.
 
-The existing `LocalRunStore.write_json()` is contained and redacting, but it is
-overwrite-capable and emits presentation JSON rather than canonical bytes.
+The existing `LocalRunStore.write_json()` performs lexical path validation and
+redaction, but it is overwrite-capable, follows existing symlink components,
+and emits presentation JSON rather than canonical bytes.
 Immutability therefore requires a narrow create-once canonical JSON operation
 on the existing run-store protocol, not a second experiment repository. That
-operation redacts first, canonicalizes once, writes atomically with
-create-exclusive semantics, and treats an identical existing payload as an
-idempotent success while rejecting different bytes. `write_file()` and
-`copy_file()` are not acceptable for structured plans because they bypass
-structural redaction.
+operation applies the shared secret policy as an invariant check, canonicalizes
+once, writes atomically with create-exclusive semantics, and treats an
+identical existing payload as an idempotent success while rejecting different
+bytes. `write_file()` and `copy_file()` are not acceptable for structured plans
+because they bypass structural redaction.
+
+The create-once operation must preserve semantic bytes: admission rejects a
+plan projection if applying the shared secret classifier/redaction policy would
+change an identity-bearing value. It must never persist a silently redacted
+plan that differs from the plan approved for execution. RFC 8785 is a direct
+runtime dependency for this operation; do not rely on it only as a transitive
+dependency of `aces-sdl`.
+
+Use an explicit plan namespace beneath the injected store. A plan ID is not a
+`run_id`, and the plan must not acquire a fake `manifest.json` merely to fit
+`LocalRunStore.list_runs()`. Extend the existing storage boundary narrowly
+rather than teaching run listing/export code that controller journals are
+runs. The operation must use descriptor-relative, no-follow publication for
+every path component. Current `LocalRunStore._run_dir()` follows an existing
+`<base>/<run_id>` symlink and can escape the configured root, so its lexical
+containment check is not sufficient for this integrity boundary.
 
 Persist the full admitted plan once under a controller-owned plan namespace.
 Each planned trial archive stores only the plan identity/digest and its own
@@ -274,36 +318,36 @@ duplicate those incumbents.
 
 | Layer | Required behavior |
 | --- | --- |
-| Auth surface | Core admission performs no authentication. A local CLI caller is the current trusted operator boundary. Any future `/api` admission route must inherit the API-wide `verify_token` dependency before resolving paths or reading bodies, use a bounded Pydantic request projection, and never accept credentials in a URL. |
+| Auth surface | Core admission performs no authentication. A local CLI caller is the current trusted operator boundary. Any future `/api` admission route must inherit the API-wide `verify_token` dependency and BFF Host/CSRF/session gates before resolving paths, enforce request-size limits before body parsing, use a bounded Pydantic request projection, and never accept credentials in a URL. |
 | Input shape | Bound the root bytes before `parse_experiment_spec`; use ACES closed-world models and validators for all ACES payloads. Reject unknown versions and malformed/duplicate or ambiguous bindings rather than coercing them into a local shape. |
-| Semantic validation | Use ACES model validators, canonical digest APIs, associated-artifact validation, and `RuntimeManager.plan()` diagnostics. Local checks are cross-artifact identity joins and explicit apparatus policy only. |
+| Semantic validation | Use ACES model validators, canonical digest APIs, associated-artifact validation, and reference-processor planning diagnostics. Local checks are parser resource/ambiguity hardening, cross-artifact identity joins, and explicit apparatus policy only. |
 | Artifact resolution | Use the injected authorized resolver, no-follow contained opens, one-handle hash/parse, digest and size verification, aggregate limits, offline default, and no ambient lookup. No input controls imports, commands, collectors, backend methods, environment names, or filesystem roots. |
-| Secret handling | Treat the whole experiment graph as untrusted. Reject secret-shaped scalar content and parameter name/value pairs using the canonical `redact()` taxonomy before plan construction; never rely on later redaction to make an executable secret safe. Keep control-plane secrets out of source artifacts and locators. |
+| Secret handling | Treat the whole experiment graph as untrusted. Reject secret-shaped scalar content and parameter name/value pairs using the taxonomy owned by `aptl.utils.redaction` before plan construction; never rely on later redaction to make executable data safe. `redact()` is currently a transformation, not a yes/no validator, so expose/reuse classification in that same module rather than copying its private token/regex tables or silently changing admitted values. Keep control-plane secrets out of source artifacts and locators. |
 | Config shape | Non-secret admission limits or resolver policy that become durable settings must be strict `AptlConfig` fields with real consumers. The experiment document cannot add config keys or override deployment provider/project identity. |
 | Environment binding | Admission must not call `.env` hydration or construct `EnvVars`. Experiment parameters cannot name or read environment variables. Runtime secrets remain in `EnvVars`, placeholder validation, and generated config after admission succeeds. |
 | Apparatus capability | Compare both task and spec constraints with canonical manifest payloads and ACES planner diagnostics. Unknown contract/capability/capture terms fail closed before `_LAB_START_STEPS`. |
 | OS/process exposure | Default admission uses no subprocess. Do not put parameter values, digests used as credentials, auth headers, or artifact contents in argv, process titles, URLs, or environment. A future resolver uses in-process transport or the existing `curl_safe` boundary without credential-bearing argv. |
 | Range-mutation gate | The complete plan must be admitted and persisted before `.env` hydration, key/cert generation, rendered config, volume seeding, image pulls, session creation, or any `DeploymentBackend` call. Clean boot/teardown is execution and cannot precede admission. |
-| Persistence | Inject `RunStorageBackend`; reuse ID/path containment and shared redaction. Add only create-once canonical structured writes. Exporter packages already-safe records and is never the first sanitizer. |
+| Persistence | Inject `RunStorageBackend`; reuse its configured root and shared redaction, but harden the create-once path against symlink components rather than assuming current lexical containment is sufficient. Keep plans in an explicit non-run namespace. Exporter packages already-safe run records and is never the first sanitizer. |
 | Logs and telemetry | Use `get_logger`; log contract/diagnostic codes, safe identities, counts, and digests only. Raw documents, parameter values, artifact bytes, locators with queries, exception strings, and validation `input` fields never enter logs or OTel attributes. Admission spans may carry plan/trial counts and digests after `redact()`. |
-| Error envelope | Normalize failures into redacted ACES `Diagnostic` values in an experiment-admission domain, then reuse `render_aces_diagnostics`, `StartupDiagnostic`, `LabResult`, Typer exits, and existing API response conventions. Do not expose raw Pydantic errors with `input_value`, YAML excerpts, absolute paths, resolver exceptions, or backend stderr. |
+| Error envelope | Normalize failures into redacted ACES `Diagnostic` values in an experiment-admission domain. Reuse the existing diagnostic formatter by parameterizing its currently hard-coded `"ACES runtime handoff failed"` prefix; do not add a second formatter or misclassify admission as a startup-readiness warning. Project only stable codes/addresses and safe messages through Typer or a future narrow authenticated API response. Do not expose raw Pydantic errors with `input_value`, YAML excerpts, absolute paths, resolver exceptions, or backend stderr. |
 
 ## Canonical incumbents
 
 | Concern | Reuse |
 | --- | --- |
-| Experiment contracts and examples | `aces_contracts.experiment_spec`, exported `aces_contracts.contracts` models, associated-artifact APIs, and the installed ACES fixture corpus |
-| Scenario parsing and parameter semantics | `aces_sdl.parse_sdl_file`, ACES canonical scenario digests, and `RuntimeManager.plan()` |
-| Backend identity and feasibility | `create_aptl_manifest()`, ACES manifest payload/model APIs, planner diagnostics, and existing conformance tests |
-| Runtime handoff | `start_aces_scenario()`, `AcesRunTarget`, `AcesStartOutcome`, and the admitted-plan retry behavior in `aces.py` |
+| Experiment contracts and examples | `aces_contracts.experiment_spec`, exported `aces_contracts.contracts` models, associated-artifact APIs, and `aces_contracts.corpus.corpus_family_root(FIXTURES)` rather than private package-path reconstruction |
+| Scenario parsing and parameter semantics | `aces_sdl.parse_sdl` over resolver-owned bytes, ACES parser limits/canonical scenario digests, and the ACES reference processor |
+| Backend identity and feasibility | `create_aptl_manifest()`, `aces_backend_protocols.manifest.backend_manifest_payload`, `aces_processor.manifest.reference_processor_manifest_model`, planner diagnostics, and existing conformance tests |
+| Runtime handoff | The apply/retry path already used by `start_aces_scenario()`, plus `AcesRunTarget` and `AcesStartOutcome`; `start_aces_scenario()` itself replans and therefore cannot be the admitted-plan entrypoint unchanged |
 | Lab lifecycle | `_LAB_START_STEPS`, orchestration contract predicates, `LabResult`, `StartupOutcome`, and `StartupDiagnostic` |
 | Deployment | `DeploymentBackend` and its typed local/SSH Compose implementations |
 | Scenario containment precedent | `scenario_catalog._resolve_project_file`, strengthened to no-follow one-open semantics rather than copied into a second path checker |
 | Config and secrets | `load_config`/`AptlConfig`, `EnvVars`, placeholder checks, ADR-028/029 generated-state rules, and `redact()` |
 | Capture | `collectors.py`, MCP/Kali capture owners, `RuntimeSnapshot`, workflow/evaluation history, and the ADR-033/044 evidence layout |
 | Persistence and export | `RunStorageBackend`/`LocalRunStore`, `RangeSnapshot.to_dict()`, ADR-044 run records, and `exporter.py` |
-| Diagnostics and observability | ACES `Diagnostic`, `render_aces_diagnostics()`, `_emit_diagnostic()`, `get_logger`, and ADR-012 telemetry rules |
-| API exposure if added | API-wide `verify_token`, `WebAuthSettings`, existing router assembly, and narrow Pydantic response projections |
+| Diagnostics and observability | ACES `Diagnostic`, the formatting logic in `render_aces_diagnostics()`, `get_logger`, and ADR-012 telemetry rules; `_emit_diagnostic()` remains the lifecycle-only projection when an execution failure enters lab startup |
+| API exposure if added | API-wide `verify_token`, `WebAuthSettings`, BFF Host/CSRF/session middleware, existing router assembly, request-size enforcement, and narrow Pydantic response projections |
 
 ## Extensibility
 
@@ -334,7 +378,8 @@ Implementation must prove the boundary without creating a new test harness:
   decisions, exact mutation ordering, redacted diagnostics, canonical bytes,
   create-once persistence, and stable IDs.
 - Property-based tests under the existing `fuzz` marker cover traversal and
-  symlink inputs, resource limits, secret-shaped values, map/list order,
+  symlink inputs (including pre-existing run-store symlinks), resource limits,
+  duplicate YAML/JSON keys, secret-shaped values, map/list order,
   condition/replication counts, digest changes, ID uniqueness, and repeated
   admission determinism.
 - Contract tests assert that every planned trial resolves to exactly one task,
@@ -353,9 +398,16 @@ version authority used by the fixtures and public APIs.
 - Pydantic validation strings can contain the rejected `input_value`; wrapping
   `str(exc)` in a diagnostic can leak an injected secret. Render only stable
   error type/location metadata and omit input values and documentation URLs.
+- The locked dependency is `aces-sdl` 0.23.1, but a stale local `.venv` can
+  still contain 0.21.0 and fail importing the current APTL manifest. Validate
+  APIs and fixtures through the locked environment; direct `python` output from
+  a stale environment is not contract evidence.
 - `parse_experiment_spec` is the public schema loader, but callers still need a
-  byte limit before passing text to it. Do not use `load_experiment_spec` on an
-  unbounded attacker-controlled file.
+  byte limit and duplicate-key preflight before passing text to it. Do not use
+  `load_experiment_spec` on an unbounded attacker-controlled file.
+- `parse_sdl_file` and SDL import expansion reopen paths. Hashing a resolver
+  handle and then parsing the original path is a TOCTOU bug; imported scenarios
+  need a fully authorized staged graph or must be rejected.
 - ACES task and capture references deliberately do not carry digest/path fields
   in their typed reference models. Pin resolved byte digests in the internal
   admission journal or an ACES associated-artifact binding; do not add forbidden
@@ -373,9 +425,27 @@ version authority used by the fixtures and public APIs.
 - Current trace capture favors `.aptl/runs`, while configured CLI run storage
   can point elsewhere. Injection of one resolved `RunStorageBackend` is
   mandatory; hardcoding either root would split evidence again.
+- `LocalRunStore._run_dir()` currently follows an existing run-directory
+  symlink outside the configured base. The admitted-plan writer must not inherit
+  that escape, and plan IDs must not be disguised as run IDs.
 - `LocalRunStore.write_json` overwrites and is not canonical. Calling it twice
   is not an immutability guarantee, and bypassing it with `write_file` loses
   structural redaction.
+- At the locked ACES surface, the published reference processor manifest names
+  only `stub` as a compatible backend while APTL names
+  `aces-reference-processor` as compatible. Strict mutual apparatus-manifest
+  compatibility cannot be fabricated by patching either payload locally; fail
+  closed until the canonical ACES declaration and the requested task
+  constraints are mutually satisfiable.
+- `create_aptl_manifest().observation` is currently `None`, and the existing
+  collectors are best-effort primitives that often collapse failure into an
+  empty result. Do not admit a capture requirement merely because a collector
+  function exists. Capture-bearing inputs need one evidence-backed shared
+  capability mapping (and an honest manifest observation declaration where the
+  ACES authority requires it); otherwise they fail closed.
+- `render_aces_diagnostics()` currently labels every failure as an ACES runtime
+  handoff failure. Reuse its formatting logic only after making the safe stage
+  label explicit; do not emit misleading admission errors.
 - A plan generated with timestamps, absolute paths, Python set/dict traversal,
   `random`, or UUIDs can look stable in one test process and still drift across
   hosts or retries.
@@ -408,6 +478,8 @@ version authority used by the fixtures and public APIs.
   hierarchy, diagnostic DTO, readiness taxonomy, or workflow state machine.
 - Resolving references after the first trial starts or reopening a path after
   hashing it.
+- Letting `parse_sdl_file` or SDL import expansion bypass the authorized
+  resolver after the root artifact was pinned.
 - Treating a digest as optional when bytes can affect execution, or treating an
   image tag/path/URI as immutable identity.
 - Passing input strings to `getattr`, `importlib`, `subprocess`, shell, Docker,
@@ -418,6 +490,8 @@ version authority used by the fixtures and public APIs.
   error envelopes.
 - Replanning a trial at execution time and accepting a plan that differs from
   the persisted digest.
+- Storing a plan as a synthetic run, adding a fake run manifest, or silently
+  redacting identity-bearing plan values during persistence.
 - Using exporter filtering, file permissions, `.gitignore`, or an offline flag
   as a substitute for admission-time containment, authorization, and redaction.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,6 +171,7 @@ nav:
     - ADR-044 ACES-Aligned Run Reproducibility Record: adrs/adr-044-aces-aligned-run-reproducibility-record.md
     - ADR-045 Ephemeral Lifecycle Policy Enforcement: adrs/adr-045-ephemeral-lifecycle-policy-enforcement.md
     - ADR-046 Dynamic ACES Scenario Realization: adrs/adr-046-dynamic-aces-scenario-realization.md
+    - ADR-047 ACES Experiment Admission and Trial-Plan Boundary: adrs/adr-047-aces-experiment-admission-and-trial-plan-boundary.md
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "opentelemetry-semantic-conventions>=0.54b0",
     "cryptography>=42.0.0",
     "aces-sdl>=0.23.1,<0.24.0",
+    "rfc8785>=0.1.4,<0.2.0",
 ]
 
 [project.urls]

--- a/src/aptl/backends/aces_diagnostics.py
+++ b/src/aptl/backends/aces_diagnostics.py
@@ -14,6 +14,7 @@ from aptl.backends.aces_observation import ObservedResource
 from aptl.utils.redaction import redact
 
 PROVISIONING_ADDRESS = "runtime.apply.provisioning"
+DEFAULT_STAGE_LABEL = "ACES runtime handoff failed"
 SUPPORTED_RESOURCE_TYPES = frozenset(
     {
         "network",
@@ -43,14 +44,25 @@ def has_error(diagnostics: list[Diagnostic]) -> bool:
     return any(item.is_error for item in diagnostics)
 
 
-def render_aces_diagnostics(diagnostics: list[Diagnostic]) -> str:
-    """Render ACES diagnostics into the APTL ``LabResult`` error surface."""
+def render_aces_diagnostics(
+    diagnostics: list[Diagnostic], *, stage_label: str = DEFAULT_STAGE_LABEL
+) -> str:
+    """Render ACES diagnostics into the APTL ``LabResult`` error surface.
+
+    ``stage_label`` names the failing phase and defaults to the original
+    hard-coded ``"ACES runtime handoff failed"`` prefix, so every existing
+    caller is unchanged. ADR-047's error envelope reuses this same
+    formatter for the experiment-admission failure surface by passing a
+    distinct label (e.g. ``"ACES experiment admission failed"``) instead of
+    adding a second formatter — do not misclassify admission as a
+    startup-readiness warning by leaving the default label in place there.
+    """
     if not diagnostics:
-        return "ACES runtime handoff failed."
+        return f"{stage_label}."
     rendered = [_format_diagnostic(item) for item in diagnostics if item.is_error]
     if not rendered:
         rendered = [_format_diagnostic(item) for item in diagnostics]
-    return redact("ACES runtime handoff failed: " + "; ".join(rendered[:5]))
+    return redact(f"{stage_label}: " + "; ".join(rendered[:5]))
 
 
 def unsupported_resource_diagnostics(

--- a/src/aptl/cli/experiment.py
+++ b/src/aptl/cli/experiment.py
@@ -14,9 +14,11 @@ no CLI surface here.
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Iterable
 from pathlib import Path
 
 import typer
+from aces_contracts.diagnostics import Diagnostic
 
 from aptl.backends.aces_diagnostics import render_aces_diagnostics
 from aptl.cli._common import resolve_run_store
@@ -31,7 +33,7 @@ log = get_logger("cli.experiment")
 app = typer.Typer(help="ACES experiment admission (EXP-002).")
 
 
-def _print_diagnostics(diagnostics) -> None:
+def _print_diagnostics(diagnostics: Iterable[Diagnostic]) -> None:
     """Render already-safe diagnostics to stderr via the shared formatter."""
     typer.echo(
         render_aces_diagnostics(list(diagnostics), stage_label=EXPERIMENT_ADMISSION_STAGE_LABEL),
@@ -58,7 +60,10 @@ def admit(
         Path("."),
         "--base-dir",
         "-d",
-        help="Containment boundary every relative locator (spec, manifest, and its bound artifacts) is resolved against.",
+        help=(
+            "Containment boundary every relative locator (spec, manifest, and its bound "
+            "artifacts) is resolved against."
+        ),
     ),
     allow_uncertified_apparatus: bool = typer.Option(
         False,

--- a/src/aptl/cli/experiment.py
+++ b/src/aptl/cli/experiment.py
@@ -1,0 +1,133 @@
+"""CLI for ACES experiment admission (ADR-047 "Experiment-controller
+boundary", EXP-002 / issue #438).
+
+This module exposes ONLY the admission phase — ``aptl experiment admit``
+resolves the authoring-input spec and its associated-artifact manifest,
+runs :class:`~aptl.core.experiment.controller.ExperimentController`, and
+prints the result. It never starts the lab: it does not import
+``aptl.core.lab``, ``DeploymentBackend``, ``.env`` hydration, or any other
+range-mutating entry point (ADR-047 "Range-mutation gate"). EXECUTION
+(running an admitted plan's trials) is downstream work (#437/#459) and has
+no CLI surface here.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import typer
+
+from aptl.backends.aces_diagnostics import render_aces_diagnostics
+from aptl.cli._common import resolve_run_store
+from aptl.core.experiment.controller import ExperimentController
+from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_STAGE_LABEL, AdmissionRejection
+from aptl.core.experiment.policy import default_admission_policy
+from aptl.core.experiment.resolver import ProjectContainedResolver, parse_locator
+from aptl.utils.logging import get_logger
+
+log = get_logger("cli.experiment")
+
+app = typer.Typer(help="ACES experiment admission (EXP-002).")
+
+
+def _print_diagnostics(diagnostics) -> None:
+    """Render already-safe diagnostics to stderr via the shared formatter."""
+    typer.echo(
+        render_aces_diagnostics(list(diagnostics), stage_label=EXPERIMENT_ADMISSION_STAGE_LABEL),
+        err=True,
+    )
+
+
+@app.command("admit")
+def admit(
+    spec_path: str = typer.Argument(
+        ...,
+        help="Experiment authoring-input document, as a project-relative locator resolved against --base-dir.",
+    ),
+    manifest: str = typer.Option(
+        ...,
+        "--manifest",
+        help=(
+            "Associated-artifact manifest (project-relative locator, resolved against --base-dir) "
+            "that binds the experiment's task/scenario/capture-spec references to project files. "
+            "Required: reference resolution has no other source."
+        ),
+    ),
+    base_dir: Path = typer.Option(
+        Path("."),
+        "--base-dir",
+        "-d",
+        help="Containment boundary every relative locator (spec, manifest, and its bound artifacts) is resolved against.",
+    ),
+    allow_uncertified_apparatus: bool = typer.Option(
+        False,
+        "--allow-uncertified-apparatus",
+        help=(
+            "DEBUG/DEV ONLY — do NOT use in production. Bypasses the strict backend/processor "
+            "mutual-compatibility gate, downgrading it to a warning instead of a rejection."
+        ),
+    ),
+) -> None:
+    """Admit an ACES experiment (ADR-047) without starting the lab.
+
+    Runs ADMISSION ONLY: bounded artifact resolution, ACES validation and
+    planning, apparatus/capture capability checks, and create-once
+    persistence of the resulting immutable trial plan. This command never
+    hydrates ``.env``, generates credentials or certificates, pulls images,
+    or otherwise mutates the range — that is downstream EXECUTION work.
+
+    On rejection, prints safe diagnostics (no raw exception text, no input
+    values, no paths) to stderr and exits 1. On admission, prints the plan
+    identity, trial count/IDs, the persisted path, and any warnings, and
+    exits 0.
+    """
+    try:
+        policy = default_admission_policy()
+        if allow_uncertified_apparatus:
+            policy = dataclasses.replace(policy, allow_uncertified_apparatus=True)
+
+        try:
+            resolver = ProjectContainedResolver(base_dir=base_dir)
+            locator = parse_locator(spec_path, address="spec_path")
+            experiment_root = resolver.resolve(locator, policy=policy)
+        except AdmissionRejection as exc:
+            _print_diagnostics(exc.diagnostics)
+            raise typer.Exit(code=1)
+
+        store = resolve_run_store(base_dir)
+        controller = ExperimentController(run_store=store, policy=policy)
+
+        result = controller.admit(
+            experiment_root=experiment_root,
+            base_dir=base_dir,
+            manifest_locator=manifest,
+        )
+
+        if not result.admitted:
+            _print_diagnostics(result.diagnostics)
+            raise typer.Exit(code=1)
+
+        typer.echo(f"Admitted plan {result.plan.plan_id}")
+        typer.echo(f"  digest:    {result.plan_digest}")
+        typer.echo(f"  trials:    {len(result.trial_ids)}")
+        for trial_id in result.trial_ids:
+            typer.echo(f"    - {trial_id}")
+        typer.echo(f"  persisted: {result.persisted_path}")
+
+        if result.warnings:
+            typer.echo("")
+            typer.echo(
+                render_aces_diagnostics(list(result.warnings), stage_label=EXPERIMENT_ADMISSION_STAGE_LABEL)
+            )
+    except typer.Exit:
+        raise
+    except Exception:
+        # Defense in depth: every documented admission failure is already
+        # returned as safe diagnostics (rejected AdmissionResult) or caught
+        # above (AdmissionRejection from the root-locator resolve step).
+        # Anything else reaching here is unexpected — never surface a raw
+        # exception message, stack trace, or path to the caller.
+        log.exception("unexpected error during experiment admission")
+        typer.echo("Error: experiment admission failed unexpectedly.", err=True)
+        raise typer.Exit(code=1)

--- a/src/aptl/cli/main.py
+++ b/src/aptl/cli/main.py
@@ -5,7 +5,7 @@ from typing import Optional
 import typer
 
 import aptl
-from aptl.cli import config, container, kill, lab, runs, web
+from aptl.cli import config, container, experiment, kill, lab, runs, web
 
 app = typer.Typer(
     name="aptl",
@@ -19,6 +19,7 @@ app.add_typer(container.app, name="container")
 app.add_typer(runs.app, name="runs")
 app.add_typer(web.app, name="web")
 app.add_typer(kill.app, name="kill")
+app.add_typer(experiment.app, name="experiment")
 
 
 def _version_callback(value: bool) -> None:

--- a/src/aptl/core/experiment/__init__.py
+++ b/src/aptl/core/experiment/__init__.py
@@ -1,0 +1,10 @@
+"""ACES experiment admission input layer (ADR-047, EXP-002 / issue #438).
+
+Deliberately empty. Downstream code imports the concrete submodules
+directly (``aptl.core.experiment.errors``, ``.policy``, ``.resolver``,
+``.spec_loading``, ...) rather than re-exporting everything from this
+package's ``__init__``, so parallel admission-slice work lands in its own
+module without every stage fighting over one shared export surface.
+"""
+
+from __future__ import annotations

--- a/src/aptl/core/experiment/admission.py
+++ b/src/aptl/core/experiment/admission.py
@@ -3,8 +3,13 @@ boundary", Stage 5 / EXP-002 / issue #438).
 
 This module wires the previously-landed Stage 1-4 modules
 (``errors``, ``policy``, ``resolver``, ``spec_loading``, ``apparatus``,
-``capture_mapping``, ``trial_plan``) into one all-or-nothing admission
-sequence: :func:`admit_experiment`. It performs ONLY:
+``capture_mapping``, ``trial_plan``) — plus this stage's own
+:mod:`aptl.core.experiment.admission_artifacts` (artifact-source
+implementations) and :mod:`aptl.core.experiment.admission_steps`
+(cross-artifact joins, per-condition planning, source-set projection),
+split out to keep this module under the 500-line budget — into one
+all-or-nothing admission sequence: :func:`admit_experiment`. It performs
+ONLY:
 
 * bounded, hardened loading of the ACES experiment graph (root, task,
   scenario, capture specs) from resolver-owned bytes;
@@ -40,67 +45,66 @@ dataclass reads back as the field's default, not a separate name). The
 ``.admitted: bool`` shape discriminator is the more heavily used contract
 (every caller branches on it), so it wins; the ADMITTED-side constructor is
 named :meth:`AdmissionResult.admit` instead.
+
+Public import surface (also relied on by ``controller.py`` and tests):
+``admit_experiment``, ``AdmissionResult``, ``ResolvedArtifact``,
+``ResolvedArtifactSource``, ``MappingArtifactSource``,
+``build_associated_artifact_source`` — ``ResolvedArtifact`` is defined in
+:mod:`aptl.core.experiment.resolver`, the other three re-exported names are
+defined in :mod:`aptl.core.experiment.admission_artifacts`; all are
+re-exported here.
 """
 
 from __future__ import annotations
 
-import io
 import json
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
 
 from aces_backend_protocols.manifest import BackendManifest
-from aces_contracts.associated_artifacts import (
-    AssociatedArtifactManifestModel,
-    AssociatedArtifactValidationLimits,
-    load_associated_artifact_manifest_json,
-    validate_associated_artifact_manifest,
-)
-from aces_contracts.contracts import ExperimentCaptureSpecModel, ExperimentReferenceModel
 from aces_contracts.diagnostics import Diagnostic
-from aces_contracts.experiment_spec import ExperimentSpecModel
 from aces_processor.capabilities import ProcessorManifest
 from aces_processor.manifest import create_reference_processor_manifest
-from aces_sdl import SDLInstantiationError
-from aces_sdl.canonical import canonical_instantiated_sdl_digest
-from aces_sdl.instantiate import instantiate_scenario
 
 from aptl.backends.aces_manifest import create_aptl_manifest
-from aptl.core.experiment.apparatus import check_apparatus_admission, plan_condition_feasibility, require_feasible_plan
+from aptl.core.experiment.admission_artifacts import (
+    MappingArtifactSource,
+    ResolvedArtifactSource,
+    build_associated_artifact_source,
+)
+from aptl.core.experiment.admission_steps import (
+    CaptureResolution,
+    ScenarioResolution,
+    TaskResolution,
+    _build_source_set_projection,
+    _check_scenario_identity,
+    _check_task_identity,
+    _effective_scenario_ref,
+    _plan_conditions,
+    _resolve_capture_specs,
+)
+from aptl.core.experiment.apparatus import check_apparatus_admission
 from aptl.core.experiment.capture_mapping import map_capture_requirements
-from aptl.core.experiment.errors import AdmissionRejection, diagnostic, normalize_aces_failure
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic
 from aptl.core.experiment.policy import AdmissionPolicy
-from aptl.core.experiment.resolver import (
-    ProjectContainedResolver,
-    ProjectFileLocator,
-    ResolvedArtifact,
-    parse_locator,
-)
-from aptl.core.experiment.spec_loading import (
-    load_capture_spec,
-    load_experiment_root,
-    load_task,
-    parse_scenario_bytes,
-)
+from aptl.core.experiment.resolver import ResolvedArtifact
+from aptl.core.experiment.spec_loading import load_experiment_root, load_task, parse_scenario_bytes
 from aptl.core.experiment.trial_plan import TrialPlan, compute_source_set_digest, expand_trial_plan
 from aptl.core.runstore import RunStorageBackend
 from aptl.utils.pathsafe import PathContainmentError
 
-_ADDRESS_TASK_REF = "task_ref"
-_ADDRESS_SCENARIO_REF = "intended_scenario_ref"
-_ADDRESS_CAPTURE_SPEC_REFS = "capture_spec_refs"
+__all__ = [
+    "AdmissionResult",
+    "MappingArtifactSource",
+    "ResolvedArtifact",
+    "ResolvedArtifactSource",
+    "admit_experiment",
+    "build_associated_artifact_source",
+]
+
 _ADDRESS_PLAN_PERSISTENCE = "trial_plan.persistence"
 
-_CODE_ARTIFACT_SOURCE_UNRESOLVED = "aptl.experiment-admission.artifact-source-unresolved"
-_CODE_REF_IDENTITY_MISMATCH = "aptl.experiment-admission.reference-identity-mismatch"
-_CODE_TASK_SCENARIO_MISMATCH = "aptl.experiment-admission.task-scenario-ref-mismatch"
-_CODE_SCENARIO_DIGEST_MISMATCH = "aptl.experiment-admission.scenario-ref-digest-mismatch"
-_CODE_DUPLICATE_CAPTURE_REF = "aptl.experiment-admission.capture-spec-ref-duplicate"
-_CODE_CAPTURE_SCOPE_MISMATCH = "aptl.experiment-admission.capture-scope-mismatch"
-_CODE_CONDITION_INSTANTIATION_FAILED = "aptl.experiment-admission.condition-instantiation-failed"
-_CODE_ASSOCIATED_ARTIFACT_MANIFEST_INVALID = "aptl.experiment-admission.associated-artifact-manifest-invalid"
 _CODE_PERSISTENCE_FAILED = "aptl.experiment-admission.plan-persistence-failed"
 _CODE_PERSISTED_PLAN_MISMATCH = "aptl.experiment-admission.persisted-plan-digest-mismatch"
 
@@ -150,6 +154,7 @@ class AdmissionResult:
 
     @classmethod
     def rejected(cls, diagnostics: Iterable[Diagnostic]) -> AdmissionResult:
+        """Build a REJECTED result carrying diagnostics and no plan."""
         return cls(admitted=False, diagnostics=tuple(diagnostics))
 
     @classmethod
@@ -162,6 +167,7 @@ class AdmissionResult:
         trial_ids: Iterable[str],
         warnings: Iterable[Diagnostic] = (),
     ) -> AdmissionResult:
+        """Build an ADMITTED result carrying the persisted plan, its digest/path, and any warnings."""
         return cls(
             admitted=True,
             plan=plan,
@@ -173,361 +179,17 @@ class AdmissionResult:
 
 
 # ---------------------------------------------------------------------------
-# ResolvedArtifactSource
-# ---------------------------------------------------------------------------
-
-
-class ResolvedArtifactSource(Protocol):
-    """The injectable seam admission resolves ``task_ref``/
-    ``intended_scenario_ref`` (or ``task.scenario_ref``)/``capture_spec_refs``
-    through — never a raw path admission could reopen.
-    """
-
-    def artifact_for(self, ref: ExperimentReferenceModel) -> ResolvedArtifact: ...
-
-
-def _unresolved(ref: ExperimentReferenceModel) -> AdmissionRejection:
-    return AdmissionRejection(
-        (
-            diagnostic(
-                _CODE_ARTIFACT_SOURCE_UNRESOLVED,
-                f"artifact_source.{ref.ref_kind}",
-                "no artifact is bound for this reference identity",
-            ),
-        )
-    )
-
-
-@dataclass(frozen=True)
-class MappingArtifactSource:
-    """A simple in-memory :class:`ResolvedArtifactSource` (``ref_id ->
-    ResolvedArtifact``) for tests — no filesystem, no ACES associated-
-    artifact manifest. Production admission uses
-    :func:`build_associated_artifact_source` instead.
-    """
-
-    artifacts: Mapping[str, ResolvedArtifact]
-
-    def artifact_for(self, ref: ExperimentReferenceModel) -> ResolvedArtifact:
-        try:
-            return self.artifacts[ref.ref_id]
-        except KeyError:
-            raise _unresolved(ref) from None
-
-
-def build_associated_artifact_source(
-    base_dir: Path,
-    manifest_relative_path: str,
-    spec: ExperimentSpecModel,
-    policy: AdmissionPolicy,
-) -> ResolvedArtifactSource:
-    """Build the production :class:`ResolvedArtifactSource`.
-
-    The ADR-blessed binding: an ACES associated-artifact manifest anchored
-    to the authoring-input ``spec`` (``parent_ref.ref_kind ==
-    "authoring-input"``) binds each artifact's ``artifact_id`` -> a
-    project-relative ``uri`` plus declared ``size_bytes``/``checksum`` — by
-    APTL convention, ``artifact_id`` IS the ACES reference's ``ref_id`` it
-    binds (``spec.task_ref.ref_id``, ``spec.intended_scenario_ref.ref_id``
-    or ``task.scenario_ref.ref_id``, each ``capture_spec_refs[].ref_id``).
-    Every declared artifact is resolved via :class:`ProjectContainedResolver`
-    (offline, no-follow, bounded, digest-verified), then the WHOLE manifest
-    is validated in one shot through ``validate_associated_artifact_manifest``
-    (identity, set-digest, per-artifact size/checksum) before anything is
-    handed back — a validation failure anywhere rejects the whole source,
-    never a partial binding.
-
-    ``spec`` must already be the ACES-validated authoring-input model (the
-    controller parses ``experiment_root.data`` once to build this source,
-    before ``admit_experiment`` parses the same bytes again as its own step
-    1 — a harmless repeat of one pure, deterministic public loader call,
-    not a second trust boundary: :func:`admit_experiment`'s contracted
-    signature takes an already-built :class:`ResolvedArtifactSource`, so
-    there is no way to thread ``spec`` through to here except by resolving
-    it once for this purpose).
-    """
-    resolver = ProjectContainedResolver(base_dir=base_dir)
-
-    manifest_locator = parse_locator(manifest_relative_path, address="associated_artifact_manifest")
-    manifest_artifact = resolver.resolve(manifest_locator, policy=policy)
-
-    try:
-        manifest: AssociatedArtifactManifestModel = load_associated_artifact_manifest_json(
-            manifest_artifact.data
-        )
-    except (ValueError, TypeError) as exc:
-        raise AdmissionRejection(
-            normalize_aces_failure(
-                exc,
-                address="associated_artifact_manifest",
-                code=_CODE_ASSOCIATED_ARTIFACT_MANIFEST_INVALID,
-            )
-        ) from exc
-
-    resolved_by_artifact_id: dict[str, ResolvedArtifact] = {}
-    readers: dict[str, io.BytesIO] = {}
-    for artifact_id, artifact_ref in manifest.artifacts.items():
-        # ACES requires `uri` to be an absolute URI (a scheme is mandatory —
-        # see `aces_contracts.contracts._validate_associated_artifact_uri`),
-        # so a project-relative binding is authored as `file:<relative
-        # path>`. `parse_locator` extracts and re-validates the relative
-        # path (scheme/traversal/NUL-byte checks); the declared
-        # size/digest come from the associated-artifact model's own
-        # structured `size_bytes`/`checksum` fields, not from a query
-        # string (the URI carries none).
-        address = f"associated_artifact_manifest.artifacts.{artifact_id}"
-        parsed_locator = parse_locator(artifact_ref.uri, address=address)
-        locator = ProjectFileLocator(
-            relative_path=parsed_locator.relative_path,
-            declared_size=artifact_ref.size_bytes,
-            declared_digest=f"{artifact_ref.checksum.algorithm}:{artifact_ref.checksum.value}",
-            media_type=artifact_ref.media_type,
-        )
-        resolved = resolver.resolve(locator, policy=policy)
-        resolved_by_artifact_id[artifact_id] = resolved
-        readers[artifact_id] = io.BytesIO(resolved.data)
-
-    validation_diagnostics = validate_associated_artifact_manifest(
-        manifest,
-        parent=spec,
-        artifact_readers=readers,
-        limits=AssociatedArtifactValidationLimits(
-            max_artifacts=policy.max_reference_count,
-            max_artifact_bytes=policy.max_artifact_bytes,
-            max_total_bytes=policy.max_aggregate_bytes,
-        ),
-    )
-    errors = tuple(item for item in validation_diagnostics if item.is_error)
-    if errors:
-        raise AdmissionRejection(errors)
-
-    return MappingArtifactSource(artifacts=resolved_by_artifact_id)
-
-
-# ---------------------------------------------------------------------------
 # admit_experiment
 # ---------------------------------------------------------------------------
 
 
 def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    """Build a one-diagnostic AdmissionRejection for a plan-persistence failure."""
     return AdmissionRejection((diagnostic(code, address, message),))
 
 
-def _check_task_identity(spec: ExperimentSpecModel, task) -> None:
-    if task.task_id != spec.task_ref.ref_id:
-        raise _reject(
-            _CODE_REF_IDENTITY_MISMATCH,
-            f"{_ADDRESS_TASK_REF}.ref_id",
-            "resolved task identity does not match spec.task_ref",
-        )
-    if spec.task_ref.ref_version is not None and task.task_version != spec.task_ref.ref_version:
-        raise _reject(
-            _CODE_REF_IDENTITY_MISMATCH,
-            f"{_ADDRESS_TASK_REF}.ref_version",
-            "resolved task version does not match spec.task_ref",
-        )
-
-
-def _effective_scenario_ref(spec: ExperimentSpecModel, task) -> ExperimentReferenceModel:
-    """Return the scenario reference to resolve, cross-checking agreement
-    between ``spec.intended_scenario_ref`` and ``task.scenario_ref`` when
-    the spec supplies one (ADR-047 "task/scenario agreement")."""
-    if spec.intended_scenario_ref is None:
-        return task.scenario_ref
-
-    intended = spec.intended_scenario_ref
-    from_task = task.scenario_ref
-    if intended.ref_id != from_task.ref_id:
-        raise _reject(
-            _CODE_TASK_SCENARIO_MISMATCH,
-            f"{_ADDRESS_SCENARIO_REF}.ref_id",
-            "spec.intended_scenario_ref does not agree with task.scenario_ref",
-        )
-    if (
-        intended.ref_version is not None
-        and from_task.ref_version is not None
-        and intended.ref_version != from_task.ref_version
-    ):
-        raise _reject(
-            _CODE_TASK_SCENARIO_MISMATCH,
-            f"{_ADDRESS_SCENARIO_REF}.ref_version",
-            "spec.intended_scenario_ref version does not agree with task.scenario_ref",
-        )
-    if (
-        intended.ref_digest is not None
-        and from_task.ref_digest is not None
-        and intended.ref_digest.casefold() != from_task.ref_digest.casefold()
-    ):
-        raise _reject(
-            _CODE_TASK_SCENARIO_MISMATCH,
-            f"{_ADDRESS_SCENARIO_REF}.ref_digest",
-            "spec.intended_scenario_ref digest does not agree with task.scenario_ref",
-        )
-    return intended
-
-
-def _check_scenario_identity(effective_ref: ExperimentReferenceModel, scenario, canonical_digest) -> None:
-    if scenario.name != effective_ref.ref_id:
-        raise _reject(
-            _CODE_REF_IDENTITY_MISMATCH,
-            f"{_ADDRESS_SCENARIO_REF}.ref_id",
-            "resolved scenario identity does not match the scenario reference",
-        )
-    if effective_ref.ref_version is not None and scenario.version != effective_ref.ref_version:
-        raise _reject(
-            _CODE_REF_IDENTITY_MISMATCH,
-            f"{_ADDRESS_SCENARIO_REF}.ref_version",
-            "resolved scenario version does not match the scenario reference",
-        )
-    if effective_ref.ref_digest is not None and canonical_digest.value.casefold() != effective_ref.ref_digest.casefold():
-        raise _reject(
-            _CODE_SCENARIO_DIGEST_MISMATCH,
-            f"{_ADDRESS_SCENARIO_REF}.ref_digest",
-            "resolved scenario canonical digest does not match the pinned scenario reference",
-        )
-
-
-def _resolve_capture_specs(
-    spec: ExperimentSpecModel, task, artifact_source: ResolvedArtifactSource, *, policy: AdmissionPolicy
-) -> tuple[list[ExperimentCaptureSpecModel], list[ResolvedArtifact]]:
-    seen_ids: set[str] = set()
-    for ref in spec.capture_spec_refs:
-        if ref.ref_id in seen_ids:
-            raise _reject(
-                _CODE_DUPLICATE_CAPTURE_REF,
-                _ADDRESS_CAPTURE_SPEC_REFS,
-                "capture_spec_refs contains a duplicate reference identity",
-            )
-        seen_ids.add(ref.ref_id)
-
-    capture_specs = []
-    capture_artifacts: list[ResolvedArtifact] = []
-    for ref in spec.capture_spec_refs:
-        artifact = artifact_source.artifact_for(ref)
-        capture_spec = load_capture_spec(artifact.data, policy=policy)
-
-        if capture_spec.capture_spec_id != ref.ref_id:
-            raise _reject(
-                _CODE_REF_IDENTITY_MISMATCH,
-                f"{_ADDRESS_CAPTURE_SPEC_REFS}.{ref.ref_id}",
-                "resolved capture-spec identity does not match its reference",
-            )
-        if ref.ref_version is not None and capture_spec.spec_version != ref.ref_version:
-            raise _reject(
-                _CODE_REF_IDENTITY_MISMATCH,
-                f"{_ADDRESS_CAPTURE_SPEC_REFS}.{ref.ref_id}.ref_version",
-                "resolved capture-spec version does not match its reference",
-            )
-
-        task_scope_match = any(
-            scope.ref_kind == "task"
-            and scope.ref_id == task.task_id
-            and (scope.ref_version is None or scope.ref_version == task.task_version)
-            for scope in capture_spec.scope_refs
-        )
-        if not task_scope_match:
-            raise _reject(
-                _CODE_CAPTURE_SCOPE_MISMATCH,
-                f"capture_spec.{capture_spec.capture_spec_id}.scope_refs",
-                "capture spec scope_refs do not include the admitted task",
-            )
-
-        capture_specs.append(capture_spec)
-        capture_artifacts.append(artifact)
-
-    return capture_specs, capture_artifacts
-
-
-def _instantiate_for_digest(scenario, parameters: Mapping[str, object], *, address: str):
-    try:
-        return instantiate_scenario(scenario, parameters)
-    except SDLInstantiationError as exc:
-        raise AdmissionRejection(
-            normalize_aces_failure(exc, address=address, code=_CODE_CONDITION_INSTANTIATION_FAILED)
-        ) from exc
-
-
-def _plan_conditions(
-    spec: ExperimentSpecModel, scenario, *, backend_manifest: BackendManifest
-) -> tuple[dict[str, str], str | None]:
-    """Run the planning-only ACES reference processor over every unique
-    condition binding (flat allocation: one empty binding) and derive each
-    binding's canonical instantiated-scenario digest.
-
-    Returns ``(condition_snapshot_digests, flat_instantiated_digest)`` — the
-    former threaded into :func:`~aptl.core.experiment.trial_plan.
-    expand_trial_plan` for a condition allocation, the latter folded into
-    the source-set projection for a flat allocation (``trial_plan``'s own
-    flat expander never attaches a per-trial snapshot digest, so a flat
-    plan's one instantiated identity has nowhere else structural to live).
-    """
-    condition_snapshot_digests: dict[str, str] = {}
-    flat_instantiated_digest: str | None = None
-
-    if spec.run_plan.allocation is not None:
-        allocation = spec.run_plan.allocation
-        for condition_id in allocation.compared_conditions:
-            assignment = allocation.condition_assignments[condition_id]
-            parameters = {p.name: p.value for p in assignment.required_parameters}
-            address = f"run_plan.allocation.condition_assignments.{condition_id}"
-
-            result = plan_condition_feasibility(scenario, parameters, backend_manifest=backend_manifest)
-            require_feasible_plan(result, address=address)
-
-            instantiated = _instantiate_for_digest(scenario, parameters, address=address)
-            condition_snapshot_digests[condition_id] = canonical_instantiated_sdl_digest(instantiated).value
-    else:
-        parameters = {}
-        result = plan_condition_feasibility(scenario, parameters, backend_manifest=backend_manifest)
-        require_feasible_plan(result, address="run_plan")
-
-        instantiated = _instantiate_for_digest(scenario, parameters, address="run_plan")
-        flat_instantiated_digest = canonical_instantiated_sdl_digest(instantiated).value
-
-    return condition_snapshot_digests, flat_instantiated_digest
-
-
-def _build_source_set_projection(
-    *,
-    spec: ExperimentSpecModel,
-    task,
-    task_artifact: ResolvedArtifact,
-    effective_scenario_ref: ExperimentReferenceModel,
-    scenario,
-    scenario_artifact: ResolvedArtifact,
-    scenario_canonical_digest,
-    capture_specs,
-    capture_artifacts: list[ResolvedArtifact],
-    flat_instantiated_digest: str | None,
-) -> dict[str, object]:
-    projection: dict[str, object] = {
-        "schema": "aptl-experiment-source-set/v1",
-        "task": {
-            "task_id": task.task_id,
-            "task_version": task.task_version,
-            "resolved_digest": task_artifact.digest,
-        },
-        "scenario": {
-            "ref_kind": effective_scenario_ref.ref_kind,
-            "ref_id": scenario.name,
-            "scenario_version": scenario.version,
-            "resolved_digest": scenario_artifact.digest,
-            "canonical_digest": scenario_canonical_digest.value,
-        },
-        "capture_specs": {
-            capture_spec.capture_spec_id: {
-                "spec_version": capture_spec.spec_version,
-                "resolved_digest": artifact.digest,
-            }
-            for capture_spec, artifact in zip(capture_specs, capture_artifacts, strict=True)
-        },
-    }
-    if flat_instantiated_digest is not None:
-        projection["flat_instantiated_scenario_digest"] = flat_instantiated_digest
-    return projection
-
-
 def _persist_plan(plan: TrialPlan, *, run_store: RunStorageBackend) -> Path:
+    """Create-once persist plan's canonical bytes and re-verify the written bytes match exactly."""
     payload = json.loads(plan.canonical_bytes)
     try:
         persisted_path = run_store.create_json_once("experiment-plans", plan.plan_id, payload)
@@ -559,6 +221,7 @@ def _admit_experiment_inner(
     backend_manifest: BackendManifest,
     processor_manifest: ProcessorManifest,
 ) -> AdmissionResult:
+    """Run the full admission sequence once; raises AdmissionRejection on any fail-closed gap."""
     # Step 1: root.
     spec = load_experiment_root(experiment_root.data, policy=policy)
 
@@ -595,15 +258,14 @@ def _admit_experiment_inner(
 
     # Step 7: source-set projection + digest.
     source_set_projection = _build_source_set_projection(
-        spec=spec,
-        task=task,
-        task_artifact=task_artifact,
-        effective_scenario_ref=effective_scenario_ref,
-        scenario=scenario,
-        scenario_artifact=scenario_artifact,
-        scenario_canonical_digest=scenario_canonical_digest,
-        capture_specs=capture_specs,
-        capture_artifacts=capture_artifacts,
+        task=TaskResolution(task=task, artifact=task_artifact),
+        scenario=ScenarioResolution(
+            effective_ref=effective_scenario_ref,
+            scenario=scenario,
+            artifact=scenario_artifact,
+            canonical_digest=scenario_canonical_digest,
+        ),
+        capture=CaptureResolution(specs=capture_specs, artifacts=capture_artifacts),
         flat_instantiated_digest=flat_instantiated_digest,
     )
     source_set_digest = compute_source_set_digest(source_set_projection)

--- a/src/aptl/core/experiment/admission.py
+++ b/src/aptl/core/experiment/admission.py
@@ -1,0 +1,673 @@
+"""The ACES experiment admission coordinator (ADR-047 "Experiment-controller
+boundary", Stage 5 / EXP-002 / issue #438).
+
+This module wires the previously-landed Stage 1-4 modules
+(``errors``, ``policy``, ``resolver``, ``spec_loading``, ``apparatus``,
+``capture_mapping``, ``trial_plan``) into one all-or-nothing admission
+sequence: :func:`admit_experiment`. It performs ONLY:
+
+* bounded, hardened loading of the ACES experiment graph (root, task,
+  scenario, capture specs) from resolver-owned bytes;
+* cross-artifact identity/version joins between those already-validated
+  ACES objects;
+* apparatus and capture capability admission;
+* planning-only per-condition feasibility plus the canonical
+  instantiated-scenario digest ACES itself derives;
+* pure, deterministic trial-plan expansion; and
+* create-once, digest-reverified persistence of the resulting plan via the
+  injected ``RunStorageBackend``.
+
+ADR-047 "Range-mutation gate": nothing here calls ``.env`` hydration,
+``EnvVars``, key/cert generation, rendered service config, volume seeding,
+image pulls, a collector, a session, or any ``DeploymentBackend`` method.
+Admission is read-only and offline except for its own final, narrow,
+create-once write of the admitted plan.
+
+``admit_experiment`` never raises :class:`~aptl.core.experiment.errors.
+AdmissionRejection` to its own caller — every rejection anywhere in the
+sequence is caught internally and converted into
+``AdmissionResult.rejected(diagnostics)``, matching the ADR's "one-shot
+result, not a parallel workflow engine" rule (rejected: diagnostics and no
+plan; admitted: immutable plan bytes, identity, and trial tuple — nothing
+in between).
+
+Naming note: the driving spec for this stage asked for a classmethod named
+``AdmissionResult.admitted(...)`` alongside an ``.admitted: bool`` instance
+field with the SAME name. That is not expressible on one Python class (a
+``@dataclass`` field named ``admitted`` and a class-body ``def admitted``
+in the same class body collide — the method definition becomes what
+dataclass reads back as the field's default, not a separate name). The
+``.admitted: bool`` shape discriminator is the more heavily used contract
+(every caller branches on it), so it wins; the ADMITTED-side constructor is
+named :meth:`AdmissionResult.admit` instead.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from aces_backend_protocols.manifest import BackendManifest
+from aces_contracts.associated_artifacts import (
+    AssociatedArtifactManifestModel,
+    AssociatedArtifactValidationLimits,
+    load_associated_artifact_manifest_json,
+    validate_associated_artifact_manifest,
+)
+from aces_contracts.contracts import ExperimentCaptureSpecModel, ExperimentReferenceModel
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.experiment_spec import ExperimentSpecModel
+from aces_processor.capabilities import ProcessorManifest
+from aces_processor.manifest import create_reference_processor_manifest
+from aces_sdl import SDLInstantiationError
+from aces_sdl.canonical import canonical_instantiated_sdl_digest
+from aces_sdl.instantiate import instantiate_scenario
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.apparatus import check_apparatus_admission, plan_condition_feasibility, require_feasible_plan
+from aptl.core.experiment.capture_mapping import map_capture_requirements
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic, normalize_aces_failure
+from aptl.core.experiment.policy import AdmissionPolicy
+from aptl.core.experiment.resolver import (
+    ProjectContainedResolver,
+    ProjectFileLocator,
+    ResolvedArtifact,
+    parse_locator,
+)
+from aptl.core.experiment.spec_loading import (
+    load_capture_spec,
+    load_experiment_root,
+    load_task,
+    parse_scenario_bytes,
+)
+from aptl.core.experiment.trial_plan import TrialPlan, compute_source_set_digest, expand_trial_plan
+from aptl.core.runstore import RunStorageBackend
+from aptl.utils.pathsafe import PathContainmentError
+
+_ADDRESS_TASK_REF = "task_ref"
+_ADDRESS_SCENARIO_REF = "intended_scenario_ref"
+_ADDRESS_CAPTURE_SPEC_REFS = "capture_spec_refs"
+_ADDRESS_PLAN_PERSISTENCE = "trial_plan.persistence"
+
+_CODE_ARTIFACT_SOURCE_UNRESOLVED = "aptl.experiment-admission.artifact-source-unresolved"
+_CODE_REF_IDENTITY_MISMATCH = "aptl.experiment-admission.reference-identity-mismatch"
+_CODE_TASK_SCENARIO_MISMATCH = "aptl.experiment-admission.task-scenario-ref-mismatch"
+_CODE_SCENARIO_DIGEST_MISMATCH = "aptl.experiment-admission.scenario-ref-digest-mismatch"
+_CODE_DUPLICATE_CAPTURE_REF = "aptl.experiment-admission.capture-spec-ref-duplicate"
+_CODE_CAPTURE_SCOPE_MISMATCH = "aptl.experiment-admission.capture-scope-mismatch"
+_CODE_CONDITION_INSTANTIATION_FAILED = "aptl.experiment-admission.condition-instantiation-failed"
+_CODE_ASSOCIATED_ARTIFACT_MANIFEST_INVALID = "aptl.experiment-admission.associated-artifact-manifest-invalid"
+_CODE_PERSISTENCE_FAILED = "aptl.experiment-admission.plan-persistence-failed"
+_CODE_PERSISTED_PLAN_MISMATCH = "aptl.experiment-admission.persisted-plan-digest-mismatch"
+
+
+# ---------------------------------------------------------------------------
+# AdmissionResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AdmissionResult:
+    """The one-shot outcome of :func:`admit_experiment`.
+
+    Two disjoint shapes (ADR-047 "Persistence and state model": "a one-shot
+    result, not a parallel workflow engine"):
+
+    * REJECTED — ``admitted is False``, ``diagnostics`` non-empty, every
+      plan-related field ``None``.
+    * ADMITTED — ``admitted is True``, ``plan``/``plan_digest``/
+      ``persisted_path`` all set, ``diagnostics`` empty (``warnings`` may be
+      non-empty — e.g. the ``allow_uncertified_apparatus`` debug override).
+
+    ``__post_init__`` enforces this split structurally so a rejected result
+    can NEVER carry a plan, even if a future caller misuses the plain
+    constructor instead of :meth:`rejected`/:meth:`admit`.
+    """
+
+    admitted: bool
+    diagnostics: tuple[Diagnostic, ...] = ()
+    plan: TrialPlan | None = None
+    plan_digest: str | None = None
+    persisted_path: Path | None = None
+    warnings: tuple[Diagnostic, ...] = ()
+    trial_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.admitted:
+            if self.plan is None or self.plan_digest is None or self.persisted_path is None:
+                raise ValueError(
+                    "an admitted AdmissionResult must carry plan, plan_digest, and persisted_path"
+                )
+        else:
+            if self.plan is not None or self.plan_digest is not None or self.persisted_path is not None:
+                raise ValueError("a rejected AdmissionResult must never carry a plan")
+            if not self.diagnostics:
+                raise ValueError("a rejected AdmissionResult must carry at least one diagnostic")
+
+    @classmethod
+    def rejected(cls, diagnostics: Iterable[Diagnostic]) -> AdmissionResult:
+        return cls(admitted=False, diagnostics=tuple(diagnostics))
+
+    @classmethod
+    def admit(
+        cls,
+        *,
+        plan: TrialPlan,
+        plan_digest: str,
+        persisted_path: Path,
+        trial_ids: Iterable[str],
+        warnings: Iterable[Diagnostic] = (),
+    ) -> AdmissionResult:
+        return cls(
+            admitted=True,
+            plan=plan,
+            plan_digest=plan_digest,
+            persisted_path=persisted_path,
+            warnings=tuple(warnings),
+            trial_ids=tuple(trial_ids),
+        )
+
+
+# ---------------------------------------------------------------------------
+# ResolvedArtifactSource
+# ---------------------------------------------------------------------------
+
+
+class ResolvedArtifactSource(Protocol):
+    """The injectable seam admission resolves ``task_ref``/
+    ``intended_scenario_ref`` (or ``task.scenario_ref``)/``capture_spec_refs``
+    through — never a raw path admission could reopen.
+    """
+
+    def artifact_for(self, ref: ExperimentReferenceModel) -> ResolvedArtifact: ...
+
+
+def _unresolved(ref: ExperimentReferenceModel) -> AdmissionRejection:
+    return AdmissionRejection(
+        (
+            diagnostic(
+                _CODE_ARTIFACT_SOURCE_UNRESOLVED,
+                f"artifact_source.{ref.ref_kind}",
+                "no artifact is bound for this reference identity",
+            ),
+        )
+    )
+
+
+@dataclass(frozen=True)
+class MappingArtifactSource:
+    """A simple in-memory :class:`ResolvedArtifactSource` (``ref_id ->
+    ResolvedArtifact``) for tests — no filesystem, no ACES associated-
+    artifact manifest. Production admission uses
+    :func:`build_associated_artifact_source` instead.
+    """
+
+    artifacts: Mapping[str, ResolvedArtifact]
+
+    def artifact_for(self, ref: ExperimentReferenceModel) -> ResolvedArtifact:
+        try:
+            return self.artifacts[ref.ref_id]
+        except KeyError:
+            raise _unresolved(ref) from None
+
+
+def build_associated_artifact_source(
+    base_dir: Path,
+    manifest_relative_path: str,
+    spec: ExperimentSpecModel,
+    policy: AdmissionPolicy,
+) -> ResolvedArtifactSource:
+    """Build the production :class:`ResolvedArtifactSource`.
+
+    The ADR-blessed binding: an ACES associated-artifact manifest anchored
+    to the authoring-input ``spec`` (``parent_ref.ref_kind ==
+    "authoring-input"``) binds each artifact's ``artifact_id`` -> a
+    project-relative ``uri`` plus declared ``size_bytes``/``checksum`` — by
+    APTL convention, ``artifact_id`` IS the ACES reference's ``ref_id`` it
+    binds (``spec.task_ref.ref_id``, ``spec.intended_scenario_ref.ref_id``
+    or ``task.scenario_ref.ref_id``, each ``capture_spec_refs[].ref_id``).
+    Every declared artifact is resolved via :class:`ProjectContainedResolver`
+    (offline, no-follow, bounded, digest-verified), then the WHOLE manifest
+    is validated in one shot through ``validate_associated_artifact_manifest``
+    (identity, set-digest, per-artifact size/checksum) before anything is
+    handed back — a validation failure anywhere rejects the whole source,
+    never a partial binding.
+
+    ``spec`` must already be the ACES-validated authoring-input model (the
+    controller parses ``experiment_root.data`` once to build this source,
+    before ``admit_experiment`` parses the same bytes again as its own step
+    1 — a harmless repeat of one pure, deterministic public loader call,
+    not a second trust boundary: :func:`admit_experiment`'s contracted
+    signature takes an already-built :class:`ResolvedArtifactSource`, so
+    there is no way to thread ``spec`` through to here except by resolving
+    it once for this purpose).
+    """
+    resolver = ProjectContainedResolver(base_dir=base_dir)
+
+    manifest_locator = parse_locator(manifest_relative_path, address="associated_artifact_manifest")
+    manifest_artifact = resolver.resolve(manifest_locator, policy=policy)
+
+    try:
+        manifest: AssociatedArtifactManifestModel = load_associated_artifact_manifest_json(
+            manifest_artifact.data
+        )
+    except (ValueError, TypeError) as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(
+                exc,
+                address="associated_artifact_manifest",
+                code=_CODE_ASSOCIATED_ARTIFACT_MANIFEST_INVALID,
+            )
+        ) from exc
+
+    resolved_by_artifact_id: dict[str, ResolvedArtifact] = {}
+    readers: dict[str, io.BytesIO] = {}
+    for artifact_id, artifact_ref in manifest.artifacts.items():
+        # ACES requires `uri` to be an absolute URI (a scheme is mandatory —
+        # see `aces_contracts.contracts._validate_associated_artifact_uri`),
+        # so a project-relative binding is authored as `file:<relative
+        # path>`. `parse_locator` extracts and re-validates the relative
+        # path (scheme/traversal/NUL-byte checks); the declared
+        # size/digest come from the associated-artifact model's own
+        # structured `size_bytes`/`checksum` fields, not from a query
+        # string (the URI carries none).
+        address = f"associated_artifact_manifest.artifacts.{artifact_id}"
+        parsed_locator = parse_locator(artifact_ref.uri, address=address)
+        locator = ProjectFileLocator(
+            relative_path=parsed_locator.relative_path,
+            declared_size=artifact_ref.size_bytes,
+            declared_digest=f"{artifact_ref.checksum.algorithm}:{artifact_ref.checksum.value}",
+            media_type=artifact_ref.media_type,
+        )
+        resolved = resolver.resolve(locator, policy=policy)
+        resolved_by_artifact_id[artifact_id] = resolved
+        readers[artifact_id] = io.BytesIO(resolved.data)
+
+    validation_diagnostics = validate_associated_artifact_manifest(
+        manifest,
+        parent=spec,
+        artifact_readers=readers,
+        limits=AssociatedArtifactValidationLimits(
+            max_artifacts=policy.max_reference_count,
+            max_artifact_bytes=policy.max_artifact_bytes,
+            max_total_bytes=policy.max_aggregate_bytes,
+        ),
+    )
+    errors = tuple(item for item in validation_diagnostics if item.is_error)
+    if errors:
+        raise AdmissionRejection(errors)
+
+    return MappingArtifactSource(artifacts=resolved_by_artifact_id)
+
+
+# ---------------------------------------------------------------------------
+# admit_experiment
+# ---------------------------------------------------------------------------
+
+
+def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    return AdmissionRejection((diagnostic(code, address, message),))
+
+
+def _check_task_identity(spec: ExperimentSpecModel, task) -> None:
+    if task.task_id != spec.task_ref.ref_id:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_TASK_REF}.ref_id",
+            "resolved task identity does not match spec.task_ref",
+        )
+    if spec.task_ref.ref_version is not None and task.task_version != spec.task_ref.ref_version:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_TASK_REF}.ref_version",
+            "resolved task version does not match spec.task_ref",
+        )
+
+
+def _effective_scenario_ref(spec: ExperimentSpecModel, task) -> ExperimentReferenceModel:
+    """Return the scenario reference to resolve, cross-checking agreement
+    between ``spec.intended_scenario_ref`` and ``task.scenario_ref`` when
+    the spec supplies one (ADR-047 "task/scenario agreement")."""
+    if spec.intended_scenario_ref is None:
+        return task.scenario_ref
+
+    intended = spec.intended_scenario_ref
+    from_task = task.scenario_ref
+    if intended.ref_id != from_task.ref_id:
+        raise _reject(
+            _CODE_TASK_SCENARIO_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_id",
+            "spec.intended_scenario_ref does not agree with task.scenario_ref",
+        )
+    if (
+        intended.ref_version is not None
+        and from_task.ref_version is not None
+        and intended.ref_version != from_task.ref_version
+    ):
+        raise _reject(
+            _CODE_TASK_SCENARIO_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_version",
+            "spec.intended_scenario_ref version does not agree with task.scenario_ref",
+        )
+    if (
+        intended.ref_digest is not None
+        and from_task.ref_digest is not None
+        and intended.ref_digest.casefold() != from_task.ref_digest.casefold()
+    ):
+        raise _reject(
+            _CODE_TASK_SCENARIO_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_digest",
+            "spec.intended_scenario_ref digest does not agree with task.scenario_ref",
+        )
+    return intended
+
+
+def _check_scenario_identity(effective_ref: ExperimentReferenceModel, scenario, canonical_digest) -> None:
+    if scenario.name != effective_ref.ref_id:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_id",
+            "resolved scenario identity does not match the scenario reference",
+        )
+    if effective_ref.ref_version is not None and scenario.version != effective_ref.ref_version:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_version",
+            "resolved scenario version does not match the scenario reference",
+        )
+    if effective_ref.ref_digest is not None and canonical_digest.value.casefold() != effective_ref.ref_digest.casefold():
+        raise _reject(
+            _CODE_SCENARIO_DIGEST_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_digest",
+            "resolved scenario canonical digest does not match the pinned scenario reference",
+        )
+
+
+def _resolve_capture_specs(
+    spec: ExperimentSpecModel, task, artifact_source: ResolvedArtifactSource, *, policy: AdmissionPolicy
+) -> tuple[list[ExperimentCaptureSpecModel], list[ResolvedArtifact]]:
+    seen_ids: set[str] = set()
+    for ref in spec.capture_spec_refs:
+        if ref.ref_id in seen_ids:
+            raise _reject(
+                _CODE_DUPLICATE_CAPTURE_REF,
+                _ADDRESS_CAPTURE_SPEC_REFS,
+                "capture_spec_refs contains a duplicate reference identity",
+            )
+        seen_ids.add(ref.ref_id)
+
+    capture_specs = []
+    capture_artifacts: list[ResolvedArtifact] = []
+    for ref in spec.capture_spec_refs:
+        artifact = artifact_source.artifact_for(ref)
+        capture_spec = load_capture_spec(artifact.data, policy=policy)
+
+        if capture_spec.capture_spec_id != ref.ref_id:
+            raise _reject(
+                _CODE_REF_IDENTITY_MISMATCH,
+                f"{_ADDRESS_CAPTURE_SPEC_REFS}.{ref.ref_id}",
+                "resolved capture-spec identity does not match its reference",
+            )
+        if ref.ref_version is not None and capture_spec.spec_version != ref.ref_version:
+            raise _reject(
+                _CODE_REF_IDENTITY_MISMATCH,
+                f"{_ADDRESS_CAPTURE_SPEC_REFS}.{ref.ref_id}.ref_version",
+                "resolved capture-spec version does not match its reference",
+            )
+
+        task_scope_match = any(
+            scope.ref_kind == "task"
+            and scope.ref_id == task.task_id
+            and (scope.ref_version is None or scope.ref_version == task.task_version)
+            for scope in capture_spec.scope_refs
+        )
+        if not task_scope_match:
+            raise _reject(
+                _CODE_CAPTURE_SCOPE_MISMATCH,
+                f"capture_spec.{capture_spec.capture_spec_id}.scope_refs",
+                "capture spec scope_refs do not include the admitted task",
+            )
+
+        capture_specs.append(capture_spec)
+        capture_artifacts.append(artifact)
+
+    return capture_specs, capture_artifacts
+
+
+def _instantiate_for_digest(scenario, parameters: Mapping[str, object], *, address: str):
+    try:
+        return instantiate_scenario(scenario, parameters)
+    except SDLInstantiationError as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(exc, address=address, code=_CODE_CONDITION_INSTANTIATION_FAILED)
+        ) from exc
+
+
+def _plan_conditions(
+    spec: ExperimentSpecModel, scenario, *, backend_manifest: BackendManifest
+) -> tuple[dict[str, str], str | None]:
+    """Run the planning-only ACES reference processor over every unique
+    condition binding (flat allocation: one empty binding) and derive each
+    binding's canonical instantiated-scenario digest.
+
+    Returns ``(condition_snapshot_digests, flat_instantiated_digest)`` — the
+    former threaded into :func:`~aptl.core.experiment.trial_plan.
+    expand_trial_plan` for a condition allocation, the latter folded into
+    the source-set projection for a flat allocation (``trial_plan``'s own
+    flat expander never attaches a per-trial snapshot digest, so a flat
+    plan's one instantiated identity has nowhere else structural to live).
+    """
+    condition_snapshot_digests: dict[str, str] = {}
+    flat_instantiated_digest: str | None = None
+
+    if spec.run_plan.allocation is not None:
+        allocation = spec.run_plan.allocation
+        for condition_id in allocation.compared_conditions:
+            assignment = allocation.condition_assignments[condition_id]
+            parameters = {p.name: p.value for p in assignment.required_parameters}
+            address = f"run_plan.allocation.condition_assignments.{condition_id}"
+
+            result = plan_condition_feasibility(scenario, parameters, backend_manifest=backend_manifest)
+            require_feasible_plan(result, address=address)
+
+            instantiated = _instantiate_for_digest(scenario, parameters, address=address)
+            condition_snapshot_digests[condition_id] = canonical_instantiated_sdl_digest(instantiated).value
+    else:
+        parameters = {}
+        result = plan_condition_feasibility(scenario, parameters, backend_manifest=backend_manifest)
+        require_feasible_plan(result, address="run_plan")
+
+        instantiated = _instantiate_for_digest(scenario, parameters, address="run_plan")
+        flat_instantiated_digest = canonical_instantiated_sdl_digest(instantiated).value
+
+    return condition_snapshot_digests, flat_instantiated_digest
+
+
+def _build_source_set_projection(
+    *,
+    spec: ExperimentSpecModel,
+    task,
+    task_artifact: ResolvedArtifact,
+    effective_scenario_ref: ExperimentReferenceModel,
+    scenario,
+    scenario_artifact: ResolvedArtifact,
+    scenario_canonical_digest,
+    capture_specs,
+    capture_artifacts: list[ResolvedArtifact],
+    flat_instantiated_digest: str | None,
+) -> dict[str, object]:
+    projection: dict[str, object] = {
+        "schema": "aptl-experiment-source-set/v1",
+        "task": {
+            "task_id": task.task_id,
+            "task_version": task.task_version,
+            "resolved_digest": task_artifact.digest,
+        },
+        "scenario": {
+            "ref_kind": effective_scenario_ref.ref_kind,
+            "ref_id": scenario.name,
+            "scenario_version": scenario.version,
+            "resolved_digest": scenario_artifact.digest,
+            "canonical_digest": scenario_canonical_digest.value,
+        },
+        "capture_specs": {
+            capture_spec.capture_spec_id: {
+                "spec_version": capture_spec.spec_version,
+                "resolved_digest": artifact.digest,
+            }
+            for capture_spec, artifact in zip(capture_specs, capture_artifacts, strict=True)
+        },
+    }
+    if flat_instantiated_digest is not None:
+        projection["flat_instantiated_scenario_digest"] = flat_instantiated_digest
+    return projection
+
+
+def _persist_plan(plan: TrialPlan, *, run_store: RunStorageBackend) -> Path:
+    payload = json.loads(plan.canonical_bytes)
+    try:
+        persisted_path = run_store.create_json_once("experiment-plans", plan.plan_id, payload)
+    except (PathContainmentError, ValueError) as exc:
+        # SecretInvariantError / RunStoreConflictError are ValueError
+        # subclasses; caught here without restating them.
+        raise _reject(
+            _CODE_PERSISTENCE_FAILED,
+            _ADDRESS_PLAN_PERSISTENCE,
+            "trial plan could not be persisted",
+        ) from exc
+
+    persisted_bytes = persisted_path.read_bytes()
+    if persisted_bytes != plan.canonical_bytes:
+        raise _reject(
+            _CODE_PERSISTED_PLAN_MISMATCH,
+            _ADDRESS_PLAN_PERSISTENCE,
+            "persisted plan bytes do not match the computed plan digest",
+        )
+    return persisted_path
+
+
+def _admit_experiment_inner(
+    *,
+    experiment_root: ResolvedArtifact,
+    artifact_source: ResolvedArtifactSource,
+    run_store: RunStorageBackend,
+    policy: AdmissionPolicy,
+    backend_manifest: BackendManifest,
+    processor_manifest: ProcessorManifest,
+) -> AdmissionResult:
+    # Step 1: root.
+    spec = load_experiment_root(experiment_root.data, policy=policy)
+
+    # Step 2: resolve + load task, scenario, capture specs. Pin digests.
+    task_artifact = artifact_source.artifact_for(spec.task_ref)
+    task = load_task(task_artifact.data, policy=policy)
+
+    effective_scenario_ref = _effective_scenario_ref(spec, task)
+    scenario_artifact = artifact_source.artifact_for(effective_scenario_ref)
+    scenario, scenario_canonical_digest = parse_scenario_bytes(scenario_artifact.data, policy=policy)
+
+    capture_specs, capture_artifacts = _resolve_capture_specs(spec, task, artifact_source, policy=policy)
+
+    # Step 3: cross-artifact joins.
+    _check_task_identity(spec, task)
+    _check_scenario_identity(effective_scenario_ref, scenario, scenario_canonical_digest)
+
+    # Step 4: apparatus admission.
+    warnings = check_apparatus_admission(
+        task,
+        spec.apparatus_intent,
+        backend_manifest=backend_manifest,
+        processor_manifest=processor_manifest,
+        policy=policy,
+    )
+
+    # Step 5: capture-requirement mapping (fail-closed; empty w/o refs).
+    map_capture_requirements(capture_specs, backend_manifest=backend_manifest, policy=policy)
+
+    # Step 6: per-condition planning-only feasibility + snapshot digests.
+    condition_snapshot_digests, flat_instantiated_digest = _plan_conditions(
+        spec, scenario, backend_manifest=backend_manifest
+    )
+
+    # Step 7: source-set projection + digest.
+    source_set_projection = _build_source_set_projection(
+        spec=spec,
+        task=task,
+        task_artifact=task_artifact,
+        effective_scenario_ref=effective_scenario_ref,
+        scenario=scenario,
+        scenario_artifact=scenario_artifact,
+        scenario_canonical_digest=scenario_canonical_digest,
+        capture_specs=capture_specs,
+        capture_artifacts=capture_artifacts,
+        flat_instantiated_digest=flat_instantiated_digest,
+    )
+    source_set_digest = compute_source_set_digest(source_set_projection)
+
+    # Step 8: pure trial-plan expansion.
+    plan = expand_trial_plan(
+        spec,
+        source_set_digest=source_set_digest,
+        condition_snapshot_digests=condition_snapshot_digests or None,
+        policy=policy,
+    )
+
+    # Step 9: create-once persistence + digest re-verification.
+    persisted_path = _persist_plan(plan, run_store=run_store)
+
+    # Step 10.
+    return AdmissionResult.admit(
+        plan=plan,
+        plan_digest=plan.plan_digest,
+        persisted_path=persisted_path,
+        warnings=warnings,
+        trial_ids=tuple(trial.planned_trial_id for trial in plan.trials),
+    )
+
+
+def admit_experiment(
+    *,
+    experiment_root: ResolvedArtifact,
+    artifact_source: ResolvedArtifactSource,
+    run_store: RunStorageBackend,
+    policy: AdmissionPolicy,
+    backend_manifest: BackendManifest | None = None,
+    processor_manifest: ProcessorManifest | None = None,
+) -> AdmissionResult:
+    """Run ADR-047 admission for one experiment-authoring-input document.
+
+    ALL-OR-NOTHING: any :class:`~aptl.core.experiment.errors.
+    AdmissionRejection` raised anywhere in the sequence — by this function's
+    own cross-artifact joins or by any Stage 1-4 module it calls — is
+    caught here and converted to ``AdmissionResult.rejected(diagnostics)``.
+    Nothing is persisted and no range mutation occurs on a rejected path;
+    this function never calls ``.env`` hydration, ``EnvVars``, key/cert
+    generation, a collector, a session, or any ``DeploymentBackend`` method
+    at all, admitted or rejected (that is downstream EXECUTION work — see
+    :class:`aptl.core.experiment.controller.ExperimentController`).
+
+    A retry with the SAME admitted inputs recomputes the same deterministic
+    plan (same ``plan_id``/``plan_digest``/``canonical_bytes``) and
+    ``run_store.create_json_once`` treats the byte-identical existing
+    target as idempotent success — this function does not special-case
+    retries itself.
+    """
+    resolved_backend = backend_manifest if backend_manifest is not None else create_aptl_manifest()
+    resolved_processor = (
+        processor_manifest if processor_manifest is not None else create_reference_processor_manifest()
+    )
+    try:
+        return _admit_experiment_inner(
+            experiment_root=experiment_root,
+            artifact_source=artifact_source,
+            run_store=run_store,
+            policy=policy,
+            backend_manifest=resolved_backend,
+            processor_manifest=resolved_processor,
+        )
+    except AdmissionRejection as exc:
+        return AdmissionResult.rejected(exc.diagnostics)

--- a/src/aptl/core/experiment/admission_artifacts.py
+++ b/src/aptl/core/experiment/admission_artifacts.py
@@ -1,0 +1,178 @@
+"""Artifact-source implementations for ACES experiment admission (ADR-047
+"Experiment-controller boundary", Stage 5 / EXP-002 / issue #438).
+
+Split out of :mod:`aptl.core.experiment.admission` to keep that module
+under the 500-line budget (``python:S104``). ``ResolvedArtifactSource``,
+``MappingArtifactSource``, and ``build_associated_artifact_source`` are
+re-exported from ``admission`` for the public import surface (tests and
+``controller.py`` import them from ``aptl.core.experiment.admission``);
+this module is the implementation home, not a second public entry point.
+
+Two implementations of the ``ResolvedArtifactSource`` seam admission
+resolves ``task_ref``/``intended_scenario_ref``/``capture_spec_refs``
+through:
+
+* :class:`MappingArtifactSource` — a simple in-memory mapping, for tests.
+* :func:`build_associated_artifact_source` — the production binding, via an
+  ACES associated-artifact manifest anchored to the authoring-input spec.
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from aces_contracts.associated_artifacts import (
+    AssociatedArtifactManifestModel,
+    AssociatedArtifactValidationLimits,
+    load_associated_artifact_manifest_json,
+    validate_associated_artifact_manifest,
+)
+from aces_contracts.contracts import ExperimentReferenceModel
+from aces_contracts.experiment_spec import ExperimentSpecModel
+
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic, normalize_aces_failure
+from aptl.core.experiment.policy import AdmissionPolicy
+from aptl.core.experiment.resolver import (
+    ProjectContainedResolver,
+    ProjectFileLocator,
+    ResolvedArtifact,
+    parse_locator,
+)
+
+_CODE_ARTIFACT_SOURCE_UNRESOLVED = "aptl.experiment-admission.artifact-source-unresolved"
+_CODE_ASSOCIATED_ARTIFACT_MANIFEST_INVALID = "aptl.experiment-admission.associated-artifact-manifest-invalid"
+
+
+class ResolvedArtifactSource(Protocol):
+    """The injectable seam admission resolves ``task_ref``/
+    ``intended_scenario_ref`` (or ``task.scenario_ref``)/``capture_spec_refs``
+    through — never a raw path admission could reopen.
+    """
+
+    def artifact_for(self, ref: ExperimentReferenceModel) -> ResolvedArtifact:
+        """Return the bound artifact for ref's reference identity, or raise AdmissionRejection."""
+        ...
+
+
+def _unresolved(ref: ExperimentReferenceModel) -> AdmissionRejection:
+    """Build the fail-closed rejection for a reference with no bound artifact."""
+    return AdmissionRejection(
+        (
+            diagnostic(
+                _CODE_ARTIFACT_SOURCE_UNRESOLVED,
+                f"artifact_source.{ref.ref_kind}",
+                "no artifact is bound for this reference identity",
+            ),
+        )
+    )
+
+
+@dataclass(frozen=True)
+class MappingArtifactSource:
+    """A simple in-memory :class:`ResolvedArtifactSource` (``ref_id ->
+    ResolvedArtifact``) for tests — no filesystem, no ACES associated-
+    artifact manifest. Production admission uses
+    :func:`build_associated_artifact_source` instead.
+    """
+
+    artifacts: Mapping[str, ResolvedArtifact]
+
+    def artifact_for(self, ref: ExperimentReferenceModel) -> ResolvedArtifact:
+        """Return the mapped artifact for ref.ref_id, or raise the unresolved rejection."""
+        try:
+            return self.artifacts[ref.ref_id]
+        except KeyError:
+            raise _unresolved(ref) from None
+
+
+def build_associated_artifact_source(
+    base_dir: Path,
+    manifest_relative_path: str,
+    spec: ExperimentSpecModel,
+    policy: AdmissionPolicy,
+) -> ResolvedArtifactSource:
+    """Build the production :class:`ResolvedArtifactSource`.
+
+    The ADR-blessed binding: an ACES associated-artifact manifest anchored
+    to the authoring-input ``spec`` (``parent_ref.ref_kind ==
+    "authoring-input"``) binds each artifact's ``artifact_id`` -> a
+    project-relative ``uri`` plus declared ``size_bytes``/``checksum`` — by
+    APTL convention, ``artifact_id`` IS the ACES reference's ``ref_id`` it
+    binds (``spec.task_ref.ref_id``, ``spec.intended_scenario_ref.ref_id``
+    or ``task.scenario_ref.ref_id``, each ``capture_spec_refs[].ref_id``).
+    Every declared artifact is resolved via :class:`ProjectContainedResolver`
+    (offline, no-follow, bounded, digest-verified), then the WHOLE manifest
+    is validated in one shot through ``validate_associated_artifact_manifest``
+    (identity, set-digest, per-artifact size/checksum) before anything is
+    handed back — a validation failure anywhere rejects the whole source,
+    never a partial binding.
+
+    ``spec`` must already be the ACES-validated authoring-input model (the
+    controller parses ``experiment_root.data`` once to build this source,
+    before ``admit_experiment`` parses the same bytes again as its own step
+    1 — a harmless repeat of one pure, deterministic public loader call,
+    not a second trust boundary: :func:`admit_experiment`'s contracted
+    signature takes an already-built :class:`ResolvedArtifactSource`, so
+    there is no way to thread ``spec`` through to here except by resolving
+    it once for this purpose).
+    """
+    resolver = ProjectContainedResolver(base_dir=base_dir)
+
+    manifest_locator = parse_locator(manifest_relative_path, address="associated_artifact_manifest")
+    manifest_artifact = resolver.resolve(manifest_locator, policy=policy)
+
+    try:
+        manifest: AssociatedArtifactManifestModel = load_associated_artifact_manifest_json(
+            manifest_artifact.data
+        )
+    except (ValueError, TypeError) as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(
+                exc,
+                address="associated_artifact_manifest",
+                code=_CODE_ASSOCIATED_ARTIFACT_MANIFEST_INVALID,
+            )
+        ) from exc
+
+    resolved_by_artifact_id: dict[str, ResolvedArtifact] = {}
+    readers: dict[str, io.BytesIO] = {}
+    for artifact_id, artifact_ref in manifest.artifacts.items():
+        # ACES requires `uri` to be an absolute URI (a scheme is mandatory —
+        # see `aces_contracts.contracts._validate_associated_artifact_uri`),
+        # so a project-relative binding is authored as `file:<relative
+        # path>`. `parse_locator` extracts and re-validates the relative
+        # path (scheme/traversal/NUL-byte checks); the declared
+        # size/digest come from the associated-artifact model's own
+        # structured `size_bytes`/`checksum` fields, not from a query
+        # string (the URI carries none).
+        address = f"associated_artifact_manifest.artifacts.{artifact_id}"
+        parsed_locator = parse_locator(artifact_ref.uri, address=address)
+        locator = ProjectFileLocator(
+            relative_path=parsed_locator.relative_path,
+            declared_size=artifact_ref.size_bytes,
+            declared_digest=f"{artifact_ref.checksum.algorithm}:{artifact_ref.checksum.value}",
+            media_type=artifact_ref.media_type,
+        )
+        resolved = resolver.resolve(locator, policy=policy)
+        resolved_by_artifact_id[artifact_id] = resolved
+        readers[artifact_id] = io.BytesIO(resolved.data)
+
+    validation_diagnostics = validate_associated_artifact_manifest(
+        manifest,
+        parent=spec,
+        artifact_readers=readers,
+        limits=AssociatedArtifactValidationLimits(
+            max_artifacts=policy.max_reference_count,
+            max_artifact_bytes=policy.max_artifact_bytes,
+            max_total_bytes=policy.max_aggregate_bytes,
+        ),
+    )
+    errors = tuple(item for item in validation_diagnostics if item.is_error)
+    if errors:
+        raise AdmissionRejection(errors)
+
+    return MappingArtifactSource(artifacts=resolved_by_artifact_id)

--- a/src/aptl/core/experiment/admission_steps.py
+++ b/src/aptl/core/experiment/admission_steps.py
@@ -1,0 +1,333 @@
+"""Cross-artifact identity joins, per-condition planning-only feasibility,
+and source-set projection for ACES experiment admission (ADR-047
+"Experiment-controller boundary", Stage 5 / EXP-002 / issue #438).
+
+Split out of :mod:`aptl.core.experiment.admission` to keep that module
+under the 500-line budget (``python:S104``). Everything here is called
+exclusively from ``admission._admit_experiment_inner`` — unlike
+:mod:`aptl.core.experiment.admission_artifacts`, nothing in this module is
+re-exported from ``aptl.core.experiment.admission``; it is an internal
+implementation detail of the admission sequence, not a second public entry
+point.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from aces_backend_protocols.manifest import BackendManifest
+from aces_contracts.contracts import ExperimentCaptureSpecModel, ExperimentReferenceModel, ExperimentTaskModel
+from aces_contracts.experiment_spec import ExperimentSpecModel
+from aces_sdl import SDLInstantiationError
+from aces_sdl.canonical import SDLCanonicalDigest, canonical_instantiated_sdl_digest
+from aces_sdl.instantiate import instantiate_scenario
+from aces_sdl.scenario import InstantiatedScenario, Scenario
+
+from aptl.core.experiment.admission_artifacts import ResolvedArtifactSource
+from aptl.core.experiment.apparatus import plan_condition_feasibility, require_feasible_plan
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic, normalize_aces_failure
+from aptl.core.experiment.policy import AdmissionPolicy
+from aptl.core.experiment.resolver import ResolvedArtifact
+from aptl.core.experiment.spec_loading import load_capture_spec
+
+_ADDRESS_TASK_REF = "task_ref"
+_ADDRESS_SCENARIO_REF = "intended_scenario_ref"
+_ADDRESS_CAPTURE_SPEC_REFS = "capture_spec_refs"
+
+_CODE_REF_IDENTITY_MISMATCH = "aptl.experiment-admission.reference-identity-mismatch"
+_CODE_TASK_SCENARIO_MISMATCH = "aptl.experiment-admission.task-scenario-ref-mismatch"
+_CODE_SCENARIO_DIGEST_MISMATCH = "aptl.experiment-admission.scenario-ref-digest-mismatch"
+_CODE_DUPLICATE_CAPTURE_REF = "aptl.experiment-admission.capture-spec-ref-duplicate"
+_CODE_CAPTURE_SCOPE_MISMATCH = "aptl.experiment-admission.capture-scope-mismatch"
+_CODE_CONDITION_INSTANTIATION_FAILED = "aptl.experiment-admission.condition-instantiation-failed"
+
+
+def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    """Build a one-diagnostic AdmissionRejection for a cross-artifact-join or condition-planning failure."""
+    return AdmissionRejection((diagnostic(code, address, message),))
+
+
+# ---------------------------------------------------------------------------
+# Cross-artifact identity joins
+# ---------------------------------------------------------------------------
+
+
+def _check_task_identity(spec: ExperimentSpecModel, task: ExperimentTaskModel) -> None:
+    """Reject when the resolved task's identity/version does not match spec.task_ref."""
+    if task.task_id != spec.task_ref.ref_id:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_TASK_REF}.ref_id",
+            "resolved task identity does not match spec.task_ref",
+        )
+    if spec.task_ref.ref_version is not None and task.task_version != spec.task_ref.ref_version:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_TASK_REF}.ref_version",
+            "resolved task version does not match spec.task_ref",
+        )
+
+
+def _effective_scenario_ref(spec: ExperimentSpecModel, task: ExperimentTaskModel) -> ExperimentReferenceModel:
+    """Return the scenario reference to resolve, cross-checking agreement
+    between ``spec.intended_scenario_ref`` and ``task.scenario_ref`` when
+    the spec supplies one (ADR-047 "task/scenario agreement")."""
+    if spec.intended_scenario_ref is None:
+        return task.scenario_ref
+
+    intended = spec.intended_scenario_ref
+    from_task = task.scenario_ref
+    if intended.ref_id != from_task.ref_id:
+        raise _reject(
+            _CODE_TASK_SCENARIO_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_id",
+            "spec.intended_scenario_ref does not agree with task.scenario_ref",
+        )
+    if (
+        intended.ref_version is not None
+        and from_task.ref_version is not None
+        and intended.ref_version != from_task.ref_version
+    ):
+        raise _reject(
+            _CODE_TASK_SCENARIO_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_version",
+            "spec.intended_scenario_ref version does not agree with task.scenario_ref",
+        )
+    if (
+        intended.ref_digest is not None
+        and from_task.ref_digest is not None
+        and intended.ref_digest.casefold() != from_task.ref_digest.casefold()
+    ):
+        raise _reject(
+            _CODE_TASK_SCENARIO_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_digest",
+            "spec.intended_scenario_ref digest does not agree with task.scenario_ref",
+        )
+    return intended
+
+
+def _check_scenario_identity(
+    effective_ref: ExperimentReferenceModel, scenario: Scenario, canonical_digest: SDLCanonicalDigest
+) -> None:
+    """Reject when the resolved scenario's identity/version/canonical digest does not match effective_ref."""
+    if scenario.name != effective_ref.ref_id:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_id",
+            "resolved scenario identity does not match the scenario reference",
+        )
+    if effective_ref.ref_version is not None and scenario.version != effective_ref.ref_version:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_version",
+            "resolved scenario version does not match the scenario reference",
+        )
+    if (
+        effective_ref.ref_digest is not None
+        and canonical_digest.value.casefold() != effective_ref.ref_digest.casefold()
+    ):
+        raise _reject(
+            _CODE_SCENARIO_DIGEST_MISMATCH,
+            f"{_ADDRESS_SCENARIO_REF}.ref_digest",
+            "resolved scenario canonical digest does not match the pinned scenario reference",
+        )
+
+
+def _reject_duplicate_capture_spec_refs(spec: ExperimentSpecModel) -> None:
+    """Raise when spec.capture_spec_refs contains a duplicate reference identity."""
+    seen_ids: set[str] = set()
+    for ref in spec.capture_spec_refs:
+        if ref.ref_id in seen_ids:
+            raise _reject(
+                _CODE_DUPLICATE_CAPTURE_REF,
+                _ADDRESS_CAPTURE_SPEC_REFS,
+                "capture_spec_refs contains a duplicate reference identity",
+            )
+        seen_ids.add(ref.ref_id)
+
+
+def _capture_spec_task_scope_match(capture_spec: ExperimentCaptureSpecModel, task: ExperimentTaskModel) -> bool:
+    """Return whether capture_spec.scope_refs includes the admitted task's identity/version."""
+    return any(
+        scope.ref_kind == "task"
+        and scope.ref_id == task.task_id
+        and (scope.ref_version is None or scope.ref_version == task.task_version)
+        for scope in capture_spec.scope_refs
+    )
+
+
+def _resolve_one_capture_spec(
+    ref: ExperimentReferenceModel,
+    task: ExperimentTaskModel,
+    artifact_source: ResolvedArtifactSource,
+    *,
+    policy: AdmissionPolicy,
+) -> tuple[ExperimentCaptureSpecModel, ResolvedArtifact]:
+    """Resolve, load, and identity/scope-check one capture-spec reference."""
+    artifact = artifact_source.artifact_for(ref)
+    capture_spec = load_capture_spec(artifact.data, policy=policy)
+
+    if capture_spec.capture_spec_id != ref.ref_id:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_CAPTURE_SPEC_REFS}.{ref.ref_id}",
+            "resolved capture-spec identity does not match its reference",
+        )
+    if ref.ref_version is not None and capture_spec.spec_version != ref.ref_version:
+        raise _reject(
+            _CODE_REF_IDENTITY_MISMATCH,
+            f"{_ADDRESS_CAPTURE_SPEC_REFS}.{ref.ref_id}.ref_version",
+            "resolved capture-spec version does not match its reference",
+        )
+    if not _capture_spec_task_scope_match(capture_spec, task):
+        raise _reject(
+            _CODE_CAPTURE_SCOPE_MISMATCH,
+            f"capture_spec.{capture_spec.capture_spec_id}.scope_refs",
+            "capture spec scope_refs do not include the admitted task",
+        )
+
+    return capture_spec, artifact
+
+
+def _resolve_capture_specs(
+    spec: ExperimentSpecModel,
+    task: ExperimentTaskModel,
+    artifact_source: ResolvedArtifactSource,
+    *,
+    policy: AdmissionPolicy,
+) -> tuple[list[ExperimentCaptureSpecModel], list[ResolvedArtifact]]:
+    """Resolve, load, and identity/scope-check every capture-spec reference in spec."""
+    _reject_duplicate_capture_spec_refs(spec)
+
+    capture_specs: list[ExperimentCaptureSpecModel] = []
+    capture_artifacts: list[ResolvedArtifact] = []
+    for ref in spec.capture_spec_refs:
+        capture_spec, artifact = _resolve_one_capture_spec(ref, task, artifact_source, policy=policy)
+        capture_specs.append(capture_spec)
+        capture_artifacts.append(artifact)
+
+    return capture_specs, capture_artifacts
+
+
+# ---------------------------------------------------------------------------
+# Per-condition planning-only feasibility
+# ---------------------------------------------------------------------------
+
+
+def _instantiate_for_digest(
+    scenario: Scenario, parameters: Mapping[str, object], *, address: str
+) -> InstantiatedScenario:
+    """Instantiate scenario under parameters, normalizing a structurally-broken binding into AdmissionRejection."""
+    try:
+        return instantiate_scenario(scenario, parameters)
+    except SDLInstantiationError as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(exc, address=address, code=_CODE_CONDITION_INSTANTIATION_FAILED)
+        ) from exc
+
+
+def _plan_conditions(
+    spec: ExperimentSpecModel, scenario: Scenario, *, backend_manifest: BackendManifest
+) -> tuple[dict[str, str], str | None]:
+    """Run the planning-only ACES reference processor over every unique
+    condition binding (flat allocation: one empty binding) and derive each
+    binding's canonical instantiated-scenario digest.
+
+    Returns ``(condition_snapshot_digests, flat_instantiated_digest)`` — the
+    former threaded into :func:`~aptl.core.experiment.trial_plan.
+    expand_trial_plan` for a condition allocation, the latter folded into
+    the source-set projection for a flat allocation (``trial_plan``'s own
+    flat expander never attaches a per-trial snapshot digest, so a flat
+    plan's one instantiated identity has nowhere else structural to live).
+    """
+    condition_snapshot_digests: dict[str, str] = {}
+    flat_instantiated_digest: str | None = None
+
+    if spec.run_plan.allocation is not None:
+        allocation = spec.run_plan.allocation
+        for condition_id in allocation.compared_conditions:
+            assignment = allocation.condition_assignments[condition_id]
+            parameters = {p.name: p.value for p in assignment.required_parameters}
+            address = f"run_plan.allocation.condition_assignments.{condition_id}"
+
+            result = plan_condition_feasibility(scenario, parameters, backend_manifest=backend_manifest)
+            require_feasible_plan(result, address=address)
+
+            instantiated = _instantiate_for_digest(scenario, parameters, address=address)
+            condition_snapshot_digests[condition_id] = canonical_instantiated_sdl_digest(instantiated).value
+    else:
+        parameters = {}
+        result = plan_condition_feasibility(scenario, parameters, backend_manifest=backend_manifest)
+        require_feasible_plan(result, address="run_plan")
+
+        instantiated = _instantiate_for_digest(scenario, parameters, address="run_plan")
+        flat_instantiated_digest = canonical_instantiated_sdl_digest(instantiated).value
+
+    return condition_snapshot_digests, flat_instantiated_digest
+
+
+# ---------------------------------------------------------------------------
+# Source-set projection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TaskResolution:
+    """The resolved task model plus its source artifact, for source-set projection."""
+
+    task: ExperimentTaskModel
+    artifact: ResolvedArtifact
+
+
+@dataclass(frozen=True)
+class ScenarioResolution:
+    """The resolved scenario, its effective ref, source artifact, and canonical digest, for source-set projection."""
+
+    effective_ref: ExperimentReferenceModel
+    scenario: Scenario
+    artifact: ResolvedArtifact
+    canonical_digest: SDLCanonicalDigest
+
+
+@dataclass(frozen=True)
+class CaptureResolution:
+    """The resolved capture specs paired with their source artifacts, for source-set projection."""
+
+    specs: list[ExperimentCaptureSpecModel]
+    artifacts: list[ResolvedArtifact]
+
+
+def _build_source_set_projection(
+    *,
+    task: TaskResolution,
+    scenario: ScenarioResolution,
+    capture: CaptureResolution,
+    flat_instantiated_digest: str | None,
+) -> dict[str, object]:
+    """Build the deterministic source-set projection dict that admission hashes into source_set_digest."""
+    projection: dict[str, object] = {
+        "schema": "aptl-experiment-source-set/v1",
+        "task": {
+            "task_id": task.task.task_id,
+            "task_version": task.task.task_version,
+            "resolved_digest": task.artifact.digest,
+        },
+        "scenario": {
+            "ref_kind": scenario.effective_ref.ref_kind,
+            "ref_id": scenario.scenario.name,
+            "scenario_version": scenario.scenario.version,
+            "resolved_digest": scenario.artifact.digest,
+            "canonical_digest": scenario.canonical_digest.value,
+        },
+        "capture_specs": {
+            capture_spec.capture_spec_id: {
+                "spec_version": capture_spec.spec_version,
+                "resolved_digest": artifact.digest,
+            }
+            for capture_spec, artifact in zip(capture.specs, capture.artifacts, strict=True)
+        },
+    }
+    if flat_instantiated_digest is not None:
+        projection["flat_instantiated_scenario_digest"] = flat_instantiated_digest
+    return projection

--- a/src/aptl/core/experiment/apparatus.py
+++ b/src/aptl/core/experiment/apparatus.py
@@ -193,19 +193,20 @@ def check_apparatus_admission(
         # debug override — never silently dropped from the raised set.
         raise AdmissionRejection(tuple(diagnostics) + mutual_diagnostics)
 
+    warnings: list[Diagnostic] = []
     if mutual_diagnostics:
-        if policy.allow_uncertified_apparatus:
-            warning = diagnostic(
+        if not policy.allow_uncertified_apparatus:
+            raise AdmissionRejection(mutual_diagnostics)
+        warnings.append(
+            diagnostic(
                 _CODE_UNCERTIFIED_COMPATIBILITY,
                 f"{_ADDRESS_APPARATUS}.mutual_compatibility",
                 "backend and processor manifests do not mutually declare each other "
                 "compatible; admitted under the allow_uncertified_apparatus debug override",
                 severity=Severity.WARNING,
             )
-            return tuple([warning])
-        raise AdmissionRejection(mutual_diagnostics)
-
-    return tuple([])
+        )
+    return tuple(warnings)
 
 
 def _intent_processor_refs(
@@ -307,18 +308,19 @@ def _identity_violations(
     is the (already-narrowing-validated) intent list when the intent
     supplies one, else the task's own list.
     """
-    if not task_refs:
-        return ()
-    effective_refs = intent_refs if intent_refs else task_refs
-    names = {ref.ref_id for ref in effective_refs}
-    if manifest_name in names:
-        return ()
-    violation = diagnostic(
-        _CODE_IDENTITY_UNRESOLVED,
-        address,
-        "the resolved manifest identity is not present in the admitted allow-list",
-    )
-    return tuple([violation])
+    violations: list[Diagnostic] = []
+    if task_refs:
+        effective_refs = intent_refs if intent_refs else task_refs
+        names = {ref.ref_id for ref in effective_refs}
+        if manifest_name not in names:
+            violations.append(
+                diagnostic(
+                    _CODE_IDENTITY_UNRESOLVED,
+                    address,
+                    "the resolved manifest identity is not present in the admitted allow-list",
+                )
+            )
+    return tuple(violations)
 
 
 def _manifest_ref_violations(
@@ -397,14 +399,16 @@ def _mutual_compat_violations(
     """Return the mutual-incompatibility violation when backend/processor don't both declare each other, else empty."""
     backend_declares_processor = processor_manifest.name in backend_manifest.compatible_processors
     processor_declares_backend = backend_manifest.name in processor_manifest.compatible_backends
-    if backend_declares_processor and processor_declares_backend:
-        return ()
-    violation = diagnostic(
-        _CODE_MUTUAL_INCOMPATIBLE,
-        f"{_ADDRESS_APPARATUS}.mutual_compatibility",
-        "backend and processor manifests do not mutually declare each other compatible",
-    )
-    return tuple([violation])
+    violations: list[Diagnostic] = []
+    if not (backend_declares_processor and processor_declares_backend):
+        violations.append(
+            diagnostic(
+                _CODE_MUTUAL_INCOMPATIBLE,
+                f"{_ADDRESS_APPARATUS}.mutual_compatibility",
+                "backend and processor manifests do not mutually declare each other compatible",
+            )
+        )
+    return tuple(violations)
 
 
 def plan_condition_feasibility(

--- a/src/aptl/core/experiment/apparatus.py
+++ b/src/aptl/core/experiment/apparatus.py
@@ -1,0 +1,440 @@
+"""Apparatus admission and planning-only feasibility (ADR-047 "Apparatus and
+capture capability admission").
+
+Two independent surfaces live here:
+
+* :func:`check_apparatus_admission` — a CONJUNCTIVE admission gate over
+  ``ExperimentTaskModel.apparatus_constraints`` and the authoring input's
+  optional ``apparatus_intent`` (the same ``ExperimentApparatusConstraintModel``
+  shape). It rejects (raises :class:`~aptl.core.experiment.errors.AdmissionRejection`)
+  on ANY incompatibility:
+
+  - ``apparatus_intent`` may only NARROW the task's constraints, never
+    weaken or expand them. Naming a processor/backend/capability the task
+    does not allow is rejected.
+  - Every allowed processor/backend identity actually being used for this
+    admission (the resolved manifests — ``create_aptl_manifest()`` and
+    ``create_reference_processor_manifest()`` by default; injectable for
+    tests) must appear in the applicable allow-list, when that allow-list
+    is non-empty. An EMPTY allow-list on one axis (e.g. no
+    ``allowed_backend_refs``) means the task did not restrict THAT axis —
+    it is not a global "allow anything" escape, because
+    ``ExperimentApparatusConstraintModel`` itself requires at least one of
+    its five fields to be non-empty.
+  - ``required_manifest_refs`` naming a processor/backend subject must pin
+    the correct contract-version literal (``processor-manifest/v2`` /
+    ``backend-manifest/v2`` — the SLASH form; never compared against a
+    ``supported_contract_versions`` HYPHEN entry) and the correct subject
+    identity. A ``ref_digest`` on a manifest ref is never verifiable here
+    (no canonical manifest-payload-digest API exists at this surface) and
+    always fails closed rather than being silently ignored.
+  - ``required_capabilities`` (from either the task or the intent) must
+    each be literally declared in the union of the resolved backend's and
+    processor's ``supported_contract_versions``.
+  - MUTUAL COMPATIBILITY — the one-directional gotcha this module exists
+    to enforce: the resolved (backend, processor) pair is admissible only
+    when BOTH sides declare each other (``backend.compatible_processors``
+    contains the processor's name AND ``processor.compatible_backends``
+    contains the backend's name). This check runs UNCONDITIONALLY for
+    every admission call (it is a structural fact about the two manifests
+    actually being used, independent of what any one task's allow-lists
+    say) — at the locked ACES 0.23.1 surface, the published
+    reference-processor manifest names only ``stub`` as a compatible
+    backend while ``create_aptl_manifest()`` names
+    ``aces-reference-processor`` as compatible, so this gate currently
+    rejects EVERY admission that uses the real default manifests. That is
+    the correct, ADR-mandated fail-closed behavior, not a bug: "Strict
+    mutual apparatus-manifest compatibility cannot be fabricated by
+    patching either payload locally; fail closed until the canonical ACES
+    declaration and the requested task constraints are mutually
+    satisfiable" (ADR-047 Gotchas). It is exercised here with real,
+    unpatched ACES manifest objects — never by constructing a fake
+    manifest whose ``compatible_backends``/``compatible_processors`` was
+    hand-edited to make the pair line up.
+
+  DEBUG OVERRIDE (``policy.allow_uncertified_apparatus``, default
+  ``False``): an explicit product decision lets dev/test admit against the
+  REAL ``aptl`` manifest despite the above one-directional mismatch.
+  ``check_apparatus_admission`` returns ``tuple[Diagnostic, ...]`` of
+  non-fatal warnings (empty in the normal case) rather than ``None``. When
+  mutual-compat is the ONLY failing gate AND the flag is set, that one
+  mismatch is downgraded to a single ``Severity.WARNING`` diagnostic
+  (code ``aptl.experiment-admission.apparatus-uncertified-compatibility``)
+  returned in the tuple, and admission does NOT raise for it. Every other
+  gate — identity mismatch, a missing required capability, a
+  ``required_manifest_refs`` pinning failure, or an intent that widens the
+  task — stays fatal regardless of the flag, and if ANY of those other
+  gates also fail, the mutual-compat diagnostic is raised as a normal
+  fatal diagnostic alongside them (the downgrade applies only when
+  mutual-compat would otherwise be the sole reason for rejection).
+
+* :func:`plan_condition_feasibility` / :func:`require_feasible_plan` —
+  planning-only scenario feasibility via ACES's reference processor
+  directly. ADR-047 "Apparatus capability admission": scenario-specific
+  feasibility remains with ``RuntimeManager.plan()`` for EXECUTION, but
+  admission must use the equivalent planning-only ACES API instead,
+  because constructing APTL's runtime target pulls in ``AptlConfig`` and a
+  ``DeploymentBackend`` — a dependency-boundary violation even with a
+  no-op backend. Neither function here imports or constructs either. A
+  green ``plan_condition_feasibility`` call is NOT proof of certified
+  mutual apparatus-manifest compatibility (``run_reference_processor``
+  does not check that — see :func:`check_apparatus_admission` above);
+  admission must run both checks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+from aces_backend_protocols.manifest import BackendManifest
+from aces_contracts.contracts import (
+    BACKEND_MANIFEST_V2_SCHEMA_VERSION,
+    PROCESSOR_MANIFEST_V2_SCHEMA_VERSION,
+    ExperimentApparatusConstraintModel,
+    ExperimentBackendReferenceModel,
+    ExperimentManifestReferenceModel,
+    ExperimentProcessorReferenceModel,
+    ExperimentTaskModel,
+)
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_processor.capabilities import ProcessorManifest
+from aces_processor.manifest import create_reference_processor_manifest
+from aces_processor.reference import ReferenceProcessorResult, ScenarioInput, run_reference_processor
+from aces_sdl import SDLInstantiationError
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic, normalize_aces_failure
+from aptl.core.experiment.policy import AdmissionPolicy
+
+_ADDRESS_APPARATUS = "task.apparatus_constraints"
+_ADDRESS_INTENT = "apparatus_intent"
+_ADDRESS_CONDITION_PARAMETERS = "condition.parameters"
+
+_CODE_INTENT_EXPANDS_TASK = "aptl.experiment-admission.apparatus-intent-expands-task"
+_CODE_IDENTITY_UNRESOLVED = "aptl.experiment-admission.apparatus-identity-unresolved"
+_CODE_MANIFEST_REF_UNVERIFIABLE = "aptl.experiment-admission.apparatus-manifest-ref-unverifiable"
+_CODE_MANIFEST_REF_MISMATCH = "aptl.experiment-admission.apparatus-manifest-ref-mismatch"
+_CODE_CAPABILITY_UNSUPPORTED = "aptl.experiment-admission.apparatus-capability-unsupported"
+_CODE_MUTUAL_INCOMPATIBLE = "aptl.experiment-admission.apparatus-mutual-incompatible"
+_CODE_UNCERTIFIED_COMPATIBILITY = "aptl.experiment-admission.apparatus-uncertified-compatibility"
+_CODE_CONDITION_PARAMETERS_INVALID = "aptl.experiment-admission.condition-parameters-invalid"
+_CODE_PLAN_INFEASIBLE = "aptl.experiment-admission.plan-infeasible"
+
+_ManifestRef = ExperimentProcessorReferenceModel | ExperimentBackendReferenceModel
+
+
+def check_apparatus_admission(
+    task: ExperimentTaskModel,
+    apparatus_intent: ExperimentApparatusConstraintModel | None,
+    *,
+    backend_manifest: BackendManifest | None = None,
+    processor_manifest: ProcessorManifest | None = None,
+    policy: AdmissionPolicy,
+) -> tuple[Diagnostic, ...]:
+    """Admit (or reject) a task's apparatus requirements.
+
+    Returns a (normally empty) tuple of NON-FATAL warning diagnostics on
+    success. Raises :class:`~aptl.core.experiment.errors.AdmissionRejection`
+    on any FATAL gap — see the module and class docstrings for the debug
+    override (``policy.allow_uncertified_apparatus``) that can downgrade an
+    isolated mutual-compat mismatch to a warning instead of raising.
+
+    ``backend_manifest``/``processor_manifest`` default to APTL's real
+    canonical manifests (``create_aptl_manifest()``,
+    ``create_reference_processor_manifest()``); tests inject alternatives.
+    """
+    resolved_backend = backend_manifest if backend_manifest is not None else create_aptl_manifest()
+    resolved_processor = (
+        processor_manifest if processor_manifest is not None else create_reference_processor_manifest()
+    )
+
+    constraints = task.apparatus_constraints
+    diagnostics: list[Diagnostic] = []
+
+    diagnostics.extend(_narrowing_violations(constraints, apparatus_intent))
+
+    diagnostics.extend(
+        _identity_violations(
+            task_refs=constraints.allowed_processor_refs,
+            intent_refs=_intent_processor_refs(apparatus_intent),
+            manifest_name=resolved_processor.name,
+            address=f"{_ADDRESS_APPARATUS}.allowed_processor_refs",
+        )
+    )
+    diagnostics.extend(
+        _identity_violations(
+            task_refs=constraints.allowed_backend_refs,
+            intent_refs=_intent_backend_refs(apparatus_intent),
+            manifest_name=resolved_backend.name,
+            address=f"{_ADDRESS_APPARATUS}.allowed_backend_refs",
+        )
+    )
+
+    diagnostics.extend(
+        _manifest_ref_violations(constraints.required_manifest_refs, resolved_backend, resolved_processor)
+    )
+    if apparatus_intent is not None:
+        diagnostics.extend(
+            _manifest_ref_violations(
+                apparatus_intent.required_manifest_refs, resolved_backend, resolved_processor
+            )
+        )
+
+    effective_capabilities = set(constraints.required_capabilities) | set(
+        apparatus_intent.required_capabilities if apparatus_intent is not None else ()
+    )
+    diagnostics.extend(_capability_violations(effective_capabilities, resolved_backend, resolved_processor))
+
+    mutual_diagnostics = _mutual_compat_violations(resolved_backend, resolved_processor)
+
+    if diagnostics:
+        # Other gates already failed: mutual-compat (if any) is not the
+        # SOLE reason for rejection, so it stays fatal regardless of the
+        # debug override — never silently dropped from the raised set.
+        raise AdmissionRejection(tuple(diagnostics) + mutual_diagnostics)
+
+    if mutual_diagnostics:
+        if policy.allow_uncertified_apparatus:
+            return (
+                diagnostic(
+                    _CODE_UNCERTIFIED_COMPATIBILITY,
+                    f"{_ADDRESS_APPARATUS}.mutual_compatibility",
+                    "backend and processor manifests do not mutually declare each other "
+                    "compatible; admitted under the allow_uncertified_apparatus debug override",
+                    severity=Severity.WARNING,
+                ),
+            )
+        raise AdmissionRejection(mutual_diagnostics)
+
+    return ()
+
+
+def _intent_processor_refs(
+    apparatus_intent: ExperimentApparatusConstraintModel | None,
+) -> Sequence[ExperimentProcessorReferenceModel]:
+    return apparatus_intent.allowed_processor_refs if apparatus_intent is not None else ()
+
+
+def _intent_backend_refs(
+    apparatus_intent: ExperimentApparatusConstraintModel | None,
+) -> Sequence[ExperimentBackendReferenceModel]:
+    return apparatus_intent.allowed_backend_refs if apparatus_intent is not None else ()
+
+
+def _ref_key(ref: _ManifestRef) -> tuple[str, str | None]:
+    return (ref.ref_id, ref.ref_version)
+
+
+def _narrowing_violations(
+    constraints: ExperimentApparatusConstraintModel,
+    apparatus_intent: ExperimentApparatusConstraintModel | None,
+) -> tuple[Diagnostic, ...]:
+    """``apparatus_intent`` may only narrow ``constraints``, never expand it.
+
+    A field is only checked when BOTH sides declare it: an empty task-side
+    list means the task did not restrict that axis (nothing to narrow),
+    and an empty intent-side list means the intent did not touch that
+    axis (nothing to check).
+    """
+    if apparatus_intent is None:
+        return ()
+
+    violations: list[Diagnostic] = []
+    violations.extend(
+        _ref_narrowing_violations(
+            constraints.allowed_processor_refs,
+            apparatus_intent.allowed_processor_refs,
+            f"{_ADDRESS_INTENT}.allowed_processor_refs",
+        )
+    )
+    violations.extend(
+        _ref_narrowing_violations(
+            constraints.allowed_backend_refs,
+            apparatus_intent.allowed_backend_refs,
+            f"{_ADDRESS_INTENT}.allowed_backend_refs",
+        )
+    )
+    if constraints.required_capabilities and apparatus_intent.required_capabilities:
+        allowed_capabilities = set(constraints.required_capabilities)
+        for capability in apparatus_intent.required_capabilities:
+            if capability not in allowed_capabilities:
+                violations.append(
+                    diagnostic(
+                        _CODE_INTENT_EXPANDS_TASK,
+                        f"{_ADDRESS_INTENT}.required_capabilities",
+                        "apparatus_intent requires a capability the task's "
+                        "apparatus_constraints does not require",
+                    )
+                )
+    return tuple(violations)
+
+
+def _ref_narrowing_violations(
+    task_refs: Sequence[_ManifestRef], intent_refs: Sequence[_ManifestRef], address: str
+) -> tuple[Diagnostic, ...]:
+    if not task_refs or not intent_refs:
+        return ()
+    allowed_keys = {_ref_key(ref) for ref in task_refs}
+    return tuple(
+        diagnostic(
+            _CODE_INTENT_EXPANDS_TASK,
+            address,
+            "apparatus_intent names an identity the task's apparatus_constraints does not allow",
+        )
+        for ref in intent_refs
+        if _ref_key(ref) not in allowed_keys
+    )
+
+
+def _identity_violations(
+    *,
+    task_refs: Sequence[_ManifestRef],
+    intent_refs: Sequence[_ManifestRef],
+    manifest_name: str,
+    address: str,
+) -> tuple[Diagnostic, ...]:
+    """The resolved manifest identity must appear in the effective allow-list.
+
+    An empty ``task_refs`` means the task does not restrict this axis —
+    there is nothing to resolve against. Otherwise the EFFECTIVE allow-list
+    is the (already-narrowing-validated) intent list when the intent
+    supplies one, else the task's own list.
+    """
+    if not task_refs:
+        return ()
+    effective_refs = intent_refs if intent_refs else task_refs
+    names = {ref.ref_id for ref in effective_refs}
+    if manifest_name in names:
+        return ()
+    return (
+        diagnostic(
+            _CODE_IDENTITY_UNRESOLVED,
+            address,
+            "the resolved manifest identity is not present in the admitted allow-list",
+        ),
+    )
+
+
+def _manifest_ref_violations(
+    manifest_refs: Sequence[ExperimentManifestReferenceModel],
+    backend_manifest: BackendManifest,
+    processor_manifest: ProcessorManifest,
+) -> tuple[Diagnostic, ...]:
+    violations: list[Diagnostic] = []
+    for ref in manifest_refs:
+        subject = ref.subject_ref
+        if subject is None or subject.ref_kind not in ("processor", "backend"):
+            continue
+        address = f"{_ADDRESS_APPARATUS}.required_manifest_refs.{ref.ref_id}"
+
+        if ref.ref_digest is not None or subject.ref_digest is not None:
+            violations.append(
+                diagnostic(
+                    _CODE_MANIFEST_REF_UNVERIFIABLE,
+                    address,
+                    "admission cannot verify a manifest ref_digest against a canonical digest source",
+                )
+            )
+            continue
+
+        expected_literal = (
+            PROCESSOR_MANIFEST_V2_SCHEMA_VERSION
+            if subject.ref_kind == "processor"
+            else BACKEND_MANIFEST_V2_SCHEMA_VERSION
+        )
+        if ref.ref_version != expected_literal:
+            violations.append(
+                diagnostic(
+                    _CODE_MANIFEST_REF_MISMATCH,
+                    address,
+                    "required_manifest_refs entry does not pin the canonical manifest schema-version literal",
+                )
+            )
+            continue
+
+        canonical_name = processor_manifest.name if subject.ref_kind == "processor" else backend_manifest.name
+        if subject.ref_id != canonical_name:
+            violations.append(
+                diagnostic(
+                    _CODE_MANIFEST_REF_MISMATCH,
+                    address,
+                    "required_manifest_refs subject_ref identity does not match the canonical manifest",
+                )
+            )
+    return tuple(violations)
+
+
+def _capability_violations(
+    required_capabilities: Iterable[str],
+    backend_manifest: BackendManifest,
+    processor_manifest: ProcessorManifest,
+) -> tuple[Diagnostic, ...]:
+    declared = set(backend_manifest.supported_contract_versions) | set(
+        processor_manifest.supported_contract_versions
+    )
+    missing = sorted(capability for capability in required_capabilities if capability not in declared)
+    return tuple(
+        diagnostic(
+            _CODE_CAPABILITY_UNSUPPORTED,
+            f"{_ADDRESS_APPARATUS}.required_capabilities.{capability}",
+            "required capability is not declared by the canonical backend/processor manifests",
+        )
+        for capability in missing
+    )
+
+
+def _mutual_compat_violations(
+    backend_manifest: BackendManifest, processor_manifest: ProcessorManifest
+) -> tuple[Diagnostic, ...]:
+    backend_declares_processor = processor_manifest.name in backend_manifest.compatible_processors
+    processor_declares_backend = backend_manifest.name in processor_manifest.compatible_backends
+    if backend_declares_processor and processor_declares_backend:
+        return ()
+    return (
+        diagnostic(
+            _CODE_MUTUAL_INCOMPATIBLE,
+            f"{_ADDRESS_APPARATUS}.mutual_compatibility",
+            "backend and processor manifests do not mutually declare each other compatible",
+        ),
+    )
+
+
+def plan_condition_feasibility(
+    scenario: ScenarioInput,
+    parameters: Mapping[str, object],
+    *,
+    backend_manifest: BackendManifest | None = None,
+    profile: str | None = None,
+) -> ReferenceProcessorResult:
+    """Planning-only feasibility for one condition's parameter binding.
+
+    Calls ACES's reference processor directly — no ``AptlConfig``,
+    ``DeploymentBackend``, or Docker probe. ``SDLInstantiationError``
+    (which ``run_reference_processor`` raises, not returns as a diagnostic,
+    for a structurally broken parameter binding — a missing, unused, or
+    undeclared target) is normalized into the same fail-closed
+    :class:`~aptl.core.experiment.errors.AdmissionRejection` surface as
+    every other admission rejection.
+    """
+    manifest = backend_manifest if backend_manifest is not None else create_aptl_manifest()
+    try:
+        return run_reference_processor(scenario, manifest, parameters=parameters, profile=profile)
+    except SDLInstantiationError as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(
+                exc, address=_ADDRESS_CONDITION_PARAMETERS, code=_CODE_CONDITION_PARAMETERS_INVALID
+            )
+        ) from exc
+
+
+def require_feasible_plan(result: ReferenceProcessorResult, *, address: str) -> None:
+    """Raise when ``result`` carries any error-severity diagnostic.
+
+    NOTE: a valid ``result`` here is NOT proof of certified mutual
+    apparatus-manifest compatibility — ``run_reference_processor`` does not
+    check that (see :func:`check_apparatus_admission`).
+    """
+    if not result.is_valid:
+        raise AdmissionRejection(
+            normalize_aces_failure(result.diagnostics, address=address, code=_CODE_PLAN_INFEASIBLE)
+        )

--- a/src/aptl/core/experiment/apparatus.py
+++ b/src/aptl/core/experiment/apparatus.py
@@ -195,33 +195,35 @@ def check_apparatus_admission(
 
     if mutual_diagnostics:
         if policy.allow_uncertified_apparatus:
-            return (
-                diagnostic(
-                    _CODE_UNCERTIFIED_COMPATIBILITY,
-                    f"{_ADDRESS_APPARATUS}.mutual_compatibility",
-                    "backend and processor manifests do not mutually declare each other "
-                    "compatible; admitted under the allow_uncertified_apparatus debug override",
-                    severity=Severity.WARNING,
-                ),
+            warning = diagnostic(
+                _CODE_UNCERTIFIED_COMPATIBILITY,
+                f"{_ADDRESS_APPARATUS}.mutual_compatibility",
+                "backend and processor manifests do not mutually declare each other "
+                "compatible; admitted under the allow_uncertified_apparatus debug override",
+                severity=Severity.WARNING,
             )
+            return tuple([warning])
         raise AdmissionRejection(mutual_diagnostics)
 
-    return ()
+    return tuple([])
 
 
 def _intent_processor_refs(
     apparatus_intent: ExperimentApparatusConstraintModel | None,
 ) -> Sequence[ExperimentProcessorReferenceModel]:
+    """Return the intent's allowed processor refs, or empty when there is no intent."""
     return apparatus_intent.allowed_processor_refs if apparatus_intent is not None else ()
 
 
 def _intent_backend_refs(
     apparatus_intent: ExperimentApparatusConstraintModel | None,
 ) -> Sequence[ExperimentBackendReferenceModel]:
+    """Return the intent's allowed backend refs, or empty when there is no intent."""
     return apparatus_intent.allowed_backend_refs if apparatus_intent is not None else ()
 
 
 def _ref_key(ref: _ManifestRef) -> tuple[str, str | None]:
+    """Return the (ref_id, ref_version) identity key used to compare manifest refs."""
     return (ref.ref_id, ref.ref_version)
 
 
@@ -272,6 +274,11 @@ def _narrowing_violations(
 def _ref_narrowing_violations(
     task_refs: Sequence[_ManifestRef], intent_refs: Sequence[_ManifestRef], address: str
 ) -> tuple[Diagnostic, ...]:
+    """Return one violation per intent ref whose identity is absent from task_refs.
+
+    Empty when either side is empty (nothing declared to narrow, or nothing
+    declared to check).
+    """
     if not task_refs or not intent_refs:
         return ()
     allowed_keys = {_ref_key(ref) for ref in task_refs}
@@ -306,13 +313,12 @@ def _identity_violations(
     names = {ref.ref_id for ref in effective_refs}
     if manifest_name in names:
         return ()
-    return (
-        diagnostic(
-            _CODE_IDENTITY_UNRESOLVED,
-            address,
-            "the resolved manifest identity is not present in the admitted allow-list",
-        ),
+    violation = diagnostic(
+        _CODE_IDENTITY_UNRESOLVED,
+        address,
+        "the resolved manifest identity is not present in the admitted allow-list",
     )
+    return tuple([violation])
 
 
 def _manifest_ref_violations(
@@ -320,6 +326,7 @@ def _manifest_ref_violations(
     backend_manifest: BackendManifest,
     processor_manifest: ProcessorManifest,
 ) -> tuple[Diagnostic, ...]:
+    """Return one violation per required_manifest_refs entry that is unverifiable, mispinned, or misidentified."""
     violations: list[Diagnostic] = []
     for ref in manifest_refs:
         subject = ref.subject_ref
@@ -369,6 +376,7 @@ def _capability_violations(
     backend_manifest: BackendManifest,
     processor_manifest: ProcessorManifest,
 ) -> tuple[Diagnostic, ...]:
+    """Return one violation per required capability not declared by either manifest's supported_contract_versions."""
     declared = set(backend_manifest.supported_contract_versions) | set(
         processor_manifest.supported_contract_versions
     )
@@ -386,17 +394,17 @@ def _capability_violations(
 def _mutual_compat_violations(
     backend_manifest: BackendManifest, processor_manifest: ProcessorManifest
 ) -> tuple[Diagnostic, ...]:
+    """Return the mutual-incompatibility violation when backend/processor don't both declare each other, else empty."""
     backend_declares_processor = processor_manifest.name in backend_manifest.compatible_processors
     processor_declares_backend = backend_manifest.name in processor_manifest.compatible_backends
     if backend_declares_processor and processor_declares_backend:
         return ()
-    return (
-        diagnostic(
-            _CODE_MUTUAL_INCOMPATIBLE,
-            f"{_ADDRESS_APPARATUS}.mutual_compatibility",
-            "backend and processor manifests do not mutually declare each other compatible",
-        ),
+    violation = diagnostic(
+        _CODE_MUTUAL_INCOMPATIBLE,
+        f"{_ADDRESS_APPARATUS}.mutual_compatibility",
+        "backend and processor manifests do not mutually declare each other compatible",
     )
+    return tuple([violation])
 
 
 def plan_condition_feasibility(

--- a/src/aptl/core/experiment/capture_mapping.py
+++ b/src/aptl/core/experiment/capture_mapping.py
@@ -79,6 +79,7 @@ SUPPORTED_CAPTURE_CAPABILITIES: tuple[CaptureCapability, ...] = ()
 def _resolve_capture_owner(
     requirement: ExperimentCaptureRequirementModel, backend_manifest: BackendManifest
 ) -> str | None:
+    """Return the evidence-backed capture owner for requirement, or None if unsupported."""
     observation = backend_manifest.observation
     if observation is None:
         return None
@@ -118,7 +119,8 @@ def map_capture_requirements(
     requires at least one entry in ``capture_requirements``, so an
     individual resolved spec can never itself be "empty".
     """
-    del policy  # reserved: no capture-specific limit exists yet.
+    # reserved: no capture-specific limit exists yet.
+    del policy
 
     manifest = backend_manifest if backend_manifest is not None else create_aptl_manifest()
     result: dict[str, str] = {}

--- a/src/aptl/core/experiment/capture_mapping.py
+++ b/src/aptl/core/experiment/capture_mapping.py
@@ -1,0 +1,145 @@
+"""ACES capture-requirement terms -> APTL capture-owner mapping (ADR-047
+"Apparatus and capture capability admission").
+
+This is the ONE code-owned mapping from ``ExperimentCaptureRequirementModel``
+terms (``capture_kind``, ``capture_scope``, ``expected_media_types``,
+``integrity_requirements``) to an existing APTL capture owner
+(``collectors.py``, MCP/Kali capture, runtime snapshots, orchestration/
+evaluation history). Admission and later execution share it. It describes
+SUPPORT only — it never replaces the ACES capture-spec model, and it never
+maps an unknown term to a collector name, import, backend method, or shell
+command (ADR-047 "Apparatus capability admission").
+
+FAIL-CLOSED BASELINE (the load-bearing rule for #438 / EXP-002): a capture
+requirement is admitted ONLY when :data:`SUPPORTED_CAPTURE_CAPABILITIES`
+declares evidence-backed support AND the resolved backend manifest's
+``observation`` capability actually declares the matching channel/media/
+sealing vocabulary. The mere existence of a best-effort collector function
+is NEVER evidence of support — ``aptl.core.collectors`` collectors are
+best-effort primitives that often collapse failure into an empty result
+(ADR-047 Gotchas), and admitting on their presence would silently promise
+evidence collection never verified end-to-end.
+
+``create_aptl_manifest().observation`` is currently ``None`` (verified live
+against aces-sdl 0.23.1 — see the ACES API reference consulted for Stage 3,
+section 11). Because of that, :data:`SUPPORTED_CAPTURE_CAPABILITIES` is
+EMPTY for #438: there is no honest backend observation declaration yet for
+any entry to point at. EXP-010 (#752) is the extension seam — it must add
+BOTH an honest ``create_aptl_manifest().observation`` declaration (naming
+the real, verified channel/media/sealing vocabulary APTL's capture owners
+actually provide) AND the corresponding :class:`CaptureCapability` entries
+here, together. Adding one without the other is exactly the failure mode
+this module exists to prevent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from aces_backend_protocols.manifest import BackendManifest
+from aces_contracts.contracts import ExperimentCaptureRequirementModel, ExperimentCaptureSpecModel
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic
+from aptl.core.experiment.policy import AdmissionPolicy
+
+_CODE_CAPTURE_UNSUPPORTED = "aptl.experiment-admission.capture-requirement-unsupported"
+
+
+@dataclass(frozen=True)
+class CaptureCapability:
+    """One evidence-backed ``(capture_kind, capture_scope)`` -> APTL owner entry.
+
+    ``media_types``/``integrity_requirements`` further narrow support: a
+    requirement is only covered when its ``expected_media_types`` and
+    ``integrity_requirements`` are each a SUBSET of what this entry
+    declares (never the reverse — a requirement asking for MORE than the
+    entry covers is not admitted by it). ``capture_owner`` is a stable,
+    human-readable identifier for the APTL capture owner (e.g. a
+    ``module.function`` path in ``collectors.py`` or an MCP/Kali capture
+    owner name) — never something admission itself resolves to an import,
+    exec, or shell command.
+    """
+
+    capture_kind: str
+    capture_scope: str
+    media_types: frozenset[str]
+    integrity_requirements: frozenset[str]
+    capture_owner: str
+
+
+#: Versioned, evidence-backed support table. EMPTY for #438 — see the
+#: module docstring. EXP-010 (#752) is the only authorized place to add an
+#: entry, and only alongside an honest, verified
+#: ``create_aptl_manifest().observation`` declaration.
+SUPPORTED_CAPTURE_CAPABILITIES: tuple[CaptureCapability, ...] = ()
+
+
+def _resolve_capture_owner(
+    requirement: ExperimentCaptureRequirementModel, backend_manifest: BackendManifest
+) -> str | None:
+    observation = backend_manifest.observation
+    if observation is None:
+        return None
+    requirement_media_types = frozenset(requirement.expected_media_types)
+    requirement_integrity = frozenset(requirement.integrity_requirements)
+    for capability in SUPPORTED_CAPTURE_CAPABILITIES:
+        if capability.capture_kind != requirement.capture_kind:
+            continue
+        if capability.capture_scope != requirement.capture_scope:
+            continue
+        if not requirement_media_types.issubset(capability.media_types):
+            continue
+        if not requirement_integrity.issubset(capability.integrity_requirements):
+            continue
+        if capability.capture_kind not in observation.supported_capture_kinds:
+            continue
+        if not requirement_media_types.issubset(observation.supported_media_types):
+            continue
+        return capability.capture_owner
+    return None
+
+
+def map_capture_requirements(
+    capture_specs: Iterable[ExperimentCaptureSpecModel],
+    *,
+    backend_manifest: BackendManifest | None = None,
+    policy: AdmissionPolicy,
+) -> Mapping[str, str]:
+    """Map every capture requirement in ``capture_specs`` to its APTL owner.
+
+    Raises :class:`~aptl.core.experiment.errors.AdmissionRejection` (fail
+    closed, naming the unsupported ``capture_kind``/``capture_scope``) the
+    moment ANY requirement across ANY spec is not evidence-backed —
+    admission is all-or-nothing, never a partial mapping. An empty
+    ``capture_specs`` iterable (no capture spec resolved at all) maps to an
+    empty result without rejecting; ``ExperimentCaptureSpecModel`` itself
+    requires at least one entry in ``capture_requirements``, so an
+    individual resolved spec can never itself be "empty".
+    """
+    del policy  # reserved: no capture-specific limit exists yet.
+
+    manifest = backend_manifest if backend_manifest is not None else create_aptl_manifest()
+    result: dict[str, str] = {}
+    diagnostics = []
+    for spec in capture_specs:
+        for requirement_id, requirement in spec.capture_requirements.items():
+            address = f"capture_spec.{spec.capture_spec_id}.capture_requirements.{requirement_id}"
+            owner = _resolve_capture_owner(requirement, manifest)
+            if owner is None:
+                diagnostics.append(
+                    diagnostic(
+                        _CODE_CAPTURE_UNSUPPORTED,
+                        address,
+                        "capture requirement (capture_kind="
+                        f"{requirement.capture_kind!r}, capture_scope={requirement.capture_scope!r}) "
+                        "is not evidence-backed by a declared backend observation capability",
+                    )
+                )
+                continue
+            result[f"{spec.capture_spec_id}.{requirement_id}"] = owner
+
+    if diagnostics:
+        raise AdmissionRejection(tuple(diagnostics))
+    return result

--- a/src/aptl/core/experiment/controller.py
+++ b/src/aptl/core/experiment/controller.py
@@ -1,0 +1,129 @@
+"""The experiment-controller composition boundary (ADR-047
+"Experiment-controller boundary", Stage 5 / EXP-002 / issue #438).
+
+:class:`ExperimentController` is a coordinator, not a runtime manager
+(ADR-047: "Do not split it into speculative repository, service, provider,
+DTO, and policy hierarchies"). Its dependencies are explicit constructor
+inputs — the configured :class:`~aptl.core.runstore.RunStorageBackend`, an
+:class:`~aptl.core.experiment.policy.AdmissionPolicy`, and the canonical
+processor/backend manifests — never a deployment backend. ``Deployment is
+not an admission dependency`` (ADR-047): this module does not import
+``DeploymentBackend``, ``EnvVars``, ``.env`` hydration, key/cert
+generation, a collector, or a session at all.
+
+``.admit()`` is the ONLY public operation and it delegates to
+:func:`aptl.core.experiment.admission.admit_experiment`. EXECUTION —
+actually running the admitted plan's trials — is downstream work
+(issues #437/#459) that consumes an :class:`~aptl.core.experiment.
+admission.AdmissionResult`'s ``plan``; it is intentionally NOT implemented
+here, and this class holds no ``PENDING``/``RUNNING``/``FAILED`` execution
+state (ADR-047 "Persistence and state model": "Do not create
+PENDING/RUNNING/FAILED experiment-controller states that duplicate those
+incumbents").
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from aces_backend_protocols.manifest import BackendManifest
+from aces_contracts.experiment_spec import ExperimentSpecModel
+from aces_processor.capabilities import ProcessorManifest
+from aces_processor.manifest import create_reference_processor_manifest
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.admission import (
+    AdmissionResult,
+    ResolvedArtifact,
+    ResolvedArtifactSource,
+    admit_experiment,
+    build_associated_artifact_source,
+)
+from aptl.core.experiment.errors import AdmissionRejection
+from aptl.core.experiment.policy import AdmissionPolicy, default_admission_policy
+from aptl.core.experiment.spec_loading import load_experiment_root
+from aptl.core.runstore import RunStorageBackend
+
+#: Factory signature for the production `ResolvedArtifactSource`: given the
+#: project root, a manifest locator, the already-parsed authoring-input
+#: spec, and the active policy, return a ready artifact source. Matches
+#: :func:`aptl.core.experiment.admission.build_associated_artifact_source`.
+ArtifactSourceFactory = Callable[[Path, str, ExperimentSpecModel, AdmissionPolicy], ResolvedArtifactSource]
+
+
+@dataclass
+class ExperimentController:
+    """The single composition boundary above lab lifecycle for ADR-047
+    experiment admission.
+
+    All dependencies are explicit and injected — none are constructed
+    ambiently. ``artifact_source_factory`` defaults to the production
+    associated-artifact-manifest-backed resolver
+    (:func:`build_associated_artifact_source`); tests can inject a factory
+    that returns a :class:`~aptl.core.experiment.admission.
+    MappingArtifactSource` instead.
+    """
+
+    run_store: RunStorageBackend
+    policy: AdmissionPolicy | None = None
+    backend_manifest: BackendManifest | None = None
+    processor_manifest: ProcessorManifest | None = None
+    artifact_source_factory: ArtifactSourceFactory = build_associated_artifact_source
+
+    def __post_init__(self) -> None:
+        # Resolved to concrete defaults here (rather than in the field
+        # declarations) so every instance genuinely owns its own policy/
+        # manifest objects and a caller inspecting `.policy` after
+        # construction never sees `None`.
+        if self.policy is None:
+            self.policy = default_admission_policy()
+        if self.backend_manifest is None:
+            self.backend_manifest = create_aptl_manifest()
+        if self.processor_manifest is None:
+            self.processor_manifest = create_reference_processor_manifest()
+
+    def admit(
+        self,
+        *,
+        experiment_root: ResolvedArtifact,
+        base_dir: Path,
+        manifest_locator: str,
+    ) -> AdmissionResult:
+        """Run ADR-047 admission for one experiment-authoring-input document.
+
+        This is the ADMISSION phase only (bounded loading, cross-artifact
+        joins, apparatus/capture capability checks, planning-only
+        feasibility, deterministic plan expansion, create-once persistence
+        with digest re-verification). It never raises
+        :class:`~aptl.core.experiment.errors.AdmissionRejection` — every
+        rejection anywhere in the sequence, including while building the
+        artifact source below, is returned as
+        ``AdmissionResult.rejected(diagnostics)``.
+
+        EXECUTION (actually running the admitted plan's trials against
+        ``RuntimeManager``/lab lifecycle) is downstream work in #437/#459
+        that consumes the returned ``AdmissionResult.plan``; it is not
+        implemented by this method.
+
+        ``base_dir``/``manifest_locator`` describe where the production
+        associated-artifact manifest binding the experiment's task/scenario/
+        capture-spec references to project files lives — see
+        :func:`aptl.core.experiment.admission.build_associated_artifact_source`.
+        A test-injected ``artifact_source_factory`` may ignore them.
+        """
+        try:
+            spec = load_experiment_root(experiment_root.data, policy=self.policy)
+            artifact_source = self.artifact_source_factory(base_dir, manifest_locator, spec, self.policy)
+        except AdmissionRejection as exc:
+            return AdmissionResult.rejected(exc.diagnostics)
+
+        return admit_experiment(
+            experiment_root=experiment_root,
+            artifact_source=artifact_source,
+            run_store=self.run_store,
+            policy=self.policy,
+            backend_manifest=self.backend_manifest,
+            processor_manifest=self.processor_manifest,
+        )

--- a/src/aptl/core/experiment/errors.py
+++ b/src/aptl/core/experiment/errors.py
@@ -29,7 +29,7 @@ parameter *name*, never the bound *value*), so it is normalized identically.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 import pydantic
 from aces_contracts.diagnostics import Diagnostic, Severity
@@ -91,10 +91,12 @@ def diagnostic(
 
 
 def _scrub_absolute_paths(text: str) -> str:
+    """Replace any POSIX-looking absolute path in text with a placeholder, as defense in depth."""
     return _ABSOLUTE_PATH_RE.sub(_PATH_PLACEHOLDER, text)
 
 
 def _safe_loc_address(base_address: str, loc: tuple[object, ...]) -> str:
+    """Append a pydantic error's ``loc`` tuple to base_address as a dotted suffix."""
     if not loc:
         return base_address
     suffix = ".".join(str(part) for part in loc)
@@ -123,6 +125,74 @@ def _diagnostics_from_pydantic_errors(
     return tuple(built)
 
 
+def _normalize_pydantic_validation_error(
+    exc: pydantic.ValidationError, *, address: str, code: str
+) -> tuple[Diagnostic, ...]:
+    """Normalize a pydantic ``ValidationError`` via its structured ``.errors()``."""
+    return _diagnostics_from_pydantic_errors(exc.errors(), address=address, code=code)
+
+
+def _normalize_experiment_spec_validation_error(
+    exc: ExperimentSpecValidationError, *, address: str, code: str
+) -> tuple[Diagnostic, ...]:
+    """Normalize an ``ExperimentSpecValidationError`` by unwrapping its pydantic cause (never its own ``str()``)."""
+    cause = exc.__cause__
+    if isinstance(cause, pydantic.ValidationError):
+        return _diagnostics_from_pydantic_errors(cause.errors(), address=address, code=code)
+    return (
+        diagnostic(
+            code,
+            address,
+            "experiment specification document failed to parse or validate",
+        ),
+    )
+
+
+def _normalize_sdl_parse_error(exc: SDLParseError, *, address: str, code: str) -> tuple[Diagnostic, ...]:
+    """Normalize an ``SDLParseError``, preferring its structured ``diagnostics`` over the raw ``details`` string."""
+    if exc.diagnostics:
+        return tuple(
+            diagnostic(code, address, _scrub_absolute_paths(item.message)) for item in exc.diagnostics
+        )
+    return (diagnostic(code, address, _scrub_absolute_paths(exc.details)),)
+
+
+def _normalize_sdl_errors_shape(
+    exc: SDLValidationError | SDLInstantiationError, *, address: str, code: str
+) -> tuple[Diagnostic, ...]:
+    """Normalize an ``SDLValidationError``/``SDLInstantiationError``'s developer-authored ``errors`` list."""
+    return tuple(diagnostic(code, address, _scrub_absolute_paths(message)) for message in exc.errors)
+
+
+#: Ordered (exception type(s), handler) dispatch table for
+#: :func:`_normalize_exception_shape`. A single-pass lookup instead of a
+#: chain of early returns, so that function stays within the 3-return
+#: budget (S1142) regardless of how many shapes are added.
+_ShapeHandler = Callable[..., tuple[Diagnostic, ...]]
+
+_SHAPE_HANDLERS: tuple[
+    tuple[type[BaseException] | tuple[type[BaseException], ...], _ShapeHandler], ...
+] = (
+    (pydantic.ValidationError, _normalize_pydantic_validation_error),
+    (ExperimentSpecValidationError, _normalize_experiment_spec_validation_error),
+    (SDLParseError, _normalize_sdl_parse_error),
+    ((SDLValidationError, SDLInstantiationError), _normalize_sdl_errors_shape),
+)
+
+
+def _normalize_exception_shape(exc: BaseException, *, address: str, code: str) -> tuple[Diagnostic, ...]:
+    """Route a raised ACES/pydantic exception to its shape-specific normalizer.
+
+    Falls back to a single generic, safe diagnostic for any exception type
+    outside the documented shapes — never ``str(exc)``, which has no
+    proven-safe rendering.
+    """
+    for exc_types, handler in _SHAPE_HANDLERS:
+        if isinstance(exc, exc_types):
+            return handler(exc, address=address, code=code)
+    return (diagnostic(code, address, "admission failed: unrecognized validation failure"),)
+
+
 def normalize_aces_failure(
     exc: BaseException | Diagnostic | tuple[Diagnostic, ...],
     *,
@@ -146,44 +216,12 @@ def normalize_aces_failure(
       (with an absolute-path scrub applied as defense in depth);
     * a ``Diagnostic`` or a tuple of ``Diagnostic`` — passed through
       unchanged (an ACES API that already returns the canonical shape).
+
+    Every other exception shape (including the four documented raised
+    shapes) is dispatched through :func:`_normalize_exception_shape`.
     """
     if isinstance(exc, Diagnostic):
         return (exc,)
     if isinstance(exc, tuple):
         return exc
-
-    if isinstance(exc, pydantic.ValidationError):
-        return _diagnostics_from_pydantic_errors(exc.errors(), address=address, code=code)
-
-    if isinstance(exc, ExperimentSpecValidationError):
-        cause = exc.__cause__
-        if isinstance(cause, pydantic.ValidationError):
-            return _diagnostics_from_pydantic_errors(
-                cause.errors(), address=address, code=code
-            )
-        return (
-            diagnostic(
-                code,
-                address,
-                "experiment specification document failed to parse or validate",
-            ),
-        )
-
-    if isinstance(exc, SDLParseError):
-        if exc.diagnostics:
-            return tuple(
-                diagnostic(code, address, _scrub_absolute_paths(item.message))
-                for item in exc.diagnostics
-            )
-        return (diagnostic(code, address, _scrub_absolute_paths(exc.details)),)
-
-    if isinstance(exc, (SDLValidationError, SDLInstantiationError)):
-        return tuple(
-            diagnostic(code, address, _scrub_absolute_paths(message))
-            for message in exc.errors
-        )
-
-    # Fail closed on any unrecognized exception shape: never fall back to
-    # str(exc) — an exception type outside the four documented shapes has
-    # no proven-safe rendering.
-    return (diagnostic(code, address, "admission failed: unrecognized validation failure"),)
+    return _normalize_exception_shape(exc, address=address, code=code)

--- a/src/aptl/core/experiment/errors.py
+++ b/src/aptl/core/experiment/errors.py
@@ -1,0 +1,189 @@
+"""Experiment-admission diagnostics and the fail-closed rejection signal.
+
+ADR-047 "Error envelope": admission normalizes every ACES/pydantic failure
+into redacted :class:`aces_contracts.diagnostics.Diagnostic` values in one
+``experiment-admission`` domain, and never lets a raw exception string
+(which for pydantic ``ValidationError`` embeds the rejected ``input_value``,
+and for ``ExperimentSpecValidationError`` wraps that same string via
+``str()``) escape into a diagnostic. See the ACES API reference's
+"Diagnostics" section for the failure shapes this module normalizes:
+a pydantic ``ValidationError`` (and ``ExperimentSpecValidationError``, which
+wraps one but must be unwrapped through ``__cause__`` rather than
+stringified), ``aces_sdl`` ``SDLParseError``/``SDLValidationError``/
+``SDLInstantiationError`` (already developer-authored, safe-to-pass-through
+text), and a pass-through ``Diagnostic`` (or tuple of them) produced by an
+ACES API that already returns the canonical shape (e.g.
+``validate_associated_artifact_manifest``, ``run_reference_processor.diagnostics``).
+
+``SDLInstantiationError`` (Stage 3 / EXP-002 apparatus admission) is what
+``aces_processor.reference.run_reference_processor`` raises when a
+condition's parameter binding is structurally broken (missing/unused/
+undeclared target) — verified live against aces-sdl 0.23.1; the ACES API
+reference doc consulted while building Stage 1 did not document this shape
+because nothing before Stage 3 called ``run_reference_processor`` with
+non-empty ``parameters``. It carries the same safe ``errors: list[str]``
+shape as ``SDLValidationError`` (ACES-authored text naming the rejected
+parameter *name*, never the bound *value*), so it is normalized identically.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+import pydantic
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.experiment_spec import ExperimentSpecValidationError
+from aces_sdl import SDLInstantiationError, SDLParseError, SDLValidationError
+
+from aptl.utils.redaction import redact
+
+EXPERIMENT_ADMISSION_DOMAIN = "experiment-admission"
+EXPERIMENT_ADMISSION_STAGE_LABEL = "Experiment admission failed"
+
+# Heuristic scrub for a POSIX-looking absolute path embedded in otherwise
+# developer-authored, pass-through SDL diagnostic text (ADR-047: "still
+# avoid embedding any absolute path present in the text"). SDL diagnostic
+# messages are safe by construction *for text ACES itself generates*, but a
+# scenario document's own authored content can flow into a semantic-
+# validation message, so this is defense in depth rather than the primary
+# control. Matches a leading `/` followed by at least one more path
+# separator so a bare `/` or a single URL-path segment is left alone.
+_ABSOLUTE_PATH_RE = re.compile(r"/(?:[\w.\-]+/)+[\w.\-]*")
+_PATH_PLACEHOLDER = "[PATH]"
+
+
+class AdmissionRejection(Exception):
+    """Fail-closed admission signal carrying already-safe diagnostics.
+
+    ``diagnostics`` is exactly what it says: a tuple of already-redacted,
+    already-safe :class:`Diagnostic` values (typically produced by
+    :func:`normalize_aces_failure`). Callers should render/log via
+    ``diagnostics``, not via ``str(exc)`` — the exception message is
+    deliberately generic and carries no document content.
+    """
+
+    def __init__(self, diagnostics: Iterable[Diagnostic]) -> None:
+        diagnostics_tuple = tuple(diagnostics)
+        self.diagnostics: tuple[Diagnostic, ...] = diagnostics_tuple
+        super().__init__(
+            f"experiment admission rejected: {len(diagnostics_tuple)} diagnostic(s)"
+        )
+
+
+def diagnostic(
+    code: str, address: str, message: str, *, severity: Severity = Severity.ERROR
+) -> Diagnostic:
+    """Build one redacted experiment-admission :class:`Diagnostic`.
+
+    Mirrors ``aptl.backends.aces_diagnostics.diagnostic()`` but fixed to the
+    ``experiment-admission`` domain. ``message`` is passed through
+    :func:`redact` as defense in depth even though every caller in this
+    package constructs it from safe, non-document-derived text.
+    """
+    return Diagnostic(
+        code=code,
+        domain=EXPERIMENT_ADMISSION_DOMAIN,
+        address=address,
+        message=redact(message),
+        severity=severity,
+    )
+
+
+def _scrub_absolute_paths(text: str) -> str:
+    return _ABSOLUTE_PATH_RE.sub(_PATH_PLACEHOLDER, text)
+
+
+def _safe_loc_address(base_address: str, loc: tuple[object, ...]) -> str:
+    if not loc:
+        return base_address
+    suffix = ".".join(str(part) for part in loc)
+    return f"{base_address}.{suffix}"
+
+
+def _diagnostics_from_pydantic_errors(
+    errors: Iterable[dict[str, object]], *, address: str, code: str
+) -> tuple[Diagnostic, ...]:
+    """Build one Diagnostic per pydantic error, keeping ONLY loc/type/msg.
+
+    ``input``, ``url``, and ``ctx`` are dropped unconditionally: ``input``
+    is the rejected value itself (can carry an injected secret), ``url``
+    is a pydantic.dev documentation link, and ``ctx`` can echo the input
+    back inside its own values.
+    """
+    built: list[Diagnostic] = []
+    for error in errors:
+        loc = error.get("loc") or ()
+        error_type = error.get("type", "validation-error")
+        msg = error.get("msg", "validation failed")
+        safe_address = _safe_loc_address(address, tuple(loc))  # type: ignore[arg-type]
+        built.append(
+            diagnostic(code, safe_address, f"{error_type}: {msg}")
+        )
+    return tuple(built)
+
+
+def normalize_aces_failure(
+    exc: BaseException | Diagnostic | tuple[Diagnostic, ...],
+    *,
+    address: str,
+    code: str,
+) -> tuple[Diagnostic, ...]:
+    """Normalize one ACES/pydantic failure into safe :class:`Diagnostic` values.
+
+    Handles exactly the shapes ADR-047 documents:
+
+    * a pydantic ``ValidationError`` (structured; ``.errors()`` is used,
+      ``input``/``url``/``ctx`` are dropped);
+    * an ``ExperimentSpecValidationError``, which wraps a pydantic
+      ``ValidationError`` via ``str()`` — its own message/``str()`` is
+      NEVER read. When ``__cause__`` is the wrapped ``ValidationError`` its
+      structured errors are used exactly like the direct case; otherwise
+      (e.g. a YAML-shape rejection with no informative cause) a single
+      generic, safe diagnostic is produced;
+    * ``aces_sdl`` ``SDLParseError``/``SDLValidationError``/
+      ``SDLInstantiationError`` — developer-authored text, passed through
+      (with an absolute-path scrub applied as defense in depth);
+    * a ``Diagnostic`` or a tuple of ``Diagnostic`` — passed through
+      unchanged (an ACES API that already returns the canonical shape).
+    """
+    if isinstance(exc, Diagnostic):
+        return (exc,)
+    if isinstance(exc, tuple):
+        return exc
+
+    if isinstance(exc, pydantic.ValidationError):
+        return _diagnostics_from_pydantic_errors(exc.errors(), address=address, code=code)
+
+    if isinstance(exc, ExperimentSpecValidationError):
+        cause = exc.__cause__
+        if isinstance(cause, pydantic.ValidationError):
+            return _diagnostics_from_pydantic_errors(
+                cause.errors(), address=address, code=code
+            )
+        return (
+            diagnostic(
+                code,
+                address,
+                "experiment specification document failed to parse or validate",
+            ),
+        )
+
+    if isinstance(exc, SDLParseError):
+        if exc.diagnostics:
+            return tuple(
+                diagnostic(code, address, _scrub_absolute_paths(item.message))
+                for item in exc.diagnostics
+            )
+        return (diagnostic(code, address, _scrub_absolute_paths(exc.details)),)
+
+    if isinstance(exc, (SDLValidationError, SDLInstantiationError)):
+        return tuple(
+            diagnostic(code, address, _scrub_absolute_paths(message))
+            for message in exc.errors
+        )
+
+    # Fail closed on any unrecognized exception shape: never fall back to
+    # str(exc) — an exception type outside the four documented shapes has
+    # no proven-safe rendering.
+    return (diagnostic(code, address, "admission failed: unrecognized validation failure"),)

--- a/src/aptl/core/experiment/policy.py
+++ b/src/aptl/core/experiment/policy.py
@@ -1,0 +1,152 @@
+"""Experiment-admission resource limits and allocation-ordering policy.
+
+ADR-047 "Deterministic immutable trial plan": ``allocation_method``,
+stochastic-control ``role``, and ordering behavior are executable only when
+they map to a supported, versioned controller policy — free-form text is
+never evaluated or silently approximated. This module owns that mapping
+plus the in-code resource limits admission enforces before any expensive
+parsing or trial expansion.
+
+These are in-code defaults, not :class:`~aptl.core.config.AptlConfig`
+fields: ADR-047 "Config shape" reserves durable ``AptlConfig`` settings for
+non-secret admission limits with a *real* consumer, and trial-plan
+expansion (a later stage) is that consumer's home, not this one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic
+
+#: Stable identity for the resource-limit/mapping policy itself. A future
+#: policy revision (e.g. a new supported allocation method) bumps this
+#: string so a persisted plan can record exactly which policy admitted it.
+_POLICY_VERSION = "aptl-admission/v1"
+
+
+class OrderingKind(str, Enum):
+    """A supported, versioned trial-ordering behavior.
+
+    Trial-plan expansion (a later stage) imports this enum rather than
+    branching on the raw ``allocation_method`` string — ADR-047 forbids
+    letting condition names or free-text method values select behavior in
+    ``if``/``match`` branches.
+    """
+
+    #: Ordinal ``0..target_run_count-1`` (flat allocation, no conditions).
+    FLAT = "flat"
+    #: The authored ``compared_conditions`` order, then a zero-based
+    #: replication ordinal within each condition.
+    CONDITION_MAJOR_REPLICATION = "condition-major-replication"
+
+
+#: Controlled mapping from the ACES contract's free-text
+#: ``allocation_method`` to a supported :class:`OrderingKind`. Additive
+#: only: a future supported method is a new entry here (plus conformance
+#: tests), never a scenario/condition-name branch.
+_DEFAULT_SUPPORTED_ALLOCATION_METHODS: MappingProxyType[str, OrderingKind] = MappingProxyType(
+    {
+        "balanced": OrderingKind.CONDITION_MAJOR_REPLICATION,
+        "condition-major": OrderingKind.CONDITION_MAJOR_REPLICATION,
+        "flat": OrderingKind.FLAT,
+    }
+)
+
+#: Subset of ``ExperimentStochasticControlModel.role``'s six ACES-legal
+#: literal values that the controller can currently derive a deterministic,
+#: domain-separated seed/order from (ADR-047: "A seed or randomized order
+#: is derived with a documented, domain-separated cryptographic hash").
+#: The remaining ACES-legal roles are structurally valid but not yet an
+#: admittable controller policy, so they fail closed here.
+_DEFAULT_SUPPORTED_STOCHASTIC_CONTROL_ROLES: frozenset[str] = frozenset({"seed", "randomization"})
+
+_DEFAULT_SUPPORTED_ORDERINGS: frozenset[OrderingKind] = frozenset(
+    {OrderingKind.FLAT, OrderingKind.CONDITION_MAJOR_REPLICATION}
+)
+
+
+@dataclass(frozen=True)
+class AdmissionPolicy:
+    """In-code experiment-admission resource limits and supported mappings.
+
+    All byte/count limits are enforced BEFORE expensive parsing or trial
+    expansion (ADR-047 "Authorized artifact resolution"). ``policy_version``
+    is recorded alongside an admitted plan so a later replay can tell
+    whether the same policy produced it.
+    """
+
+    policy_version: str = _POLICY_VERSION
+
+    #: Byte bound for the root experiment-authoring-input document, applied
+    #: before ``parse_experiment_spec`` ever sees the bytes.
+    max_root_bytes: int = 1 * 1024 * 1024
+    #: Byte bound for any single resolved artifact (task, capture-spec,
+    #: scenario, associated artifact).
+    max_artifact_bytes: int = 16 * 1024 * 1024
+    #: Byte bound across every artifact resolved during one admission.
+    max_aggregate_bytes: int = 128 * 1024 * 1024
+    #: Maximum distinct artifact references resolved during one admission.
+    max_reference_count: int = 256
+    #: Maximum total planned trials across the whole allocation.
+    max_allocation_size: int = 10_000
+    #: Maximum structural nesting depth admission will walk (same order of
+    #: magnitude as ``aces_sdl.SDLParserLimits.max_depth``).
+    max_nesting_depth: int = 128
+
+    #: DEBUG-ONLY escape hatch, default ``False`` (production stays
+    #: strict/fail-closed). At the locked ACES 0.23.1 surface, the published
+    #: reference-processor manifest names only ``stub`` as a compatible
+    #: backend, so ``check_apparatus_admission`` rejects EVERY admission
+    #: that uses the real default manifests (ADR-047 Gotchas). This is an
+    #: explicit product decision to let dev/test admit against the REAL
+    #: ``aptl`` manifest anyway: when mutual apparatus-manifest
+    #: compatibility is the ONLY failing admission gate,
+    #: ``check_apparatus_admission`` downgrades that one mismatch to a
+    #: non-fatal warning instead of raising. Every OTHER gate (identity
+    #: mismatch, missing required capability, a ``required_manifest_refs``
+    #: pinning failure, an intent that widens the task) stays fatal
+    #: regardless of this flag — it narrows exactly one documented,
+    #: structural gap, never the whole admission surface.
+    allow_uncertified_apparatus: bool = False
+
+    supported_allocation_methods: MappingProxyType[str, OrderingKind] = field(
+        default_factory=lambda: _DEFAULT_SUPPORTED_ALLOCATION_METHODS
+    )
+    supported_stochastic_control_roles: frozenset[str] = field(
+        default_factory=lambda: _DEFAULT_SUPPORTED_STOCHASTIC_CONTROL_ROLES
+    )
+    supported_orderings: frozenset[OrderingKind] = field(
+        default_factory=lambda: _DEFAULT_SUPPORTED_ORDERINGS
+    )
+
+
+def default_admission_policy() -> AdmissionPolicy:
+    """Return the standard :class:`AdmissionPolicy` (in-code defaults)."""
+    return AdmissionPolicy()
+
+
+def resolve_allocation_ordering(policy: AdmissionPolicy, allocation_method: str) -> OrderingKind:
+    """Map a free-text ``allocation_method`` to a supported ordering.
+
+    ``allocation_method`` is untrusted, authored free text
+    (``ExperimentRunAllocationPlanModel.allocation_method: NonEmptyString``)
+    — it is looked up in ``policy.supported_allocation_methods`` and never
+    evaluated, formatted into a shell/import/template, or fuzzily matched.
+    An unmapped value raises :class:`AdmissionRejection`; the raw value is
+    deliberately never echoed into the diagnostic message.
+    """
+    kind = policy.supported_allocation_methods.get(allocation_method)
+    if kind is None:
+        raise AdmissionRejection(
+            (
+                diagnostic(
+                    "aptl.experiment-admission.allocation-method-unsupported",
+                    "run_plan.allocation.allocation_method",
+                    "allocation_method does not map to a supported ordering policy",
+                ),
+            )
+        )
+    return kind

--- a/src/aptl/core/experiment/resolver.py
+++ b/src/aptl/core/experiment/resolver.py
@@ -114,6 +114,7 @@ class ArtifactResolver(Protocol):
 
 
 def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    """Build a one-diagnostic AdmissionRejection for a locator/resolver failure."""
     return AdmissionRejection((diagnostic(code, address, message),))
 
 
@@ -176,47 +177,64 @@ def parse_locator(raw: str, *, address: str = "artifact-locator") -> ProjectFile
     )
 
 
+def _validate_query_key(key: str, value: str, *, address: str) -> None:
+    """Reject an unrecognized or secret-shaped locator query key/value before it is interpreted."""
+    if key not in _RECOGNIZED_QUERY_KEYS:
+        raise _reject(
+            "aptl.experiment-admission.locator-unrecognized-query-field",
+            address,
+            "artifact locator query field is not recognized",
+        )
+    if is_sensitive_key(key) or is_secret_shaped_value(value):
+        raise _reject(
+            "aptl.experiment-admission.locator-secret-bearing-query",
+            address,
+            "artifact locator query field looks secret-shaped",
+        )
+
+
+def _parse_size_field(value: str, *, address: str) -> int:
+    """Validate and parse the locator query's ``size`` field into a non-negative int."""
+    if not value.isdigit():
+        raise _reject(
+            "aptl.experiment-admission.locator-invalid-size",
+            address,
+            "artifact locator size field must be a non-negative integer",
+        )
+    return int(value)
+
+
+def _parse_digest_field(value: str, *, address: str) -> str:
+    """Validate the locator query's ``digest`` field against the supported prefixed-digest pattern."""
+    if not _DIGEST_PATTERN.match(value):
+        raise _reject(
+            "aptl.experiment-admission.locator-invalid-digest",
+            address,
+            "artifact locator digest field is not a supported prefixed digest",
+        )
+    return value
+
+
 def _parse_query(
     query: str, *, address: str
 ) -> tuple[int | None, str | None, str | None]:
+    """Parse and validate the locator's query string into (declared_size, declared_digest, media_type)."""
     declared_size: int | None = None
     declared_digest: str | None = None
     media_type: str | None = None
     for key, value in parse_qsl(query, keep_blank_values=True):
-        if key not in _RECOGNIZED_QUERY_KEYS:
-            raise _reject(
-                "aptl.experiment-admission.locator-unrecognized-query-field",
-                address,
-                "artifact locator query field is not recognized",
-            )
-        if is_sensitive_key(key) or is_secret_shaped_value(value):
-            raise _reject(
-                "aptl.experiment-admission.locator-secret-bearing-query",
-                address,
-                "artifact locator query field looks secret-shaped",
-            )
+        _validate_query_key(key, value, address=address)
         if key == "size":
-            if not value.isdigit():
-                raise _reject(
-                    "aptl.experiment-admission.locator-invalid-size",
-                    address,
-                    "artifact locator size field must be a non-negative integer",
-                )
-            declared_size = int(value)
+            declared_size = _parse_size_field(value, address=address)
         elif key == "digest":
-            if not _DIGEST_PATTERN.match(value):
-                raise _reject(
-                    "aptl.experiment-admission.locator-invalid-digest",
-                    address,
-                    "artifact locator digest field is not a supported prefixed digest",
-                )
-            declared_digest = value
+            declared_digest = _parse_digest_field(value, address=address)
         elif key == "media_type":
             media_type = value
     return declared_size, declared_digest, media_type
 
 
 def _validate_relative_path(path: str, *, address: str) -> None:
+    """Reject an empty, absolute, or '.'/'..'/empty-component-bearing relative path."""
     if not path:
         raise _reject(
             "aptl.experiment-admission.locator-empty-path",
@@ -239,6 +257,7 @@ def _validate_relative_path(path: str, *, address: str) -> None:
 
 
 def _digest_hex(data: bytes, algorithm: str) -> str:
+    """Return the lowercase hex digest of data under the named algorithm (blake3 or a hashlib algorithm)."""
     if algorithm == "blake3":
         return blake3.blake3(data).hexdigest()
     hasher = hashlib.new(algorithm)

--- a/src/aptl/core/experiment/resolver.py
+++ b/src/aptl/core/experiment/resolver.py
@@ -1,0 +1,348 @@
+"""The offline, project-contained authorized artifact resolver.
+
+ADR-047 "Authorized artifact resolution": experiment references are
+capabilities, not paths or commands. The default resolver is offline and
+project-contained; it accepts only explicitly supported locator forms and
+returns one bounded byte stream plus normalized locator metadata — never an
+executable object or a path to reopen.
+
+Two layers, tested independently:
+
+* :func:`parse_locator` is pure string classification of an untrusted
+  locator string into a normalized :class:`ProjectFileLocator`. It never
+  touches the filesystem, so a hostile locator can be rejected before any
+  I/O happens.
+* :class:`ProjectContainedResolver` actually resolves bytes. It opens the
+  target exactly once via
+  :func:`aptl.utils.pathsafe.open_contained_nofollow` (descriptor-relative,
+  no-follow — a symlinked path component anywhere, including the leaf, is
+  rejected rather than silently followed), verifies declared size/digest
+  from that single handle, and tracks aggregate bytes/reference count
+  across its own lifetime so a caller can fail an entire admission closed
+  once either limit is exceeded.
+
+SDL import graphs are explicitly OUT of scope for this resolver: ADR-047
+"Authorized artifact resolution" requires a future staged-import resolver
+to materialize a digest-pinned, size-bounded transitive graph into private
+staging before ACES ever parses an import-declaring scenario. This module
+does not attempt that; ``spec_loading.parse_scenario_bytes`` rejects any
+scenario that declares imports instead. A remote/staged-import resolver
+implementing the same :class:`ArtifactResolver` protocol is the documented
+extension seam — it must not fall back to ambient filesystem/PATH/env/
+package-import lookup on failure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import parse_qsl, urlsplit
+
+import blake3
+
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic
+from aptl.core.experiment.policy import AdmissionPolicy
+from aptl.utils.pathsafe import PathContainmentError, open_contained_nofollow
+from aptl.utils.redaction import is_secret_shaped_value, is_sensitive_key
+
+# Same four algorithms as the ACES `PrefixedDigestString` pattern
+# (`^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|
+# blake3:[A-Fa-f0-9]{64})$`) — kept in lockstep so a locator this resolver
+# accepts is always a digest ACES itself would also accept.
+_DIGEST_PATTERN = re.compile(
+    r"^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|"
+    r"sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$"
+)
+_HASHLIB_ALGORITHMS: frozenset[str] = frozenset({"sha256", "sha384", "sha512"})
+
+# Locators are treated as opaque project-relative paths by default (no
+# scheme), or explicitly `file:...` — never `http(s)`, `oci`, `registry`,
+# or any other transport (ADR-047: "Network, OCI, or registry fetching is
+# disabled by default").
+_ALLOWED_SCHEMES = frozenset({"", "file"})
+_RECOGNIZED_QUERY_KEYS = frozenset({"size", "digest", "media_type"})
+
+
+@dataclass(frozen=True)
+class ResolvedArtifact:
+    """One bounded, verified byte stream plus normalized locator metadata.
+
+    Never a path to reopen and never executable: ``data`` is the exact
+    bytes read from the single open handle, ``locator`` is a normalized
+    PORTABLE (project-relative, never host-absolute) reference, and
+    ``digest`` is the sha256 of ``data`` computed by the resolver itself
+    (not merely echoed from a caller-declared value).
+    """
+
+    data: bytes
+    locator: str
+    digest: str
+    media_type: str | None
+
+
+@dataclass(frozen=True)
+class ProjectFileLocator:
+    """A normalized, validated project-file locator.
+
+    Produced by :func:`parse_locator` from an untrusted raw string, or
+    constructed directly by a caller that already has a trusted relative
+    path. ``resolve()`` re-validates every field regardless of origin —
+    it never assumes a ``ProjectFileLocator`` was necessarily built by
+    :func:`parse_locator`.
+    """
+
+    relative_path: str
+    declared_size: int | None = None
+    declared_digest: str | None = None
+    media_type: str | None = None
+
+
+class ArtifactResolver(Protocol):
+    """The narrow resolver contract admission depends on.
+
+    A future remote/staged-import resolver (ADR-047's documented
+    extension seam) implements this same protocol, parameterized by
+    allowed scheme/authority, offline mode, limits, and digest policy,
+    while always returning the same bounded immutable byte binding.
+    """
+
+    def resolve(self, locator: ProjectFileLocator, *, policy: AdmissionPolicy) -> ResolvedArtifact: ...
+
+
+def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    return AdmissionRejection((diagnostic(code, address, message),))
+
+
+def parse_locator(raw: str, *, address: str = "artifact-locator") -> ProjectFileLocator:
+    """Parse and validate an untrusted locator string.
+
+    Pure string classification — never touches the filesystem. Rejects
+    every locator shape ADR-047 "Authorized artifact resolution"
+    disallows: credential userinfo (``user:pass@``), a secret-shaped or
+    unrecognized query field, any scheme other than the implicit/`file:`
+    project-relative form (so ``http(s)``, ``oci``, ``registry``, ``urn``,
+    etc. are all rejected), an absolute path, and any ``..``/``.``/empty
+    path component. ``size``/``digest``/``media_type`` query fields
+    populate the corresponding :class:`ProjectFileLocator` fields; every
+    other query key is rejected closed rather than silently ignored.
+    """
+    if not raw:
+        raise _reject(
+            "aptl.experiment-admission.locator-empty", address, "artifact locator must not be empty"
+        )
+    if "\x00" in raw:
+        raise _reject(
+            "aptl.experiment-admission.locator-nul-byte",
+            address,
+            "artifact locator must not contain a NUL byte",
+        )
+
+    parts = urlsplit(raw)
+    if parts.scheme not in _ALLOWED_SCHEMES:
+        raise _reject(
+            "aptl.experiment-admission.locator-unsupported-scheme",
+            address,
+            "artifact locator scheme is not supported; only project-relative file "
+            "locators are permitted",
+        )
+    if parts.username is not None or parts.password is not None:
+        raise _reject(
+            "aptl.experiment-admission.locator-credential-userinfo",
+            address,
+            "artifact locator must not carry credential userinfo",
+        )
+    if parts.netloc and parts.scheme == "":
+        # A bare "host/path"-shaped string with no scheme is ambiguous
+        # (urlsplit only populates netloc for a `scheme://...`-style
+        # input); reject rather than guess at intent.
+        raise _reject(
+            "aptl.experiment-admission.locator-unsupported-scheme",
+            address,
+            "artifact locator must be a project-relative path",
+        )
+
+    declared_size, declared_digest, media_type = _parse_query(parts.query, address=address)
+    _validate_relative_path(parts.path, address=address)
+
+    return ProjectFileLocator(
+        relative_path=parts.path,
+        declared_size=declared_size,
+        declared_digest=declared_digest,
+        media_type=media_type,
+    )
+
+
+def _parse_query(
+    query: str, *, address: str
+) -> tuple[int | None, str | None, str | None]:
+    declared_size: int | None = None
+    declared_digest: str | None = None
+    media_type: str | None = None
+    for key, value in parse_qsl(query, keep_blank_values=True):
+        if key not in _RECOGNIZED_QUERY_KEYS:
+            raise _reject(
+                "aptl.experiment-admission.locator-unrecognized-query-field",
+                address,
+                "artifact locator query field is not recognized",
+            )
+        if is_sensitive_key(key) or is_secret_shaped_value(value):
+            raise _reject(
+                "aptl.experiment-admission.locator-secret-bearing-query",
+                address,
+                "artifact locator query field looks secret-shaped",
+            )
+        if key == "size":
+            if not value.isdigit():
+                raise _reject(
+                    "aptl.experiment-admission.locator-invalid-size",
+                    address,
+                    "artifact locator size field must be a non-negative integer",
+                )
+            declared_size = int(value)
+        elif key == "digest":
+            if not _DIGEST_PATTERN.match(value):
+                raise _reject(
+                    "aptl.experiment-admission.locator-invalid-digest",
+                    address,
+                    "artifact locator digest field is not a supported prefixed digest",
+                )
+            declared_digest = value
+        elif key == "media_type":
+            media_type = value
+    return declared_size, declared_digest, media_type
+
+
+def _validate_relative_path(path: str, *, address: str) -> None:
+    if not path:
+        raise _reject(
+            "aptl.experiment-admission.locator-empty-path",
+            address,
+            "artifact locator path must not be empty",
+        )
+    if path.startswith("/"):
+        raise _reject(
+            "aptl.experiment-admission.locator-absolute-path",
+            address,
+            "artifact locator path must be project-relative, not absolute",
+        )
+    for component in path.split("/"):
+        if component in ("", ".", ".."):
+            raise _reject(
+                "aptl.experiment-admission.locator-invalid-path-component",
+                address,
+                "artifact locator path must not contain empty, '.', or '..' components",
+            )
+
+
+def _digest_hex(data: bytes, algorithm: str) -> str:
+    if algorithm == "blake3":
+        return blake3.blake3(data).hexdigest()
+    hasher = hashlib.new(algorithm)
+    hasher.update(data)
+    return hasher.hexdigest()
+
+
+@dataclass
+class _ResolverAccumulator:
+    """Mutable per-resolver-instance counters (one instance = one session)."""
+
+    total_bytes: int = 0
+    reference_count: int = 0
+
+
+@dataclass
+class ProjectContainedResolver:
+    """Offline, project-contained :class:`ArtifactResolver`.
+
+    Every ``resolve()`` call opens its target exactly once via
+    :func:`aptl.utils.pathsafe.open_contained_nofollow` under ``base_dir``
+    — no fallback to CWD, ``PATH``, environment, or package import on any
+    failure. Aggregate bytes and reference count are tracked across the
+    resolver instance's own lifetime (one instance is one resolve
+    session); construct a fresh instance per admission attempt.
+    """
+
+    base_dir: Path
+    _accumulator: _ResolverAccumulator = field(default_factory=_ResolverAccumulator, init=False)
+
+    def resolve(self, locator: ProjectFileLocator, *, policy: AdmissionPolicy) -> ResolvedArtifact:
+        address = locator.relative_path
+
+        if locator.declared_digest is not None and not _DIGEST_PATTERN.match(locator.declared_digest):
+            raise _reject(
+                "aptl.experiment-admission.artifact-unsupported-digest-algorithm",
+                address,
+                "artifact declared digest algorithm is not supported",
+            )
+        if self._accumulator.reference_count >= policy.max_reference_count:
+            raise _reject(
+                "aptl.experiment-admission.reference-count-exceeded",
+                address,
+                "artifact reference count exceeds the admission policy limit",
+            )
+
+        data = self._open_and_read(locator, policy=policy)
+
+        if locator.declared_size is not None and locator.declared_size != len(data):
+            raise _reject(
+                "aptl.experiment-admission.artifact-size-mismatch",
+                address,
+                "artifact declared size does not match the resolved bytes",
+            )
+
+        if locator.declared_digest is not None:
+            algorithm, _, expected_hex = locator.declared_digest.partition(":")
+            actual_hex = _digest_hex(data, algorithm)
+            if actual_hex.lower() != expected_hex.lower():
+                raise _reject(
+                    "aptl.experiment-admission.artifact-digest-mismatch",
+                    address,
+                    "artifact declared digest does not match the resolved bytes",
+                )
+
+        new_total = self._accumulator.total_bytes + len(data)
+        if new_total > policy.max_aggregate_bytes:
+            raise _reject(
+                "aptl.experiment-admission.aggregate-bytes-exceeded",
+                address,
+                "aggregate resolved bytes exceed the admission policy limit",
+            )
+
+        self._accumulator.total_bytes = new_total
+        self._accumulator.reference_count += 1
+
+        return ResolvedArtifact(
+            data=data,
+            locator=locator.relative_path,
+            digest=f"sha256:{_digest_hex(data, 'sha256')}",
+            media_type=locator.media_type,
+        )
+
+    def _open_and_read(self, locator: ProjectFileLocator, *, policy: AdmissionPolicy) -> bytes:
+        address = locator.relative_path
+        try:
+            handle = open_contained_nofollow(self.base_dir, locator.relative_path)
+        except PathContainmentError as exc:
+            raise _reject(
+                f"aptl.experiment-admission.artifact-{exc.reason}",
+                address,
+                "artifact locator could not be safely opened under the project root",
+            ) from exc
+        try:
+            # fstat the already-open handle (not a second path lookup) so
+            # an oversized file is rejected before it is fully read into
+            # memory.
+            size = os.fstat(handle.fileno()).st_size
+            if size > policy.max_artifact_bytes:
+                raise _reject(
+                    "aptl.experiment-admission.artifact-too-large",
+                    address,
+                    "artifact exceeds the per-artifact byte limit",
+                )
+            return handle.read()
+        finally:
+            handle.close()

--- a/src/aptl/core/experiment/spec_loading.py
+++ b/src/aptl/core/experiment/spec_loading.py
@@ -75,10 +75,12 @@ _CODE_SCENARIO_IMPORTS_UNSUPPORTED = "aptl.experiment-admission.scenario-imports
 
 
 def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    """Build a one-diagnostic AdmissionRejection for a document-loading failure."""
     return AdmissionRejection((diagnostic(code, address, message),))
 
 
 def _decode_bounded_utf8(data: bytes, *, max_bytes: int, address: str, code: str) -> str:
+    """Decode data as UTF-8 text, rejecting an over-size payload, invalid UTF-8, or an embedded NUL byte."""
     if len(data) > max_bytes:
         raise _reject(code, address, "document exceeds the configured byte limit")
     try:
@@ -104,6 +106,7 @@ class _DuplicateKeyRejectingLoader(yaml.SafeLoader):
 def _construct_mapping_no_duplicates(
     loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False
 ) -> dict[object, object]:
+    """YAML mapping constructor that raises on a duplicate key instead of silently keeping the last one."""
     mapping: dict[object, object] = {}
     for key_node, value_node in node.value:
         key = loader.construct_object(key_node, deep=deep)
@@ -154,6 +157,7 @@ def _reject_duplicate_json_members(pairs: list[tuple[str, object]]) -> dict[str,
 def _load_bounded_json(
     data: bytes, *, policy: AdmissionPolicy, address: str, code: str
 ) -> object:
+    """Bounded-decode and duplicate-member-rejecting JSON load of data."""
     text = _decode_bounded_utf8(data, max_bytes=policy.max_artifact_bytes, address=address, code=code)
     try:
         return json.loads(text, object_pairs_hook=_reject_duplicate_json_members)

--- a/src/aptl/core/experiment/spec_loading.py
+++ b/src/aptl/core/experiment/spec_loading.py
@@ -1,0 +1,268 @@
+"""Bounded, hardened loading of ACES artifacts from resolver bytes.
+
+ADR-047 "ACES contracts remain authoritative": the root enters through
+``parse_experiment_spec``; task/capture-spec payloads validate through the
+exported ``ExperimentTaskModel``/``ExperimentCaptureSpecModel`` surfaces;
+import-free scenario material is parsed from resolver-owned bytes with
+``aces_sdl.parse_sdl``. APTL does not define a local authoring-input, task,
+capture, or scenario model — every function here returns the ACES object
+directly.
+
+Every loader here takes ``data: bytes`` (never a path) — the caller is
+expected to have already produced those bytes through
+``aptl.core.experiment.resolver`` (one-open, no-follow, digest-verified).
+Nothing in this module reopens a path.
+
+Two parser-hardening gaps are closed before ANY ACES/pydantic model ever
+sees the payload (ADR-047 "Input shape" / "Gotchas"):
+
+* ``parse_experiment_spec`` uses ``yaml.safe_load``, which silently keeps
+  the LAST of a duplicate mapping key instead of rejecting the ambiguity.
+  A narrow duplicate-key-rejecting YAML preflight runs first.
+* ``load_associated_artifact_manifest_json`` and the task/capture-spec
+  loaders here use JSON; a duplicate JSON object member is rejected the
+  same way ``load_associated_artifact_manifest_json`` already does.
+
+Every failure — parser preflight, YAML/JSON decode, or the underlying ACES
+validator — is normalized through
+:func:`aptl.core.experiment.errors.normalize_aces_failure` and raised as
+:class:`aptl.core.experiment.errors.AdmissionRejection`. In particular,
+``ExperimentSpecValidationError``'s ``str()`` (which embeds pydantic's
+``input_value``) is never read.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import BinaryIO
+
+import yaml
+from aces_contracts.associated_artifacts import (
+    AssociatedArtifactManifestModel,
+    AssociatedArtifactValidationLimits,
+    validate_associated_artifact_manifest,
+)
+from aces_contracts.contracts import ExperimentCaptureSpecModel, ExperimentTaskModel
+from aces_contracts.experiment_spec import (
+    ExperimentSpecModel,
+    ExperimentSpecValidationError,
+    parse_experiment_spec,
+)
+from aces_sdl import SDLParseError, SDLValidationError, parse_sdl
+from aces_sdl.canonical import SDLCanonicalDigest, canonical_sdl_digest
+from aces_sdl.scenario import Scenario
+from pydantic import ValidationError as PydanticValidationError
+
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic, normalize_aces_failure
+from aptl.core.experiment.policy import AdmissionPolicy
+
+_ADDRESS_ROOT = "root"
+_ADDRESS_TASK = "task"
+_ADDRESS_CAPTURE_SPEC = "capture_spec"
+_ADDRESS_SCENARIO = "scenario"
+
+_CODE_ROOT_INVALID = "aptl.experiment-admission.root-invalid"
+_CODE_TASK_INVALID = "aptl.experiment-admission.task-invalid"
+_CODE_CAPTURE_SPEC_INVALID = "aptl.experiment-admission.capture-spec-invalid"
+_CODE_SCENARIO_INVALID = "aptl.experiment-admission.scenario-invalid"
+_CODE_SCENARIO_IMPORTS_UNSUPPORTED = "aptl.experiment-admission.scenario-imports-unsupported"
+
+
+# ---------------------------------------------------------------------------
+# Shared bounded-decode + duplicate-key preflight helpers
+# ---------------------------------------------------------------------------
+
+
+def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    return AdmissionRejection((diagnostic(code, address, message),))
+
+
+def _decode_bounded_utf8(data: bytes, *, max_bytes: int, address: str, code: str) -> str:
+    if len(data) > max_bytes:
+        raise _reject(code, address, "document exceeds the configured byte limit")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _reject(code, address, "document is not valid UTF-8") from exc
+    if "\x00" in text:
+        raise _reject(code, address, "document must not contain a NUL byte")
+    return text
+
+
+class _DuplicateKeyRejectingLoader(yaml.SafeLoader):
+    """A ``SafeLoader`` that raises on a duplicate YAML mapping key.
+
+    Stock ``yaml.safe_load`` (what ``parse_experiment_spec`` uses)
+    silently keeps the LAST of a duplicate key instead of rejecting the
+    ambiguity (ADR-047 gotcha). This loader is used ONLY for the
+    preflight pass — the result is discarded and ``parse_experiment_spec``
+    is still the sole authority for the actual model.
+    """
+
+
+def _construct_mapping_no_duplicates(
+    loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[object, object]:
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found duplicate key",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_DuplicateKeyRejectingLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping_no_duplicates
+)
+
+
+def _yaml_duplicate_key_preflight(text: str, *, address: str, code: str) -> None:
+    """Reject a duplicate mapping key or a multi-document stream.
+
+    ``yaml.load`` (used with any ``Loader``, including this one) already
+    raises ``ComposerError`` for a multi-document stream, since it calls
+    the loader's ``get_single_data()``. The result is intentionally
+    discarded: this is a preflight, not a second parse path — the public
+    ACES loader remains the sole model authority.
+    """
+    try:
+        yaml.load(text, Loader=_DuplicateKeyRejectingLoader)
+    except yaml.YAMLError as exc:
+        raise _reject(
+            code, address, "document failed the duplicate-key/single-document preflight"
+        ) from exc
+
+
+def _reject_duplicate_json_members(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """``object_pairs_hook`` mirroring ``load_associated_artifact_manifest_json``'s
+    own duplicate-member rejection, reused here for task/capture-spec JSON."""
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON member {key!r}")
+        result[key] = value
+    return result
+
+
+def _load_bounded_json(
+    data: bytes, *, policy: AdmissionPolicy, address: str, code: str
+) -> object:
+    text = _decode_bounded_utf8(data, max_bytes=policy.max_artifact_bytes, address=address, code=code)
+    try:
+        return json.loads(text, object_pairs_hook=_reject_duplicate_json_members)
+    except ValueError as exc:
+        raise _reject(
+            code, address, "document failed the duplicate-key/JSON preflight"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Public loaders
+# ---------------------------------------------------------------------------
+
+
+def load_experiment_root(data: bytes, *, policy: AdmissionPolicy) -> ExperimentSpecModel:
+    """Bounded, hardened load of the root ``experiment-authoring-input/v1`` document."""
+    text = _decode_bounded_utf8(
+        data, max_bytes=policy.max_root_bytes, address=_ADDRESS_ROOT, code=_CODE_ROOT_INVALID
+    )
+    _yaml_duplicate_key_preflight(text, address=_ADDRESS_ROOT, code=_CODE_ROOT_INVALID)
+    try:
+        return parse_experiment_spec(text)
+    except ExperimentSpecValidationError as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(exc, address=_ADDRESS_ROOT, code=_CODE_ROOT_INVALID)
+        ) from exc
+
+
+def load_task(data: bytes, *, policy: AdmissionPolicy) -> ExperimentTaskModel:
+    """Bounded, hardened load of an ``experiment-task/v1`` artifact (JSON)."""
+    payload = _load_bounded_json(
+        data, policy=policy, address=_ADDRESS_TASK, code=_CODE_TASK_INVALID
+    )
+    try:
+        return ExperimentTaskModel.model_validate(payload)
+    except PydanticValidationError as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(exc, address=_ADDRESS_TASK, code=_CODE_TASK_INVALID)
+        ) from exc
+
+
+def load_capture_spec(data: bytes, *, policy: AdmissionPolicy) -> ExperimentCaptureSpecModel:
+    """Bounded, hardened load of an ``experiment-capture-spec/v1`` artifact (JSON)."""
+    payload = _load_bounded_json(
+        data, policy=policy, address=_ADDRESS_CAPTURE_SPEC, code=_CODE_CAPTURE_SPEC_INVALID
+    )
+    try:
+        return ExperimentCaptureSpecModel.model_validate(payload)
+    except PydanticValidationError as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(exc, address=_ADDRESS_CAPTURE_SPEC, code=_CODE_CAPTURE_SPEC_INVALID)
+        ) from exc
+
+
+def parse_scenario_bytes(
+    data: bytes, *, policy: AdmissionPolicy
+) -> tuple[Scenario, SDLCanonicalDigest]:
+    """Bounded parse of import-free SDL scenario bytes plus its canonical digest.
+
+    ``aces_sdl.parse_sdl`` is called with ``path=None`` ALWAYS — never the
+    resolver's original path — so a symlink swap after the resolver's
+    single open cannot change what gets parsed (ADR-047 "never hand the
+    original untrusted path to ``parse_sdl_file``"). This has a load-
+    bearing side effect: at the locked ACES version, ``parse_sdl(text,
+    path=None)`` itself raises ``SDLParseError`` before returning when the
+    document declares a non-empty ``imports:`` list, because import
+    resolution requires file-backed parsing. The explicit
+    ``scenario.imports`` check below is kept as an independent, defense-
+    in-depth fail-closed guard rather than relying solely on that
+    implementation detail.
+    """
+    text = _decode_bounded_utf8(
+        data, max_bytes=policy.max_artifact_bytes, address=_ADDRESS_SCENARIO, code=_CODE_SCENARIO_INVALID
+    )
+    try:
+        scenario = parse_sdl(text)
+    except (SDLParseError, SDLValidationError) as exc:
+        raise AdmissionRejection(
+            normalize_aces_failure(exc, address=_ADDRESS_SCENARIO, code=_CODE_SCENARIO_INVALID)
+        ) from exc
+
+    if scenario.imports:
+        raise _reject(
+            _CODE_SCENARIO_IMPORTS_UNSUPPORTED,
+            f"{_ADDRESS_SCENARIO}.imports",
+            "scenario declares imports, which admission does not resolve in this release",
+        )
+
+    return scenario, canonical_sdl_digest(scenario)
+
+
+def validate_associated_artifacts(
+    manifest: AssociatedArtifactManifestModel,
+    *,
+    parent: object,
+    artifact_readers: Mapping[str, BinaryIO],
+    limits: AssociatedArtifactValidationLimits,
+) -> None:
+    """Validate an associated-artifact manifest and fail closed on any error.
+
+    Thin wiring over ``validate_associated_artifact_manifest`` (which
+    itself never raises for content — an empty diagnostics tuple means
+    valid). Any error-severity diagnostic in the result is promoted to
+    :class:`AdmissionRejection`; the diagnostics it returns are already
+    the safe canonical shape, so they are used unchanged.
+    """
+    diagnostics = validate_associated_artifact_manifest(
+        manifest, parent=parent, artifact_readers=artifact_readers, limits=limits
+    )
+    errors = tuple(item for item in diagnostics if item.is_error)
+    if errors:
+        raise AdmissionRejection(errors)

--- a/src/aptl/core/experiment/trial_plan.py
+++ b/src/aptl/core/experiment/trial_plan.py
@@ -146,16 +146,19 @@ def compute_source_set_digest(source_set_projection: Mapping[str, object]) -> st
 
 
 def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    """Build a one-diagnostic AdmissionRejection for a trial-plan expansion failure."""
     return AdmissionRejection((diagnostic(code, address, message),))
 
 
 def _coordinate(condition_id: str | None) -> str:
+    """Return condition_id, or the flat-allocation sentinel when there is no condition."""
     return _FLAT_CONDITION_SENTINEL if condition_id is None else condition_id
 
 
 def _derive_seed(
     *, source_set_digest: str, condition_id: str | None, replication_ordinal: int, control_id: str
 ) -> str:
+    """Derive one stochastic control's seed hex digest from the plan's source-set digest and trial coordinate."""
     digest_input = (
         _SEED_DOMAIN
         + _FIELD_SEP
@@ -173,6 +176,7 @@ def _derive_seed(
 def _derive_planned_trial_id(
     *, source_set_digest: str, condition_id: str | None, replication_ordinal: int
 ) -> str:
+    """Derive one trial's planned_trial_id hex digest from the plan's source-set digest and trial coordinate."""
     digest_input = (
         _TRIAL_ID_DOMAIN
         + _FIELD_SEP
@@ -186,6 +190,7 @@ def _derive_planned_trial_id(
 
 
 def _validate_stochastic_controls(spec: ExperimentSpecModel, *, policy: AdmissionPolicy) -> None:
+    """Reject when any stochastic control's role does not map to a supported controller policy."""
     for control in spec.run_plan.stochastic_controls:
         if control.role not in policy.supported_stochastic_control_roles:
             raise _reject(
@@ -196,6 +201,7 @@ def _validate_stochastic_controls(spec: ExperimentSpecModel, *, policy: Admissio
 
 
 def _resolve_ordering_kind(spec: ExperimentSpecModel, *, policy: AdmissionPolicy) -> OrderingKind:
+    """Resolve run_plan's ordering kind (flat vs. condition-major), failing closed on an unsupported alloc method."""
     run_plan = spec.run_plan
     has_allocation = run_plan.allocation is not None
     has_flat_count = run_plan.target_run_count is not None
@@ -225,6 +231,7 @@ def _resolve_ordering_kind(spec: ExperimentSpecModel, *, policy: AdmissionPolicy
 
 
 def _capture_spec_refs(spec: ExperimentSpecModel) -> tuple[str, ...]:
+    """Return the capture-spec reference IDs every trial in this plan carries."""
     return tuple(ref.ref_id for ref in spec.capture_spec_refs)
 
 
@@ -235,6 +242,7 @@ def _build_seeds(
     condition_id: str | None,
     replication_ordinal: int,
 ) -> tuple[tuple[str, str], ...]:
+    """Build one trial's sorted (control_id, seed) pairs for every seed-bearing stochastic control."""
     seeds = [
         (
             control.control_id,
@@ -251,37 +259,47 @@ def _build_seeds(
     return tuple(sorted(seeds))
 
 
+@dataclass(frozen=True)
+class _TrialCoordinate:
+    """One trial's ordering coordinate: its condition (``None`` for a flat
+    plan), replication ordinal, and overall ordering index. Bundled so
+    :func:`_build_trial` stays within the 7-parameter budget (S107)."""
+
+    condition_id: str | None
+    replication_ordinal: int
+    ordering_index: int
+
+
 def _build_trial(
     spec: ExperimentSpecModel,
     *,
     source_set_digest: str,
-    condition_id: str | None,
-    replication_ordinal: int,
-    ordering_index: int,
+    coordinate: _TrialCoordinate,
     factor_levels: tuple[tuple[str, str], ...],
     parameter_bindings: tuple[tuple[str, object], ...],
     condition_snapshot_digests: Mapping[str, str] | None,
     capture_spec_refs: tuple[str, ...],
 ) -> PlannedTrial:
+    """Build one immutable PlannedTrial, deriving its ID and stochastic seeds from source_set_digest and coordinate."""
     scenario_snapshot_digest = (
-        condition_snapshot_digests.get(condition_id) if condition_snapshot_digests else None
+        condition_snapshot_digests.get(coordinate.condition_id) if condition_snapshot_digests else None
     )
     return PlannedTrial(
         planned_trial_id=_derive_planned_trial_id(
             source_set_digest=source_set_digest,
-            condition_id=condition_id,
-            replication_ordinal=replication_ordinal,
+            condition_id=coordinate.condition_id,
+            replication_ordinal=coordinate.replication_ordinal,
         ),
-        condition_id=condition_id,
-        replication_ordinal=replication_ordinal,
-        ordering_index=ordering_index,
+        condition_id=coordinate.condition_id,
+        replication_ordinal=coordinate.replication_ordinal,
+        ordering_index=coordinate.ordering_index,
         factor_levels=factor_levels,
         parameter_bindings=parameter_bindings,
         stochastic_seeds=_build_seeds(
             spec,
             source_set_digest=source_set_digest,
-            condition_id=condition_id,
-            replication_ordinal=replication_ordinal,
+            condition_id=coordinate.condition_id,
+            replication_ordinal=coordinate.replication_ordinal,
         ),
         scenario_snapshot_digest=scenario_snapshot_digest,
         capture_spec_refs=capture_spec_refs,
@@ -294,14 +312,13 @@ def _expand_flat(
     source_set_digest: str,
     capture_spec_refs: tuple[str, ...],
 ) -> tuple[PlannedTrial, ...]:
+    """Expand a flat (unconditioned) run_plan into target_run_count independently-replicated trials."""
     target_run_count = spec.run_plan.target_run_count
     return tuple(
         _build_trial(
             spec,
             source_set_digest=source_set_digest,
-            condition_id=None,
-            replication_ordinal=ordinal,
-            ordering_index=ordinal,
+            coordinate=_TrialCoordinate(condition_id=None, replication_ordinal=ordinal, ordering_index=ordinal),
             factor_levels=(),
             parameter_bindings=(),
             condition_snapshot_digests=None,
@@ -318,6 +335,7 @@ def _expand_condition(
     condition_snapshot_digests: Mapping[str, str] | None,
     capture_spec_refs: tuple[str, ...],
 ) -> tuple[PlannedTrial, ...]:
+    """Expand a condition allocation into condition-major-replication-ordered trials, one per condition/replication."""
     allocation = spec.run_plan.allocation
     trials: list[PlannedTrial] = []
     ordering_index = 0
@@ -335,9 +353,11 @@ def _expand_condition(
                 _build_trial(
                     spec,
                     source_set_digest=source_set_digest,
-                    condition_id=condition_id,
-                    replication_ordinal=replication_ordinal,
-                    ordering_index=ordering_index,
+                    coordinate=_TrialCoordinate(
+                        condition_id=condition_id,
+                        replication_ordinal=replication_ordinal,
+                        ordering_index=ordering_index,
+                    ),
                     factor_levels=factor_levels,
                     parameter_bindings=parameter_bindings,
                     condition_snapshot_digests=condition_snapshot_digests,
@@ -349,6 +369,7 @@ def _expand_condition(
 
 
 def _trial_projection(trial: PlannedTrial) -> dict[str, object]:
+    """Project one PlannedTrial into its canonical-JSON-ready dict shape."""
     return {
         "planned_trial_id": trial.planned_trial_id,
         "condition_id": trial.condition_id,
@@ -373,6 +394,7 @@ def _canonicalize(
     ordering_kind: OrderingKind,
     trials: tuple[PlannedTrial, ...],
 ) -> tuple[bytes, str, str]:
+    """Canonicalize the plan projection to RFC 8785 bytes and derive (canonical_bytes, plan_digest, plan_id)."""
     projection = {
         "plan_schema": _PLAN_PROJECTION_SCHEMA,
         "policy_version": policy_version,

--- a/src/aptl/core/experiment/trial_plan.py
+++ b/src/aptl/core/experiment/trial_plan.py
@@ -1,0 +1,457 @@
+"""Deterministic immutable trial-plan expansion (ADR-047 "Deterministic
+immutable trial plan").
+
+Pure, side-effect-free expansion from an admitted
+``ExperimentSpecModel.run_plan`` (flat ``target_run_count`` XOR condition
+``allocation``) into an immutable, host-independent :class:`TrialPlan` of
+:class:`PlannedTrial` value objects. No I/O and no persistence — this
+module only builds in-memory, hashable plan data; a later stage wires the
+result through ``LocalRunStore.create_json_once``.
+
+The trial plan is an APTL-internal execution journal, not a portable ACES
+experiment/task/study/run/apparatus/capture/analysis contract (ADR-047). It
+carries only source identities/digests, canonical condition/factor
+assignments, resolved non-secret parameter bindings, stochastic controls,
+ordering coordinates, and stable planned-trial IDs.
+
+Determinism is the whole point: two expansions of the same admitted spec —
+on any host, in any process, regardless of ``PYTHONHASHSEED``, and
+regardless of the key-insertion order of any authored dict
+(``condition_assignments``, ``factor_levels``) — must produce
+byte-identical :attr:`TrialPlan.canonical_bytes`. That rules out Python
+``hash()``, ``set``/``dict`` iteration order leaking into anything but a
+sorted or RFC 8785 canonical-JSON projection, wall-clock time, UUIDs, and
+ambient/library RNG (ADR-047 "Deterministic immutable trial plan" /
+"Gotchas"). Every planned-trial ID and derived seed is a SHA-256 digest of
+a fixed, versioned domain-separation prefix plus the caller-supplied
+``source_set_digest`` and that trial's logical coordinates (condition ID —
+or a flat sentinel — and replication ordinal, plus, for seeds, the
+stochastic control ID).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import rfc8785
+from aces_contracts.experiment_spec import ExperimentSpecModel
+
+from aptl.core.experiment.errors import AdmissionRejection, diagnostic
+from aptl.core.experiment.policy import AdmissionPolicy, OrderingKind, resolve_allocation_ordering
+
+# ---------------------------------------------------------------------------
+# Domain-separation constants
+# ---------------------------------------------------------------------------
+
+#: Versioned domain separator for stochastic-seed derivation. A future
+#: change to the derivation formula, field order, or field encoding bumps
+#: the version suffix (never reuses one) so old plan bytes can never
+#: silently reinterpret under a new formula.
+_SEED_DOMAIN = b"aptl.exp.trial-seed/v1"
+
+#: Versioned domain separator for planned-trial-ID derivation. Independent
+#: from ``_SEED_DOMAIN`` so a seed-only or ID-only algorithm revision never
+#: collides with the other.
+_TRIAL_ID_DOMAIN = b"aptl.exp.trial-id/v1"
+
+#: ASCII unit separator (0x1F) used to join hash-input fields. Not a legal
+#: character in any authored ACES identifier, so it cannot be abused to
+#: fabricate a cross-field collision (e.g. by embedding the separator
+#: inside a condition ID to make two distinct coordinate tuples hash the
+#: same input bytes).
+_FIELD_SEP = b"\x1f"
+
+#: Sentinel substituted for ``condition_id`` in a flat allocation (there is
+#: no condition). A single :class:`TrialPlan` is always structurally either
+#: flat (every trial's ``condition_id`` is ``None``) or condition-based
+#: (every trial's ``condition_id`` is a real authored ID), so this can
+#: never collide with an authored condition ID within the same plan.
+_FLAT_CONDITION_SENTINEL = "flat"
+
+#: The subset of admitted stochastic-control roles that receive a derived
+#: seed. Currently identical to
+#: ``AdmissionPolicy.supported_stochastic_control_roles``'s default, but
+#: kept as an independent, explicit set: a future supported role that is
+#: *not* seed-bearing (e.g. a scheduling-only role) would be admitted by
+#: policy without gaining a meaningless derived seed here.
+_SEED_BEARING_ROLES = frozenset({"seed", "randomization"})
+
+_PLAN_ID_PREFIX = "plan-"
+_TRIAL_ID_PREFIX = "trial-"
+
+#: Versioned identity for the canonical plan projection shape itself
+#: (distinct from any ACES ``schema_version`` literal — this is an
+#: APTL-internal journal format, never an ACES contract).
+_PLAN_PROJECTION_SCHEMA = "aptl-experiment-trial-plan/v1"
+
+_ADDRESS_RUN_PLAN = "run_plan"
+_ADDRESS_STOCHASTIC_CONTROLS = "run_plan.stochastic_controls"
+_ADDRESS_ALLOCATION_METHOD = "run_plan.allocation.allocation_method"
+
+_CODE_ALLOCATION_TOO_LARGE = "aptl.experiment-admission.allocation-too-large"
+_CODE_STOCHASTIC_ROLE_UNSUPPORTED = "aptl.experiment-admission.stochastic-control-role-unsupported"
+_CODE_ALLOCATION_ORDERING_MISMATCH = "aptl.experiment-admission.allocation-ordering-mismatch"
+
+
+@dataclass(frozen=True)
+class PlannedTrial:
+    """One immutable planned trial coordinate within a :class:`TrialPlan`.
+
+    Every field is a scalar or an already-sorted tuple. No list or dict
+    escapes to a caller, so nothing here is mutable after construction.
+    """
+
+    planned_trial_id: str
+    condition_id: str | None
+    replication_ordinal: int
+    ordering_index: int
+    factor_levels: tuple[tuple[str, str], ...]
+    parameter_bindings: tuple[tuple[str, object], ...]
+    stochastic_seeds: tuple[tuple[str, str], ...]
+    scenario_snapshot_digest: str | None
+    capture_spec_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TrialPlan:
+    """An immutable, deterministically-derived plan for one admitted spec.
+
+    ``canonical_bytes``/``plan_digest`` are RFC 8785 canonical JSON (and its
+    SHA-256 digest) of a projection that excludes admission time and any
+    host-absolute/temp path — two expansions of the same admitted inputs
+    always produce byte-identical ``canonical_bytes``.
+    """
+
+    plan_id: str
+    policy_version: str
+    source_set_digest: str
+    ordering_kind: OrderingKind
+    trials: tuple[PlannedTrial, ...]
+    canonical_bytes: bytes
+    plan_digest: str
+
+
+def compute_source_set_digest(source_set_projection: Mapping[str, object]) -> str:
+    """Return ``sha256:<hex>`` of the RFC 8785 canonical bytes of ``source_set_projection``.
+
+    The caller builds ``source_set_projection`` from resolved artifact
+    identities/digests/versions and must already exclude host-absolute/temp
+    paths and admission time before it reaches here — this function
+    performs no filtering of its own, only canonicalization and hashing.
+    """
+    canonical = rfc8785.dumps(dict(source_set_projection))
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def _reject(code: str, address: str, message: str) -> AdmissionRejection:
+    return AdmissionRejection((diagnostic(code, address, message),))
+
+
+def _coordinate(condition_id: str | None) -> str:
+    return _FLAT_CONDITION_SENTINEL if condition_id is None else condition_id
+
+
+def _derive_seed(
+    *, source_set_digest: str, condition_id: str | None, replication_ordinal: int, control_id: str
+) -> str:
+    digest_input = (
+        _SEED_DOMAIN
+        + _FIELD_SEP
+        + source_set_digest.encode("utf-8")
+        + _FIELD_SEP
+        + _coordinate(condition_id).encode("utf-8")
+        + _FIELD_SEP
+        + str(replication_ordinal).encode("utf-8")
+        + _FIELD_SEP
+        + control_id.encode("utf-8")
+    )
+    return hashlib.sha256(digest_input).hexdigest()
+
+
+def _derive_planned_trial_id(
+    *, source_set_digest: str, condition_id: str | None, replication_ordinal: int
+) -> str:
+    digest_input = (
+        _TRIAL_ID_DOMAIN
+        + _FIELD_SEP
+        + source_set_digest.encode("utf-8")
+        + _FIELD_SEP
+        + _coordinate(condition_id).encode("utf-8")
+        + _FIELD_SEP
+        + str(replication_ordinal).encode("utf-8")
+    )
+    return _TRIAL_ID_PREFIX + hashlib.sha256(digest_input).hexdigest()
+
+
+def _validate_stochastic_controls(spec: ExperimentSpecModel, *, policy: AdmissionPolicy) -> None:
+    for control in spec.run_plan.stochastic_controls:
+        if control.role not in policy.supported_stochastic_control_roles:
+            raise _reject(
+                _CODE_STOCHASTIC_ROLE_UNSUPPORTED,
+                f"{_ADDRESS_STOCHASTIC_CONTROLS}.{control.control_id}.role",
+                "stochastic control role does not map to a supported controller policy",
+            )
+
+
+def _resolve_ordering_kind(spec: ExperimentSpecModel, *, policy: AdmissionPolicy) -> OrderingKind:
+    run_plan = spec.run_plan
+    has_allocation = run_plan.allocation is not None
+    has_flat_count = run_plan.target_run_count is not None
+    if has_allocation == has_flat_count:
+        # ACES's own model validator already enforces this XOR at parse
+        # time; this is a defensive invariant check on an already-admitted
+        # model, not a user-triggerable failure mode.
+        raise AssertionError(
+            "run_plan must declare exactly one of allocation or target_run_count"
+        )
+
+    if not has_allocation:
+        return OrderingKind.FLAT
+
+    kind = resolve_allocation_ordering(policy, run_plan.allocation.allocation_method)
+    if kind is not OrderingKind.CONDITION_MAJOR_REPLICATION:
+        # The method resolved to a *supported* ordering, but not one this
+        # expander implements for a condition allocation (currently the
+        # only condition-shaped algorithm is condition-major-replication).
+        # Fail closed rather than silently mis-expand.
+        raise _reject(
+            _CODE_ALLOCATION_ORDERING_MISMATCH,
+            _ADDRESS_ALLOCATION_METHOD,
+            "allocation_method resolves to an ordering incompatible with a condition allocation",
+        )
+    return kind
+
+
+def _capture_spec_refs(spec: ExperimentSpecModel) -> tuple[str, ...]:
+    return tuple(ref.ref_id for ref in spec.capture_spec_refs)
+
+
+def _build_seeds(
+    spec: ExperimentSpecModel,
+    *,
+    source_set_digest: str,
+    condition_id: str | None,
+    replication_ordinal: int,
+) -> tuple[tuple[str, str], ...]:
+    seeds = [
+        (
+            control.control_id,
+            _derive_seed(
+                source_set_digest=source_set_digest,
+                condition_id=condition_id,
+                replication_ordinal=replication_ordinal,
+                control_id=control.control_id,
+            ),
+        )
+        for control in spec.run_plan.stochastic_controls
+        if control.role in _SEED_BEARING_ROLES
+    ]
+    return tuple(sorted(seeds))
+
+
+def _build_trial(
+    spec: ExperimentSpecModel,
+    *,
+    source_set_digest: str,
+    condition_id: str | None,
+    replication_ordinal: int,
+    ordering_index: int,
+    factor_levels: tuple[tuple[str, str], ...],
+    parameter_bindings: tuple[tuple[str, object], ...],
+    condition_snapshot_digests: Mapping[str, str] | None,
+    capture_spec_refs: tuple[str, ...],
+) -> PlannedTrial:
+    scenario_snapshot_digest = (
+        condition_snapshot_digests.get(condition_id) if condition_snapshot_digests else None
+    )
+    return PlannedTrial(
+        planned_trial_id=_derive_planned_trial_id(
+            source_set_digest=source_set_digest,
+            condition_id=condition_id,
+            replication_ordinal=replication_ordinal,
+        ),
+        condition_id=condition_id,
+        replication_ordinal=replication_ordinal,
+        ordering_index=ordering_index,
+        factor_levels=factor_levels,
+        parameter_bindings=parameter_bindings,
+        stochastic_seeds=_build_seeds(
+            spec,
+            source_set_digest=source_set_digest,
+            condition_id=condition_id,
+            replication_ordinal=replication_ordinal,
+        ),
+        scenario_snapshot_digest=scenario_snapshot_digest,
+        capture_spec_refs=capture_spec_refs,
+    )
+
+
+def _expand_flat(
+    spec: ExperimentSpecModel,
+    *,
+    source_set_digest: str,
+    capture_spec_refs: tuple[str, ...],
+) -> tuple[PlannedTrial, ...]:
+    target_run_count = spec.run_plan.target_run_count
+    return tuple(
+        _build_trial(
+            spec,
+            source_set_digest=source_set_digest,
+            condition_id=None,
+            replication_ordinal=ordinal,
+            ordering_index=ordinal,
+            factor_levels=(),
+            parameter_bindings=(),
+            condition_snapshot_digests=None,
+            capture_spec_refs=capture_spec_refs,
+        )
+        for ordinal in range(target_run_count)
+    )
+
+
+def _expand_condition(
+    spec: ExperimentSpecModel,
+    *,
+    source_set_digest: str,
+    condition_snapshot_digests: Mapping[str, str] | None,
+    capture_spec_refs: tuple[str, ...],
+) -> tuple[PlannedTrial, ...]:
+    allocation = spec.run_plan.allocation
+    trials: list[PlannedTrial] = []
+    ordering_index = 0
+    # Authored order (`compared_conditions`) is the outer loop; condition
+    # dict/key insertion order (`condition_assignments`) never affects the
+    # result because each condition is looked up by ID, not iterated.
+    for condition_id in allocation.compared_conditions:
+        assignment = allocation.condition_assignments[condition_id]
+        factor_levels = tuple(sorted(assignment.factor_levels.items()))
+        parameter_bindings = tuple(
+            sorted((parameter.name, parameter.value) for parameter in assignment.required_parameters)
+        )
+        for replication_ordinal in range(allocation.target_runs_per_condition):
+            trials.append(
+                _build_trial(
+                    spec,
+                    source_set_digest=source_set_digest,
+                    condition_id=condition_id,
+                    replication_ordinal=replication_ordinal,
+                    ordering_index=ordering_index,
+                    factor_levels=factor_levels,
+                    parameter_bindings=parameter_bindings,
+                    condition_snapshot_digests=condition_snapshot_digests,
+                    capture_spec_refs=capture_spec_refs,
+                )
+            )
+            ordering_index += 1
+    return tuple(trials)
+
+
+def _trial_projection(trial: PlannedTrial) -> dict[str, object]:
+    return {
+        "planned_trial_id": trial.planned_trial_id,
+        "condition_id": trial.condition_id,
+        "replication_ordinal": trial.replication_ordinal,
+        "ordering_index": trial.ordering_index,
+        # Represented as JSON objects (not arrays of pairs): RFC 8785
+        # sorts object member names, so this is where "sort semantically
+        # unordered maps" is actually enforced for the persisted bytes,
+        # independent of the in-memory tuple already being pre-sorted.
+        "factor_levels": dict(trial.factor_levels),
+        "parameter_bindings": dict(trial.parameter_bindings),
+        "stochastic_seeds": dict(trial.stochastic_seeds),
+        "scenario_snapshot_digest": trial.scenario_snapshot_digest,
+        "capture_spec_refs": list(trial.capture_spec_refs),
+    }
+
+
+def _canonicalize(
+    *,
+    policy_version: str,
+    source_set_digest: str,
+    ordering_kind: OrderingKind,
+    trials: tuple[PlannedTrial, ...],
+) -> tuple[bytes, str, str]:
+    projection = {
+        "plan_schema": _PLAN_PROJECTION_SCHEMA,
+        "policy_version": policy_version,
+        "source_set_digest": source_set_digest,
+        "ordering_kind": ordering_kind.value,
+        # The trial sequence itself is an authored-meaningful ordered list
+        # (execution order) and stays a JSON array.
+        "trials": [_trial_projection(trial) for trial in trials],
+    }
+    canonical_bytes = rfc8785.dumps(projection)
+    digest_hex = hashlib.sha256(canonical_bytes).hexdigest()
+    plan_digest = f"sha256:{digest_hex}"
+    plan_id = _PLAN_ID_PREFIX + digest_hex
+    return canonical_bytes, plan_digest, plan_id
+
+
+def expand_trial_plan(
+    spec: ExperimentSpecModel,
+    *,
+    source_set_digest: str,
+    condition_snapshot_digests: Mapping[str, str] | None = None,
+    policy: AdmissionPolicy,
+) -> TrialPlan:
+    """Pure expansion of an admitted spec's ``run_plan`` into an immutable :class:`TrialPlan`.
+
+    ``source_set_digest`` and ``condition_snapshot_digests`` are supplied by
+    the caller (a later admission stage) — this function does no artifact
+    resolution or digesting of its own beyond the plan projection itself.
+
+    Raises :class:`AdmissionRejection` when the planned trial count would
+    exceed ``policy.max_allocation_size``, a stochastic control's role does
+    not map to a supported controller policy, or the allocation's free-text
+    ``allocation_method`` does not resolve to a usable ordering.
+    """
+    _validate_stochastic_controls(spec, policy=policy)
+    ordering_kind = _resolve_ordering_kind(spec, policy=policy)
+    capture_refs = _capture_spec_refs(spec)
+
+    if ordering_kind is OrderingKind.FLAT:
+        total = spec.run_plan.target_run_count
+    else:
+        allocation = spec.run_plan.allocation
+        total = len(allocation.compared_conditions) * allocation.target_runs_per_condition
+
+    # Enforced BEFORE allocating the trial list itself.
+    if total > policy.max_allocation_size:
+        raise _reject(
+            _CODE_ALLOCATION_TOO_LARGE,
+            _ADDRESS_RUN_PLAN,
+            "planned trial count exceeds the configured allocation size limit",
+        )
+
+    if ordering_kind is OrderingKind.FLAT:
+        trials = _expand_flat(spec, source_set_digest=source_set_digest, capture_spec_refs=capture_refs)
+    else:
+        trials = _expand_condition(
+            spec,
+            source_set_digest=source_set_digest,
+            condition_snapshot_digests=condition_snapshot_digests,
+            capture_spec_refs=capture_refs,
+        )
+
+    ids = [trial.planned_trial_id for trial in trials]
+    if len(set(ids)) != len(ids):
+        raise AssertionError("planned_trial_id collision within one trial plan")
+
+    canonical_bytes, plan_digest, plan_id = _canonicalize(
+        policy_version=policy.policy_version,
+        source_set_digest=source_set_digest,
+        ordering_kind=ordering_kind,
+        trials=trials,
+    )
+
+    return TrialPlan(
+        plan_id=plan_id,
+        policy_version=policy.policy_version,
+        source_set_digest=source_set_digest,
+        ordering_kind=ordering_kind,
+        trials=trials,
+        canonical_bytes=canonical_bytes,
+        plan_digest=plan_digest,
+    )

--- a/src/aptl/core/runstore.py
+++ b/src/aptl/core/runstore.py
@@ -19,10 +19,37 @@ import shutil
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, TypedDict
 
+import rfc8785
+
 from aptl.utils.logging import get_logger
+from aptl.utils.pathsafe import create_exclusive_nofollow, read_contained_nofollow
 from aptl.utils.redaction import redact
 
 log = get_logger("runstore")
+
+
+class SecretInvariantError(ValueError):
+    """Raised by :meth:`LocalRunStore.create_json_once` when applying the
+    shared secret-classification policy (:mod:`aptl.utils.redaction`) would
+    change the payload.
+
+    ADR-047 "Persistence and state model": the create-once operation must
+    preserve semantic bytes exactly. It must never silently persist a
+    payload that differs from what was approved for execution, so a
+    payload containing identity-bearing secret-shaped content is rejected
+    outright rather than redacted-and-written.
+    """
+
+
+class RunStoreConflictError(ValueError):
+    """Raised by :meth:`LocalRunStore.create_json_once` when the target
+    already exists with canonical bytes that differ from the payload being
+    written.
+
+    A byte-identical existing payload is treated as idempotent success
+    (ADR-047); only a genuine mismatch is an error.
+    """
+
 
 # OBS-003: run / session identifiers become directory components, so they
 # must be filesystem-safe. ``trace_id`` from ``trace-context.json`` is hex
@@ -66,6 +93,44 @@ def _validate_relative_path(relative_path: str) -> str:
             f"invalid relative_path (contains '..'): {relative_path!r}"
         )
     return relative_path
+
+
+def _canonicalize_payload(payload: object) -> tuple[bytes, object]:
+    """Return ``(RFC 8785 canonical bytes, JSON-round-tripped structure)``
+    for :meth:`LocalRunStore.create_json_once`.
+
+    The round-tripped structure is what is actually compared and
+    persisted: a tuple normalizes to a list, and any value that is not
+    already JSON-serializable is a caller bug, not something to silently
+    stringify — ``create_json_once`` payloads are structured plan/trial
+    projections, not free-form archive data, so (unlike :func:`_safe_default`
+    below) no ``default=str`` escape hatch is offered here.
+    """
+    try:
+        raw = json.dumps(payload)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"create_json_once payload is not JSON-serializable: {exc}") from exc
+    normalized = json.loads(raw)
+    return rfc8785.dumps(normalized), normalized
+
+
+def _assert_no_secret_drift(normalized: object) -> None:
+    """Reject ``normalized`` if the shared :func:`redact` policy would
+    change it at all (ADR-047 create-once secret invariant).
+
+    Reuses the exact production :func:`redact` — the same classification
+    :func:`aptl.utils.redaction.is_sensitive_key` and
+    :func:`aptl.utils.redaction.is_secret_shaped_value` are built from — so
+    this can never silently drift out of lockstep with what actually gets
+    redacted elsewhere.
+    """
+    if redact(normalized) != normalized:
+        raise SecretInvariantError(
+            "create_json_once payload contains identity-bearing content "
+            "the shared secret-classification policy (aptl.utils.redaction) "
+            "would change; rejecting rather than silently persisting a "
+            "payload that differs from what was approved for execution"
+        )
 
 
 def _safe_default(obj: object) -> str:
@@ -114,6 +179,8 @@ class RunStorageBackend(Protocol):
     ) -> None: ...
 
     def copy_file(self, run_id: str, relative_path: str, source: Path) -> None: ...
+
+    def create_json_once(self, namespace: str, name: str, payload: object) -> Path: ...
 
     def list_runs(self) -> list[str]: ...
 
@@ -213,6 +280,59 @@ class LocalRunStore:
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, target)
         log.debug("Copied %s -> %s", source, target)
+
+    def create_json_once(self, namespace: str, name: str, payload: object) -> Path:
+        """Create-once, canonical, no-follow, atomic persistence for a
+        controller-owned journal artifact (e.g. a future admitted
+        experiment trial plan).
+
+        ADR-047 "Persistence and state model": distinct from the run-id
+        run-archive tree (:meth:`write_json`/``_run_dir``) — this targets
+        ``<base_dir>/<namespace>/<name>.json``, an explicit non-run
+        namespace beneath the injected store root. It never synthesizes a
+        ``manifest.json`` and is invisible to :meth:`list_runs`.
+
+        Semantics:
+          1. Canonicalize ``payload`` ONCE to RFC 8785 bytes, after a JSON
+             round-trip so both the secret-invariant comparison and the
+             persisted bytes reflect exactly the same structure (a tuple or
+             other non-JSON shape cannot silently disagree with what lands
+             on disk).
+          2. Secret invariant: if the shared ``redact()`` policy would
+             change the canonicalized structure at all, raise
+             :class:`SecretInvariantError` — never silently persist a
+             payload that differs from what was approved.
+          3. Publish with ``O_CREAT | O_EXCL`` under a descriptor-relative,
+             no-follow path (:mod:`aptl.utils.pathsafe`), so a pre-existing
+             symlink at any path component cannot redirect the write
+             outside ``base_dir``.
+          4. Idempotent: a target that already exists with byte-identical
+             canonical content is a no-op success. Different existing
+             bytes raise :class:`RunStoreConflictError`.
+
+        Returns the absolute path written (or already present).
+        """
+        safe_namespace = _validate_id(namespace, "namespace")
+        safe_name = _validate_id(name, "name")
+        canonical, normalized = _canonicalize_payload(payload)
+        _assert_no_secret_drift(normalized)
+
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+        relative_path = f"{safe_namespace}/{safe_name}.json"
+        target = self._base_dir / safe_namespace / f"{safe_name}.json"
+        try:
+            create_exclusive_nofollow(self._base_dir, relative_path, canonical)
+        except FileExistsError:
+            existing = read_contained_nofollow(self._base_dir, relative_path)
+            if existing != canonical:
+                raise RunStoreConflictError(
+                    "create_json_once target already exists with different "
+                    f"content: {namespace}/{name}"
+                ) from None
+            log.debug("create_json_once idempotent no-op: %s", target)
+            return target
+        log.info("create_json_once wrote %d bytes to %s", len(canonical), target)
+        return target
 
     def list_runs(self) -> list[str]:
         if not self._base_dir.exists():

--- a/src/aptl/core/scenario_catalog.py
+++ b/src/aptl/core/scenario_catalog.py
@@ -12,7 +12,31 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 from pydantic import model_validator
 
 from aptl.core.scenarios import ScenarioNotFoundError, ScenarioValidationError
+from aptl.utils.pathsafe import (
+    REASON_DOT_COMPONENT,
+    REASON_EMPTY_COMPONENT,
+    REASON_NOT_RELATIVE,
+    REASON_NUL_BYTE,
+    REASON_TRAVERSAL,
+    PathContainmentError,
+    open_contained_nofollow,
+)
 from aptl.utils.redaction import redact
+
+# Reasons that mean "the candidate path's own shape tried to reach outside
+# project_dir" (mirrors the legacy "outside project" ValueError). Every other
+# PathContainmentError reason (missing, symlinked, not-a-regular-file, base
+# dir unavailable) means the *target* did not safely resolve to a contained
+# file, which mirrors the legacy "does not exist or is not a file" message.
+_OUTSIDE_PROJECT_REASONS = frozenset(
+    {
+        REASON_NOT_RELATIVE,
+        REASON_TRAVERSAL,
+        REASON_NUL_BYTE,
+        REASON_EMPTY_COMPONENT,
+        REASON_DOT_COMPONENT,
+    }
+)
 
 CATALOG_RELATIVE_PATH = Path("scenarios") / "catalog.json"
 _SCENARIO_ID = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
@@ -154,15 +178,41 @@ def resolve_scenario_selection(
 
 
 def _resolve_project_file(project_dir: Path, candidate: Path) -> Path:
-    """Resolve ``candidate`` and require it to stay within ``project_dir``."""
+    """Resolve ``candidate`` and require it to stay within ``project_dir``.
+
+    Containment walks the relative path component-by-component with
+    :func:`aptl.utils.pathsafe.open_contained_nofollow` (ADR-047 "Scenario
+    containment precedent") instead of a lexical ``resolve()`` +
+    ``is_relative_to()`` check: the lexical check could be defeated by a
+    symlink swapped in between the check and a later open (TOCTOU), and it
+    silently followed symlinks that stayed under ``project_dir``. A
+    previously-followed symlinked scenario path is now rejected outright —
+    see ``test_rejects_symlinked_scenario_path`` /
+    ``test_rejects_symlinked_scenario_directory_component`` in
+    ``tests/test_scenario_catalog.py``.
+
+    An absolute ``candidate`` is still accepted when it is lexically inside
+    ``project_dir`` (preserves the CLI ``--scenario-path`` contract); the
+    derived relative path is what actually walks the no-follow check.
+    """
     project_root = project_dir.resolve()
-    absolute = candidate if candidate.is_absolute() else project_root / candidate
-    resolved = absolute.resolve(strict=False)
-    if not resolved.is_relative_to(project_root):
-        raise ValueError(f"Scenario path is outside project: {candidate}")
-    if not resolved.is_file():
-        raise ValueError(f"Scenario path does not exist or is not a file: {candidate}")
-    return resolved
+    if candidate.is_absolute():
+        try:
+            relative = candidate.relative_to(project_root)
+        except ValueError as exc:
+            raise ValueError(f"Scenario path is outside project: {candidate}") from exc
+    else:
+        relative = candidate
+    try:
+        handle = open_contained_nofollow(project_root, relative)
+    except PathContainmentError as exc:
+        if exc.reason in _OUTSIDE_PROJECT_REASONS:
+            raise ValueError(f"Scenario path is outside project: {candidate}") from exc
+        raise ValueError(
+            f"Scenario path does not exist or is not a file: {candidate}"
+        ) from exc
+    handle.close()
+    return project_root / relative
 
 
 def resolve_and_parse_scenario(

--- a/src/aptl/utils/pathsafe.py
+++ b/src/aptl/utils/pathsafe.py
@@ -109,16 +109,27 @@ def _reason_for(exc: OSError, component: str, parent_fd: int) -> str:
     """
     if exc.errno == errno.ELOOP:
         return REASON_SYMLINK
-    if exc.errno in (errno.ENOENT, errno.ENOTDIR):
-        try:
-            st = os.stat(component, dir_fd=parent_fd, follow_symlinks=False)
-        except OSError:
-            return REASON_NOT_FOUND
-        return REASON_SYMLINK if stat.S_ISLNK(st.st_mode) else REASON_NOT_FOUND
-    return REASON_OPEN_FAILED
+    if exc.errno not in (errno.ENOENT, errno.ENOTDIR):
+        return REASON_OPEN_FAILED
+    return _reason_for_missing_component(component, parent_fd)
+
+
+def _reason_for_missing_component(component: str, parent_fd: int) -> str:
+    """Distinguish a genuinely missing path component from an existing symlink at that path.
+
+    Called only for the ``ENOENT``/``ENOTDIR`` case, where a symlinked
+    intermediate component surfaces as ``ENOTDIR`` rather than ``ELOOP``
+    (see :func:`_reason_for`).
+    """
+    try:
+        st = os.stat(component, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return REASON_NOT_FOUND
+    return REASON_SYMLINK if stat.S_ISLNK(st.st_mode) else REASON_NOT_FOUND
 
 
 def _open_base_fd(base_dir: Path | str) -> int:
+    """Open base_dir as a read-only directory file descriptor, the trusted root every walk starts from."""
     try:
         return os.open(base_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
     except OSError as exc:
@@ -158,6 +169,7 @@ def _walk(
 
 
 def _open_dir_nofollow(component: str, parent_fd: int) -> int:
+    """Open component as a directory under parent_fd, no-follow; raise PathContainmentError on any failure."""
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
     try:
         return os.open(component, flags, dir_fd=parent_fd)
@@ -169,6 +181,7 @@ def _open_dir_nofollow(component: str, parent_fd: int) -> int:
 
 
 def _open_leaf_read_nofollow(component: str, parent_fd: int) -> int:
+    """Open component read-only under parent_fd, no-follow, rejecting a non-regular-file target."""
     flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC
     try:
         fd = os.open(component, flags, dir_fd=parent_fd)
@@ -242,7 +255,8 @@ def _open_dir_nofollow_or_create(component: str, parent_fd: int) -> int:
     try:
         os.mkdir(component, 0o700, dir_fd=parent_fd)
     except FileExistsError:
-        pass  # lost a create race with another writer; fall through to open
+        # lost a create race with another writer; fall through to open
+        pass
     except OSError as exc:
         raise PathContainmentError(
             _reason_for(exc, component, parent_fd),
@@ -258,6 +272,7 @@ def _open_dir_nofollow_or_create(component: str, parent_fd: int) -> int:
 
 
 def _open_leaf_create_exclusive_nofollow(component: str, parent_fd: int) -> int:
+    """Create-exclusive-open component under parent_fd, no-follow, for the create-once write path."""
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
     try:
         return os.open(component, flags, 0o600, dir_fd=parent_fd)

--- a/src/aptl/utils/pathsafe.py
+++ b/src/aptl/utils/pathsafe.py
@@ -1,0 +1,312 @@
+"""Shared descriptor-relative, no-follow path containment.
+
+ADR-047 "Authorized artifact resolution": resolving a path and checking its
+prefix (``Path.resolve()`` + ``is_relative_to()``) is not enough, because a
+symlink can be swapped in between that check and a later open — the classic
+TOCTOU race. This module walks an untrusted relative path component-by-
+component with ``os.open(..., os.O_NOFOLLOW, dir_fd=<parent fd>)``
+(openat-style), so:
+
+- every intermediate directory component, AND the leaf, are opened
+  no-follow. A symlinked component anywhere in the path (including the
+  leaf) raises :class:`PathContainmentError` (``ELOOP`` under
+  ``O_NOFOLLOW``) instead of being silently followed.
+- the target is opened exactly ONCE. Callers hash/read/write bytes through
+  the same handle that was opened, so nothing can swap the underlying file
+  between a "check" and a later independent re-open by path.
+
+``base_dir`` is the trusted starting point (an already-established
+project/store root, e.g. from ``AptlConfig`` or a caller-resolved project
+directory) — only ``relative_path``, the untrusted part, is walked
+no-follow. Absolute paths, and ``..``/``.``/empty path components, and NUL
+bytes are rejected before any syscall runs.
+
+This is the ONE shared containment helper (ADR-047 "Scenario containment
+precedent" / "Persistence" security layers): ``scenario_catalog`` and the
+run store's create-once persistence both reuse it rather than each
+maintaining their own lexical path checker.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import stat
+from collections.abc import Callable
+from pathlib import Path
+from typing import BinaryIO
+
+REASON_NOT_RELATIVE = "not_relative"
+REASON_NUL_BYTE = "nul_byte"
+REASON_EMPTY_COMPONENT = "empty_component"
+REASON_DOT_COMPONENT = "dot_component"
+REASON_TRAVERSAL = "traversal"
+REASON_SYMLINK = "symlink"
+REASON_NOT_FOUND = "not_found"
+REASON_NOT_REGULAR_FILE = "not_regular_file"
+REASON_BASE_DIR_UNAVAILABLE = "base_dir_unavailable"
+REASON_OPEN_FAILED = "open_failed"
+
+
+class PathContainmentError(Exception):
+    """Raised when ``relative_path`` cannot be safely opened under ``base_dir``.
+
+    ``reason`` is a short, stable, machine-checkable code (one of this
+    module's ``REASON_*`` constants) so callers can translate this single
+    typed error into their own domain-specific message without parsing
+    prose out of ``str(exc)``.
+    """
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def _split_components(relative_path: str | Path) -> list[str]:
+    """Validate and split ``relative_path`` into literal ``/``-separated
+    components, rejecting anything that could escape or be ambiguous.
+
+    Splits on literal ``/`` rather than going through ``pathlib`` so a
+    double slash or trailing slash surfaces as the empty component it
+    lexically is, instead of being silently collapsed away.
+    """
+    text = str(relative_path)
+    if "\x00" in text:
+        raise PathContainmentError(REASON_NUL_BYTE, "path must not contain NUL bytes")
+    if not text:
+        raise PathContainmentError(REASON_EMPTY_COMPONENT, "path must not be empty")
+    if text.startswith("/"):
+        raise PathContainmentError(REASON_NOT_RELATIVE, f"path must be relative: {text!r}")
+    components = text.split("/")
+    for component in components:
+        if component == "":
+            raise PathContainmentError(
+                REASON_EMPTY_COMPONENT, f"path contains an empty component: {text!r}"
+            )
+        if component == "..":
+            raise PathContainmentError(
+                REASON_TRAVERSAL, f"path contains a '..' component: {text!r}"
+            )
+        if component == ".":
+            raise PathContainmentError(
+                REASON_DOT_COMPONENT, f"path contains a '.' component: {text!r}"
+            )
+    return components
+
+
+def _reason_for(exc: OSError, component: str, parent_fd: int) -> str:
+    """Classify a failed component open into a stable ``REASON_*`` code.
+
+    ``ELOOP`` is the unambiguous no-follow-hit-a-symlink signal for a leaf
+    open (no ``O_DIRECTORY``). For an intermediate directory open, Linux's
+    ``O_DIRECTORY | O_NOFOLLOW`` combination surfaces a symlinked component
+    as ``ENOTDIR`` instead of ``ELOOP`` (empirically verified), which is
+    indistinguishable from an ordinary "not a directory" without a further
+    check. Since the access has *already been rejected* either way by the
+    failed ``os.open()``, a no-follow ``fstatat`` purely to choose the more
+    honest reason code is safe — it cannot reopen, follow, or grant access
+    to anything; it only makes the error message accurate.
+    """
+    if exc.errno == errno.ELOOP:
+        return REASON_SYMLINK
+    if exc.errno in (errno.ENOENT, errno.ENOTDIR):
+        try:
+            st = os.stat(component, dir_fd=parent_fd, follow_symlinks=False)
+        except OSError:
+            return REASON_NOT_FOUND
+        return REASON_SYMLINK if stat.S_ISLNK(st.st_mode) else REASON_NOT_FOUND
+    return REASON_OPEN_FAILED
+
+
+def _open_base_fd(base_dir: Path | str) -> int:
+    try:
+        return os.open(base_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    except OSError as exc:
+        raise PathContainmentError(
+            REASON_BASE_DIR_UNAVAILABLE, f"base directory unavailable: {exc}"
+        ) from exc
+
+
+def _walk(
+    components: list[str],
+    base_fd: int,
+    *,
+    open_dir: Callable[[str, int], int],
+    open_leaf: Callable[[str, int], int],
+) -> int:
+    """Walk ``components`` under ``base_fd``, closing intermediate fds.
+
+    Every fd opened along the way except the final leaf is closed before
+    returning or raising, so only the caller-owned leaf descriptor (on
+    success) survives. ``base_fd`` is never closed here — that remains the
+    caller's responsibility.
+    """
+    current_fd = base_fd
+    try:
+        for index, component in enumerate(components):
+            is_leaf = index == len(components) - 1
+            opener = open_leaf if is_leaf else open_dir
+            next_fd = opener(component, current_fd)
+            if current_fd != base_fd:
+                os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except BaseException:
+        if current_fd != base_fd:
+            os.close(current_fd)
+        raise
+
+
+def _open_dir_nofollow(component: str, parent_fd: int) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        return os.open(component, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc
+
+
+def _open_leaf_read_nofollow(component: str, parent_fd: int) -> int:
+    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        fd = os.open(component, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        os.close(fd)
+        raise PathContainmentError(REASON_NOT_REGULAR_FILE, "target is not a regular file")
+    return fd
+
+
+def open_contained_nofollow(base_dir: Path | str, relative_path: str | Path) -> BinaryIO:
+    """Open ``relative_path`` under ``base_dir`` with one-open, no-follow semantics.
+
+    Walks each path component with ``os.open(..., O_NOFOLLOW, dir_fd=parent)``
+    so a symlinked directory component or leaf is rejected rather than
+    silently followed, and opens the final regular file exactly once.
+    Returns a binary file object bound to that single open handle — read or
+    hash directly from it; never reopen the original path afterward (that
+    would reintroduce the TOCTOU race this function exists to close).
+
+    Raises :class:`PathContainmentError` for: an absolute ``relative_path``;
+    a NUL byte; an empty, ``.``, or ``..`` path component; any symlinked
+    component (including the leaf); a missing component; or a leaf that is
+    not a regular file. Every intermediate directory descriptor is closed;
+    only the leaf descriptor is returned (open) on success.
+    """
+    components = _split_components(relative_path)
+    base_fd = _open_base_fd(base_dir)
+    try:
+        leaf_fd = _walk(
+            components, base_fd, open_dir=_open_dir_nofollow, open_leaf=_open_leaf_read_nofollow
+        )
+    finally:
+        os.close(base_fd)
+    return os.fdopen(leaf_fd, "rb")
+
+
+def read_contained_nofollow(base_dir: Path | str, relative_path: str | Path) -> bytes:
+    """Return the exact bytes of ``relative_path`` under ``base_dir``.
+
+    One-open convenience over :func:`open_contained_nofollow`: reads from
+    the very handle that was opened no-follow, so nothing can be swapped
+    between validation and read (TOCTOU-proof by construction).
+    """
+    with open_contained_nofollow(base_dir, relative_path) as handle:
+        return handle.read()
+
+
+def _open_dir_nofollow_or_create(component: str, parent_fd: int) -> int:
+    """Open ``component`` no-follow, creating it as a real directory if
+    (and only if) it does not already exist. A pre-existing symlink or
+    non-directory at this path is rejected exactly like
+    :func:`_open_dir_nofollow` — creation never overwrites or follows an
+    existing entry.
+    """
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        return os.open(component, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc
+    try:
+        os.mkdir(component, 0o700, dir_fd=parent_fd)
+    except FileExistsError:
+        pass  # lost a create race with another writer; fall through to open
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"cannot create directory {component!r}: {exc}",
+        ) from exc
+    try:
+        return os.open(component, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc
+
+
+def _open_leaf_create_exclusive_nofollow(component: str, parent_fd: int) -> int:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        return os.open(component, flags, 0o600, dir_fd=parent_fd)
+    except FileExistsError:
+        # A distinct, un-wrapped signal: the leaf already exists (whether a
+        # regular file, a directory, or a symlink — O_EXCL fires before
+        # O_NOFOLLOW is even consulted for an existing path per open(2)).
+        # Callers decide the idempotency policy from here.
+        raise
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected leaf component {component!r}: {exc}",
+        ) from exc
+
+
+def create_exclusive_nofollow(
+    base_dir: Path | str, relative_path: str | Path, data: bytes
+) -> None:
+    """Create ``relative_path`` under ``base_dir`` and write ``data`` once.
+
+    Intermediate directory components are created if missing (still walked
+    no-follow — an existing symlinked intermediate is rejected, never
+    followed or replaced). The leaf is opened with
+    ``O_CREAT | O_EXCL | O_NOFOLLOW`` under its parent directory's
+    descriptor, so a pre-existing symlink anywhere on the path — including
+    right at the leaf — cannot redirect the write outside ``base_dir``, and
+    two processes racing to create the same path cannot silently clobber
+    one another.
+
+    Raises :class:`PathContainmentError` for the same structural/symlink
+    reasons as :func:`open_contained_nofollow`. Raises ``FileExistsError``
+    (unwrapped) when the leaf already exists — the create-once caller
+    decides the idempotency policy (e.g. compare-then-accept on a byte
+    match via :func:`read_contained_nofollow`).
+    """
+    components = _split_components(relative_path)
+    base_fd = _open_base_fd(base_dir)
+    try:
+        leaf_fd = _walk(
+            components,
+            base_fd,
+            open_dir=_open_dir_nofollow_or_create,
+            open_leaf=_open_leaf_create_exclusive_nofollow,
+        )
+    finally:
+        os.close(base_fd)
+    try:
+        os.write(leaf_fd, data)
+        os.fsync(leaf_fd)
+    finally:
+        os.close(leaf_fd)

--- a/src/aptl/utils/redaction.py
+++ b/src/aptl/utils/redaction.py
@@ -130,6 +130,23 @@ def _is_sensitive_key(name: str) -> bool:
     return any(token in lower for token in _SENSITIVE_TOKENS)
 
 
+def is_sensitive_key(key: str) -> bool:
+    """Public yes/no predicate: does ``redact()`` treat ``key`` as a
+    sensitive dict key (redacting its value wholesale, regardless of the
+    value's own shape)?
+
+    This is a thin public wrapper around the exact same
+    ``_is_sensitive_key``/``_SENSITIVE_TOKENS``/``_SAFE_KEY_NAMES`` table
+    :func:`redact` uses internally for dict keys — ADR-047 "Secret
+    handling" requires reusing this classification (e.g. to validate an
+    experiment parameter *name* before it is ever used to build a plan)
+    rather than copying the token table into a second checker. Keep
+    ``tests/test_redaction.py``'s parity assertions passing when either
+    changes.
+    """
+    return _is_sensitive_key(key)
+
+
 # Inline-secret patterns for plain-text strings (command lines, headers,
 # query strings, etc.). Mirrors the TypeScript helper so artifacts emitted
 # from either language match shape.
@@ -1007,6 +1024,32 @@ def redact(value: Any) -> Any:
     bound collapses to ``[REDACTED]`` rather than raising ``RecursionError``.
     """
     return _redact(value, 0)
+
+
+def is_secret_shaped_value(value: Any) -> bool:
+    """Public yes/no predicate: would :func:`redact` change ``value`` at all?
+
+    Delegates to the exact recursive core ``redact()`` uses
+    (:func:`_redact`) rather than a separate token/regex table, so this
+    predicate can never drift out of lockstep with the transform — it IS
+    the transform, compared against its own input. Useful as a validator
+    ahead of persistence (ADR-047 "Secret handling": reject secret-shaped
+    parameter values before plan construction, never rely on later
+    redaction to make executable data safe).
+
+    Works over scalars (a plain string/bytes value) and over containers
+    (a dict/list "value" is secret-shaped if ``redact()`` would touch
+    anything inside it, including via a nested sensitive key — see
+    :func:`is_sensitive_key` for the key-only check). ``bytes``/
+    ``bytearray`` are decoded the same way :func:`redact` decodes them
+    before comparing, so an unmodified byte string correctly reports
+    ``False`` instead of always reporting ``True`` from a bytes-vs-str
+    type mismatch.
+    """
+    baseline: Any = bytes(value).decode("utf-8", "replace") if isinstance(
+        value, (bytes, bytearray)
+    ) else value
+    return _redact(value, 0) != baseline
 
 
 def _redact_scalar(value: object, depth: int) -> object:

--- a/src/aptl/utils/redaction.py
+++ b/src/aptl/utils/redaction.py
@@ -1026,7 +1026,7 @@ def redact(value: Any) -> Any:
     return _redact(value, 0)
 
 
-def is_secret_shaped_value(value: Any) -> bool:
+def is_secret_shaped_value(value: object) -> bool:
     """Public yes/no predicate: would :func:`redact` change ``value`` at all?
 
     Delegates to the exact recursive core ``redact()`` uses
@@ -1046,9 +1046,9 @@ def is_secret_shaped_value(value: Any) -> bool:
     ``False`` instead of always reporting ``True`` from a bytes-vs-str
     type mismatch.
     """
-    baseline: Any = bytes(value).decode("utf-8", "replace") if isinstance(
-        value, (bytes, bytearray)
-    ) else value
+    baseline: object = (
+        bytes(value).decode("utf-8", "replace") if isinstance(value, (bytes, bytearray)) else value
+    )
     return _redact(value, 0) != baseline
 
 

--- a/tests/test_aces_diagnostics.py
+++ b/tests/test_aces_diagnostics.py
@@ -1,0 +1,60 @@
+"""Tests for the ACES diagnostics rendering helper (ADR-047 error envelope).
+
+``render_aces_diagnostics()`` previously hard-coded the "ACES runtime
+handoff failed" stage label. ADR-047 reuses this formatter for the future
+experiment-admission failure surface by parameterizing that label instead
+of adding a second formatter — every existing caller keeps the exact
+original default text.
+"""
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+
+from aptl.backends.aces_diagnostics import render_aces_diagnostics
+
+
+def _diagnostic(message: str, *, severity: Severity = Severity.ERROR) -> Diagnostic:
+    return Diagnostic(
+        code="test.diagnostic",
+        domain="provisioning",
+        address="test.address",
+        message=message,
+        severity=severity,
+    )
+
+
+class TestDefaultStageLabelIsUnchanged:
+    def test_empty_diagnostics(self):
+        assert render_aces_diagnostics([]) == "ACES runtime handoff failed."
+
+    def test_with_error_diagnostics(self):
+        rendered = render_aces_diagnostics([_diagnostic("boom")])
+        assert rendered.startswith("ACES runtime handoff failed: ")
+        assert "boom" in rendered
+
+    def test_with_only_non_error_diagnostics(self):
+        rendered = render_aces_diagnostics([_diagnostic("heads up", severity=Severity.WARNING)])
+        assert rendered.startswith("ACES runtime handoff failed: ")
+        assert "heads up" in rendered
+
+
+class TestCustomStageLabel:
+    def test_empty_diagnostics_uses_custom_label(self):
+        rendered = render_aces_diagnostics([], stage_label="ACES experiment admission failed")
+        assert rendered == "ACES experiment admission failed."
+
+    def test_with_diagnostics_uses_custom_label_prefix(self):
+        rendered = render_aces_diagnostics(
+            [_diagnostic("bad reference")],
+            stage_label="ACES experiment admission failed",
+        )
+        assert rendered.startswith("ACES experiment admission failed: ")
+        assert "bad reference" in rendered
+        assert "ACES runtime handoff failed" not in rendered
+
+    def test_custom_label_is_still_redacted(self):
+        rendered = render_aces_diagnostics(
+            [_diagnostic("Authorization: Bearer abc.def.ghi")],
+            stage_label="ACES experiment admission failed",
+        )
+        assert "abc.def.ghi" not in rendered
+        assert "[REDACTED]" in rendered

--- a/tests/test_experiment_admission.py
+++ b/tests/test_experiment_admission.py
@@ -1,0 +1,1217 @@
+"""Tests for ``aptl.core.experiment.admission`` (ADR-047 Stage 5 - the
+INTEGRATION KEYSTONE of EXP-002 / issue #438).
+
+``admit_experiment`` is the single coordinator wiring Stages 1-4
+(``errors``, ``policy``, ``resolver``, ``spec_loading``, ``apparatus``,
+``capture_mapping``, ``trial_plan``) into one all-or-nothing sequence, ending
+in create-once persistence via ``LocalRunStore.create_json_once`` with a
+digest re-verification read-back. Two coverage axes matter most here:
+
+* the ADMITTED happy path actually produces a persisted, digest-matching
+  plan for both a capability-only task (default policy) and a task pinned
+  to real APTL/reference-processor identities (rejected under default
+  policy, admitted-with-exactly-one-warning under the
+  ``allow_uncertified_apparatus`` debug override);
+* the MUTATION-SPY proof that a REJECTED admission never calls any
+  range-mutating entry point or writes to the run store — this is ADR-047's
+  core "Range-mutation gate" boundary.
+
+Uses ``MappingArtifactSource`` (an in-memory ``ref_id -> ResolvedArtifact``
+seam) for everything except the dedicated
+``TestBuildAssociatedArtifactSource*`` classes, which exercise the
+production, on-disk, ``ProjectContainedResolver``-backed artifact source
+directly (``tests/test_experiment_controller.py`` additionally exercises it
+through the full ``ExperimentController.admit()`` composition).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import sys
+
+import pytest
+import yaml
+from aces_backend_protocols.backend_manifest import BackendManifest
+from aces_contracts.associated_artifacts import (
+    AssociatedArtifactManifestModel,
+    associated_artifact_set_digest,
+)
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+from aces_contracts.diagnostics import Severity
+from aces_processor.capabilities import ProcessorManifest
+from aces_processor.manifest import create_reference_processor_manifest
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.admission import (
+    AdmissionResult,
+    MappingArtifactSource,
+    admit_experiment,
+    build_associated_artifact_source,
+)
+from aptl.core.experiment.errors import AdmissionRejection
+from aptl.core.experiment.policy import default_admission_policy
+from aptl.core.experiment.resolver import ResolvedArtifact
+from aptl.core.experiment.spec_loading import load_experiment_root
+from aptl.core.runstore import LocalRunStore
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+SECRET = "sk-super-secret-injected-token-98765"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture-building helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolved(data: bytes, locator: str, media_type: str) -> ResolvedArtifact:
+    return ResolvedArtifact(
+        data=data,
+        locator=locator,
+        digest=f"sha256:{hashlib.sha256(data).hexdigest()}",
+        media_type=media_type,
+    )
+
+
+def _read_corpus_task_payload() -> dict:
+    path = CORPUS_ROOT / "experiment-core" / "experiment-task-v1" / "valid" / "reference.json"
+    return json.loads(path.read_text())
+
+
+def _read_corpus_capture_spec_payload() -> dict:
+    path = CORPUS_ROOT / "experiment-core" / "experiment-capture-spec-v1" / "valid" / "reference.json"
+    return json.loads(path.read_text())
+
+
+def _minimal_scenario_bytes() -> bytes:
+    path = CORPUS_ROOT / "sdl" / "sdl-yaml-v1" / "valid" / "minimal.yaml"
+    return path.read_bytes()
+
+
+def _synthetic_manifests() -> tuple[BackendManifest, ProcessorManifest]:
+    """A test-only manifest pair that genuinely mutually declares
+    compatibility, cloned from the real aptl / reference-processor
+    manifests' capability fields (only ``name``/compatibility differ). NOT
+    the real canonical manifests — the sibling apparatus tests already
+    prove admission must never fabricate compatibility by patching those;
+    this is legitimate dependency injection through the ``backend_manifest``
+    /``processor_manifest`` override params, proving the pipeline admits
+    end-to-end when a certified-compatible pair genuinely exists.
+    """
+    real_backend = create_aptl_manifest()
+    real_processor = create_reference_processor_manifest()
+    test_backend = BackendManifest(
+        name="test-backend",
+        version=real_backend.version,
+        supported_contract_versions=real_backend.supported_contract_versions,
+        compatible_processors=frozenset({"test-processor"}),
+        realization_support=real_backend.realization_support,
+        concept_bindings=real_backend.concept_bindings,
+        provisioner=real_backend.provisioner,
+        orchestrator=real_backend.orchestrator,
+        evaluator=real_backend.evaluator,
+        participant_runtime=real_backend.participant_runtime,
+    )
+    test_processor = ProcessorManifest(
+        name="test-processor",
+        version=real_processor.version,
+        supported_contract_versions=real_processor.supported_contract_versions,
+        capabilities=real_processor.capabilities,
+        compatible_backends=frozenset({"test-backend"}),
+        concept_bindings=real_processor.concept_bindings,
+        constraints=real_processor.constraints,
+    )
+    return test_backend, test_processor
+
+
+def _capability_only_task_payload(*, declared_capability: str, extra_notes: list[str] | None = None) -> dict:
+    payload = _read_corpus_task_payload()
+    payload["task_id"] = "task-minimal"
+    payload["task_version"] = "1.0.0"
+    payload["scenario_ref"] = {"ref_kind": "scenario", "ref_id": "canonical-minimal"}
+    payload["apparatus_constraints"] = {
+        "required_capabilities": [declared_capability],
+        "notes": extra_notes or [],
+    }
+    return payload
+
+
+def _pinned_identity_task_payload() -> dict:
+    payload = _read_corpus_task_payload()
+    payload["task_id"] = "task-minimal"
+    payload["task_version"] = "1.0.0"
+    payload["scenario_ref"] = {"ref_kind": "scenario", "ref_id": "canonical-minimal"}
+    payload["apparatus_constraints"] = {
+        "allowed_processor_refs": [
+            {"ref_kind": "processor", "ref_id": "aces-reference-processor", "ref_version": "0.1.0"}
+        ],
+        "allowed_backend_refs": [{"ref_kind": "backend", "ref_id": "aptl", "ref_version": "0.1.0"}],
+        "required_manifest_refs": [
+            {
+                "ref_kind": "manifest",
+                "ref_id": "aces-reference-processor",
+                "ref_version": "processor-manifest/v2",
+                "subject_ref": {
+                    "ref_kind": "processor",
+                    "ref_id": "aces-reference-processor",
+                    "ref_version": "0.1.0",
+                },
+            },
+            {
+                "ref_kind": "manifest",
+                "ref_id": "aptl",
+                "ref_version": "backend-manifest/v2",
+                "subject_ref": {"ref_kind": "backend", "ref_id": "aptl", "ref_version": "0.1.0"},
+            },
+        ],
+        "required_capabilities": [],
+        "notes": [],
+    }
+    return payload
+
+
+def _flat_spec_payload(
+    *,
+    spec_id: str = "spec-minimal-v1",
+    target_run_count: int = 3,
+    capture_spec_refs: list[dict] | None = None,
+) -> dict:
+    payload: dict = {
+        "schema_version": "experiment-authoring-input/v1",
+        "spec_id": spec_id,
+        "spec_version": "1.0.0",
+        "title": "Minimal flat spec",
+        "description": "Minimal flat allocation admission fixture.",
+        "task_ref": {"ref_kind": "task", "ref_id": "task-minimal", "ref_version": "1.0.0"},
+        "run_plan": {
+            "stochastic_controls": [{"control_id": "seed-a", "role": "seed", "value": 1}],
+            "episode_control": {
+                "turn_order": "sequential",
+                "max_steps": 10,
+                "termination_rule": "fixed horizon",
+            },
+            "target_run_count": target_run_count,
+        },
+    }
+    if capture_spec_refs is not None:
+        payload["capture_spec_refs"] = capture_spec_refs
+    return payload
+
+
+class _Bundle:
+    """A fully built admission-ready bundle: root/task/scenario (+ optional
+    capture-spec) bytes plus a :class:`MappingArtifactSource` binding them
+    by reference identity."""
+
+    def __init__(self, *, task_payload: dict, spec_payload: dict, capture_spec_payload: dict | None = None):
+        self.task_bytes = json.dumps(task_payload).encode("utf-8")
+        self.scenario_bytes = _minimal_scenario_bytes()
+        self.root_bytes = yaml.safe_dump(spec_payload).encode("utf-8")
+        self.experiment_root = _resolved(self.root_bytes, "experiment.yaml", "application/x-yaml")
+
+        artifacts = {
+            task_payload["task_id"]: _resolved(self.task_bytes, "task.json", "application/json"),
+            "canonical-minimal": _resolved(self.scenario_bytes, "scenario.sdl.yaml", "application/x-yaml"),
+        }
+        if capture_spec_payload is not None:
+            capture_bytes = json.dumps(capture_spec_payload).encode("utf-8")
+            artifacts[capture_spec_payload["capture_spec_id"]] = _resolved(
+                capture_bytes, "capture.json", "application/json"
+            )
+        self.artifact_source = MappingArtifactSource(artifacts=artifacts)
+
+
+def _capability_only_bundle(
+    *, spec_id: str = "spec-minimal-v1", target_run_count: int = 3, extra_notes: list[str] | None = None
+) -> tuple[_Bundle, BackendManifest, ProcessorManifest]:
+    backend, processor = _synthetic_manifests()
+    declared = sorted(backend.supported_contract_versions)[0]
+    task_payload = _capability_only_task_payload(declared_capability=declared, extra_notes=extra_notes)
+    spec_payload = _flat_spec_payload(spec_id=spec_id, target_run_count=target_run_count)
+    return _Bundle(task_payload=task_payload, spec_payload=spec_payload), backend, processor
+
+
+def _pinned_identity_bundle(*, spec_id: str = "spec-pinned-v1", target_run_count: int = 3) -> _Bundle:
+    task_payload = _pinned_identity_task_payload()
+    spec_payload = _flat_spec_payload(spec_id=spec_id, target_run_count=target_run_count)
+    return _Bundle(task_payload=task_payload, spec_payload=spec_payload)
+
+
+class _SpyRunStore:
+    """Wraps a real :class:`LocalRunStore`, recording every protocol call
+    so a rejected-admission test can assert NO write occurred at all."""
+
+    def __init__(self, base_dir):
+        self._inner = LocalRunStore(base_dir)
+        self.calls: dict[str, int] = {}
+
+    def _record(self, name: str) -> None:
+        self.calls[name] = self.calls.get(name, 0) + 1
+
+    def create_run(self, run_id):
+        self._record("create_run")
+        return self._inner.create_run(run_id)
+
+    def write_file(self, run_id, relative_path, data):
+        self._record("write_file")
+        return self._inner.write_file(run_id, relative_path, data)
+
+    def write_json(self, run_id, relative_path, obj):
+        self._record("write_json")
+        return self._inner.write_json(run_id, relative_path, obj)
+
+    def write_jsonl(self, run_id, relative_path, records):
+        self._record("write_jsonl")
+        return self._inner.write_jsonl(run_id, relative_path, records)
+
+    def append_jsonl(self, run_id, relative_path, records):
+        self._record("append_jsonl")
+        return self._inner.append_jsonl(run_id, relative_path, records)
+
+    def copy_file(self, run_id, relative_path, source):
+        self._record("copy_file")
+        return self._inner.copy_file(run_id, relative_path, source)
+
+    def create_json_once(self, namespace, name, payload):
+        self._record("create_json_once")
+        return self._inner.create_json_once(namespace, name, payload)
+
+    def list_runs(self):
+        self._record("list_runs")
+        return self._inner.list_runs()
+
+    def get_run_manifest(self, run_id):
+        self._record("get_run_manifest")
+        return self._inner.get_run_manifest(run_id)
+
+    def get_run_path(self, run_id):
+        self._record("get_run_path")
+        return self._inner.get_run_path(run_id)
+
+
+def _install_mutation_spies(monkeypatch) -> None:
+    """Patch every range-mutating entry point ADR-047's "Range-mutation
+    gate" names so a call from admission fails the test loudly instead of
+    silently succeeding. Mirrors the pattern already proven in
+    ``test_experiment_apparatus.py``'s
+    ``TestPlanConditionFeasibilityNeverTouchesDocker``.
+    """
+    import aptl.core.collectors as collectors_module
+    import aptl.core.deployment.docker_compose as docker_compose_module
+    import aptl.core.env as env_module
+    import aptl.core.lab as lab_module
+    import aptl.core.soc_ca as soc_ca_module
+    import aptl.core.ssh as ssh_module
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("range-mutating entry point must never be called by rejected admission")
+
+    monkeypatch.setattr(lab_module, "start_lab", _boom)
+    monkeypatch.setattr(lab_module, "stop_lab", _boom)
+    monkeypatch.setattr(lab_module, "clean_boot_lab", _boom)
+    monkeypatch.setattr(soc_ca_module, "ensure_soc_certs", _boom)
+    monkeypatch.setattr(ssh_module, "ensure_ssh_keys", _boom)
+    monkeypatch.setattr(ssh_module, "ensure_pivot_key", _boom)
+    monkeypatch.setattr(env_module, "hydrate_dotenv", _boom)
+    monkeypatch.setattr(collectors_module, "_run_cmd", _boom)
+    monkeypatch.setattr(docker_compose_module.subprocess, "run", _boom)
+
+    for leftover in ("aptl.core.deployment.ssh_compose", "aces_runtime.manager"):
+        monkeypatch.delitem(sys.modules, leftover, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# AdmissionResult
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionResult:
+    def test_rejected_never_carries_a_plan(self):
+        from aces_contracts.diagnostics import Diagnostic
+
+        d = Diagnostic(code="c", domain="experiment-admission", address="a", message="m")
+        result = AdmissionResult.rejected((d,))
+
+        assert result.admitted is False
+        assert result.diagnostics == (d,)
+        assert result.plan is None
+        assert result.plan_digest is None
+        assert result.persisted_path is None
+
+    def test_rejected_requires_at_least_one_diagnostic(self):
+        with pytest.raises(ValueError, match="diagnostic"):
+            AdmissionResult.rejected(())
+
+    def test_plain_constructor_rejects_a_rejected_shape_carrying_a_plan(self):
+        with pytest.raises(ValueError, match="must never carry a plan"):
+            AdmissionResult(admitted=False, diagnostics=(), plan_digest="sha256:" + "0" * 64)
+
+    def test_plain_constructor_rejects_an_admitted_shape_missing_a_plan(self):
+        with pytest.raises(ValueError, match="must carry plan"):
+            AdmissionResult(admitted=True)
+
+
+# ---------------------------------------------------------------------------
+# admit_experiment — happy path (a): capability-only task, default policy
+# ---------------------------------------------------------------------------
+
+
+class TestAdmitExperimentHappyPathCapabilityOnly:
+    def test_admits_under_default_policy_with_no_warnings(self, tmp_path):
+        bundle, backend, processor = _capability_only_bundle()
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is True
+        assert result.warnings == ()
+        assert result.diagnostics == ()
+        assert len(result.trial_ids) == 3
+        assert len(result.plan.trials) == 3
+
+    def test_persists_a_plan_whose_bytes_match_the_computed_digest(self, tmp_path):
+        bundle, backend, processor = _capability_only_bundle()
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.persisted_path.exists()
+        assert result.persisted_path.read_bytes() == result.plan.canonical_bytes
+        assert result.plan_digest == result.plan.plan_digest
+        assert result.persisted_path == tmp_path / "store" / "experiment-plans" / f"{result.plan.plan_id}.json"
+
+
+# ---------------------------------------------------------------------------
+# admit_experiment — happy path (b): identity-pinned task, real manifests
+# ---------------------------------------------------------------------------
+
+
+class TestAdmitExperimentHappyPathPinnedIdentity:
+    def test_rejected_under_default_policy_for_mutual_incompatibility(self, tmp_path):
+        bundle = _pinned_identity_bundle()
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+        )
+
+        assert result.admitted is False
+        assert any("mutual-incompatible" in d.code for d in result.diagnostics)
+
+    def test_admitted_with_the_debug_override_and_exactly_one_warning(self, tmp_path):
+        bundle = _pinned_identity_bundle()
+        store = LocalRunStore(tmp_path / "store")
+        policy = dataclasses.replace(default_admission_policy(), allow_uncertified_apparatus=True)
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=policy,
+        )
+
+        assert result.admitted is True
+        assert len(result.warnings) == 1
+        assert result.warnings[0].severity == Severity.WARNING
+        assert "uncertified-compatibility" in result.warnings[0].code
+        assert result.persisted_path.exists()
+        assert result.persisted_path.read_bytes() == result.plan.canonical_bytes
+
+
+# ---------------------------------------------------------------------------
+# admit_experiment — condition allocation, all-or-nothing (Finding 3)
+# ---------------------------------------------------------------------------
+
+_CONDITION_ALLOCATION_SCENARIO_TEXT = """
+name: scenario-condition-admission
+variables:
+  danger_level:
+    type: string
+    default: low
+nodes:
+  on:
+    type: switch
+"""
+
+
+def _condition_allocation_task_payload() -> dict:
+    payload = _read_corpus_task_payload()
+    payload["task_id"] = "task-condition-admission"
+    payload["task_version"] = "1.0.0"
+    payload["scenario_ref"] = {"ref_kind": "scenario", "ref_id": "scenario-condition-admission"}
+    payload["apparatus_constraints"] = {"required_capabilities": [], "notes": ["unrestricted apparatus"]}
+    return payload
+
+
+def _condition_allocation_spec_payload_one_infeasible() -> dict:
+    """Two compared conditions, one of which binds an UNDECLARED SDL
+    variable target -- ``run_reference_processor`` raises
+    ``SDLInstantiationError`` for exactly this shape (proven directly in
+    ``TestPlanConditionFeasibilityBrokenParameterBinding`` in
+    ``test_experiment_apparatus.py``), which ``_plan_conditions`` normalizes
+    into an ``AdmissionRejection``. ``cond-feasible`` sorts before
+    ``cond-infeasible`` in ``compared_conditions`` (authored order), so the
+    feasible condition is planned successfully FIRST and would already have
+    a snapshot digest computed before the second condition blows up -- this
+    is exactly what must NOT leak into a partial plan or a partial write.
+    """
+    return {
+        "schema_version": "experiment-authoring-input/v1",
+        "spec_id": "spec-condition-admission-v1",
+        "spec_version": "1.0.0",
+        "title": "One infeasible condition",
+        "description": "Proves per-condition all-or-nothing admission (Finding 3).",
+        "task_ref": {"ref_kind": "task", "ref_id": "task-condition-admission", "ref_version": "1.0.0"},
+        "run_plan": {
+            "stochastic_controls": [{"control_id": "seed-a", "role": "seed", "value": 1}],
+            "episode_control": {
+                "turn_order": "sequential",
+                "max_steps": 10,
+                "termination_rule": "fixed horizon",
+            },
+            "allocation": {
+                "allocation_unit": "trial",
+                "allocation_method": "balanced",
+                "compared_conditions": ["cond-feasible", "cond-infeasible"],
+                "condition_assignments": {
+                    "cond-feasible": {
+                        "condition_id": "cond-feasible",
+                        "factor_levels": {"danger": "high"},
+                        "required_parameters": [
+                            {"name": "danger_level", "value": "high", "value_kind": "configuration"}
+                        ],
+                    },
+                    "cond-infeasible": {
+                        "condition_id": "cond-infeasible",
+                        "factor_levels": {"danger": "undeclared"},
+                        "required_parameters": [
+                            {
+                                "name": "totally-undeclared-target",
+                                "value": "x",
+                                "value_kind": "configuration",
+                            }
+                        ],
+                    },
+                },
+                "target_runs_per_condition": 2,
+                "blocking_factors": [],
+                "replication_policy": "independent-replications",
+            },
+        },
+    }
+
+
+class TestAdmitExperimentConditionAllocationAllOrNothing:
+    def test_one_infeasible_condition_rejects_the_whole_admission_with_no_partial_plan_or_write(self, tmp_path):
+        task_payload = _condition_allocation_task_payload()
+        task_bytes = json.dumps(task_payload).encode("utf-8")
+        scenario_bytes = _CONDITION_ALLOCATION_SCENARIO_TEXT.encode("utf-8")
+        spec_payload = _condition_allocation_spec_payload_one_infeasible()
+        root_bytes = yaml.safe_dump(spec_payload).encode("utf-8")
+        backend, processor = _synthetic_manifests()
+
+        artifact_source = MappingArtifactSource(
+            artifacts={
+                "task-condition-admission": _resolved(task_bytes, "task.json", "application/json"),
+                "scenario-condition-admission": _resolved(
+                    scenario_bytes, "scenario.sdl.yaml", "application/x-yaml"
+                ),
+            }
+        )
+        store = _SpyRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=_resolved(root_bytes, "experiment.yaml", "application/x-yaml"),
+            artifact_source=artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any("condition-parameters-invalid" in d.code for d in result.diagnostics)
+        # No partial plan on the rejected result...
+        assert result.plan is None
+        assert result.plan_digest is None
+        assert result.persisted_path is None
+        assert result.trial_ids == ()
+        # ...and nothing was ever written to the run store (the feasible
+        # condition's own snapshot digest, computed before the second
+        # condition failed, never reaches persistence).
+        assert store.calls == {}
+
+
+# ---------------------------------------------------------------------------
+# admit_experiment — determinism
+# ---------------------------------------------------------------------------
+
+
+class TestAdmitExperimentDeterminism:
+    def test_admitting_the_same_inputs_twice_yields_the_same_digest_and_is_idempotent(self, tmp_path):
+        bundle, backend, processor = _capability_only_bundle()
+        store = LocalRunStore(tmp_path / "store")
+
+        first = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+        second = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert first.admitted is True
+        assert second.admitted is True
+        assert first.plan_digest == second.plan_digest
+        assert first.persisted_path == second.persisted_path
+        assert first.trial_ids == second.trial_ids
+
+
+@pytest.mark.fuzz
+class TestFuzzAdmitExperimentDeterminism:
+    from hypothesis import given, settings
+    from hypothesis import strategies as st
+
+    @given(target_run_count=st.integers(min_value=1, max_value=30))
+    @settings(max_examples=20, deadline=None)
+    def test_repeated_admission_is_deterministic_across_random_flat_counts(self, tmp_path_factory, target_run_count):
+        bundle, backend, processor = _capability_only_bundle(
+            spec_id=f"spec-fuzz-{target_run_count}", target_run_count=target_run_count
+        )
+        store = LocalRunStore(tmp_path_factory.mktemp("store"))
+
+        first = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+        second = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert first.admitted is True
+        assert second.admitted is True
+        assert first.plan_digest == second.plan_digest
+        assert len(first.trial_ids) == target_run_count
+        assert len(set(first.trial_ids)) == target_run_count
+
+
+# ---------------------------------------------------------------------------
+# Mutation spy (mandatory, security-critical) — ADR-047 "Range-mutation gate"
+# ---------------------------------------------------------------------------
+
+
+class TestMutationSpyRejectedAdmissionMakesNoMutatingCalls:
+    def test_apparatus_fatal_rejection_makes_no_mutating_or_write_calls(self, tmp_path, monkeypatch):
+        _install_mutation_spies(monkeypatch)
+        bundle = _pinned_identity_bundle()
+        store = _SpyRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+        )
+
+        assert result.admitted is False
+        assert store.calls == {}
+        assert "aptl.core.deployment.ssh_compose" not in sys.modules
+        assert "aces_runtime.manager" not in sys.modules
+
+    def test_cross_artifact_identity_mismatch_rejection_makes_no_mutating_or_write_calls(
+        self, tmp_path, monkeypatch
+    ):
+        _install_mutation_spies(monkeypatch)
+        bundle, backend, processor = _capability_only_bundle()
+        bad_task_payload = json.loads(bundle.task_bytes)
+        bad_task_payload["task_id"] = "task-DIFFERENT-IDENTITY"
+        bad_source = MappingArtifactSource(
+            artifacts={
+                "task-minimal": _resolved(
+                    json.dumps(bad_task_payload).encode("utf-8"), "task.json", "application/json"
+                ),
+                "canonical-minimal": _resolved(bundle.scenario_bytes, "scenario.sdl.yaml", "application/x-yaml"),
+            }
+        )
+        store = _SpyRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bad_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any("identity-mismatch" in d.code for d in result.diagnostics)
+        assert store.calls == {}
+
+    def test_oversize_root_rejection_makes_no_mutating_or_write_calls(self, tmp_path, monkeypatch):
+        _install_mutation_spies(monkeypatch)
+        bundle, backend, processor = _capability_only_bundle()
+        tiny_policy = dataclasses.replace(default_admission_policy(), max_root_bytes=1)
+        store = _SpyRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=tiny_policy,
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert store.calls == {}
+
+    def test_capture_bearing_spec_fail_closed_rejection_makes_no_mutating_or_write_calls(
+        self, tmp_path, monkeypatch
+    ):
+        _install_mutation_spies(monkeypatch)
+        backend, processor = _synthetic_manifests()
+        declared = sorted(backend.supported_contract_versions)[0]
+        task_payload = _capability_only_task_payload(declared_capability=declared)
+        capture_payload = _read_corpus_capture_spec_payload()
+        capture_payload["capture_spec_id"] = "capture-minimal"
+        capture_payload["spec_version"] = "1.0.0"
+        capture_payload["scope_refs"] = [
+            {"ref_kind": "task", "ref_id": task_payload["task_id"], "ref_version": task_payload["task_version"]}
+        ]
+        spec_payload = _flat_spec_payload(
+            capture_spec_refs=[
+                {"ref_kind": "capture-spec", "ref_id": "capture-minimal", "ref_version": "1.0.0"}
+            ]
+        )
+        bundle = _Bundle(task_payload=task_payload, spec_payload=spec_payload, capture_spec_payload=capture_payload)
+        store = _SpyRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any("capture-requirement-unsupported" in d.code for d in result.diagnostics)
+        assert store.calls == {}
+
+
+# ---------------------------------------------------------------------------
+# Rejection-path coverage
+# ---------------------------------------------------------------------------
+
+
+class TestAdmitExperimentRejectionPaths:
+    def test_oversize_root_is_rejected_with_safe_diagnostics(self, tmp_path):
+        bundle, backend, processor = _capability_only_bundle()
+        tiny_policy = dataclasses.replace(default_admission_policy(), max_root_bytes=1)
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=tiny_policy,
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert result.diagnostics
+        assert result.plan is None
+
+    def test_cross_artifact_identity_mismatch_is_rejected(self, tmp_path):
+        bundle, backend, processor = _capability_only_bundle()
+        bad_task_payload = json.loads(bundle.task_bytes)
+        bad_task_payload["task_id"] = "task-DIFFERENT-IDENTITY"
+        bad_source = MappingArtifactSource(
+            artifacts={
+                "task-minimal": _resolved(
+                    json.dumps(bad_task_payload).encode("utf-8"), "task.json", "application/json"
+                ),
+                "canonical-minimal": _resolved(bundle.scenario_bytes, "scenario.sdl.yaml", "application/x-yaml"),
+            }
+        )
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bad_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any("identity-mismatch" in d.code for d in result.diagnostics)
+
+    def test_capture_bearing_spec_fails_closed(self, tmp_path):
+        backend, processor = _synthetic_manifests()
+        declared = sorted(backend.supported_contract_versions)[0]
+        task_payload = _capability_only_task_payload(declared_capability=declared)
+        capture_payload = _read_corpus_capture_spec_payload()
+        capture_payload["capture_spec_id"] = "capture-minimal"
+        capture_payload["spec_version"] = "1.0.0"
+        capture_payload["scope_refs"] = [
+            {"ref_kind": "task", "ref_id": task_payload["task_id"], "ref_version": task_payload["task_version"]}
+        ]
+        spec_payload = _flat_spec_payload(
+            capture_spec_refs=[
+                {"ref_kind": "capture-spec", "ref_id": "capture-minimal", "ref_version": "1.0.0"}
+            ]
+        )
+        bundle = _Bundle(task_payload=task_payload, spec_payload=spec_payload, capture_spec_payload=capture_payload)
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any("capture-requirement-unsupported" in d.code for d in result.diagnostics)
+
+    def test_apparatus_fatal_independent_of_mutual_compat_is_rejected(self, tmp_path):
+        backend, processor = _synthetic_manifests()
+        task_payload = _capability_only_task_payload(declared_capability="totally-made-up-capability")
+        spec_payload = _flat_spec_payload()
+        bundle = _Bundle(task_payload=task_payload, spec_payload=spec_payload)
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any("capability-unsupported" in d.code for d in result.diagnostics)
+
+    def test_secret_bearing_failing_input_never_leaks_into_diagnostics(self, tmp_path):
+        backend, processor = _synthetic_manifests()
+        task_payload = _capability_only_task_payload(
+            declared_capability="totally-made-up-capability",
+            extra_notes=[f"internal-secret={SECRET}"],
+        )
+        spec_payload = _flat_spec_payload()
+        bundle = _Bundle(task_payload=task_payload, spec_payload=spec_payload)
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        for d in result.diagnostics:
+            assert SECRET not in d.message
+            assert SECRET not in d.code
+            assert SECRET not in d.address
+
+    def test_unresolvable_artifact_reference_is_rejected(self, tmp_path):
+        bundle, backend, processor = _capability_only_bundle()
+        empty_source = MappingArtifactSource(artifacts={})
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=empty_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any("artifact-source-unresolved" in d.code for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Cross-artifact join guards -- each branch tested in isolation (Finding 6)
+# ---------------------------------------------------------------------------
+
+
+class TestAdmitExperimentCrossArtifactJoinGuards:
+    def test_task_version_mismatch_is_rejected(self, tmp_path):
+        # task_id matches ("task-minimal") but spec.task_ref pins a
+        # ref_version the resolved task does not carry -- the SECOND branch
+        # of _check_task_identity, distinct from the ref_id-mismatch branch
+        # already covered by test_cross_artifact_identity_mismatch_is_rejected.
+        bundle, backend, processor = _capability_only_bundle()
+        spec_payload = _flat_spec_payload()
+        spec_payload["task_ref"]["ref_version"] = "9.9.9"
+        bad_root = _resolved(
+            yaml.safe_dump(spec_payload).encode("utf-8"), "experiment.yaml", "application/x-yaml"
+        )
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bad_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any(
+            d.code == "aptl.experiment-admission.reference-identity-mismatch" and d.address == "task_ref.ref_version"
+            for d in result.diagnostics
+        )
+
+    def test_intended_scenario_ref_disagreement_with_task_scenario_ref_is_rejected(self, tmp_path):
+        # spec.intended_scenario_ref names a DIFFERENT ref_id than
+        # task.scenario_ref ("canonical-minimal") -- _effective_scenario_ref's
+        # task/scenario agreement gate.
+        bundle, backend, processor = _capability_only_bundle()
+        spec_payload = _flat_spec_payload()
+        spec_payload["intended_scenario_ref"] = {"ref_kind": "scenario", "ref_id": "some-other-scenario-id"}
+        bad_root = _resolved(
+            yaml.safe_dump(spec_payload).encode("utf-8"), "experiment.yaml", "application/x-yaml"
+        )
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bad_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any(
+            d.code == "aptl.experiment-admission.task-scenario-ref-mismatch"
+            and d.address == "intended_scenario_ref.ref_id"
+            for d in result.diagnostics
+        )
+
+    def test_scenario_version_mismatch_is_rejected(self, tmp_path):
+        # intended_scenario_ref pins the correct ref_id but a ref_version
+        # the resolved scenario does not carry (the corpus minimal.yaml
+        # scenario parses with version "*") -- _check_scenario_identity's
+        # version branch. ref_kind must be "scenario-snapshot": a
+        # ("scenario", id-only) ref rejects a ref_version/ref_digest at the
+        # pydantic layer before admission's own cross-artifact join ever
+        # runs (ACES: "generic scenario references are id-only").
+        bundle, backend, processor = _capability_only_bundle()
+        spec_payload = _flat_spec_payload()
+        spec_payload["intended_scenario_ref"] = {
+            "ref_kind": "scenario-snapshot",
+            "ref_id": "canonical-minimal",
+            "ref_version": "9.9.9",
+        }
+        bad_root = _resolved(
+            yaml.safe_dump(spec_payload).encode("utf-8"), "experiment.yaml", "application/x-yaml"
+        )
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bad_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any(
+            d.code == "aptl.experiment-admission.reference-identity-mismatch"
+            and d.address == "intended_scenario_ref.ref_version"
+            for d in result.diagnostics
+        )
+
+    def test_scenario_digest_mismatch_is_rejected(self, tmp_path):
+        # intended_scenario_ref pins the correct ref_id (no ref_version) but
+        # a ref_digest that does not match the resolved scenario's own
+        # canonical digest -- _check_scenario_identity's digest branch.
+        # ref_kind must be "scenario-snapshot" (see the version-mismatch
+        # test above for why).
+        bundle, backend, processor = _capability_only_bundle()
+        spec_payload = _flat_spec_payload()
+        spec_payload["intended_scenario_ref"] = {
+            "ref_kind": "scenario-snapshot",
+            "ref_id": "canonical-minimal",
+            "ref_digest": "sha256:" + "0" * 64,
+        }
+        bad_root = _resolved(
+            yaml.safe_dump(spec_payload).encode("utf-8"), "experiment.yaml", "application/x-yaml"
+        )
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bad_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any(
+            d.code == "aptl.experiment-admission.scenario-ref-digest-mismatch"
+            and d.address == "intended_scenario_ref.ref_digest"
+            for d in result.diagnostics
+        )
+
+    def test_duplicate_capture_spec_refs_is_rejected(self, tmp_path):
+        # Same capture-spec ref_id named twice in spec.capture_spec_refs --
+        # _resolve_capture_specs' own duplicate-identity guard, which fires
+        # before any capture-spec artifact is even resolved.
+        bundle, backend, processor = _capability_only_bundle()
+        spec_payload = _flat_spec_payload(
+            capture_spec_refs=[
+                {"ref_kind": "capture-spec", "ref_id": "capture-minimal", "ref_version": "1.0.0"},
+                {"ref_kind": "capture-spec", "ref_id": "capture-minimal", "ref_version": "1.0.0"},
+            ]
+        )
+        bad_root = _resolved(
+            yaml.safe_dump(spec_payload).encode("utf-8"), "experiment.yaml", "application/x-yaml"
+        )
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bad_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert any(
+            d.code == "aptl.experiment-admission.capture-spec-ref-duplicate" for d in result.diagnostics
+        )
+
+
+# ---------------------------------------------------------------------------
+# _persist_plan — mismatch and failure diagnostics (Finding 4)
+# ---------------------------------------------------------------------------
+
+
+class _MismatchedReadBackRunStore:
+    """A fake ``run_store`` whose ``create_json_once`` "succeeds" but
+    persists bytes that do NOT match what the caller asked to persist
+    (simulating e.g. a corrupted write or a concurrent external write to
+    the same path) -- trips ``_persist_plan``'s post-write digest
+    re-verification read-back.
+    """
+
+    def __init__(self, base_dir):
+        self._base_dir = base_dir
+
+    def create_json_once(self, namespace, name, payload):
+        del payload
+        path = self._base_dir / namespace / f"{name}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b'{"tampered": true}')
+        return path
+
+
+class _RaisingRunStore:
+    """A fake ``run_store`` whose ``create_json_once`` always raises --
+    simulating a ``RunStoreConflictError``/``SecretInvariantError`` (both
+    ``ValueError`` subclasses) from the real ``LocalRunStore``.
+    """
+
+    def create_json_once(self, namespace, name, payload):
+        del namespace, name, payload
+        raise ValueError("simulated run-store write conflict")
+
+
+class TestPersistPlanDiagnostics:
+    def test_a_persisted_bytes_mismatch_is_rejected_with_the_specific_diagnostic(self, tmp_path):
+        bundle, backend, processor = _capability_only_bundle()
+        store = _MismatchedReadBackRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert result.plan is None
+        assert any(
+            d.code == "aptl.experiment-admission.persisted-plan-digest-mismatch" for d in result.diagnostics
+        )
+
+    def test_a_persistence_failure_surfaces_as_a_rejection_not_an_unhandled_exception(self, tmp_path):
+        bundle, backend, processor = _capability_only_bundle()
+        store = _RaisingRunStore()
+
+        # If admission ever let a bare ValueError from the run store escape
+        # uncaught, this call itself would raise instead of returning --
+        # asserting on the returned result (not a pytest.raises block) is
+        # the point: a raised exception here fails the test just as surely
+        # as a wrong diagnostic would.
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+        )
+
+        assert result.admitted is False
+        assert result.plan is None
+        assert any(d.code == "aptl.experiment-admission.plan-persistence-failed" for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# build_associated_artifact_source — production resolver-backed source
+# ---------------------------------------------------------------------------
+
+
+def _write_associated_artifact_bundle(base_dir, *, spec_id: str, task_bytes: bytes, scenario_bytes: bytes, corrupt_checksum: bool = False):
+    (base_dir / "task.json").write_bytes(task_bytes)
+    (base_dir / "scenario.sdl.yaml").write_bytes(scenario_bytes)
+
+    def artifact_ref(artifact_id, uri, data, media_type, role, *, bad_checksum=False):
+        checksum_value = "1" * 64 if bad_checksum else hashlib.sha256(data).hexdigest()
+        return {
+            "artifact_id": artifact_id,
+            "role": role,
+            "media_type": media_type,
+            "uri": f"file:{uri}",
+            "checksum": {"algorithm": "sha256", "value": checksum_value},
+            "size_bytes": len(data),
+            "created_at": "2026-05-26T00:00:00Z",
+            "source": "test bundle",
+            "satisfies_refs": [],
+            "sensitivity": "internal",
+        }
+
+    artifacts = {
+        "task-minimal": artifact_ref(
+            "task-minimal", "task.json", task_bytes, "application/json", "other", bad_checksum=corrupt_checksum
+        ),
+        "canonical-minimal": artifact_ref(
+            "canonical-minimal", "scenario.sdl.yaml", scenario_bytes, "application/x-yaml", "scenario-snapshot"
+        ),
+    }
+    manifest_dict = {
+        "schema_version": "associated-artifact-manifest/v1",
+        "manifest_id": f"manifest-{spec_id}",
+        "manifest_version": "1.0.0",
+        "canonicalization_profile": "associated-artifact-set/v1",
+        "scope": "experiment",
+        "parent_ref": {"ref_kind": "authoring-input", "ref_id": spec_id, "ref_version": "1.0.0"},
+        "artifacts": artifacts,
+        "set_digest": "sha256:" + "0" * 64,
+    }
+    manifest_model = AssociatedArtifactManifestModel.model_validate(manifest_dict)
+    manifest_dict["set_digest"] = associated_artifact_set_digest(manifest_model)
+    manifest_path = base_dir / "associated-artifact-manifest.json"
+    manifest_path.write_bytes(json.dumps(manifest_dict).encode("utf-8"))
+    return manifest_path
+
+
+class TestBuildAssociatedArtifactSource:
+    def test_resolves_task_and_scenario_by_ref_identity(self, tmp_path):
+        backend, _processor = _synthetic_manifests()
+        declared = sorted(backend.supported_contract_versions)[0]
+        task_payload = _capability_only_task_payload(declared_capability=declared)
+        task_bytes = json.dumps(task_payload).encode("utf-8")
+        scenario_bytes = _minimal_scenario_bytes()
+        spec_payload = _flat_spec_payload(spec_id="spec-associated-v1")
+        _write_associated_artifact_bundle(
+            tmp_path, spec_id="spec-associated-v1", task_bytes=task_bytes, scenario_bytes=scenario_bytes
+        )
+        spec = load_experiment_root(
+            yaml.safe_dump(spec_payload).encode("utf-8"), policy=default_admission_policy()
+        )
+
+        source = build_associated_artifact_source(
+            tmp_path, "associated-artifact-manifest.json", spec, default_admission_policy()
+        )
+
+        task_artifact = source.artifact_for(spec.task_ref)
+        assert task_artifact.data == task_bytes
+
+    def test_a_corrupted_checksum_raises_admission_rejection(self, tmp_path):
+        backend, _processor = _synthetic_manifests()
+        declared = sorted(backend.supported_contract_versions)[0]
+        task_payload = _capability_only_task_payload(declared_capability=declared)
+        task_bytes = json.dumps(task_payload).encode("utf-8")
+        scenario_bytes = _minimal_scenario_bytes()
+        spec_payload = _flat_spec_payload(spec_id="spec-associated-bad-v1")
+        _write_associated_artifact_bundle(
+            tmp_path,
+            spec_id="spec-associated-bad-v1",
+            task_bytes=task_bytes,
+            scenario_bytes=scenario_bytes,
+            corrupt_checksum=True,
+        )
+        spec = load_experiment_root(
+            yaml.safe_dump(spec_payload).encode("utf-8"), policy=default_admission_policy()
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            build_associated_artifact_source(
+                tmp_path, "associated-artifact-manifest.json", spec, default_admission_policy()
+            )
+
+        assert excinfo.value.diagnostics

--- a/tests/test_experiment_admission.py
+++ b/tests/test_experiment_admission.py
@@ -1205,13 +1205,10 @@ class TestBuildAssociatedArtifactSource:
             scenario_bytes=scenario_bytes,
             corrupt_checksum=True,
         )
-        spec = load_experiment_root(
-            yaml.safe_dump(spec_payload).encode("utf-8"), policy=default_admission_policy()
-        )
+        policy = default_admission_policy()
+        spec = load_experiment_root(yaml.safe_dump(spec_payload).encode("utf-8"), policy=policy)
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            build_associated_artifact_source(
-                tmp_path, "associated-artifact-manifest.json", spec, default_admission_policy()
-            )
+            build_associated_artifact_source(tmp_path, "associated-artifact-manifest.json", spec, policy)
 
         assert excinfo.value.diagnostics

--- a/tests/test_experiment_apparatus.py
+++ b/tests/test_experiment_apparatus.py
@@ -86,13 +86,10 @@ def _minimal_scenario_bytes() -> bytes:
 class TestCheckApparatusAdmissionMutualCompatGotcha:
     def test_the_realistic_corpus_task_requiring_aces_reference_processor_is_rejected(self):
         task = _load_reference_task()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            check_apparatus_admission(
-                task,
-                None,
-                policy=default_admission_policy(),
-            )
+            check_apparatus_admission(task, None, policy=policy)
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
@@ -140,9 +137,10 @@ class TestCheckApparatusAdmissionMutualCompatGotcha:
                 "notes": [],
             }
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            check_apparatus_admission(task, None, policy=default_admission_policy())
+            check_apparatus_admission(task, None, policy=policy)
 
         messages = " ".join(d.message for d in excinfo.value.diagnostics)
         assert "compat" in messages.lower()
@@ -189,14 +187,16 @@ class TestCheckApparatusAdmissionMutualCompatGotcha:
                 "notes": [],
             }
         )
+        backend_manifest = create_aptl_manifest()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
             check_apparatus_admission(
                 task,
                 None,
-                backend_manifest=create_aptl_manifest(),
+                backend_manifest=backend_manifest,
                 processor_manifest=real_processor_manifest,
-                policy=default_admission_policy(),
+                policy=policy,
             )
 
 
@@ -317,9 +317,11 @@ class TestCheckApparatusAdmissionIdentityAndManifestRefViolations:
             }
         )
 
+        policy = default_admission_policy()
+
         with pytest.raises(AdmissionRejection) as excinfo:
             check_apparatus_admission(
-                task, None, backend_manifest=backend, processor_manifest=processor, policy=default_admission_policy()
+                task, None, backend_manifest=backend, processor_manifest=processor, policy=policy
             )
 
         codes = {d.code for d in excinfo.value.diagnostics}
@@ -355,9 +357,11 @@ class TestCheckApparatusAdmissionIdentityAndManifestRefViolations:
             }
         )
 
+        policy = default_admission_policy()
+
         with pytest.raises(AdmissionRejection) as excinfo:
             check_apparatus_admission(
-                task, None, backend_manifest=backend, processor_manifest=processor, policy=default_admission_policy()
+                task, None, backend_manifest=backend, processor_manifest=processor, policy=policy
             )
 
         codes = {d.code for d in excinfo.value.diagnostics}
@@ -390,10 +394,11 @@ class TestCheckApparatusAdmissionIdentityAndManifestRefViolations:
                 "notes": [],
             }
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
             check_apparatus_admission(
-                task, None, backend_manifest=backend, processor_manifest=processor, policy=default_admission_policy()
+                task, None, backend_manifest=backend, processor_manifest=processor, policy=policy
             )
 
         codes = {d.code for d in excinfo.value.diagnostics}
@@ -422,10 +427,11 @@ class TestCheckApparatusAdmissionIdentityAndManifestRefViolations:
                 "notes": [],
             }
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
             check_apparatus_admission(
-                task, None, backend_manifest=backend, processor_manifest=processor, policy=default_admission_policy()
+                task, None, backend_manifest=backend, processor_manifest=processor, policy=policy
             )
 
         codes = {d.code for d in excinfo.value.diagnostics}
@@ -499,9 +505,10 @@ class TestCheckApparatusAdmissionUncertifiedApparatusOverride:
 
     def test_flag_off_the_mutual_compat_mismatch_still_raises(self):
         task = self._pinned_task()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            check_apparatus_admission(task, None, policy=default_admission_policy())
+            check_apparatus_admission(task, None, policy=policy)
 
         assert excinfo.value.diagnostics
 
@@ -632,18 +639,20 @@ class TestCheckApparatusAdmissionIntentNarrowing:
     def test_intent_naming_a_processor_the_task_does_not_allow_is_rejected(self):
         task = _load_reference_task()
         intent = self._processor_intent("some-other-processor", "9.9.9")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            check_apparatus_admission(task, intent, policy=default_admission_policy())
+            check_apparatus_admission(task, intent, policy=policy)
 
         assert excinfo.value.diagnostics
 
     def test_intent_naming_a_backend_the_task_does_not_allow_is_rejected(self):
         task = _load_reference_task()
         intent = self._backend_intent("some-other-backend", "9.9.9")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            check_apparatus_admission(task, intent, policy=default_admission_policy())
+            check_apparatus_admission(task, intent, policy=policy)
 
     def test_intent_that_only_narrows_to_an_already_allowed_processor_does_not_add_a_narrowing_violation(self):
         # The task's own allow-list still fails admission (mutual compat /
@@ -651,9 +660,10 @@ class TestCheckApparatusAdmissionIntentNarrowing:
         # what rejects a same-or-subset intent.
         task = _load_reference_task()
         intent = self._processor_intent("aces-reference-processor", "0.1.0")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            check_apparatus_admission(task, intent, policy=default_admission_policy())
+            check_apparatus_admission(task, intent, policy=policy)
 
         codes = {d.code for d in excinfo.value.diagnostics}
         assert not any("intent-expands" in code for code in codes)
@@ -669,9 +679,10 @@ class TestCheckApparatusAdmissionRequiredCapabilities:
         task = _task_with_apparatus_constraints(
             {"required_capabilities": ["totally-made-up-capability"], "notes": []}
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            check_apparatus_admission(task, None, policy=default_admission_policy())
+            check_apparatus_admission(task, None, policy=policy)
 
         assert excinfo.value.diagnostics
 
@@ -681,12 +692,13 @@ class TestCheckApparatusAdmissionRequiredCapabilities:
         task = _task_with_apparatus_constraints(
             {"required_capabilities": [declared], "notes": []}
         )
+        policy = default_admission_policy()
 
         # Overall admission still fails (mutual compat is unconditional at
         # the locked surface), but the diagnostics must not include a
         # capability-unsupported complaint about this specific capability.
         with pytest.raises(AdmissionRejection) as excinfo:
-            check_apparatus_admission(task, None, policy=default_admission_policy())
+            check_apparatus_admission(task, None, policy=policy)
 
         for d in excinfo.value.diagnostics:
             assert declared not in d.address or "capability" not in d.code
@@ -702,9 +714,10 @@ class TestCheckApparatusAdmissionDoesNotLeak:
         task = _task_with_apparatus_constraints(
             {"required_capabilities": ["made-up"], "notes": [f"secret={SECRET}"]}
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            check_apparatus_admission(task, None, policy=default_admission_policy())
+            check_apparatus_admission(task, None, policy=policy)
 
         for d in excinfo.value.diagnostics:
             assert SECRET not in d.message
@@ -885,9 +898,10 @@ class TestFuzzApparatusIntentSupersetsAlwaysReject:
                 ],
             }
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            check_apparatus_admission(task, intent, policy=default_admission_policy())
+            check_apparatus_admission(task, intent, policy=policy)
 
     @given(
         capture_kind=st.text(alphabet="abcdefghijklmnopqrstuvwxyz-", min_size=1, max_size=24),
@@ -897,6 +911,7 @@ class TestFuzzApparatusIntentSupersetsAlwaysReject:
         task = _task_with_apparatus_constraints(
             {"required_capabilities": [capture_kind], "notes": []}
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            check_apparatus_admission(task, None, policy=default_admission_policy())
+            check_apparatus_admission(task, None, policy=policy)

--- a/tests/test_experiment_apparatus.py
+++ b/tests/test_experiment_apparatus.py
@@ -1,0 +1,902 @@
+"""Tests for ``aptl.core.experiment.apparatus`` (ADR-047 "Apparatus and
+capture capability admission").
+
+Two things are exercised here:
+
+* ``check_apparatus_admission`` — conjunctive identity/manifest-ref/
+  capability/mutual-compat admission over ``ExperimentTaskModel.
+  apparatus_constraints`` and the authoring input's optional
+  ``apparatus_intent``. At the locked ACES 0.23.1 surface the published
+  reference-processor manifest names only ``stub`` as a compatible backend
+  while APTL names ``aces-reference-processor`` as compatible — a
+  one-directional mismatch — so ANY admission using the real default
+  manifests is expected to fail closed at the mutual-compatibility gate.
+  This is documented, ADR-mandated behavior, not a bug.
+* ``plan_condition_feasibility``/``require_feasible_plan`` — planning-only
+  feasibility over a real parsed SDL ``Scenario``, using ACES's reference
+  processor directly (no ``AptlConfig``/``DeploymentBackend``/Docker).
+
+Uses the installed ACES fixture corpus
+(``aces_contracts.corpus.corpus_family_root(FIXTURES)``) as the contract
+test source rather than a copied-in schema, per ADR-047's testing contract.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import sys
+
+import pytest
+from aces_contracts.contracts import ExperimentApparatusConstraintModel, ExperimentTaskModel
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+from aces_contracts.diagnostics import Severity
+from aces_processor.manifest import create_reference_processor_manifest
+from aces_processor.reference import ReferenceProcessorResult, run_reference_processor
+from aces_sdl import parse_sdl
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.apparatus import (
+    check_apparatus_admission,
+    plan_condition_feasibility,
+    require_feasible_plan,
+)
+from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_DOMAIN, AdmissionRejection
+from aptl.core.experiment.policy import default_admission_policy
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+SECRET = "sk-super-secret-injected-token-98765"
+
+
+def _read(*parts: str) -> bytes:
+    path = CORPUS_ROOT
+    for part in parts:
+        path = path / part
+    return path.read_bytes()
+
+
+def _load_reference_task() -> ExperimentTaskModel:
+    payload = json.loads(
+        _read("experiment-core", "experiment-task-v1", "valid", "reference.json")
+    )
+    return ExperimentTaskModel.model_validate(payload)
+
+
+def _load_reference_task_payload() -> dict:
+    return json.loads(
+        _read("experiment-core", "experiment-task-v1", "valid", "reference.json")
+    )
+
+
+def _task_with_apparatus_constraints(apparatus_constraints: dict) -> ExperimentTaskModel:
+    payload = _load_reference_task_payload()
+    payload["apparatus_constraints"] = apparatus_constraints
+    return ExperimentTaskModel.model_validate(payload)
+
+
+def _minimal_scenario_bytes() -> bytes:
+    return _read("sdl", "sdl-yaml-v1", "valid", "minimal.yaml")
+
+
+# ---------------------------------------------------------------------------
+# check_apparatus_admission — mutual-compat fail-closed gotcha
+# ---------------------------------------------------------------------------
+
+
+class TestCheckApparatusAdmissionMutualCompatGotcha:
+    def test_the_realistic_corpus_task_requiring_aces_reference_processor_is_rejected(self):
+        task = _load_reference_task()
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(
+                task,
+                None,
+                policy=default_admission_policy(),
+            )
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+
+    def test_default_aptl_and_reference_processor_manifests_are_not_mutually_declared_compatible(self):
+        # Structural fact about the two *canonical* manifests, independent
+        # of any task: aptl.compatible_processors names
+        # "aces-reference-processor", but the reference-processor manifest's
+        # compatible_backends names only "stub" (never "aptl"). Isolated
+        # here with a task that explicitly allows both identities (and
+        # pins them correctly via required_manifest_refs) so the
+        # rejection can only be coming from the mutual-compat rule, not a
+        # simpler identity mismatch.
+        task = _task_with_apparatus_constraints(
+            {
+                "allowed_processor_refs": [
+                    {"ref_kind": "processor", "ref_id": "aces-reference-processor", "ref_version": "0.1.0"}
+                ],
+                "allowed_backend_refs": [
+                    {"ref_kind": "backend", "ref_id": "aptl", "ref_version": "0.1.0"}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "aces-reference-processor",
+                        "ref_version": "processor-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "processor",
+                            "ref_id": "aces-reference-processor",
+                            "ref_version": "0.1.0",
+                        },
+                    },
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "aptl",
+                        "ref_version": "backend-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "backend",
+                            "ref_id": "aptl",
+                            "ref_version": "0.1.0",
+                        },
+                    },
+                ],
+                "required_capabilities": [],
+                "notes": [],
+            }
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, None, policy=default_admission_policy())
+
+        messages = " ".join(d.message for d in excinfo.value.diagnostics)
+        assert "compat" in messages.lower()
+
+    def test_never_fabricates_compatibility_by_patching_the_processor_payload(self):
+        # Injecting a *real* (unpatched) reference processor manifest whose
+        # compatible_backends genuinely includes "aptl" would pass; the
+        # locked surface's actual manifest does not, and admission must
+        # never treat a superficially-similar payload as proof.
+        real_processor_manifest = create_reference_processor_manifest()
+        assert "aptl" not in real_processor_manifest.compatible_backends
+
+        task = _task_with_apparatus_constraints(
+            {
+                "allowed_processor_refs": [
+                    {"ref_kind": "processor", "ref_id": "aces-reference-processor", "ref_version": "0.1.0"}
+                ],
+                "allowed_backend_refs": [
+                    {"ref_kind": "backend", "ref_id": "aptl", "ref_version": "0.1.0"}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "aces-reference-processor",
+                        "ref_version": "processor-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "processor",
+                            "ref_id": "aces-reference-processor",
+                            "ref_version": "0.1.0",
+                        },
+                    },
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "aptl",
+                        "ref_version": "backend-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "backend",
+                            "ref_id": "aptl",
+                            "ref_version": "0.1.0",
+                        },
+                    },
+                ],
+                "required_capabilities": [],
+                "notes": [],
+            }
+        )
+
+        with pytest.raises(AdmissionRejection):
+            check_apparatus_admission(
+                task,
+                None,
+                backend_manifest=create_aptl_manifest(),
+                processor_manifest=real_processor_manifest,
+                policy=default_admission_policy(),
+            )
+
+
+    def _pinned_task(self) -> ExperimentTaskModel:
+        return _task_with_apparatus_constraints(
+            {
+                "allowed_processor_refs": [
+                    {"ref_kind": "processor", "ref_id": "aces-reference-processor", "ref_version": "0.1.0"}
+                ],
+                "allowed_backend_refs": [
+                    {"ref_kind": "backend", "ref_id": "aptl", "ref_version": "0.1.0"}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "aces-reference-processor",
+                        "ref_version": "processor-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "processor",
+                            "ref_id": "aces-reference-processor",
+                            "ref_version": "0.1.0",
+                        },
+                    },
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "aptl",
+                        "ref_version": "backend-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "backend",
+                            "ref_id": "aptl",
+                            "ref_version": "0.1.0",
+                        },
+                    },
+                ],
+                "required_capabilities": [],
+                "notes": [],
+            }
+        )
+
+
+def _synthetic_mutually_compatible_manifests():
+    """A genuinely mutually-compatible test backend/processor pair (mirrors
+    ``test_experiment_admission.py``'s ``_synthetic_manifests()``) so a test
+    can isolate ONE apparatus gate at a time without the unconditional
+    mutual-compatibility gate also firing alongside it.
+    """
+    from aces_backend_protocols.backend_manifest import BackendManifest
+    from aces_processor.capabilities import ProcessorManifest
+
+    real_backend = create_aptl_manifest()
+    real_processor = create_reference_processor_manifest()
+    test_backend = BackendManifest(
+        name="test-backend",
+        version=real_backend.version,
+        supported_contract_versions=real_backend.supported_contract_versions,
+        compatible_processors=frozenset({"test-processor"}),
+        realization_support=real_backend.realization_support,
+        concept_bindings=real_backend.concept_bindings,
+        provisioner=real_backend.provisioner,
+        orchestrator=real_backend.orchestrator,
+        evaluator=real_backend.evaluator,
+        participant_runtime=real_backend.participant_runtime,
+    )
+    test_processor = ProcessorManifest(
+        name="test-processor",
+        version=real_processor.version,
+        supported_contract_versions=real_processor.supported_contract_versions,
+        capabilities=real_processor.capabilities,
+        compatible_backends=frozenset({"test-backend"}),
+        concept_bindings=real_processor.concept_bindings,
+        constraints=real_processor.constraints,
+    )
+    return test_backend, test_processor
+
+
+# ---------------------------------------------------------------------------
+# check_apparatus_admission — _identity_violations / _manifest_ref_violations
+# distinct from the unconditional mutual-compat gate
+# ---------------------------------------------------------------------------
+
+
+class TestCheckApparatusAdmissionIdentityAndManifestRefViolations:
+    """Both gates isolated with a synthetic, genuinely mutually-compatible
+    backend/processor pair, so the unconditional mutual-compat gate cannot
+    be what raises -- only the gate under test.
+    """
+
+    def test_identity_violation_when_the_resolved_processor_is_outside_the_allow_list(self):
+        backend, processor = _synthetic_mutually_compatible_manifests()
+        # ExperimentApparatusConstraintModel's own pydantic validator
+        # requires any allowed_processor_refs entry to have a PAIRED
+        # required_manifest_refs entry (same ref_id, canonical schema-
+        # version literal) -- so that paired manifest ref necessarily also
+        # names the same "wrong" identity, which independently also trips
+        # _manifest_ref_violations' subject-identity check below (both are
+        # real, structurally-coupled diagnostics for this input shape, not
+        # a test artifact). The assertion below checks the
+        # identity-unresolved code is genuinely PRESENT rather than
+        # requiring total exclusivity.
+        task = _task_with_apparatus_constraints(
+            {
+                "allowed_processor_refs": [
+                    {"ref_kind": "processor", "ref_id": "some-other-processor", "ref_version": "9.9.9"}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "some-other-processor",
+                        "ref_version": "processor-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "processor",
+                            "ref_id": "some-other-processor",
+                            "ref_version": "9.9.9",
+                        },
+                    }
+                ],
+                "notes": [],
+            }
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(
+                task, None, backend_manifest=backend, processor_manifest=processor, policy=default_admission_policy()
+            )
+
+        codes = {d.code for d in excinfo.value.diagnostics}
+        assert "aptl.experiment-admission.apparatus-identity-unresolved" in codes
+        identity_diagnostics = [
+            d for d in excinfo.value.diagnostics if d.code == "aptl.experiment-admission.apparatus-identity-unresolved"
+        ]
+        assert identity_diagnostics
+        assert all("allowed_processor_refs" in d.address for d in identity_diagnostics)
+
+    def test_identity_violation_when_the_resolved_backend_is_outside_the_allow_list(self):
+        backend, processor = _synthetic_mutually_compatible_manifests()
+        # Same pydantic pairing requirement as the processor case above,
+        # mirrored for allowed_backend_refs/required_manifest_refs.
+        task = _task_with_apparatus_constraints(
+            {
+                "allowed_backend_refs": [
+                    {"ref_kind": "backend", "ref_id": "some-other-backend", "ref_version": "9.9.9"}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "some-other-backend",
+                        "ref_version": "backend-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "backend",
+                            "ref_id": "some-other-backend",
+                            "ref_version": "9.9.9",
+                        },
+                    }
+                ],
+                "notes": [],
+            }
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(
+                task, None, backend_manifest=backend, processor_manifest=processor, policy=default_admission_policy()
+            )
+
+        codes = {d.code for d in excinfo.value.diagnostics}
+        assert "aptl.experiment-admission.apparatus-identity-unresolved" in codes
+        identity_diagnostics = [
+            d for d in excinfo.value.diagnostics if d.code == "aptl.experiment-admission.apparatus-identity-unresolved"
+        ]
+        assert identity_diagnostics
+        assert all("allowed_backend_refs" in d.address for d in identity_diagnostics)
+
+    def test_manifest_ref_mismatch_when_the_schema_version_literal_is_wrong(self):
+        backend, processor = _synthetic_mutually_compatible_manifests()
+        task = _task_with_apparatus_constraints(
+            {
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "test-processor",
+                        # Wrong literal: must be the slash form
+                        # "processor-manifest/v2", never a
+                        # supported_contract_versions-shaped hyphen entry.
+                        "ref_version": "processor-manifest/v1",
+                        "subject_ref": {
+                            "ref_kind": "processor",
+                            "ref_id": "test-processor",
+                            "ref_version": "0.1.0",
+                        },
+                    }
+                ],
+                "notes": [],
+            }
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(
+                task, None, backend_manifest=backend, processor_manifest=processor, policy=default_admission_policy()
+            )
+
+        codes = {d.code for d in excinfo.value.diagnostics}
+        assert codes == {"aptl.experiment-admission.apparatus-manifest-ref-mismatch"}
+        assert all("required_manifest_refs" in d.address for d in excinfo.value.diagnostics)
+
+    def test_manifest_ref_mismatch_when_the_subject_identity_is_wrong(self):
+        backend, processor = _synthetic_mutually_compatible_manifests()
+        task = _task_with_apparatus_constraints(
+            {
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "wrong-processor-name",
+                        "ref_version": "processor-manifest/v2",
+                        "subject_ref": {
+                            # Correct schema-version literal, but the
+                            # subject identity does not match the resolved
+                            # processor manifest's own name.
+                            "ref_kind": "processor",
+                            "ref_id": "wrong-processor-name",
+                            "ref_version": "0.1.0",
+                        },
+                    }
+                ],
+                "notes": [],
+            }
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(
+                task, None, backend_manifest=backend, processor_manifest=processor, policy=default_admission_policy()
+            )
+
+        codes = {d.code for d in excinfo.value.diagnostics}
+        assert codes == {"aptl.experiment-admission.apparatus-manifest-ref-mismatch"}
+        assert all("required_manifest_refs" in d.address for d in excinfo.value.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# check_apparatus_admission — allow_uncertified_apparatus debug override
+# ---------------------------------------------------------------------------
+
+
+class TestCheckApparatusAdmissionUncertifiedApparatusOverride:
+    """ADR-047: production stays strict/fail-closed, but a clearly-named
+    DEBUG override (``AdmissionPolicy.allow_uncertified_apparatus``) lets
+    dev/test admit against the REAL ``aptl`` manifest despite the
+    reference-processor manifest naming only ``stub``.
+    """
+
+    def _pinned_task(self) -> ExperimentTaskModel:
+        return TestCheckApparatusAdmissionMutualCompatGotcha()._pinned_task()
+
+    def test_default_return_value_on_a_clean_admission_is_an_empty_tuple(self):
+        # A synthetic (test-only, but honest) manifest pair that genuinely
+        # DOES mutually declare compatibility, cloned from the real aptl /
+        # reference-processor manifests' capability fields so only `name`
+        # and the compatibility declarations differ. This is dependency
+        # injection through the function's own documented override params,
+        # never patching the real manifest objects (which the sibling
+        # "never fabricates compatibility" test above forbids).
+        real_backend = create_aptl_manifest()
+        real_processor = create_reference_processor_manifest()
+        from aces_backend_protocols.backend_manifest import BackendManifest
+        from aces_processor.capabilities import ProcessorManifest
+
+        test_backend = BackendManifest(
+            name="test-backend",
+            version=real_backend.version,
+            supported_contract_versions=real_backend.supported_contract_versions,
+            compatible_processors=frozenset({"test-processor"}),
+            realization_support=real_backend.realization_support,
+            concept_bindings=real_backend.concept_bindings,
+            provisioner=real_backend.provisioner,
+            orchestrator=real_backend.orchestrator,
+            evaluator=real_backend.evaluator,
+            participant_runtime=real_backend.participant_runtime,
+        )
+        test_processor = ProcessorManifest(
+            name="test-processor",
+            version=real_processor.version,
+            supported_contract_versions=real_processor.supported_contract_versions,
+            capabilities=real_processor.capabilities,
+            compatible_backends=frozenset({"test-backend"}),
+            concept_bindings=real_processor.concept_bindings,
+            constraints=real_processor.constraints,
+        )
+        declared_capability = sorted(test_backend.supported_contract_versions)[0]
+        task = _task_with_apparatus_constraints(
+            {"required_capabilities": [declared_capability], "notes": []}
+        )
+
+        warnings = check_apparatus_admission(
+            task,
+            None,
+            backend_manifest=test_backend,
+            processor_manifest=test_processor,
+            policy=default_admission_policy(),
+        )
+
+        assert warnings == ()
+
+    def test_flag_off_the_mutual_compat_mismatch_still_raises(self):
+        task = self._pinned_task()
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, None, policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+
+    def test_flag_on_it_returns_exactly_one_warning_and_does_not_raise(self):
+        task = self._pinned_task()
+        policy = dataclasses.replace(default_admission_policy(), allow_uncertified_apparatus=True)
+
+        warnings = check_apparatus_admission(task, None, policy=policy)
+
+        assert len(warnings) == 1
+        assert warnings[0].severity == Severity.WARNING
+        assert warnings[0].code == "aptl.experiment-admission.apparatus-uncertified-compatibility"
+        assert warnings[0].domain == EXPERIMENT_ADMISSION_DOMAIN
+
+    def test_flag_on_a_non_mutual_compat_failure_still_raises(self):
+        # required_capabilities names something neither manifest declares:
+        # a real fatal gate independent of mutual-compat. The flag must not
+        # blanket-suppress it.
+        task = _task_with_apparatus_constraints(
+            {"required_capabilities": ["totally-made-up-capability"], "notes": []}
+        )
+        policy = dataclasses.replace(default_admission_policy(), allow_uncertified_apparatus=True)
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, None, policy=policy)
+
+        codes = {d.code for d in excinfo.value.diagnostics}
+        assert any("capability" in code for code in codes)
+
+    def test_flag_on_with_both_a_fatal_gate_and_mutual_compat_failing_raises_both(self):
+        # Pinned identity (mutual-compat WILL fail with real manifests) plus
+        # an unrelated bogus capability requirement (a second, independent
+        # fatal gate). The flag must not make the overall call succeed.
+        task = _task_with_apparatus_constraints(
+            {
+                "allowed_processor_refs": [
+                    {"ref_kind": "processor", "ref_id": "aces-reference-processor", "ref_version": "0.1.0"}
+                ],
+                "allowed_backend_refs": [
+                    {"ref_kind": "backend", "ref_id": "aptl", "ref_version": "0.1.0"}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "aces-reference-processor",
+                        "ref_version": "processor-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "processor",
+                            "ref_id": "aces-reference-processor",
+                            "ref_version": "0.1.0",
+                        },
+                    },
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": "aptl",
+                        "ref_version": "backend-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "backend",
+                            "ref_id": "aptl",
+                            "ref_version": "0.1.0",
+                        },
+                    },
+                ],
+                "required_capabilities": ["totally-made-up-capability"],
+                "notes": [],
+            }
+        )
+        policy = dataclasses.replace(default_admission_policy(), allow_uncertified_apparatus=True)
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, None, policy=policy)
+
+        codes = {d.code for d in excinfo.value.diagnostics}
+        assert any("capability" in code for code in codes)
+        assert any("compat" in code for code in codes)
+
+
+# ---------------------------------------------------------------------------
+# check_apparatus_admission — conjunctive narrowing of apparatus_intent
+# ---------------------------------------------------------------------------
+
+
+class TestCheckApparatusAdmissionIntentNarrowing:
+    @staticmethod
+    def _processor_intent(ref_id: str, ref_version: str) -> ExperimentApparatusConstraintModel:
+        return ExperimentApparatusConstraintModel.model_validate(
+            {
+                "allowed_processor_refs": [
+                    {"ref_kind": "processor", "ref_id": ref_id, "ref_version": ref_version}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": ref_id,
+                        "ref_version": "processor-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "processor",
+                            "ref_id": ref_id,
+                            "ref_version": ref_version,
+                        },
+                    }
+                ],
+            }
+        )
+
+    @staticmethod
+    def _backend_intent(ref_id: str, ref_version: str) -> ExperimentApparatusConstraintModel:
+        return ExperimentApparatusConstraintModel.model_validate(
+            {
+                "allowed_backend_refs": [
+                    {"ref_kind": "backend", "ref_id": ref_id, "ref_version": ref_version}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": ref_id,
+                        "ref_version": "backend-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "backend",
+                            "ref_id": ref_id,
+                            "ref_version": ref_version,
+                        },
+                    }
+                ],
+            }
+        )
+
+    def test_intent_naming_a_processor_the_task_does_not_allow_is_rejected(self):
+        task = _load_reference_task()
+        intent = self._processor_intent("some-other-processor", "9.9.9")
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, intent, policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+
+    def test_intent_naming_a_backend_the_task_does_not_allow_is_rejected(self):
+        task = _load_reference_task()
+        intent = self._backend_intent("some-other-backend", "9.9.9")
+
+        with pytest.raises(AdmissionRejection):
+            check_apparatus_admission(task, intent, policy=default_admission_policy())
+
+    def test_intent_that_only_narrows_to_an_already_allowed_processor_does_not_add_a_narrowing_violation(self):
+        # The task's own allow-list still fails admission (mutual compat /
+        # capability gates), but the *narrowing* check itself must not be
+        # what rejects a same-or-subset intent.
+        task = _load_reference_task()
+        intent = self._processor_intent("aces-reference-processor", "0.1.0")
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, intent, policy=default_admission_policy())
+
+        codes = {d.code for d in excinfo.value.diagnostics}
+        assert not any("intent-expands" in code for code in codes)
+
+
+# ---------------------------------------------------------------------------
+# check_apparatus_admission — required_capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestCheckApparatusAdmissionRequiredCapabilities:
+    def test_a_capability_not_declared_by_either_manifest_is_rejected(self):
+        task = _task_with_apparatus_constraints(
+            {"required_capabilities": ["totally-made-up-capability"], "notes": []}
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, None, policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+
+    def test_a_capability_declared_in_backend_supported_contract_versions_passes_that_gate(self):
+        backend_manifest = create_aptl_manifest()
+        declared = sorted(backend_manifest.supported_contract_versions)[0]
+        task = _task_with_apparatus_constraints(
+            {"required_capabilities": [declared], "notes": []}
+        )
+
+        # Overall admission still fails (mutual compat is unconditional at
+        # the locked surface), but the diagnostics must not include a
+        # capability-unsupported complaint about this specific capability.
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, None, policy=default_admission_policy())
+
+        for d in excinfo.value.diagnostics:
+            assert declared not in d.address or "capability" not in d.code
+
+
+# ---------------------------------------------------------------------------
+# check_apparatus_admission — does not leak values
+# ---------------------------------------------------------------------------
+
+
+class TestCheckApparatusAdmissionDoesNotLeak:
+    def test_an_unsupported_capability_name_is_safe_to_echo_but_a_secret_note_never_is(self):
+        task = _task_with_apparatus_constraints(
+            {"required_capabilities": ["made-up"], "notes": [f"secret={SECRET}"]}
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            check_apparatus_admission(task, None, policy=default_admission_policy())
+
+        for d in excinfo.value.diagnostics:
+            assert SECRET not in d.message
+            assert SECRET not in d.code
+            assert SECRET not in d.address
+
+
+# ---------------------------------------------------------------------------
+# plan_condition_feasibility / require_feasible_plan — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestPlanConditionFeasibilityHappyPath:
+    def test_a_valid_corpus_scenario_with_empty_parameters_is_feasible(self):
+        scenario = parse_sdl(_minimal_scenario_bytes().decode("utf-8"))
+
+        result = plan_condition_feasibility(scenario, {})
+
+        assert isinstance(result, ReferenceProcessorResult)
+        assert result.is_valid is True
+        require_feasible_plan(result, address="condition")  # must not raise
+
+    def test_uses_the_aptl_manifest_by_default(self):
+        scenario = parse_sdl(_minimal_scenario_bytes().decode("utf-8"))
+
+        result = plan_condition_feasibility(scenario, {})
+        direct = run_reference_processor(scenario, create_aptl_manifest(), parameters={})
+
+        assert result.scenario_name == direct.scenario_name
+        assert result.is_valid == direct.is_valid
+
+
+class TestPlanConditionFeasibilityBrokenParameterBinding:
+    """At the locked ACES 0.23.1 surface, ``run_reference_processor`` itself
+    *raises* ``SDLInstantiationError`` for a structurally broken parameter
+    binding (verified live) rather than returning an invalid
+    ``ReferenceProcessorResult`` — a delta from what a naive reading of the
+    planning API might suggest. ``plan_condition_feasibility`` normalizes
+    that raise into the same fail-closed ``AdmissionRejection`` surface as
+    every other admission rejection, rather than letting a raw ACES
+    exception escape or fabricating a fake successful plan.
+    """
+
+    def test_an_undeclared_parameter_target_is_rejected(self):
+        scenario = parse_sdl(_minimal_scenario_bytes().decode("utf-8"))
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            plan_condition_feasibility(scenario, {"undeclared_target": SECRET})
+
+        assert excinfo.value.diagnostics
+
+    def test_the_bound_secret_value_is_never_leaked_in_the_rejection(self):
+        scenario = parse_sdl(_minimal_scenario_bytes().decode("utf-8"))
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            plan_condition_feasibility(scenario, {"undeclared_target": SECRET})
+
+        for d in excinfo.value.diagnostics:
+            assert SECRET not in d.message
+            assert SECRET not in d.code
+            assert SECRET not in d.address
+
+
+class TestRequireFeasiblePlanRejectsAnInvalidResult:
+    def test_raises_when_the_result_carries_an_error_diagnostic(self):
+        from aces_contracts.diagnostics import Diagnostic, Severity
+
+        bad_diagnostic = Diagnostic(
+            code="aces.some-planning-error",
+            domain="aces-processor",
+            address="scenario.nodes",
+            message=f"unresolvable reference; rejected value was {SECRET}",
+            severity=Severity.ERROR,
+        )
+        fake_result = ReferenceProcessorResult(
+            scenario_name="fake",
+            runtime_model=None,
+            execution_plan=None,
+            diagnostics=(bad_diagnostic,),
+        )
+        assert fake_result.is_valid is False
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            require_feasible_plan(fake_result, address="condition")
+
+        assert excinfo.value.diagnostics == (bad_diagnostic,)
+
+    def test_does_not_raise_for_a_valid_result(self):
+        fake_result = ReferenceProcessorResult(
+            scenario_name="fake",
+            runtime_model=None,
+            execution_plan=None,
+            diagnostics=(),
+        )
+
+        require_feasible_plan(fake_result, address="condition")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# plan_condition_feasibility — no Docker / DeploymentBackend construction
+# ---------------------------------------------------------------------------
+
+
+class TestPlanConditionFeasibilityNeverTouchesDocker:
+    def test_no_deployment_backend_or_docker_module_is_imported_or_invoked(self, monkeypatch):
+        # `monkeypatch.delitem` (not a raw `sys.modules.pop`) so the ENTIRE
+        # sys.modules mutation — including the fresh re-import performed
+        # below to install the spy — is unconditionally reverted at test
+        # teardown. A bare pop/reimport would leak a *different* module
+        # object into sys.modules for the rest of this worker process,
+        # which can break identity/patch-target assumptions in unrelated
+        # tests sharing the same pytest-xdist worker.
+        for leftover in (
+            "aptl.core.deployment.docker_compose",
+            "aptl.core.deployment.ssh_compose",
+            "aces_runtime.manager",
+        ):
+            monkeypatch.delitem(sys.modules, leftover, raising=False)
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("subprocess.run must never be called by planning-only admission")
+
+        # Belt-and-suspenders spy: if docker_compose ever gets imported and
+        # exercised, its one real chokepoint (subprocess.run) must not fire.
+        import aptl.core.deployment.docker_compose as docker_compose_module
+
+        monkeypatch.setattr(docker_compose_module.subprocess, "run", _boom)
+
+        scenario = parse_sdl(_minimal_scenario_bytes().decode("utf-8"))
+        result = plan_condition_feasibility(scenario, {})
+
+        assert result.is_valid is True
+        assert "aptl.core.deployment.ssh_compose" not in sys.modules
+        # aces_runtime.manager (RuntimeManager, the execution-side
+        # incumbent) must never be pulled in by planning-only admission.
+        assert "aces_runtime.manager" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# Fuzz
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@pytest.mark.fuzz
+class TestFuzzApparatusIntentSupersetsAlwaysReject:
+    @given(
+        extra_ref_id=st.text(alphabet="abcdefghijklmnopqrstuvwxyz-", min_size=1, max_size=24),
+        extra_ref_version=st.text(alphabet="0123456789.", min_size=1, max_size=8),
+    )
+    @settings(max_examples=50, deadline=2000)
+    def test_an_intent_processor_ref_outside_the_tasks_allow_list_always_rejects(
+        self, extra_ref_id, extra_ref_version
+    ):
+        task = _load_reference_task()
+        allowed_ids = {ref.ref_id for ref in task.apparatus_constraints.allowed_processor_refs}
+        if extra_ref_id in allowed_ids:
+            extra_ref_id += "-not-allowed"
+
+        intent = ExperimentApparatusConstraintModel.model_validate(
+            {
+                "allowed_processor_refs": [
+                    {"ref_kind": "processor", "ref_id": extra_ref_id, "ref_version": extra_ref_version}
+                ],
+                "required_manifest_refs": [
+                    {
+                        "ref_kind": "manifest",
+                        "ref_id": extra_ref_id,
+                        "ref_version": "processor-manifest/v2",
+                        "subject_ref": {
+                            "ref_kind": "processor",
+                            "ref_id": extra_ref_id,
+                            "ref_version": extra_ref_version,
+                        },
+                    }
+                ],
+            }
+        )
+
+        with pytest.raises(AdmissionRejection):
+            check_apparatus_admission(task, intent, policy=default_admission_policy())
+
+    @given(
+        capture_kind=st.text(alphabet="abcdefghijklmnopqrstuvwxyz-", min_size=1, max_size=24),
+    )
+    @settings(max_examples=50, deadline=2000)
+    def test_an_arbitrary_unknown_required_capability_always_rejects(self, capture_kind):
+        task = _task_with_apparatus_constraints(
+            {"required_capabilities": [capture_kind], "notes": []}
+        )
+
+        with pytest.raises(AdmissionRejection):
+            check_apparatus_admission(task, None, policy=default_admission_policy())

--- a/tests/test_experiment_capture_mapping.py
+++ b/tests/test_experiment_capture_mapping.py
@@ -1,0 +1,399 @@
+"""Tests for ``aptl.core.experiment.capture_mapping`` (ADR-047 "Apparatus and
+capture capability admission" + the ``observation=None`` gotcha).
+
+``create_aptl_manifest().observation`` is currently ``None`` (Stage 3 /
+EXP-002), and the existing capture collectors (``aptl.core.collectors``) are
+best-effort primitives that often collapse failure into an empty result.
+Per ADR-047's Gotchas: "Do not admit a capture requirement merely because a
+collector function exists." This module's ``SUPPORTED_CAPTURE_CAPABILITIES``
+table is the ONLY thing that can admit a capture requirement, and it is
+empty/minimal for #438 — an honest fail-closed baseline. EXP-010 (#752) is
+the seam that extends the table alongside an honest
+``create_aptl_manifest().observation`` declaration.
+
+Uses the installed ACES fixture corpus
+(``aces_contracts.corpus.corpus_family_root(FIXTURES)``) as the contract
+test source rather than a copied-in schema, per ADR-047's testing contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aces_backend_protocols.capabilities import BackendManifest, ObservationCapabilities
+from aces_contracts.contracts import ExperimentCaptureSpecModel
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.collectors import collect_traces
+from aptl.core.experiment import capture_mapping
+from aptl.core.experiment.capture_mapping import (
+    SUPPORTED_CAPTURE_CAPABILITIES,
+    CaptureCapability,
+    map_capture_requirements,
+)
+from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_DOMAIN, AdmissionRejection
+from aptl.core.experiment.policy import default_admission_policy
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+
+
+def _read(*parts: str) -> bytes:
+    path = CORPUS_ROOT
+    for part in parts:
+        path = path / part
+    return path.read_bytes()
+
+
+def _load_reference_capture_spec() -> ExperimentCaptureSpecModel:
+    payload = json.loads(
+        _read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json")
+    )
+    return ExperimentCaptureSpecModel.model_validate(payload)
+
+
+def _capture_spec_with_requirement(*, capture_kind: str, capture_scope: str) -> ExperimentCaptureSpecModel:
+    payload = json.loads(
+        _read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json")
+    )
+    requirement = next(iter(payload["capture_requirements"].values()))
+    requirement["capture_kind"] = capture_kind
+    requirement["capture_scope"] = capture_scope
+    payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
+    return ExperimentCaptureSpecModel.model_validate(payload)
+
+
+def _capture_spec_with_requirement_fields(
+    *,
+    capture_kind: str = "trace",
+    capture_scope: str = "network",
+    expected_media_types: list[str] | None = None,
+    integrity_requirements: list[str] | None = None,
+) -> ExperimentCaptureSpecModel:
+    """Like :func:`_capture_spec_with_requirement` but also lets a test
+    independently override ``expected_media_types``/``integrity_requirements``
+    -- needed to isolate the media-type-subset and integrity-subset
+    continue-conditions in ``_resolve_capture_owner`` from the
+    capture_kind/capture_scope ones.
+    """
+    payload = json.loads(
+        _read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json")
+    )
+    requirement = next(iter(payload["capture_requirements"].values()))
+    requirement["capture_kind"] = capture_kind
+    requirement["capture_scope"] = capture_scope
+    if expected_media_types is not None:
+        requirement["expected_media_types"] = expected_media_types
+    if integrity_requirements is not None:
+        requirement["integrity_requirements"] = integrity_requirements
+    payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
+    return ExperimentCaptureSpecModel.model_validate(payload)
+
+
+def _matching_capability(*, capture_owner: str = "aptl.core.collectors.collect_traces") -> CaptureCapability:
+    """The one ``CaptureCapability`` that exactly matches
+    ``_capture_spec_with_requirement_fields()``'s default requirement
+    (capture_kind="trace", capture_scope="network",
+    expected_media_types=["application/json"],
+    integrity_requirements=["sha256-digest"]) on every predicate --
+    the SUCCESS baseline every miss-test below deviates from by exactly
+    one field.
+    """
+    return CaptureCapability(
+        capture_kind="trace",
+        capture_scope="network",
+        media_types=frozenset({"application/json"}),
+        integrity_requirements=frozenset({"sha256-digest"}),
+        capture_owner=capture_owner,
+    )
+
+
+def _matching_observation(
+    *,
+    supported_capture_kinds: frozenset[str] = frozenset({"trace"}),
+    supported_media_types: frozenset[str] = frozenset({"application/json"}),
+) -> ObservationCapabilities:
+    return ObservationCapabilities(
+        name="test-observation",
+        supported_capture_kinds=supported_capture_kinds,
+        supported_channel_kinds=frozenset({"file-artifact"}),
+        supported_evidence_contracts=frozenset({"experiment-capture-spec-v1"}),
+        supported_media_types=supported_media_types,
+        supported_sealing_modes=frozenset({"digest"}),
+    )
+
+
+def _backend_manifest_with_observation(observation: ObservationCapabilities) -> BackendManifest:
+    # NOTE: dataclasses.replace(create_aptl_manifest(), observation=...)
+    # does NOT work here -- BackendManifest has a custom __init__ that
+    # resolves a pre-built `capabilities` object from its own `capabilities`
+    # kwarg when present (which dataclasses.replace always supplies, since
+    # it is itself a real dataclass field), silently discarding a sibling
+    # `observation=` kwarg. Explicit reconstruction (the pattern the
+    # existing "never fabricates support" test below already uses) is the
+    # only way to actually set `observation`.
+    manifest = create_aptl_manifest()
+    return BackendManifest(
+        name=manifest.name,
+        version=manifest.version,
+        supported_contract_versions=manifest.supported_contract_versions,
+        compatible_processors=manifest.compatible_processors,
+        realization_support=manifest.realization_support,
+        concept_bindings=manifest.concept_bindings,
+        provisioner=manifest.provisioner,
+        orchestrator=manifest.orchestrator,
+        evaluator=manifest.evaluator,
+        participant_runtime=manifest.participant_runtime,
+        observation=observation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SUPPORTED_CAPTURE_CAPABILITIES — honest fail-closed baseline
+# ---------------------------------------------------------------------------
+
+
+class TestSupportedCaptureCapabilitiesBaseline:
+    def test_the_table_is_empty_for_438(self):
+        assert tuple(SUPPORTED_CAPTURE_CAPABILITIES) == ()
+
+    def test_create_aptl_manifest_observation_is_still_none(self):
+        # If this ever flips true, SUPPORTED_CAPTURE_CAPABILITIES may gain
+        # entries (EXP-010) — until then the fail-closed baseline below is
+        # load-bearing and this sanity check documents the precondition.
+        assert create_aptl_manifest().observation is None
+
+    def test_capture_capability_is_a_frozen_dataclass_shape(self):
+        capability = CaptureCapability(
+            capture_kind="trace",
+            capture_scope="network",
+            media_types=frozenset({"application/json"}),
+            integrity_requirements=frozenset({"sha256-digest"}),
+            capture_owner="aptl.core.collectors.collect_traces",
+        )
+        with pytest.raises(Exception):  # noqa: B017 - frozen dataclass FrozenInstanceError
+            capability.capture_kind = "log"
+
+
+# ---------------------------------------------------------------------------
+# map_capture_requirements — fail-closed on the realistic corpus spec
+# ---------------------------------------------------------------------------
+
+
+class TestMapCaptureRequirementsFailsClosed:
+    def test_the_realistic_corpus_capture_spec_is_rejected(self):
+        spec = _load_reference_capture_spec()
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            map_capture_requirements([spec], policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+
+    def test_the_rejection_names_the_unsupported_capture_kind_and_scope(self):
+        spec = _load_reference_capture_spec()
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            map_capture_requirements([spec], policy=default_admission_policy())
+
+        messages = " ".join(d.message + " " + d.address for d in excinfo.value.diagnostics)
+        assert "trace" in messages
+        assert "network" in messages
+
+    def test_an_unknown_capture_kind_also_fails_closed(self):
+        spec = _capture_spec_with_requirement(capture_kind="other", capture_scope="service")
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], policy=default_admission_policy())
+
+    def test_a_collector_function_existing_does_not_cause_admission(self):
+        # collect_traces is a real, importable, callable collector for
+        # exactly the "trace" capture_kind the corpus spec requires. Its
+        # mere existence must never be what admission consults.
+        assert callable(collect_traces)
+        spec = _load_reference_capture_spec()
+        assert spec.capture_requirements["network-trace"].capture_kind == "trace"
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], policy=default_admission_policy())
+
+    def test_never_fabricates_support_by_injecting_a_backend_manifest_with_non_none_observation_but_wrong_terms(self):
+        # Even if a caller injects a backend manifest whose observation IS
+        # populated, an empty SUPPORTED_CAPTURE_CAPABILITIES table still
+        # fails closed -- the table gates admission, not observation
+        # presence alone.
+        from aces_backend_protocols.capabilities import BackendManifest, ObservationCapabilities
+
+        manifest = create_aptl_manifest()
+        with_observation = BackendManifest(
+            name=manifest.name,
+            version=manifest.version,
+            supported_contract_versions=manifest.supported_contract_versions,
+            compatible_processors=manifest.compatible_processors,
+            realization_support=manifest.realization_support,
+            concept_bindings=manifest.concept_bindings,
+            provisioner=manifest.provisioner,
+            orchestrator=manifest.orchestrator,
+            evaluator=manifest.evaluator,
+            participant_runtime=manifest.participant_runtime,
+            observation=ObservationCapabilities(
+                name="test-observation",
+                supported_capture_kinds=frozenset({"trace"}),
+                supported_channel_kinds=frozenset({"file-artifact"}),
+                supported_evidence_contracts=frozenset({"experiment-capture-spec-v1"}),
+                supported_media_types=frozenset({"application/json"}),
+                supported_sealing_modes=frozenset({"digest"}),
+            ),
+        )
+        spec = _load_reference_capture_spec()
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], backend_manifest=with_observation, policy=default_admission_policy())
+
+
+# ---------------------------------------------------------------------------
+# map_capture_requirements — no capture specs at all
+# ---------------------------------------------------------------------------
+
+
+class TestMapCaptureRequirementsEmptyInput:
+    def test_no_capture_specs_yields_an_empty_mapping_and_does_not_reject(self):
+        result = map_capture_requirements([], policy=default_admission_policy())
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_capture_owner — the matching loop's own predicates (Finding 1)
+#
+# SUPPORTED_CAPTURE_CAPABILITIES is empty in production (see the module
+# docstring), so this loop body -- every `continue` and the eventual
+# `return capability.capture_owner` -- never runs against the real table.
+# Each test below monkeypatches in exactly ONE synthetic capability so the
+# loop body genuinely executes, and isolates exactly one predicate at a
+# time: the requirement deviates from a capability/observation pair that
+# would otherwise fully match on every other axis, so if that one guard
+# were ever deleted the requirement WOULD wrongly match and the test would
+# fail (no AdmissionRejection raised).
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCaptureOwnerSuccessPath:
+    def test_a_requirement_matching_a_supported_capability_and_observation_is_admitted(self, monkeypatch):
+        capability = _matching_capability()
+        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
+        manifest = _backend_manifest_with_observation(_matching_observation())
+        spec = _capture_spec_with_requirement_fields()
+
+        result = map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+
+        assert result == {f"{spec.capture_spec_id}.network-trace": "aptl.core.collectors.collect_traces"}
+
+
+class TestResolveCaptureOwnerEachContinueConditionFailsClosed:
+    """One requirement per miss -- every test below deviates from the
+    matching baseline (``_matching_capability()``/``_matching_observation()``
+    exactly matching ``_capture_spec_with_requirement_fields()``'s default
+    requirement) on exactly one predicate.
+    """
+
+    def test_capture_kind_mismatch(self, monkeypatch):
+        capability = _matching_capability()  # capture_kind="trace"
+        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
+        manifest = _backend_manifest_with_observation(_matching_observation())
+        spec = _capture_spec_with_requirement_fields(capture_kind="observation", capture_scope="network")
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+
+    def test_capture_scope_mismatch(self, monkeypatch):
+        capability = _matching_capability()  # capture_scope="network"
+        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
+        manifest = _backend_manifest_with_observation(_matching_observation())
+        spec = _capture_spec_with_requirement_fields(capture_kind="trace", capture_scope="service")
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+
+    def test_expected_media_types_not_a_subset_of_the_capability(self, monkeypatch):
+        capability = _matching_capability()  # media_types={"application/json"}
+        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
+        # The observation's own supported_media_types is deliberately made
+        # WIDER than the capability's (includes "application/xml" too) so
+        # this test isolates the capability-side subset guard specifically
+        # from the later, separate observation-side subset guard (which
+        # would otherwise also reject "application/xml" and mask a removal
+        # of the earlier check).
+        manifest = _backend_manifest_with_observation(
+            _matching_observation(supported_media_types=frozenset({"application/json", "application/xml"}))
+        )
+        spec = _capture_spec_with_requirement_fields(expected_media_types=["application/xml"])
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+
+    def test_integrity_requirements_not_a_subset_of_the_capability(self, monkeypatch):
+        capability = _matching_capability()  # integrity_requirements={"sha256-digest"}
+        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
+        manifest = _backend_manifest_with_observation(_matching_observation())
+        spec = _capture_spec_with_requirement_fields(integrity_requirements=["sha512-digest"])
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+
+    def test_capability_capture_kind_not_declared_by_the_observation(self, monkeypatch):
+        # Requirement fully matches the capability on every one of its own
+        # fields; the capability's declared capture_kind ("trace") is
+        # simply never named in the observation's own declaration.
+        capability = _matching_capability()
+        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
+        manifest = _backend_manifest_with_observation(
+            _matching_observation(supported_capture_kinds=frozenset({"log"}))
+        )
+        spec = _capture_spec_with_requirement_fields()
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+
+    def test_expected_media_types_not_a_subset_of_the_observation(self, monkeypatch):
+        # Requirement/capability fully match each other (and the
+        # capability's capture_kind IS declared by the observation); only
+        # the observation's own supported_media_types excludes what the
+        # requirement asks for.
+        capability = _matching_capability()
+        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
+        manifest = _backend_manifest_with_observation(
+            _matching_observation(supported_media_types=frozenset({"text/plain"}))
+        )
+        spec = _capture_spec_with_requirement_fields()
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+
+
+# ---------------------------------------------------------------------------
+# Fuzz
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+_CAPTURE_KINDS = ("artifact", "observation", "trace", "telemetry", "log", "packet-capture", "other")
+_CAPTURE_SCOPES = ("task", "run", "apparatus", "participant", "backend", "processor", "network", "service")
+
+
+@pytest.mark.fuzz
+class TestFuzzCaptureRequirementsAlwaysFailClosed:
+    @given(
+        capture_kind=st.sampled_from(_CAPTURE_KINDS),
+        capture_scope=st.sampled_from(_CAPTURE_SCOPES),
+    )
+    @settings(max_examples=56, deadline=2000)
+    def test_every_aces_legal_capture_kind_and_scope_combination_fails_closed(
+        self, capture_kind, capture_scope
+    ):
+        spec = _capture_spec_with_requirement(capture_kind=capture_kind, capture_scope=capture_scope)
+
+        with pytest.raises(AdmissionRejection):
+            map_capture_requirements([spec], policy=default_admission_policy())

--- a/tests/test_experiment_capture_mapping.py
+++ b/tests/test_experiment_capture_mapping.py
@@ -18,6 +18,7 @@ test source rather than a copied-in schema, per ADR-047's testing contract.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 
 import pytest
@@ -172,7 +173,7 @@ class TestSupportedCaptureCapabilitiesBaseline:
             integrity_requirements=frozenset({"sha256-digest"}),
             capture_owner="aptl.core.collectors.collect_traces",
         )
-        with pytest.raises(Exception):  # noqa: B017 - frozen dataclass FrozenInstanceError
+        with pytest.raises(dataclasses.FrozenInstanceError):
             capability.capture_kind = "log"
 
 
@@ -184,18 +185,20 @@ class TestSupportedCaptureCapabilitiesBaseline:
 class TestMapCaptureRequirementsFailsClosed:
     def test_the_realistic_corpus_capture_spec_is_rejected(self):
         spec = _load_reference_capture_spec()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            map_capture_requirements([spec], policy=default_admission_policy())
+            map_capture_requirements([spec], policy=policy)
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
 
     def test_the_rejection_names_the_unsupported_capture_kind_and_scope(self):
         spec = _load_reference_capture_spec()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            map_capture_requirements([spec], policy=default_admission_policy())
+            map_capture_requirements([spec], policy=policy)
 
         messages = " ".join(d.message + " " + d.address for d in excinfo.value.diagnostics)
         assert "trace" in messages
@@ -203,9 +206,10 @@ class TestMapCaptureRequirementsFailsClosed:
 
     def test_an_unknown_capture_kind_also_fails_closed(self):
         spec = _capture_spec_with_requirement(capture_kind="other", capture_scope="service")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], policy=default_admission_policy())
+            map_capture_requirements([spec], policy=policy)
 
     def test_a_collector_function_existing_does_not_cause_admission(self):
         # collect_traces is a real, importable, callable collector for
@@ -214,9 +218,10 @@ class TestMapCaptureRequirementsFailsClosed:
         assert callable(collect_traces)
         spec = _load_reference_capture_spec()
         assert spec.capture_requirements["network-trace"].capture_kind == "trace"
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], policy=default_admission_policy())
+            map_capture_requirements([spec], policy=policy)
 
     def test_never_fabricates_support_by_injecting_a_backend_manifest_with_non_none_observation_but_wrong_terms(self):
         # Even if a caller injects a backend manifest whose observation IS
@@ -247,9 +252,10 @@ class TestMapCaptureRequirementsFailsClosed:
             ),
         )
         spec = _load_reference_capture_spec()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=with_observation, policy=default_admission_policy())
+            map_capture_requirements([spec], backend_manifest=with_observation, policy=policy)
 
 
 # ---------------------------------------------------------------------------
@@ -303,18 +309,20 @@ class TestResolveCaptureOwnerEachContinueConditionFailsClosed:
         monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
         manifest = _backend_manifest_with_observation(_matching_observation())
         spec = _capture_spec_with_requirement_fields(capture_kind="observation", capture_scope="network")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
 
     def test_capture_scope_mismatch(self, monkeypatch):
         capability = _matching_capability()  # capture_scope="network"
         monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
         manifest = _backend_manifest_with_observation(_matching_observation())
         spec = _capture_spec_with_requirement_fields(capture_kind="trace", capture_scope="service")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
 
     def test_expected_media_types_not_a_subset_of_the_capability(self, monkeypatch):
         capability = _matching_capability()  # media_types={"application/json"}
@@ -329,18 +337,20 @@ class TestResolveCaptureOwnerEachContinueConditionFailsClosed:
             _matching_observation(supported_media_types=frozenset({"application/json", "application/xml"}))
         )
         spec = _capture_spec_with_requirement_fields(expected_media_types=["application/xml"])
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
 
     def test_integrity_requirements_not_a_subset_of_the_capability(self, monkeypatch):
         capability = _matching_capability()  # integrity_requirements={"sha256-digest"}
         monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
         manifest = _backend_manifest_with_observation(_matching_observation())
         spec = _capture_spec_with_requirement_fields(integrity_requirements=["sha512-digest"])
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
 
     def test_capability_capture_kind_not_declared_by_the_observation(self, monkeypatch):
         # Requirement fully matches the capability on every one of its own
@@ -352,9 +362,10 @@ class TestResolveCaptureOwnerEachContinueConditionFailsClosed:
             _matching_observation(supported_capture_kinds=frozenset({"log"}))
         )
         spec = _capture_spec_with_requirement_fields()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
 
     def test_expected_media_types_not_a_subset_of_the_observation(self, monkeypatch):
         # Requirement/capability fully match each other (and the
@@ -367,9 +378,10 @@ class TestResolveCaptureOwnerEachContinueConditionFailsClosed:
             _matching_observation(supported_media_types=frozenset({"text/plain"}))
         )
         spec = _capture_spec_with_requirement_fields()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
+            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +406,7 @@ class TestFuzzCaptureRequirementsAlwaysFailClosed:
         self, capture_kind, capture_scope
     ):
         spec = _capture_spec_with_requirement(capture_kind=capture_kind, capture_scope=capture_scope)
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], policy=default_admission_policy())
+            map_capture_requirements([spec], policy=policy)

--- a/tests/test_experiment_cli.py
+++ b/tests/test_experiment_cli.py
@@ -193,21 +193,30 @@ _CLI_ARGS = [
 
 
 class TestExperimentAdmitCliHelp:
-    def test_help_renders(self, runner: CliRunner) -> None:
-        # Force a wide terminal so Rich does not wrap the metavar/option tokens
-        # by the CI default width of 80 (no TTY -> COLUMNS-or-80).
-        result = runner.invoke(
-            app, ["experiment", "admit", "--help"], env={"COLUMNS": "200"}
-        )
-        assert result.exit_code == 0
-        assert "SPEC_PATH" in result.stdout
-        assert "--manifest" in result.stdout
-        assert "DEBUG/DEV ONLY" in result.stdout
+    def test_admit_command_declares_its_documented_parameters(self) -> None:
+        # The Rich-rendered ``--help`` output is TTY/width/Rich-version
+        # dependent and unreliable to assert on across CI environments (some
+        # non-TTY renderers capture only an empty bordered panel). Assert the
+        # declared command surface directly — it is what the help is generated
+        # from — so the contract holds regardless of the rendering environment.
+        import typer.main
 
-    def test_group_help_renders(self, runner: CliRunner) -> None:
-        result = runner.invoke(app, ["experiment", "--help"], env={"COLUMNS": "200"})
-        assert result.exit_code == 0
-        assert "admit" in result.stdout
+        admit = typer.main.get_command(app).commands["experiment"].commands["admit"]
+        names = {p.name for p in admit.params}
+        opts = {opt for p in admit.params for opt in p.opts}
+        assert "spec_path" in names
+        assert "--manifest" in opts
+        assert "--allow-uncertified-apparatus" in opts
+        allow = next(
+            p for p in admit.params if "--allow-uncertified-apparatus" in p.opts
+        )
+        assert "DEBUG/DEV ONLY" in (allow.help or "")
+
+    def test_experiment_group_exposes_the_admit_command(self) -> None:
+        import typer.main
+
+        experiment = typer.main.get_command(app).commands["experiment"]
+        assert "admit" in experiment.commands
 
 
 class TestExperimentAdmitDebugOverrideFlag:

--- a/tests/test_experiment_cli.py
+++ b/tests/test_experiment_cli.py
@@ -1,0 +1,308 @@
+"""Tests for ``aptl experiment admit`` (ADR-047 "Experiment-controller
+boundary", Stage 6 / EXP-002 / issue #438).
+
+Builds an on-disk project bundle (task/scenario files plus an ACES
+associated-artifact manifest binding them, mirroring
+``test_experiment_controller.py``'s helper of the same shape) and drives the
+real Typer CLI through ``CliRunner`` — proving the production
+``ExperimentController`` -> ``build_associated_artifact_source`` ->
+``ProjectContainedResolver`` wiring end to end, not just the pure admission
+sequence.
+
+Covers: the ``allow_uncertified_apparatus`` debug-flag behavior (rejected
+without it, admitted-with-a-warning with it — same real-manifest mutual
+apparatus-mismatch gate exercised in ``test_experiment_admission.py`` and
+``test_experiment_controller.py``), a content-derived rejection that must
+not leak an embedded secret into stdout/stderr, the ADR "Range-mutation
+gate" (no range-mutating entry point is ever called), and ``--help``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from aces_contracts.associated_artifacts import (
+    AssociatedArtifactManifestModel,
+    associated_artifact_set_digest,
+)
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+from typer.testing import CliRunner
+
+from aptl.cli.main import app
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+SECRET = "sk-super-secret-cli-injected-token-13579"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture-building helpers (on-disk bundle)
+# ---------------------------------------------------------------------------
+
+
+def _read_corpus_task_payload() -> dict:
+    path = CORPUS_ROOT / "experiment-core" / "experiment-task-v1" / "valid" / "reference.json"
+    return json.loads(path.read_text())
+
+
+def _minimal_scenario_bytes() -> bytes:
+    path = CORPUS_ROOT / "sdl" / "sdl-yaml-v1" / "valid" / "minimal.yaml"
+    return path.read_bytes()
+
+
+def _pinned_identity_task_payload(*, extra_notes: list[str] | None = None) -> dict:
+    """A task whose apparatus_constraints pin the REAL aptl/reference-processor
+    identities — the exact shape ``test_experiment_admission.py`` uses to
+    exercise the real mutual-compatibility gate (rejected by default,
+    admitted-with-one-warning under ``allow_uncertified_apparatus``)."""
+    payload = _read_corpus_task_payload()
+    payload["task_id"] = "task-minimal"
+    payload["task_version"] = "1.0.0"
+    payload["scenario_ref"] = {"ref_kind": "scenario", "ref_id": "canonical-minimal"}
+    payload["apparatus_constraints"] = {
+        "allowed_processor_refs": [
+            {"ref_kind": "processor", "ref_id": "aces-reference-processor", "ref_version": "0.1.0"}
+        ],
+        "allowed_backend_refs": [{"ref_kind": "backend", "ref_id": "aptl", "ref_version": "0.1.0"}],
+        "required_manifest_refs": [
+            {
+                "ref_kind": "manifest",
+                "ref_id": "aces-reference-processor",
+                "ref_version": "processor-manifest/v2",
+                "subject_ref": {
+                    "ref_kind": "processor",
+                    "ref_id": "aces-reference-processor",
+                    "ref_version": "0.1.0",
+                },
+            },
+            {
+                "ref_kind": "manifest",
+                "ref_id": "aptl",
+                "ref_version": "backend-manifest/v2",
+                "subject_ref": {"ref_kind": "backend", "ref_id": "aptl", "ref_version": "0.1.0"},
+            },
+        ],
+        "required_capabilities": [],
+        "notes": extra_notes or [],
+    }
+    return payload
+
+
+def _capability_only_task_payload(*, declared_capability: str, extra_notes: list[str] | None = None) -> dict:
+    """A task requiring a single (possibly unsupported) capability — used
+    for the content-derived rejection / secret-leak test, mirroring
+    ``test_experiment_admission.py``'s helper of the same shape."""
+    payload = _read_corpus_task_payload()
+    payload["task_id"] = "task-minimal"
+    payload["task_version"] = "1.0.0"
+    payload["scenario_ref"] = {"ref_kind": "scenario", "ref_id": "canonical-minimal"}
+    payload["apparatus_constraints"] = {
+        "required_capabilities": [declared_capability],
+        "notes": extra_notes or [],
+    }
+    return payload
+
+
+def _flat_spec_payload(*, spec_id: str = "spec-cli-v1", target_run_count: int = 3) -> dict:
+    return {
+        "schema_version": "experiment-authoring-input/v1",
+        "spec_id": spec_id,
+        "spec_version": "1.0.0",
+        "title": "CLI admission fixture",
+        "description": "Minimal flat allocation CLI fixture.",
+        "task_ref": {"ref_kind": "task", "ref_id": "task-minimal", "ref_version": "1.0.0"},
+        "run_plan": {
+            "stochastic_controls": [{"control_id": "seed-a", "role": "seed", "value": 1}],
+            "episode_control": {
+                "turn_order": "sequential",
+                "max_steps": 10,
+                "termination_rule": "fixed horizon",
+            },
+            "target_run_count": target_run_count,
+        },
+    }
+
+
+def _write_bundle(base_dir: Path, *, spec_id: str, task_bytes: bytes, scenario_bytes: bytes) -> None:
+    (base_dir / "task.json").write_bytes(task_bytes)
+    (base_dir / "scenario.sdl.yaml").write_bytes(scenario_bytes)
+
+    def artifact_ref(artifact_id: str, uri: str, data: bytes, media_type: str, role: str) -> dict:
+        return {
+            "artifact_id": artifact_id,
+            "role": role,
+            "media_type": media_type,
+            "uri": f"file:{uri}",
+            "checksum": {"algorithm": "sha256", "value": hashlib.sha256(data).hexdigest()},
+            "size_bytes": len(data),
+            "created_at": "2026-05-26T00:00:00Z",
+            "source": "test bundle",
+            "satisfies_refs": [],
+            "sensitivity": "internal",
+        }
+
+    artifacts = {
+        "task-minimal": artifact_ref("task-minimal", "task.json", task_bytes, "application/json", "other"),
+        "canonical-minimal": artifact_ref(
+            "canonical-minimal", "scenario.sdl.yaml", scenario_bytes, "application/x-yaml", "scenario-snapshot"
+        ),
+    }
+    manifest_dict = {
+        "schema_version": "associated-artifact-manifest/v1",
+        "manifest_id": f"manifest-{spec_id}",
+        "manifest_version": "1.0.0",
+        "canonicalization_profile": "associated-artifact-set/v1",
+        "scope": "experiment",
+        "parent_ref": {"ref_kind": "authoring-input", "ref_id": spec_id, "ref_version": "1.0.0"},
+        "artifacts": artifacts,
+        "set_digest": "sha256:" + "0" * 64,
+    }
+    manifest_model = AssociatedArtifactManifestModel.model_validate(manifest_dict)
+    manifest_dict["set_digest"] = associated_artifact_set_digest(manifest_model)
+    (base_dir / "associated-artifact-manifest.json").write_bytes(json.dumps(manifest_dict).encode("utf-8"))
+
+
+def _build_pinned_identity_project(tmp_path: Path, *, spec_id: str = "spec-cli-v1") -> Path:
+    base_dir = tmp_path / spec_id
+    base_dir.mkdir()
+    task_payload = _pinned_identity_task_payload()
+    task_bytes = json.dumps(task_payload).encode("utf-8")
+    scenario_bytes = _minimal_scenario_bytes()
+    spec_payload = _flat_spec_payload(spec_id=spec_id)
+    root_bytes = yaml.safe_dump(spec_payload).encode("utf-8")
+    (base_dir / "experiment.yaml").write_bytes(root_bytes)
+    _write_bundle(base_dir, spec_id=spec_id, task_bytes=task_bytes, scenario_bytes=scenario_bytes)
+    return base_dir
+
+
+_CLI_ARGS = [
+    "experiment",
+    "admit",
+    "experiment.yaml",
+    "--manifest",
+    "associated-artifact-manifest.json",
+]
+
+
+class TestExperimentAdmitCliHelp:
+    def test_help_renders(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["experiment", "admit", "--help"])
+        assert result.exit_code == 0
+        assert "SPEC_PATH" in result.stdout
+        assert "--manifest" in result.stdout
+        assert "DEBUG/DEV ONLY" in result.stdout
+
+    def test_group_help_renders(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["experiment", "--help"])
+        assert result.exit_code == 0
+        assert "admit" in result.stdout
+
+
+class TestExperimentAdmitDebugOverrideFlag:
+    def test_rejected_without_the_override_flag(self, runner: CliRunner, tmp_path: Path) -> None:
+        base_dir = _build_pinned_identity_project(tmp_path, spec_id="spec-cli-reject-v1")
+
+        result = runner.invoke(app, [*_CLI_ARGS, "--base-dir", str(base_dir)])
+
+        assert result.exit_code == 1
+        assert "Admitted plan" not in result.stdout
+        assert "Experiment admission failed" in result.stderr
+        assert "mutual-incompatible" in result.stderr
+
+    def test_admitted_with_the_override_flag_and_prints_a_warning(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        base_dir = _build_pinned_identity_project(tmp_path, spec_id="spec-cli-admit-v1")
+
+        result = runner.invoke(
+            app, [*_CLI_ARGS, "--base-dir", str(base_dir), "--allow-uncertified-apparatus"]
+        )
+
+        assert result.exit_code == 0, result.stderr
+        assert "Admitted plan plan-" in result.stdout
+        assert "digest:" in result.stdout
+        assert "trials:    3" in result.stdout
+        assert "persisted:" in result.stdout
+        # The debug-override warning is rendered too, not silently dropped.
+        assert "uncertified-compatibility" in result.stdout
+
+        persisted_dir = base_dir / "runs" / "experiment-plans"
+        assert persisted_dir.exists()
+        assert any(persisted_dir.iterdir())
+
+
+class TestExperimentAdmitRejectionIsSafe:
+    def test_content_derived_rejection_exits_one_and_never_leaks_an_embedded_secret(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        base_dir = tmp_path / "project"
+        base_dir.mkdir()
+        spec_id = "spec-cli-secret-v1"
+        task_payload = _capability_only_task_payload(
+            declared_capability="totally-made-up-capability",
+            extra_notes=[f"internal-secret={SECRET}"],
+        )
+        task_bytes = json.dumps(task_payload).encode("utf-8")
+        scenario_bytes = _minimal_scenario_bytes()
+        spec_payload = _flat_spec_payload(spec_id=spec_id)
+        root_bytes = yaml.safe_dump(spec_payload).encode("utf-8")
+        (base_dir / "experiment.yaml").write_bytes(root_bytes)
+        _write_bundle(base_dir, spec_id=spec_id, task_bytes=task_bytes, scenario_bytes=scenario_bytes)
+
+        result = runner.invoke(app, [*_CLI_ARGS, "--base-dir", str(base_dir)])
+
+        assert result.exit_code == 1
+        assert "capability-unsupported" in result.stderr
+        assert SECRET not in result.stdout
+        assert SECRET not in result.stderr
+        assert (result.exception is None) or isinstance(result.exception, SystemExit)
+
+
+class TestExperimentAdmitNeverMutatesTheRange:
+    def test_admission_never_calls_a_range_mutating_entry_point(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ADR-047 "Range-mutation gate": admission — rejected OR admitted —
+        must never hydrate ``.env``, generate keys/certs, or call
+        ``DeploymentBackend``/lab-lifecycle entry points. Mirrors the spy
+        pattern in ``test_experiment_admission.py``'s
+        ``_install_mutation_spies``.
+        """
+        import aptl.core.env as env_module
+        import aptl.core.lab as lab_module
+        import aptl.core.soc_ca as soc_ca_module
+        import aptl.core.ssh as ssh_module
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise AssertionError("range-mutating entry point must never be called by `aptl experiment admit`")
+
+        monkeypatch.setattr(lab_module, "start_lab", _boom)
+        monkeypatch.setattr(lab_module, "stop_lab", _boom)
+        monkeypatch.setattr(lab_module, "clean_boot_lab", _boom)
+        monkeypatch.setattr(soc_ca_module, "ensure_soc_certs", _boom)
+        monkeypatch.setattr(ssh_module, "ensure_ssh_keys", _boom)
+        monkeypatch.setattr(ssh_module, "ensure_pivot_key", _boom)
+        monkeypatch.setattr(env_module, "hydrate_dotenv", _boom)
+
+        base_dir = _build_pinned_identity_project(tmp_path, spec_id="spec-cli-spy-v1")
+
+        # The admitted path (the more dangerous of the two to get wrong,
+        # since it is the "success" case most likely to accidentally chain
+        # into execution) still must not touch any of the above.
+        result = runner.invoke(
+            app, [*_CLI_ARGS, "--base-dir", str(base_dir), "--allow-uncertified-apparatus"]
+        )
+        assert result.exit_code == 0, result.stderr
+
+        # The rejected path (default policy, same bundle) likewise.
+        base_dir_rejected = _build_pinned_identity_project(tmp_path, spec_id="spec-cli-spy-reject-v1")
+        result_rejected = runner.invoke(app, [*_CLI_ARGS, "--base-dir", str(base_dir_rejected)])
+        assert result_rejected.exit_code == 1

--- a/tests/test_experiment_cli.py
+++ b/tests/test_experiment_cli.py
@@ -194,14 +194,18 @@ _CLI_ARGS = [
 
 class TestExperimentAdmitCliHelp:
     def test_help_renders(self, runner: CliRunner) -> None:
-        result = runner.invoke(app, ["experiment", "admit", "--help"])
+        # Force a wide terminal so Rich does not wrap the metavar/option tokens
+        # by the CI default width of 80 (no TTY -> COLUMNS-or-80).
+        result = runner.invoke(
+            app, ["experiment", "admit", "--help"], env={"COLUMNS": "200"}
+        )
         assert result.exit_code == 0
         assert "SPEC_PATH" in result.stdout
         assert "--manifest" in result.stdout
         assert "DEBUG/DEV ONLY" in result.stdout
 
     def test_group_help_renders(self, runner: CliRunner) -> None:
-        result = runner.invoke(app, ["experiment", "--help"])
+        result = runner.invoke(app, ["experiment", "--help"], env={"COLUMNS": "200"})
         assert result.exit_code == 0
         assert "admit" in result.stdout
 

--- a/tests/test_experiment_contract.py
+++ b/tests/test_experiment_contract.py
@@ -1,0 +1,290 @@
+"""ADR-047 "Testing contract" CONTRACT test (Stage 6 / EXP-002 / issue #438).
+
+The ADR's Testing contract requires proving: "every planned trial resolves
+to exactly one task, one scenario snapshot, one condition or flat sentinel,
+one stochastic-control set, one episode-control set, and the admitted
+capture-spec references."
+
+This test admits a self-consistent CONDITION-allocation experiment end to
+end through the public :class:`~aptl.core.experiment.controller.
+ExperimentController` boundary (reusing Stage 5's ``MappingArtifactSource``
+plus a genuinely mutually-compatible synthetic backend/processor pair — the
+same legitimate dependency-injection pattern ``test_experiment_controller.py``
+and ``test_experiment_admission.py`` already use, not a hand-edited
+production manifest), then independently re-derives every one of those six
+bindings from the admitted spec/scenario bytes and asserts each
+``PlannedTrial`` in the resulting plan is internally consistent with them.
+
+``PlannedTrial`` itself (``src/aptl/core/experiment/trial_plan.py``) does
+not carry a per-trial task-identity or episode-control field — both are
+single, plan-wide facts (``ExperimentSpecModel.task_ref`` and
+``ExperimentRunPlanModel.episode_control`` are singular fields, not lists),
+so "exactly one" for those two bindings is a structural property of the
+admitted spec shared by the whole plan; this test asserts that directly
+against the re-parsed spec rather than against a nonexistent per-trial
+field. The remaining four bindings (scenario snapshot digest, condition id,
+stochastic-control set, capture-spec refs) DO vary per trial and are
+asserted per :class:`~aptl.core.experiment.trial_plan.PlannedTrial`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import yaml
+from aces_backend_protocols.backend_manifest import BackendManifest
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+from aces_contracts.experiment_spec import parse_experiment_spec
+from aces_processor.capabilities import ProcessorManifest
+from aces_processor.manifest import create_reference_processor_manifest
+from aces_sdl import parse_sdl
+from aces_sdl.canonical import canonical_instantiated_sdl_digest
+from aces_sdl.instantiate import instantiate_scenario
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.admission import MappingArtifactSource
+from aptl.core.experiment.controller import ExperimentController
+from aptl.core.experiment.policy import default_admission_policy
+from aptl.core.experiment.resolver import ResolvedArtifact
+from aptl.core.runstore import LocalRunStore
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+
+_SCENARIO_TEXT = """
+name: scenario-condition
+variables:
+  danger_level:
+    type: string
+    default: low
+nodes:
+  on:
+    type: switch
+"""
+
+
+def _resolved(data: bytes, locator: str, media_type: str) -> ResolvedArtifact:
+    return ResolvedArtifact(
+        data=data, locator=locator, digest=f"sha256:{hashlib.sha256(data).hexdigest()}", media_type=media_type
+    )
+
+
+def _read_corpus_task_payload() -> dict:
+    path = CORPUS_ROOT / "experiment-core" / "experiment-task-v1" / "valid" / "reference.json"
+    return json.loads(path.read_text())
+
+
+def _synthetic_manifests() -> tuple[BackendManifest, ProcessorManifest]:
+    """A genuinely mutually-compatible test backend/processor pair.
+
+    Mirrors ``test_experiment_controller.py``'s helper of the same name:
+    real manifest shape, injected via ``ExperimentController``'s documented
+    seam, never a hand-edited production manifest.
+    """
+    real_backend = create_aptl_manifest()
+    real_processor = create_reference_processor_manifest()
+    test_backend = BackendManifest(
+        name="test-backend",
+        version=real_backend.version,
+        supported_contract_versions=real_backend.supported_contract_versions,
+        compatible_processors=frozenset({"test-processor"}),
+        realization_support=real_backend.realization_support,
+        concept_bindings=real_backend.concept_bindings,
+        provisioner=real_backend.provisioner,
+        orchestrator=real_backend.orchestrator,
+        evaluator=real_backend.evaluator,
+        participant_runtime=real_backend.participant_runtime,
+    )
+    test_processor = ProcessorManifest(
+        name="test-processor",
+        version=real_processor.version,
+        supported_contract_versions=real_processor.supported_contract_versions,
+        capabilities=real_processor.capabilities,
+        compatible_backends=frozenset({"test-backend"}),
+        concept_bindings=real_processor.concept_bindings,
+        constraints=real_processor.constraints,
+    )
+    return test_backend, test_processor
+
+
+def _condition_task_payload() -> dict:
+    payload = _read_corpus_task_payload()
+    payload["task_id"] = "task-condition"
+    payload["task_version"] = "1.0.0"
+    payload["scenario_ref"] = {"ref_kind": "scenario", "ref_id": "scenario-condition"}
+    payload["apparatus_constraints"] = {"required_capabilities": [], "notes": ["unrestricted apparatus"]}
+    return payload
+
+
+def _condition_spec_payload() -> dict:
+    return {
+        "schema_version": "experiment-authoring-input/v1",
+        "spec_id": "spec-contract-v1",
+        "spec_version": "1.0.0",
+        "title": "CONTRACT-TEST condition-allocation spec",
+        "description": "Two-condition allocation proving the ADR-047 per-trial binding contract.",
+        "task_ref": {"ref_kind": "task", "ref_id": "task-condition", "ref_version": "1.0.0"},
+        "run_plan": {
+            "stochastic_controls": [
+                {"control_id": "seed-a", "role": "seed", "value": 1},
+                {"control_id": "rand-a", "role": "randomization", "value": 2},
+            ],
+            "episode_control": {
+                "turn_order": "sequential",
+                "max_steps": 10,
+                "termination_rule": "fixed horizon",
+            },
+            "allocation": {
+                "allocation_unit": "trial",
+                "allocation_method": "balanced",
+                "compared_conditions": ["cond-a", "cond-b"],
+                "condition_assignments": {
+                    "cond-a": {
+                        "condition_id": "cond-a",
+                        "factor_levels": {"danger": "high"},
+                        "required_parameters": [
+                            {"name": "danger_level", "value": "high", "value_kind": "configuration"}
+                        ],
+                    },
+                    "cond-b": {
+                        "condition_id": "cond-b",
+                        "factor_levels": {"danger": "low"},
+                        "required_parameters": [
+                            {"name": "danger_level", "value": "low", "value_kind": "configuration"}
+                        ],
+                    },
+                },
+                "target_runs_per_condition": 2,
+                "blocking_factors": [],
+                "replication_policy": "independent-replications",
+            },
+        },
+    }
+
+
+class TestPlannedTrialBindingContract:
+    """Every planned trial resolves to exactly one of each ADR-047 binding."""
+
+    def test_every_trial_binds_exactly_one_of_each_contracted_element(self, tmp_path):
+        task_payload = _condition_task_payload()
+        task_bytes = json.dumps(task_payload).encode("utf-8")
+        scenario_bytes = _SCENARIO_TEXT.encode("utf-8")
+        spec_payload = _condition_spec_payload()
+        root_bytes = yaml.safe_dump(spec_payload).encode("utf-8")
+
+        backend, processor = _synthetic_manifests()
+
+        def _factory(base_dir, manifest_locator, spec, policy):
+            del base_dir, manifest_locator, policy, spec
+            return MappingArtifactSource(
+                artifacts={
+                    "task-condition": _resolved(task_bytes, "task.json", "application/json"),
+                    "scenario-condition": _resolved(scenario_bytes, "scenario.sdl.yaml", "application/x-yaml"),
+                }
+            )
+
+        store = LocalRunStore(tmp_path / "store")
+        controller = ExperimentController(
+            run_store=store,
+            backend_manifest=backend,
+            processor_manifest=processor,
+            artifact_source_factory=_factory,
+        )
+
+        result = controller.admit(
+            experiment_root=_resolved(root_bytes, "experiment.yaml", "application/x-yaml"),
+            base_dir=tmp_path,
+            manifest_locator="unused.json",
+        )
+
+        assert result.admitted is True, result.diagnostics
+        plan = result.plan
+        # Two conditions x two replications each.
+        assert len(plan.trials) == 4
+
+        # Independently re-derive the admitted graph from the same bytes
+        # the controller consumed, so every assertion below is checked
+        # against the admitted spec/scenario, not against this test's own
+        # authoring intent.
+        admitted_spec = parse_experiment_spec(root_bytes.decode("utf-8"))
+        scenario = parse_sdl(scenario_bytes.decode("utf-8"))
+        allocation = admitted_spec.run_plan.allocation
+        assert allocation is not None
+
+        # --- ONE task identity for the whole plan ---------------------
+        # PlannedTrial carries no per-trial task field: task identity is a
+        # single, plan-wide fact (`ExperimentSpecModel.task_ref` is one
+        # field, never a list), and every trial in one admitted plan
+        # shares the one `source_set_digest` that pins it.
+        assert admitted_spec.task_ref.ref_id == task_payload["task_id"]
+        assert admitted_spec.task_ref.ref_version == task_payload["task_version"]
+        assert len({plan.source_set_digest}) == 1
+
+        # --- ONE episode-control set for the whole plan ----------------
+        # Likewise `run_plan.episode_control` is a single object, not a
+        # list: every trial in this plan is bound to the identical one.
+        assert admitted_spec.run_plan.episode_control is not None
+        assert admitted_spec.run_plan.episode_control.termination_rule == "fixed horizon"
+
+        # Expected per-condition scenario-snapshot digest, recomputed
+        # independently from the admitted scenario bytes and the admitted
+        # condition parameter bindings (never read back off the plan).
+        expected_digest_by_condition = {}
+        for condition_id in allocation.compared_conditions:
+            assignment = allocation.condition_assignments[condition_id]
+            parameters = {p.name: p.value for p in assignment.required_parameters}
+            instantiated = instantiate_scenario(scenario, parameters)
+            expected_digest_by_condition[condition_id] = canonical_instantiated_sdl_digest(instantiated).value
+
+        # Every declared-supported stochastic control that must appear on
+        # every trial (unsupported roles, if any, would be admission
+        # rejections upstream, not silently dropped here).
+        supported_roles = default_admission_policy().supported_stochastic_control_roles
+        expected_control_ids = frozenset(
+            control.control_id
+            for control in admitted_spec.run_plan.stochastic_controls
+            if control.role in supported_roles
+        )
+        assert expected_control_ids == {"seed-a", "rand-a"}
+
+        expected_capture_refs = tuple(ref.ref_id for ref in admitted_spec.capture_spec_refs)
+        assert expected_capture_refs == ()
+
+        seen_trial_ids: set[str] = set()
+        seen_condition_replications: set[tuple[str, int]] = set()
+        for trial in plan.trials:
+            # --- ONE condition (never the flat sentinel here; this is a
+            # condition allocation, so every trial's condition_id is one
+            # of the two admitted conditions, never None). -------------
+            assert trial.condition_id is not None
+            assert trial.condition_id in allocation.compared_conditions
+
+            # --- ONE scenario snapshot digest, and it is the CORRECT one
+            # for this trial's own condition (not merely non-None). ----
+            assert trial.scenario_snapshot_digest is not None
+            assert trial.scenario_snapshot_digest == expected_digest_by_condition[trial.condition_id]
+
+            # --- ONE stochastic-control set: the same control IDs on
+            # every trial, each bound to exactly one derived seed. ------
+            control_ids = tuple(control_id for control_id, _ in trial.stochastic_seeds)
+            assert len(control_ids) == len(set(control_ids)), "duplicate control id within one trial"
+            assert set(control_ids) == expected_control_ids
+
+            # --- the admitted capture-spec references, identical and
+            # consistent on every trial. ---------------------------------
+            assert trial.capture_spec_refs == expected_capture_refs
+
+            seen_trial_ids.add(trial.planned_trial_id)
+            seen_condition_replications.add((trial.condition_id, trial.replication_ordinal))
+
+        # Every trial has a distinct stable ID and a distinct logical
+        # coordinate: the plan does not silently collapse two trials into
+        # the same identity.
+        assert len(seen_trial_ids) == len(plan.trials)
+        assert len(seen_condition_replications) == len(plan.trials)
+
+        # The two conditions really do resolve to two DIFFERENT scenario
+        # snapshots (proving the per-condition binding is not vacuously
+        # true because every condition happens to instantiate the same
+        # scenario).
+        assert expected_digest_by_condition["cond-a"] != expected_digest_by_condition["cond-b"]

--- a/tests/test_experiment_controller.py
+++ b/tests/test_experiment_controller.py
@@ -1,0 +1,293 @@
+"""Tests for ``aptl.core.experiment.controller.ExperimentController``
+(ADR-047 "Experiment-controller boundary", Stage 5 / EXP-002 / issue #438).
+
+Unlike ``test_experiment_admission.py`` (which drives ``admit_experiment``
+directly through an in-memory ``MappingArtifactSource``), these tests
+exercise the controller's default composition end-to-end: an on-disk
+project bundle (task/scenario files plus an ACES associated-artifact
+manifest binding them), resolved through the REAL
+``build_associated_artifact_source`` -> ``ProjectContainedResolver`` path —
+proving the production artifact-source wiring, not just the pure admission
+sequence, actually works.
+
+Execution (running the admitted plan's trials) is explicitly out of scope —
+``ExperimentController`` has no ``.execute()``/``.run()`` method at all;
+that is downstream work in #437/#459.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+import yaml
+from aces_backend_protocols.backend_manifest import BackendManifest
+from aces_contracts.associated_artifacts import (
+    AssociatedArtifactManifestModel,
+    associated_artifact_set_digest,
+)
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+from aces_processor.capabilities import ProcessorManifest
+from aces_processor.manifest import create_reference_processor_manifest
+
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.admission import MappingArtifactSource
+from aptl.core.experiment.controller import ExperimentController
+from aptl.core.experiment.policy import default_admission_policy
+from aptl.core.experiment.resolver import ResolvedArtifact
+from aptl.core.runstore import LocalRunStore
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+
+
+def _resolved(data: bytes, locator: str, media_type: str) -> ResolvedArtifact:
+    return ResolvedArtifact(
+        data=data,
+        locator=locator,
+        digest=f"sha256:{hashlib.sha256(data).hexdigest()}",
+        media_type=media_type,
+    )
+
+
+def _read_corpus_task_payload() -> dict:
+    path = CORPUS_ROOT / "experiment-core" / "experiment-task-v1" / "valid" / "reference.json"
+    return json.loads(path.read_text())
+
+
+def _minimal_scenario_bytes() -> bytes:
+    path = CORPUS_ROOT / "sdl" / "sdl-yaml-v1" / "valid" / "minimal.yaml"
+    return path.read_bytes()
+
+
+def _synthetic_manifests() -> tuple[BackendManifest, ProcessorManifest]:
+    """See ``test_experiment_admission.py``'s helper of the same name for
+    why this test-only, but genuinely mutually-compatible, manifest pair
+    is legitimate dependency injection rather than fabricated compatibility."""
+    real_backend = create_aptl_manifest()
+    real_processor = create_reference_processor_manifest()
+    test_backend = BackendManifest(
+        name="test-backend",
+        version=real_backend.version,
+        supported_contract_versions=real_backend.supported_contract_versions,
+        compatible_processors=frozenset({"test-processor"}),
+        realization_support=real_backend.realization_support,
+        concept_bindings=real_backend.concept_bindings,
+        provisioner=real_backend.provisioner,
+        orchestrator=real_backend.orchestrator,
+        evaluator=real_backend.evaluator,
+        participant_runtime=real_backend.participant_runtime,
+    )
+    test_processor = ProcessorManifest(
+        name="test-processor",
+        version=real_processor.version,
+        supported_contract_versions=real_processor.supported_contract_versions,
+        capabilities=real_processor.capabilities,
+        compatible_backends=frozenset({"test-backend"}),
+        concept_bindings=real_processor.concept_bindings,
+        constraints=real_processor.constraints,
+    )
+    return test_backend, test_processor
+
+
+def _capability_only_task_payload(*, declared_capability: str) -> dict:
+    payload = _read_corpus_task_payload()
+    payload["task_id"] = "task-minimal"
+    payload["task_version"] = "1.0.0"
+    payload["scenario_ref"] = {"ref_kind": "scenario", "ref_id": "canonical-minimal"}
+    payload["apparatus_constraints"] = {"required_capabilities": [declared_capability], "notes": []}
+    return payload
+
+
+def _flat_spec_payload(*, spec_id: str = "spec-controller-v1", target_run_count: int = 3) -> dict:
+    return {
+        "schema_version": "experiment-authoring-input/v1",
+        "spec_id": spec_id,
+        "spec_version": "1.0.0",
+        "title": "Controller happy-path spec",
+        "description": "Minimal flat allocation controller fixture.",
+        "task_ref": {"ref_kind": "task", "ref_id": "task-minimal", "ref_version": "1.0.0"},
+        "run_plan": {
+            "stochastic_controls": [{"control_id": "seed-a", "role": "seed", "value": 1}],
+            "episode_control": {
+                "turn_order": "sequential",
+                "max_steps": 10,
+                "termination_rule": "fixed horizon",
+            },
+            "target_run_count": target_run_count,
+        },
+    }
+
+
+def _write_associated_artifact_bundle(
+    base_dir, *, spec_id: str, task_bytes: bytes, scenario_bytes: bytes, corrupt_checksum: bool = False
+) -> None:
+    (base_dir / "task.json").write_bytes(task_bytes)
+    (base_dir / "scenario.sdl.yaml").write_bytes(scenario_bytes)
+
+    def artifact_ref(artifact_id, uri, data, media_type, role, *, bad_checksum=False):
+        checksum_value = "1" * 64 if bad_checksum else hashlib.sha256(data).hexdigest()
+        return {
+            "artifact_id": artifact_id,
+            "role": role,
+            "media_type": media_type,
+            "uri": f"file:{uri}",
+            "checksum": {"algorithm": "sha256", "value": checksum_value},
+            "size_bytes": len(data),
+            "created_at": "2026-05-26T00:00:00Z",
+            "source": "test bundle",
+            "satisfies_refs": [],
+            "sensitivity": "internal",
+        }
+
+    artifacts = {
+        "task-minimal": artifact_ref(
+            "task-minimal", "task.json", task_bytes, "application/json", "other", bad_checksum=corrupt_checksum
+        ),
+        "canonical-minimal": artifact_ref(
+            "canonical-minimal", "scenario.sdl.yaml", scenario_bytes, "application/x-yaml", "scenario-snapshot"
+        ),
+    }
+    manifest_dict = {
+        "schema_version": "associated-artifact-manifest/v1",
+        "manifest_id": f"manifest-{spec_id}",
+        "manifest_version": "1.0.0",
+        "canonicalization_profile": "associated-artifact-set/v1",
+        "scope": "experiment",
+        "parent_ref": {"ref_kind": "authoring-input", "ref_id": spec_id, "ref_version": "1.0.0"},
+        "artifacts": artifacts,
+        "set_digest": "sha256:" + "0" * 64,
+    }
+    manifest_model = AssociatedArtifactManifestModel.model_validate(manifest_dict)
+    manifest_dict["set_digest"] = associated_artifact_set_digest(manifest_model)
+    (base_dir / "associated-artifact-manifest.json").write_bytes(json.dumps(manifest_dict).encode("utf-8"))
+
+
+class TestExperimentControllerHappyPath:
+    def test_admit_returns_an_admitted_result_through_the_production_artifact_source(self, tmp_path):
+        backend, processor = _synthetic_manifests()
+        declared = sorted(backend.supported_contract_versions)[0]
+        task_payload = _capability_only_task_payload(declared_capability=declared)
+        task_bytes = json.dumps(task_payload).encode("utf-8")
+        scenario_bytes = _minimal_scenario_bytes()
+        spec_payload = _flat_spec_payload()
+        root_bytes = yaml.safe_dump(spec_payload).encode("utf-8")
+
+        base_dir = tmp_path / "project"
+        base_dir.mkdir()
+        _write_associated_artifact_bundle(
+            base_dir, spec_id=spec_payload["spec_id"], task_bytes=task_bytes, scenario_bytes=scenario_bytes
+        )
+
+        store = LocalRunStore(tmp_path / "store")
+        controller = ExperimentController(run_store=store, backend_manifest=backend, processor_manifest=processor)
+
+        result = controller.admit(
+            experiment_root=_resolved(root_bytes, "experiment.yaml", "application/x-yaml"),
+            base_dir=base_dir,
+            manifest_locator="associated-artifact-manifest.json",
+        )
+
+        assert result.admitted is True
+        assert len(result.trial_ids) == 3
+        assert result.persisted_path.exists()
+        assert result.persisted_path.read_bytes() == result.plan.canonical_bytes
+
+    def test_defaults_policy_and_manifests_when_not_injected(self, tmp_path):
+        controller = ExperimentController(run_store=LocalRunStore(tmp_path / "store"))
+
+        assert controller.policy is not None
+        assert controller.backend_manifest is not None
+        assert controller.processor_manifest is not None
+        assert controller.backend_manifest.name == "aptl"
+
+    def test_has_no_execution_method(self):
+        # ADR-047: execution (running an admitted plan's trials) is
+        # downstream work (#437/#459); the controller must not implement it.
+        for forbidden in ("execute", "run", "run_trials", "start"):
+            assert not hasattr(ExperimentController, forbidden)
+
+
+class TestExperimentControllerRejectionPaths:
+    def test_a_corrupted_checksum_in_the_associated_artifact_manifest_is_rejected(self, tmp_path):
+        backend, processor = _synthetic_manifests()
+        declared = sorted(backend.supported_contract_versions)[0]
+        task_payload = _capability_only_task_payload(declared_capability=declared)
+        task_bytes = json.dumps(task_payload).encode("utf-8")
+        scenario_bytes = _minimal_scenario_bytes()
+        spec_payload = _flat_spec_payload(spec_id="spec-controller-bad-v1")
+        root_bytes = yaml.safe_dump(spec_payload).encode("utf-8")
+
+        base_dir = tmp_path / "project"
+        base_dir.mkdir()
+        _write_associated_artifact_bundle(
+            base_dir,
+            spec_id=spec_payload["spec_id"],
+            task_bytes=task_bytes,
+            scenario_bytes=scenario_bytes,
+            corrupt_checksum=True,
+        )
+
+        store = LocalRunStore(tmp_path / "store")
+        controller = ExperimentController(run_store=store, backend_manifest=backend, processor_manifest=processor)
+
+        result = controller.admit(
+            experiment_root=_resolved(root_bytes, "experiment.yaml", "application/x-yaml"),
+            base_dir=base_dir,
+            manifest_locator="associated-artifact-manifest.json",
+        )
+
+        assert result.admitted is False
+        assert result.plan is None
+        assert result.diagnostics
+
+    def test_a_malformed_root_document_is_rejected_not_raised(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        controller = ExperimentController(run_store=store)
+        base_dir = tmp_path / "project"
+        base_dir.mkdir()
+
+        result = controller.admit(
+            experiment_root=_resolved(b"not: [valid, experiment", "experiment.yaml", "application/x-yaml"),
+            base_dir=base_dir,
+            manifest_locator="does-not-matter.json",
+        )
+
+        assert result.admitted is False
+        assert result.diagnostics
+
+
+class TestExperimentControllerInjectableArtifactSourceFactory:
+    def test_a_test_injected_factory_bypasses_the_filesystem_entirely(self, tmp_path):
+        backend, processor = _synthetic_manifests()
+        declared = sorted(backend.supported_contract_versions)[0]
+        task_payload = _capability_only_task_payload(declared_capability=declared)
+        task_bytes = json.dumps(task_payload).encode("utf-8")
+        scenario_bytes = _minimal_scenario_bytes()
+        spec_payload = _flat_spec_payload(spec_id="spec-controller-mapping-v1")
+        root_bytes = yaml.safe_dump(spec_payload).encode("utf-8")
+
+        def _factory(base_dir, manifest_locator, spec, policy):
+            del base_dir, manifest_locator, policy, spec
+            return MappingArtifactSource(
+                artifacts={
+                    "task-minimal": _resolved(task_bytes, "task.json", "application/json"),
+                    "canonical-minimal": _resolved(scenario_bytes, "scenario.sdl.yaml", "application/x-yaml"),
+                }
+            )
+
+        store = LocalRunStore(tmp_path / "store")
+        controller = ExperimentController(
+            run_store=store,
+            backend_manifest=backend,
+            processor_manifest=processor,
+            artifact_source_factory=_factory,
+        )
+
+        result = controller.admit(
+            experiment_root=_resolved(root_bytes, "experiment.yaml", "application/x-yaml"),
+            base_dir=tmp_path / "nonexistent-unused-dir",
+            manifest_locator="unused.json",
+        )
+
+        assert result.admitted is True

--- a/tests/test_experiment_errors.py
+++ b/tests/test_experiment_errors.py
@@ -1,0 +1,320 @@
+"""Tests for ``aptl.core.experiment.errors`` (ADR-047 "Error envelope").
+
+``normalize_aces_failure`` is the one place admission is allowed to turn an
+ACES/pydantic exception into a :class:`Diagnostic`. It must handle exactly
+the three documented failure shapes and must never let a raw
+``str(exc))`` — which for pydantic ``ValidationError`` embeds the rejected
+``input_value`` — leak into the produced diagnostics.
+"""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.experiment_spec import (
+    ExperimentSpecValidationError,
+    parse_experiment_spec,
+)
+from aces_sdl import SDLInstantiationError, SDLParseError, SDLValidationError, parse_sdl
+
+from aptl.core.experiment.errors import (
+    EXPERIMENT_ADMISSION_DOMAIN,
+    EXPERIMENT_ADMISSION_STAGE_LABEL,
+    AdmissionRejection,
+    diagnostic,
+    normalize_aces_failure,
+)
+
+SECRET = "sk-super-secret-injected-token-12345"
+
+
+class TestAdmissionRejection:
+    def test_stores_diagnostics_tuple(self):
+        d = diagnostic("aptl.experiment-admission.x", "root", "bad thing")
+
+        rejection = AdmissionRejection((d,))
+
+        assert rejection.diagnostics == (d,)
+        assert isinstance(rejection.diagnostics, tuple)
+
+    def test_is_an_exception(self):
+        d = diagnostic("aptl.experiment-admission.x", "root", "bad thing")
+        with pytest.raises(AdmissionRejection):
+            raise AdmissionRejection((d,))
+
+    def test_accepts_any_iterable_and_normalizes_to_a_tuple(self):
+        d = diagnostic("aptl.experiment-admission.x", "root", "bad thing")
+
+        rejection = AdmissionRejection(iter([d, d]))
+
+        assert rejection.diagnostics == (d, d)
+
+
+class TestDiagnosticHelper:
+    def test_builds_a_redacted_error_diagnostic(self):
+        d = diagnostic("aptl.experiment-admission.x", "root.field", "message text")
+
+        assert d.code == "aptl.experiment-admission.x"
+        assert d.domain == EXPERIMENT_ADMISSION_DOMAIN
+        assert d.address == "root.field"
+        assert d.message == "message text"
+        assert d.severity == Severity.ERROR
+        assert d.is_error
+
+    def test_redacts_secret_shaped_message_content(self):
+        d = diagnostic("aptl.experiment-admission.x", "root", "password=hunter2hunter2")
+
+        assert "hunter2hunter2" not in d.message
+
+
+class TestNormalizeAcesFailurePassthrough:
+    def test_passes_a_single_diagnostic_through_unchanged(self):
+        original = Diagnostic(
+            code="c", domain="d", address="a", message="m", severity=Severity.ERROR
+        )
+
+        result = normalize_aces_failure(
+            original, address="root", code="aptl.experiment-admission.x"
+        )
+
+        assert result == (original,)
+
+    def test_passes_a_tuple_of_diagnostics_through_unchanged(self):
+        d1 = Diagnostic(code="c1", domain="d", address="a1", message="m1")
+        d2 = Diagnostic(code="c2", domain="d", address="a2", message="m2")
+
+        result = normalize_aces_failure(
+            (d1, d2), address="root", code="aptl.experiment-admission.x"
+        )
+
+        assert result == (d1, d2)
+
+    def test_passes_an_empty_diagnostic_tuple_through_unchanged(self):
+        result = normalize_aces_failure(
+            (), address="root", code="aptl.experiment-admission.x"
+        )
+
+        assert result == ()
+
+
+class TestNormalizeAcesFailurePydanticValidationError:
+    def _validation_error(self) -> pydantic.ValidationError:
+        class Model(pydantic.BaseModel):
+            x: int
+
+        try:
+            Model(x=SECRET)
+        except pydantic.ValidationError as exc:
+            return exc
+        raise AssertionError("expected a ValidationError")
+
+    def test_extracts_one_diagnostic_per_pydantic_error(self):
+        exc = self._validation_error()
+
+        result = normalize_aces_failure(
+            exc, address="root", code="aptl.experiment-admission.root-invalid"
+        )
+
+        assert len(result) == 1
+        assert all(isinstance(item, Diagnostic) for item in result)
+
+    def test_never_leaks_the_rejected_input_value(self):
+        exc = self._validation_error()
+        assert SECRET in str(exc)  # sanity: pydantic's own str() DOES leak it
+
+        result = normalize_aces_failure(
+            exc, address="root", code="aptl.experiment-admission.root-invalid"
+        )
+
+        for item in result:
+            assert SECRET not in item.message
+            assert SECRET not in item.code
+            assert SECRET not in item.address
+
+    def test_diagnostic_carries_loc_derived_address_and_safe_code(self):
+        exc = self._validation_error()
+
+        result = normalize_aces_failure(
+            exc, address="root", code="aptl.experiment-admission.root-invalid"
+        )
+
+        item = result[0]
+        assert item.code == "aptl.experiment-admission.root-invalid"
+        assert "root" in item.address
+        assert "x" in item.address
+        assert item.domain == EXPERIMENT_ADMISSION_DOMAIN
+
+
+class TestNormalizeAcesFailureExperimentSpecValidationError:
+    """``ExperimentSpecValidationError`` wraps a pydantic ``ValidationError``
+    via ``str()`` (ADR-047 gotcha) — the normalizer must reach through
+    ``__cause__`` rather than ever calling ``str(exc)`` on it.
+    """
+
+    def _leaking_yaml(self) -> str:
+        return f"""
+schema_version: experiment-authoring-input/v1
+spec_id: s1
+spec_version: v1
+title: t
+description: d
+task_ref: {{ref_kind: {SECRET}, ref_id: t1}}
+run_plan: {{}}
+"""
+
+    def test_never_leaks_a_secret_embedded_in_the_rejected_field(self):
+        try:
+            parse_experiment_spec(self._leaking_yaml())
+        except ExperimentSpecValidationError as exc:
+            assert SECRET in str(exc)  # sanity: the wrapped str() DOES leak it
+
+            result = normalize_aces_failure(
+                exc, address="root", code="aptl.experiment-admission.root-invalid"
+            )
+        else:
+            raise AssertionError("expected ExperimentSpecValidationError")
+
+        assert result
+        for item in result:
+            assert SECRET not in item.message
+            assert SECRET not in item.code
+            assert SECRET not in item.address
+
+    def test_falls_back_to_a_safe_generic_diagnostic_without_a_pydantic_cause(self):
+        # "Experiment spec must be a YAML mapping" — no `__cause__` at all;
+        # the normalizer must not try to inspect a non-existent cause and
+        # must not surface the (safe, but still untrusted) raw message.
+        try:
+            parse_experiment_spec("- a\n- b\n")
+        except ExperimentSpecValidationError as exc:
+            assert exc.__cause__ is None
+
+            result = normalize_aces_failure(
+                exc, address="root", code="aptl.experiment-admission.root-invalid"
+            )
+        else:
+            raise AssertionError("expected ExperimentSpecValidationError")
+
+        assert len(result) == 1
+        assert result[0].code == "aptl.experiment-admission.root-invalid"
+        assert result[0].domain == EXPERIMENT_ADMISSION_DOMAIN
+
+
+class TestNormalizeAcesFailureSdlParseError:
+    def test_uses_structured_parse_diagnostics_when_present(self):
+        try:
+            parse_sdl(f"name: x\nimports:\n  - path: {SECRET}.yaml\n")
+        except SDLParseError as exc:
+            result = normalize_aces_failure(
+                exc, address="scenario", code="aptl.experiment-admission.scenario-invalid"
+            )
+        else:
+            raise AssertionError("expected SDLParseError")
+
+        assert result
+        assert all(isinstance(item, Diagnostic) for item in result)
+        # The SECRET was embedded in the SDL import path this exception was
+        # raised for; matching the adjacent secret-absence pattern
+        # (TestNormalizeAcesFailureExperimentSpecValidationError above), the
+        # secret must never surface in any produced diagnostic field.
+        for item in result:
+            assert SECRET not in item.message
+            assert SECRET not in item.code
+            assert SECRET not in item.address
+
+    def test_scrubs_an_absolute_path_embedded_in_the_message(self):
+        # Constructed directly: exercise the scrub without depending on a
+        # real ACES code path happening to embed a path today.
+        exc = SDLParseError("failed near /home/attacker/secret-project/scenario.yaml")
+
+        result = normalize_aces_failure(
+            exc, address="scenario", code="aptl.experiment-admission.scenario-invalid"
+        )
+
+        assert len(result) == 1
+        assert "/home/attacker/secret-project/scenario.yaml" not in result[0].message
+
+
+class TestNormalizeAcesFailureSdlValidationError:
+    def test_one_diagnostic_per_error_string(self):
+        exc = SDLValidationError(["first problem", "second problem"])
+
+        result = normalize_aces_failure(
+            exc, address="scenario", code="aptl.experiment-admission.scenario-invalid"
+        )
+
+        assert len(result) == 2
+        messages = {item.message for item in result}
+        assert messages == {"first problem", "second problem"}
+
+    def test_scrubs_an_absolute_path_embedded_in_an_error_string(self):
+        exc = SDLValidationError(["bad reference at /etc/aptl/secret-config.yaml"])
+
+        result = normalize_aces_failure(
+            exc, address="scenario", code="aptl.experiment-admission.scenario-invalid"
+        )
+
+        assert "/etc/aptl/secret-config.yaml" not in result[0].message
+
+
+class TestNormalizeAcesFailureSdlInstantiationError:
+    """``run_reference_processor`` raises this (not documented in the ACES
+    API reference consulted for Stage 1) when a condition's parameter
+    binding is structurally broken — verified live in Stage 3. It shares
+    ``SDLValidationError``'s safe ``errors: list[str]`` shape.
+    """
+
+    def test_one_diagnostic_per_error_string(self):
+        exc = SDLInstantiationError(["first problem", "second problem"])
+
+        result = normalize_aces_failure(
+            exc, address="condition.parameters", code="aptl.experiment-admission.condition-parameters-invalid"
+        )
+
+        assert len(result) == 2
+        messages = {item.message for item in result}
+        assert messages == {"first problem", "second problem"}
+
+    def test_scrubs_an_absolute_path_embedded_in_an_error_string(self):
+        exc = SDLInstantiationError(["bad target at /etc/aptl/secret-config.yaml"])
+
+        result = normalize_aces_failure(
+            exc, address="condition.parameters", code="aptl.experiment-admission.condition-parameters-invalid"
+        )
+
+        assert "/etc/aptl/secret-config.yaml" not in result[0].message
+
+    def test_a_real_undeclared_parameter_binding_never_leaks_the_bound_value(self):
+        # Mirrors the real Stage 3 call shape: run_reference_processor
+        # raises SDLInstantiationError naming the undeclared parameter
+        # *name*; the *value* bound to it must never appear anywhere.
+        from aces_processor.reference import run_reference_processor
+        from aces_sdl import parse_sdl
+
+        from aptl.backends.aces_manifest import create_aptl_manifest
+
+        scenario = parse_sdl("name: canonical-minimal\n")
+        try:
+            run_reference_processor(
+                scenario,
+                create_aptl_manifest(),
+                parameters={"undeclared_target": SECRET},
+            )
+        except SDLInstantiationError as exc:
+            result = normalize_aces_failure(
+                exc,
+                address="condition.parameters",
+                code="aptl.experiment-admission.condition-parameters-invalid",
+            )
+        else:
+            raise AssertionError("expected SDLInstantiationError")
+
+        assert result
+        for item in result:
+            assert SECRET not in item.message
+
+
+def test_stage_label_is_not_the_misleading_default():
+    assert EXPERIMENT_ADMISSION_STAGE_LABEL != "ACES runtime handoff failed"
+    assert "admission" in EXPERIMENT_ADMISSION_STAGE_LABEL.lower()

--- a/tests/test_experiment_persistence.py
+++ b/tests/test_experiment_persistence.py
@@ -1,0 +1,161 @@
+"""Tests for ``LocalRunStore.create_json_once`` (ADR-047 "Persistence and
+state model").
+
+Create-once, canonical (RFC 8785), atomic persistence for a controller-owned
+journal artifact (e.g. a future admitted experiment trial plan) — distinct
+from the timestamp run-id run-archive tree (``write_json``/``_run_dir``).
+Immutability requires more than calling ``write_json`` twice: this is a
+narrow new create-once operation on the existing run-store protocol, not a
+second experiment repository.
+"""
+
+import json
+
+import pytest
+import rfc8785
+
+from aptl.core.runstore import (
+    LocalRunStore,
+    RunStoreConflictError,
+    SecretInvariantError,
+)
+from aptl.utils.pathsafe import PathContainmentError
+
+
+class TestCreateJsonOnceHappyPath:
+    def test_writes_canonical_rfc8785_bytes(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        payload = {"b": 2, "a": 1, "nested": {"z": [3, 2, 1], "y": True}}
+
+        path = store.create_json_once("experiment-plans", "plan-abc", payload)
+
+        expected = rfc8785.dumps(json.loads(json.dumps(payload)))
+        assert path.read_bytes() == expected
+        # RFC 8785 sorts object member names.
+        assert path.read_bytes().startswith(b'{"a":1')
+
+    def test_returns_the_written_path(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        path = store.create_json_once("ns", "plan-1", {"x": 1})
+        assert path == tmp_path / "store" / "ns" / "plan-1.json"
+
+    def test_creates_the_store_root_if_missing(self, tmp_path):
+        store = LocalRunStore(tmp_path / "does-not-exist-yet")
+        path = store.create_json_once("ns", "plan-1", {"x": 1})
+        assert path.exists()
+
+    def test_does_not_synthesize_a_manifest_or_register_as_a_run(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        store.create_json_once("ns", "plan-1", {"x": 1})
+        assert store.list_runs() == []
+        assert not (tmp_path / "store" / "ns" / "manifest.json").exists()
+
+    def test_distinct_namespaces_do_not_collide(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        p1 = store.create_json_once("ns-a", "plan-1", {"x": 1})
+        p2 = store.create_json_once("ns-b", "plan-1", {"x": 2})
+        assert p1 != p2
+        assert json.loads(p1.read_bytes()) == {"x": 1}
+        assert json.loads(p2.read_bytes()) == {"x": 2}
+
+
+class TestCreateJsonOnceIdempotency:
+    def test_second_write_of_byte_identical_payload_is_idempotent(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        payload = {"a": 1, "b": [1, 2, 3]}
+
+        path1 = store.create_json_once("ns", "plan-1", payload)
+        bytes1 = path1.read_bytes()
+        # A structurally-identical-but-differently-ordered dict must produce
+        # the exact same canonical bytes and be accepted as the same write.
+        path2 = store.create_json_once("ns", "plan-1", {"b": [1, 2, 3], "a": 1})
+
+        assert path2 == path1
+        assert path2.read_bytes() == bytes1
+
+    def test_second_write_of_different_payload_is_rejected(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        store.create_json_once("ns", "plan-1", {"a": 1})
+
+        with pytest.raises(RunStoreConflictError):
+            store.create_json_once("ns", "plan-1", {"a": 2})
+
+        # The original bytes must be untouched by the rejected write.
+        assert json.loads((tmp_path / "store" / "ns" / "plan-1.json").read_bytes()) == {
+            "a": 1
+        }
+
+
+class TestCreateJsonOnceSymlinkContainment:
+    def test_pre_existing_symlinked_namespace_does_not_escape_root(self, tmp_path):
+        store_root = tmp_path / "store"
+        store_root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (store_root / "ns").symlink_to(outside, target_is_directory=True)
+
+        store = LocalRunStore(store_root)
+        with pytest.raises(PathContainmentError):
+            store.create_json_once("ns", "plan-1", {"a": 1})
+
+        assert list(outside.iterdir()) == []
+
+    def test_pre_existing_symlinked_leaf_does_not_escape_root(self, tmp_path):
+        store_root = tmp_path / "store"
+        (store_root / "ns").mkdir(parents=True)
+        outside_target = tmp_path / "outside.json"
+        (store_root / "ns" / "plan-1.json").symlink_to(outside_target)
+
+        store = LocalRunStore(store_root)
+        with pytest.raises(PathContainmentError):
+            store.create_json_once("ns", "plan-1", {"a": 1})
+
+        assert not outside_target.exists()
+
+
+class TestCreateJsonOnceSecretInvariant:
+    def test_rejects_payload_with_a_sensitive_key(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+
+        with pytest.raises(SecretInvariantError):
+            store.create_json_once(
+                "ns", "plan-1", {"condition_id": "c1", "api_key": "should-not-persist"}
+            )
+
+        assert not (tmp_path / "store" / "ns" / "plan-1.json").exists()
+
+    def test_rejects_payload_with_embedded_credential_shaped_string(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+
+        with pytest.raises(SecretInvariantError):
+            store.create_json_once(
+                "ns",
+                "plan-1",
+                {"note": "boot ok; Authorization: Bearer XYZ.TOKEN"},
+            )
+
+        assert not (tmp_path / "store" / "ns" / "plan-1.json").exists()
+
+    def test_accepts_a_payload_with_no_secret_shaped_content(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        path = store.create_json_once(
+            "ns", "plan-1", {"condition_id": "c1", "trial_count": 3}
+        )
+        assert json.loads(path.read_bytes()) == {"condition_id": "c1", "trial_count": 3}
+
+
+class TestCreateJsonOnceInputValidation:
+    def test_rejects_invalid_namespace(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        with pytest.raises(ValueError, match="namespace"):
+            store.create_json_once("../escape", "plan-1", {"a": 1})
+
+    def test_rejects_invalid_name(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        with pytest.raises(ValueError, match="name"):
+            store.create_json_once("ns", "../escape", {"a": 1})
+
+    def test_rejects_non_json_serializable_payload(self, tmp_path):
+        store = LocalRunStore(tmp_path / "store")
+        with pytest.raises(ValueError):
+            store.create_json_once("ns", "plan-1", {"a": object()})

--- a/tests/test_experiment_persistence.py
+++ b/tests/test_experiment_persistence.py
@@ -157,5 +157,6 @@ class TestCreateJsonOnceInputValidation:
 
     def test_rejects_non_json_serializable_payload(self, tmp_path):
         store = LocalRunStore(tmp_path / "store")
+        payload = {"a": object()}
         with pytest.raises(ValueError):
-            store.create_json_once("ns", "plan-1", {"a": object()})
+            store.create_json_once("ns", "plan-1", payload)

--- a/tests/test_experiment_policy.py
+++ b/tests/test_experiment_policy.py
@@ -9,6 +9,8 @@ table to a supported :class:`OrderingKind`. An unmapped value fails closed.
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 
 from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_DOMAIN, AdmissionRejection
@@ -27,7 +29,7 @@ class TestDefaultAdmissionPolicy:
 
     def test_is_frozen(self):
         policy = default_admission_policy()
-        with pytest.raises(Exception):  # noqa: B017 - dataclass frozen raises FrozenInstanceError
+        with pytest.raises(dataclasses.FrozenInstanceError):
             policy.max_root_bytes = 1  # type: ignore[misc]
 
     @pytest.mark.parametrize(
@@ -128,9 +130,10 @@ class TestResolveAllocationOrdering:
     def test_is_case_sensitive_not_fuzzy_matched(self):
         policy = default_admission_policy()
         method, _ = next(iter(policy.supported_allocation_methods.items()))
+        garbled_method = method.upper() + "-not-quite"
 
         with pytest.raises(AdmissionRejection):
-            resolve_allocation_ordering(policy, method.upper() + "-not-quite")
+            resolve_allocation_ordering(policy, garbled_method)
 
 
 class TestOrderingKind:

--- a/tests/test_experiment_policy.py
+++ b/tests/test_experiment_policy.py
@@ -1,0 +1,138 @@
+"""Tests for ``aptl.core.experiment.policy`` (ADR-047 admission policy and
+allocation-ordering resolution).
+
+``allocation_method`` is FREE TEXT in the ACES contract
+(``ExperimentRunAllocationPlanModel.allocation_method: NonEmptyString``) —
+never evaluated, only mapped through a small controller-owned, versioned
+table to a supported :class:`OrderingKind`. An unmapped value fails closed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_DOMAIN, AdmissionRejection
+from aptl.core.experiment.policy import (
+    AdmissionPolicy,
+    OrderingKind,
+    default_admission_policy,
+    resolve_allocation_ordering,
+)
+
+
+class TestDefaultAdmissionPolicy:
+    def test_returns_an_admission_policy(self):
+        policy = default_admission_policy()
+        assert isinstance(policy, AdmissionPolicy)
+
+    def test_is_frozen(self):
+        policy = default_admission_policy()
+        with pytest.raises(Exception):  # noqa: B017 - dataclass frozen raises FrozenInstanceError
+            policy.max_root_bytes = 1  # type: ignore[misc]
+
+    @pytest.mark.parametrize(
+        "field_name",
+        [
+            "max_root_bytes",
+            "max_artifact_bytes",
+            "max_aggregate_bytes",
+            "max_reference_count",
+            "max_allocation_size",
+            "max_nesting_depth",
+        ],
+    )
+    def test_limits_are_positive_integers(self, field_name):
+        policy = default_admission_policy()
+        value = getattr(policy, field_name)
+        assert isinstance(value, int)
+        assert value > 0
+
+    def test_aggregate_bytes_is_at_least_the_per_artifact_limit(self):
+        policy = default_admission_policy()
+        assert policy.max_aggregate_bytes >= policy.max_artifact_bytes
+
+    def test_has_a_stable_policy_version_string(self):
+        policy = default_admission_policy()
+        assert isinstance(policy.policy_version, str)
+        assert policy.policy_version
+
+    def test_supported_allocation_methods_is_a_non_empty_mapping(self):
+        policy = default_admission_policy()
+        assert len(policy.supported_allocation_methods) > 0
+        for method, kind in policy.supported_allocation_methods.items():
+            assert isinstance(method, str)
+            assert isinstance(kind, OrderingKind)
+
+    def test_supported_stochastic_control_roles_is_a_non_empty_set(self):
+        policy = default_admission_policy()
+        assert len(policy.supported_stochastic_control_roles) > 0
+        assert all(isinstance(role, str) for role in policy.supported_stochastic_control_roles)
+
+    def test_supported_orderings_is_a_non_empty_set_of_ordering_kind(self):
+        policy = default_admission_policy()
+        assert len(policy.supported_orderings) > 0
+        assert all(isinstance(kind, OrderingKind) for kind in policy.supported_orderings)
+
+    def test_allow_uncertified_apparatus_defaults_to_false(self):
+        policy = default_admission_policy()
+        assert policy.allow_uncertified_apparatus is False
+
+    def test_allow_uncertified_apparatus_is_overridable_via_replace(self):
+        import dataclasses
+
+        policy = dataclasses.replace(default_admission_policy(), allow_uncertified_apparatus=True)
+        assert policy.allow_uncertified_apparatus is True
+
+
+class TestResolveAllocationOrdering:
+    def test_resolves_a_supported_allocation_method(self):
+        policy = default_admission_policy()
+        method, expected_kind = next(iter(policy.supported_allocation_methods.items()))
+
+        kind = resolve_allocation_ordering(policy, method)
+
+        assert kind == expected_kind
+        assert kind in policy.supported_orderings
+
+    def test_rejects_an_unsupported_free_text_allocation_method(self):
+        policy = default_admission_policy()
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            resolve_allocation_ordering(policy, "definitely-not-a-real-method")
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+        assert all(d.is_error for d in excinfo.value.diagnostics)
+
+    def test_never_evaluates_the_free_text_value(self):
+        """`allocation_method` is data, not code — a value shaped like an
+        expression/import must be rejected exactly like any other unknown
+        method, never executed or imported."""
+        policy = default_admission_policy()
+
+        with pytest.raises(AdmissionRejection):
+            resolve_allocation_ordering(policy, "__import__('os').system('echo pwned')")
+
+    def test_rejection_message_does_not_echo_the_raw_free_text_value(self):
+        policy = default_admission_policy()
+        injected = "sk-should-never-appear-in-a-diagnostic"
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            resolve_allocation_ordering(policy, injected)
+
+        for d in excinfo.value.diagnostics:
+            assert injected not in d.message
+            assert injected not in d.code
+            assert injected not in d.address
+
+    def test_is_case_sensitive_not_fuzzy_matched(self):
+        policy = default_admission_policy()
+        method, _ = next(iter(policy.supported_allocation_methods.items()))
+
+        with pytest.raises(AdmissionRejection):
+            resolve_allocation_ordering(policy, method.upper() + "-not-quite")
+
+
+class TestOrderingKind:
+    def test_has_a_flat_and_condition_major_replication_member(self):
+        assert OrderingKind.FLAT is not OrderingKind.CONDITION_MAJOR_REPLICATION

--- a/tests/test_experiment_resolver.py
+++ b/tests/test_experiment_resolver.py
@@ -1,0 +1,416 @@
+"""Tests for ``aptl.core.experiment.resolver`` (ADR-047 "Authorized artifact
+resolution").
+
+Two layers are tested separately:
+
+* ``parse_locator`` — pure string classification of an untrusted locator
+  into a normalized :class:`ProjectFileLocator`. Never touches the
+  filesystem.
+* ``ProjectContainedResolver`` — the offline, project-contained resolver
+  that actually opens bytes, via ``pathsafe`` no-follow one-open semantics,
+  and enforces size/digest/aggregate/reference-count policy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_DOMAIN, AdmissionRejection
+from aptl.core.experiment.policy import AdmissionPolicy, default_admission_policy
+from aptl.core.experiment.resolver import (
+    ProjectContainedResolver,
+    ProjectFileLocator,
+    ResolvedArtifact,
+    parse_locator,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_locator
+# ---------------------------------------------------------------------------
+
+
+class TestParseLocatorHappyPath:
+    def test_bare_relative_path(self):
+        locator = parse_locator("scenarios/techvault.sdl.yaml")
+
+        assert locator == ProjectFileLocator(
+            relative_path="scenarios/techvault.sdl.yaml",
+            declared_size=None,
+            declared_digest=None,
+            media_type=None,
+        )
+
+    def test_explicit_file_scheme(self):
+        locator = parse_locator("file:scenarios/techvault.sdl.yaml")
+
+        assert locator.relative_path == "scenarios/techvault.sdl.yaml"
+
+    def test_declared_size_digest_and_media_type_query_fields(self):
+        locator = parse_locator(
+            "file:scenarios/techvault.sdl.yaml"
+            "?size=1234&digest=sha256:"
+            + ("a" * 64)
+            + "&media_type=application/yaml"
+        )
+
+        assert locator.relative_path == "scenarios/techvault.sdl.yaml"
+        assert locator.declared_size == 1234
+        assert locator.declared_digest == "sha256:" + ("a" * 64)
+        assert locator.media_type == "application/yaml"
+
+    def test_nested_relative_path(self):
+        locator = parse_locator("a/b/c/d.txt")
+        assert locator.relative_path == "a/b/c/d.txt"
+
+
+class TestParseLocatorRejectsCredentialUserinfo:
+    def test_rejects_userinfo_in_a_file_authority(self):
+        with pytest.raises(AdmissionRejection):
+            parse_locator("file://user:pass@localhost/etc/passwd")
+
+    def test_rejects_userinfo_in_an_http_authority(self):
+        with pytest.raises(AdmissionRejection):
+            parse_locator("https://user:secret@example.test/guide")
+
+
+class TestParseLocatorRejectsSecretBearingQuery:
+    def test_rejects_a_sensitive_key_name(self):
+        with pytest.raises(AdmissionRejection):
+            parse_locator("file:scenario.yaml?token=abcd1234")
+
+    def test_rejects_a_secret_shaped_value_under_a_recognized_key(self):
+        with pytest.raises(AdmissionRejection):
+            parse_locator("file:scenario.yaml?media_type=Authorization:%20Bearer%20abc")
+
+
+class TestParseLocatorRejectsUnrecognizedQueryField:
+    def test_rejects_a_benign_undeclared_query_key(self):
+        # "color" is well-formed and not secret-shaped/sensitive at all --
+        # it must still fail closed for not being one of the three
+        # recognized keys (size/digest/media_type), never silently ignored.
+        with pytest.raises(AdmissionRejection) as excinfo:
+            parse_locator("file:scenario.yaml?color=blue")
+
+        assert any(
+            d.code == "aptl.experiment-admission.locator-unrecognized-query-field"
+            for d in excinfo.value.diagnostics
+        )
+
+
+class TestParseLocatorRejectsUnsupportedScheme:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "https://example.test/scenario.yaml",
+            "http://example.test/scenario.yaml",
+            "oci://registry.example.test/image:tag",
+            "registry://example.test/artifact",
+            "urn:sha256:" + "a" * 64,
+        ],
+    )
+    def test_rejects_non_file_schemes(self, raw):
+        with pytest.raises(AdmissionRejection):
+            parse_locator(raw)
+
+
+class TestParseLocatorRejectsTraversal:
+    def test_rejects_absolute_path(self):
+        with pytest.raises(AdmissionRejection):
+            parse_locator("/etc/passwd")
+
+    def test_rejects_dotdot_component(self):
+        with pytest.raises(AdmissionRejection):
+            parse_locator("../outside.yaml")
+
+    def test_rejects_embedded_dotdot_component(self):
+        with pytest.raises(AdmissionRejection):
+            parse_locator("scenarios/../../../etc/passwd")
+
+    def test_rejects_empty_locator(self):
+        with pytest.raises(AdmissionRejection):
+            parse_locator("")
+
+
+class TestParseLocatorRejectionShape:
+    def test_raises_admission_rejection_with_a_safe_diagnostic(self):
+        with pytest.raises(AdmissionRejection) as excinfo:
+            parse_locator("/etc/passwd")
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+        assert all(d.is_error for d in excinfo.value.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# ProjectContainedResolver
+# ---------------------------------------------------------------------------
+
+
+class TestProjectContainedResolverHappyPath:
+    def test_resolves_correct_bytes_digest_and_portable_locator(self, tmp_path):
+        (tmp_path / "scenario.yaml").write_bytes(b"name: canonical-minimal\n")
+        resolver = ProjectContainedResolver(tmp_path)
+        locator = parse_locator("scenario.yaml")
+
+        artifact = resolver.resolve(locator, policy=default_admission_policy())
+
+        assert isinstance(artifact, ResolvedArtifact)
+        assert artifact.data == b"name: canonical-minimal\n"
+        assert artifact.locator == "scenario.yaml"
+        assert not os.path.isabs(artifact.locator)
+        assert artifact.digest.startswith("sha256:")
+
+        expected = hashlib.sha256(b"name: canonical-minimal\n").hexdigest()
+        assert artifact.digest == f"sha256:{expected}"
+
+    def test_media_type_carries_through_from_the_locator(self, tmp_path):
+        (tmp_path / "f.json").write_bytes(b"{}")
+        resolver = ProjectContainedResolver(tmp_path)
+        locator = parse_locator("file:f.json?media_type=application/json")
+
+        artifact = resolver.resolve(locator, policy=default_admission_policy())
+
+        assert artifact.media_type == "application/json"
+
+    def test_nested_directory_path(self, tmp_path):
+        nested = tmp_path / "scenarios" / "sub"
+        nested.mkdir(parents=True)
+        (nested / "f.yaml").write_bytes(b"data")
+        resolver = ProjectContainedResolver(tmp_path)
+
+        artifact = resolver.resolve(parse_locator("scenarios/sub/f.yaml"), policy=default_admission_policy())
+
+        assert artifact.data == b"data"
+
+
+class TestProjectContainedResolverDeclaredSize:
+    def test_rejects_a_declared_size_mismatch(self, tmp_path):
+        (tmp_path / "f.txt").write_bytes(b"exactly-11b")  # 11 bytes
+        resolver = ProjectContainedResolver(tmp_path)
+        locator = parse_locator("file:f.txt?size=999")
+
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(locator, policy=default_admission_policy())
+
+    def test_accepts_a_matching_declared_size(self, tmp_path):
+        (tmp_path / "f.txt").write_bytes(b"exactly-11b")
+        resolver = ProjectContainedResolver(tmp_path)
+        locator = parse_locator("file:f.txt?size=11")
+
+        artifact = resolver.resolve(locator, policy=default_admission_policy())
+
+        assert len(artifact.data) == 11
+
+
+class TestProjectContainedResolverDeclaredDigest:
+    def test_rejects_a_declared_digest_mismatch(self, tmp_path):
+        (tmp_path / "f.txt").write_bytes(b"hello world")
+        resolver = ProjectContainedResolver(tmp_path)
+        wrong_digest = "sha256:" + ("0" * 64)
+        locator = parse_locator(f"file:f.txt?digest={wrong_digest}")
+
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(locator, policy=default_admission_policy())
+
+    def test_accepts_a_matching_declared_digest(self, tmp_path):
+        data = b"hello world"
+        (tmp_path / "f.txt").write_bytes(data)
+        resolver = ProjectContainedResolver(tmp_path)
+        digest = "sha256:" + hashlib.sha256(data).hexdigest()
+        locator = parse_locator(f"file:f.txt?digest={digest}")
+
+        artifact = resolver.resolve(locator, policy=default_admission_policy())
+
+        assert artifact.digest == digest
+
+    def test_accepts_a_matching_blake3_declared_digest(self, tmp_path):
+        import blake3
+
+        data = b"hello blake3 world"
+        (tmp_path / "f.txt").write_bytes(data)
+        resolver = ProjectContainedResolver(tmp_path)
+        digest = "blake3:" + blake3.blake3(data).hexdigest()
+        locator = parse_locator(f"file:f.txt?digest={digest}")
+
+        artifact = resolver.resolve(locator, policy=default_admission_policy())
+
+        assert artifact.data == data
+
+    def test_rejects_an_unsupported_digest_algorithm_on_a_hand_built_locator(self, tmp_path):
+        # Bypasses parse_locator entirely: resolve() must independently
+        # fail closed on an unsupported algorithm rather than trusting
+        # that every locator came from the parser's own regex gate.
+        (tmp_path / "f.txt").write_bytes(b"hello world")
+        resolver = ProjectContainedResolver(tmp_path)
+        locator = ProjectFileLocator(
+            relative_path="f.txt",
+            declared_size=None,
+            declared_digest="md5:5eb63bbbe01eeed093cb22bb8f5acdc3",
+            media_type=None,
+        )
+
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(locator, policy=default_admission_policy())
+
+
+class TestProjectContainedResolverSizeLimit:
+    def test_rejects_over_max_artifact_bytes(self, tmp_path):
+        (tmp_path / "big.txt").write_bytes(b"x" * 1000)
+        resolver = ProjectContainedResolver(tmp_path)
+        policy = AdmissionPolicy(max_artifact_bytes=10)
+
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(parse_locator("big.txt"), policy=policy)
+
+    def test_accepts_at_exactly_the_limit(self, tmp_path):
+        (tmp_path / "exact.txt").write_bytes(b"x" * 10)
+        resolver = ProjectContainedResolver(tmp_path)
+        policy = AdmissionPolicy(max_artifact_bytes=10)
+
+        artifact = resolver.resolve(parse_locator("exact.txt"), policy=policy)
+        assert len(artifact.data) == 10
+
+
+class TestProjectContainedResolverSymlinks:
+    def test_rejects_a_symlinked_leaf(self, tmp_path):
+        target = tmp_path / "real.txt"
+        target.write_bytes(b"real")
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+        resolver = ProjectContainedResolver(tmp_path)
+
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(parse_locator("link.txt"), policy=default_admission_policy())
+
+    def test_rejects_a_symlinked_directory_component(self, tmp_path):
+        real_dir = tmp_path / "real_dir"
+        real_dir.mkdir()
+        (real_dir / "f.txt").write_bytes(b"data")
+        link_dir = tmp_path / "link_dir"
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+        resolver = ProjectContainedResolver(tmp_path)
+
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(parse_locator("link_dir/f.txt"), policy=default_admission_policy())
+
+
+class TestProjectContainedResolverAggregateLimits:
+    def test_fails_closed_past_max_aggregate_bytes(self, tmp_path):
+        (tmp_path / "a.txt").write_bytes(b"x" * 6)
+        (tmp_path / "b.txt").write_bytes(b"x" * 6)
+        resolver = ProjectContainedResolver(tmp_path)
+        policy = AdmissionPolicy(max_artifact_bytes=100, max_aggregate_bytes=10)
+
+        resolver.resolve(parse_locator("a.txt"), policy=policy)
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(parse_locator("b.txt"), policy=policy)
+
+    def test_fails_closed_past_max_reference_count(self, tmp_path):
+        (tmp_path / "a.txt").write_bytes(b"a")
+        (tmp_path / "b.txt").write_bytes(b"b")
+        resolver = ProjectContainedResolver(tmp_path)
+        policy = AdmissionPolicy(max_reference_count=1)
+
+        resolver.resolve(parse_locator("a.txt"), policy=policy)
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(parse_locator("b.txt"), policy=policy)
+
+    def test_independent_resolvers_do_not_share_accumulated_state(self, tmp_path):
+        (tmp_path / "a.txt").write_bytes(b"a")
+        policy = AdmissionPolicy(max_reference_count=1)
+
+        ProjectContainedResolver(tmp_path).resolve(parse_locator("a.txt"), policy=policy)
+        # A second, independent resolver instance starts a fresh session.
+        artifact = ProjectContainedResolver(tmp_path).resolve(parse_locator("a.txt"), policy=policy)
+        assert artifact.data == b"a"
+
+
+class TestProjectContainedResolverRejectionShape:
+    def test_raises_admission_rejection_with_safe_diagnostics(self, tmp_path):
+        resolver = ProjectContainedResolver(tmp_path)
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            resolver.resolve(parse_locator("missing.txt"), policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Fuzz
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fuzz
+class TestFuzzParseLocator:
+    @given(
+        raw=st.text(
+            alphabet=st.characters(blacklist_categories=("Cs",), max_codepoint=0x2FFFF),
+            min_size=0,
+            max_size=200,
+        )
+    )
+    @settings(max_examples=300, deadline=1000)
+    def test_never_raises_anything_other_than_admission_rejection(self, raw):
+        try:
+            parse_locator(raw)
+        except AdmissionRejection:
+            pass
+
+    @given(
+        segments=st.lists(
+            st.text(alphabet=st.characters(min_codepoint=0x21, max_codepoint=0x7E), min_size=1, max_size=10)
+            .filter(lambda s: "/" not in s and "?" not in s and "\x00" not in s),
+            min_size=1,
+            max_size=5,
+        )
+    )
+    @settings(max_examples=200, deadline=1000)
+    def test_a_parsed_relative_path_never_contains_a_dotdot_component(self, segments):
+        raw = "/".join(segments)
+        try:
+            locator = parse_locator(raw)
+        except AdmissionRejection:
+            return
+        assert ".." not in locator.relative_path.split("/")
+
+
+@pytest.mark.fuzz
+class TestFuzzProjectContainedResolver:
+    @given(
+        declared_size=st.integers(min_value=0, max_value=10_000).filter(lambda n: n != 4),
+    )
+    @settings(max_examples=50, deadline=1000)
+    def test_declared_size_mismatch_always_rejects(self, tmp_path_factory, declared_size):
+        base = tmp_path_factory.mktemp("resolver-fuzz")
+        (base / "f.txt").write_bytes(b"data")  # 4 bytes
+        resolver = ProjectContainedResolver(base)
+        locator = ProjectFileLocator(
+            relative_path="f.txt", declared_size=declared_size, declared_digest=None, media_type=None
+        )
+
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(locator, policy=default_admission_policy())
+
+    @given(bad_hex=st.text(alphabet="0123456789abcdef", min_size=64, max_size=64))
+    @settings(max_examples=50, deadline=1000)
+    def test_declared_digest_mismatch_always_rejects(self, tmp_path_factory, bad_hex):
+        real_digest = "sha256:" + hashlib.sha256(b"data").hexdigest()
+        candidate = f"sha256:{bad_hex}"
+        if candidate == real_digest:
+            return
+        base = tmp_path_factory.mktemp("resolver-fuzz")
+        (base / "f.txt").write_bytes(b"data")
+        resolver = ProjectContainedResolver(base)
+        locator = ProjectFileLocator(
+            relative_path="f.txt", declared_size=None, declared_digest=candidate, media_type=None
+        )
+
+        with pytest.raises(AdmissionRejection):
+            resolver.resolve(locator, policy=default_admission_policy())

--- a/tests/test_experiment_resolver.py
+++ b/tests/test_experiment_resolver.py
@@ -194,9 +194,10 @@ class TestProjectContainedResolverDeclaredSize:
         (tmp_path / "f.txt").write_bytes(b"exactly-11b")  # 11 bytes
         resolver = ProjectContainedResolver(tmp_path)
         locator = parse_locator("file:f.txt?size=999")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(locator, policy=default_admission_policy())
+            resolver.resolve(locator, policy=policy)
 
     def test_accepts_a_matching_declared_size(self, tmp_path):
         (tmp_path / "f.txt").write_bytes(b"exactly-11b")
@@ -214,9 +215,10 @@ class TestProjectContainedResolverDeclaredDigest:
         resolver = ProjectContainedResolver(tmp_path)
         wrong_digest = "sha256:" + ("0" * 64)
         locator = parse_locator(f"file:f.txt?digest={wrong_digest}")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(locator, policy=default_admission_policy())
+            resolver.resolve(locator, policy=policy)
 
     def test_accepts_a_matching_declared_digest(self, tmp_path):
         data = b"hello world"
@@ -254,9 +256,10 @@ class TestProjectContainedResolverDeclaredDigest:
             declared_digest="md5:5eb63bbbe01eeed093cb22bb8f5acdc3",
             media_type=None,
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(locator, policy=default_admission_policy())
+            resolver.resolve(locator, policy=policy)
 
 
 class TestProjectContainedResolverSizeLimit:
@@ -264,9 +267,10 @@ class TestProjectContainedResolverSizeLimit:
         (tmp_path / "big.txt").write_bytes(b"x" * 1000)
         resolver = ProjectContainedResolver(tmp_path)
         policy = AdmissionPolicy(max_artifact_bytes=10)
+        locator = parse_locator("big.txt")
 
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(parse_locator("big.txt"), policy=policy)
+            resolver.resolve(locator, policy=policy)
 
     def test_accepts_at_exactly_the_limit(self, tmp_path):
         (tmp_path / "exact.txt").write_bytes(b"x" * 10)
@@ -284,9 +288,11 @@ class TestProjectContainedResolverSymlinks:
         link = tmp_path / "link.txt"
         link.symlink_to(target)
         resolver = ProjectContainedResolver(tmp_path)
+        locator = parse_locator("link.txt")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(parse_locator("link.txt"), policy=default_admission_policy())
+            resolver.resolve(locator, policy=policy)
 
     def test_rejects_a_symlinked_directory_component(self, tmp_path):
         real_dir = tmp_path / "real_dir"
@@ -295,9 +301,11 @@ class TestProjectContainedResolverSymlinks:
         link_dir = tmp_path / "link_dir"
         link_dir.symlink_to(real_dir, target_is_directory=True)
         resolver = ProjectContainedResolver(tmp_path)
+        locator = parse_locator("link_dir/f.txt")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(parse_locator("link_dir/f.txt"), policy=default_admission_policy())
+            resolver.resolve(locator, policy=policy)
 
 
 class TestProjectContainedResolverAggregateLimits:
@@ -308,8 +316,9 @@ class TestProjectContainedResolverAggregateLimits:
         policy = AdmissionPolicy(max_artifact_bytes=100, max_aggregate_bytes=10)
 
         resolver.resolve(parse_locator("a.txt"), policy=policy)
+        locator_b = parse_locator("b.txt")
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(parse_locator("b.txt"), policy=policy)
+            resolver.resolve(locator_b, policy=policy)
 
     def test_fails_closed_past_max_reference_count(self, tmp_path):
         (tmp_path / "a.txt").write_bytes(b"a")
@@ -318,8 +327,9 @@ class TestProjectContainedResolverAggregateLimits:
         policy = AdmissionPolicy(max_reference_count=1)
 
         resolver.resolve(parse_locator("a.txt"), policy=policy)
+        locator_b = parse_locator("b.txt")
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(parse_locator("b.txt"), policy=policy)
+            resolver.resolve(locator_b, policy=policy)
 
     def test_independent_resolvers_do_not_share_accumulated_state(self, tmp_path):
         (tmp_path / "a.txt").write_bytes(b"a")
@@ -334,9 +344,11 @@ class TestProjectContainedResolverAggregateLimits:
 class TestProjectContainedResolverRejectionShape:
     def test_raises_admission_rejection_with_safe_diagnostics(self, tmp_path):
         resolver = ProjectContainedResolver(tmp_path)
+        locator = parse_locator("missing.txt")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            resolver.resolve(parse_locator("missing.txt"), policy=default_admission_policy())
+            resolver.resolve(locator, policy=policy)
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
@@ -394,9 +406,10 @@ class TestFuzzProjectContainedResolver:
         locator = ProjectFileLocator(
             relative_path="f.txt", declared_size=declared_size, declared_digest=None, media_type=None
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(locator, policy=default_admission_policy())
+            resolver.resolve(locator, policy=policy)
 
     @given(bad_hex=st.text(alphabet="0123456789abcdef", min_size=64, max_size=64))
     @settings(max_examples=50, deadline=1000)
@@ -411,6 +424,7 @@ class TestFuzzProjectContainedResolver:
         locator = ProjectFileLocator(
             relative_path="f.txt", declared_size=None, declared_digest=candidate, media_type=None
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            resolver.resolve(locator, policy=default_admission_policy())
+            resolver.resolve(locator, policy=policy)

--- a/tests/test_experiment_spec_loading.py
+++ b/tests/test_experiment_spec_loading.py
@@ -1,0 +1,458 @@
+"""Tests for ``aptl.core.experiment.spec_loading`` (ADR-047 "ACES contracts
+remain authoritative" + "Input shape").
+
+Uses the installed ACES fixture corpus
+(``aces_contracts.corpus.corpus_family_root(FIXTURES)``) as the contract
+test source rather than a copied-in schema, per ADR-047's testing contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+
+import pytest
+from aces_contracts.associated_artifacts import (
+    AssociatedArtifactManifestModel,
+    AssociatedArtifactValidationLimits,
+    associated_artifact_set_digest,
+)
+from aces_contracts.contracts import (
+    ExperimentCaptureSpecModel,
+    ExperimentTaskModel,
+)
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+from aces_contracts.experiment_spec import ExperimentSpecModel
+from aces_sdl.canonical import canonical_sdl_digest
+from aces_sdl.scenario import Scenario
+
+from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_DOMAIN, AdmissionRejection
+from aptl.core.experiment.policy import AdmissionPolicy, default_admission_policy
+from aptl.core.experiment.spec_loading import (
+    load_capture_spec,
+    load_experiment_root,
+    load_task,
+    parse_scenario_bytes,
+    validate_associated_artifacts,
+)
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+SECRET = "sk-super-secret-injected-token-98765"
+
+
+def _read(*parts: str) -> bytes:
+    path = CORPUS_ROOT
+    for part in parts:
+        path = path / part
+    return path.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# load_experiment_root
+# ---------------------------------------------------------------------------
+
+
+class TestLoadExperimentRootHappyPath:
+    def test_loads_the_valid_corpus_fixture(self):
+        data = _read(
+            "experiment-core", "experiment-authoring-input-v1", "valid", "reference.json"
+        )
+
+        model = load_experiment_root(data, policy=default_admission_policy())
+
+        assert isinstance(model, ExperimentSpecModel)
+        assert model.spec_id == "spec-techvault-red-tactic-sweep-v1"
+
+
+class TestLoadExperimentRootDuplicateKeyPreflight:
+    def test_rejects_a_duplicate_top_level_key(self):
+        text = (
+            "schema_version: experiment-authoring-input/v1\n"
+            "spec_id: s1\n"
+            "spec_version: v1\n"
+            "title: t\n"
+            "title: t-again\n"
+            "description: d\n"
+            "task_ref: {ref_kind: task, ref_id: t1}\n"
+            "run_plan: {}\n"
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+
+    def test_rejects_a_duplicate_nested_key(self):
+        text = (
+            "schema_version: experiment-authoring-input/v1\n"
+            "spec_id: s1\n"
+            "spec_version: v1\n"
+            "title: t\n"
+            "description: d\n"
+            "task_ref: {ref_kind: task, ref_id: t1, ref_id: t2}\n"
+            "run_plan: {}\n"
+        )
+
+        with pytest.raises(AdmissionRejection):
+            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+
+    def test_rejects_a_multi_document_stream(self):
+        text = "schema_version: experiment-authoring-input/v1\n---\nspec_id: s1\n"
+
+        with pytest.raises(AdmissionRejection):
+            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+
+    def test_a_document_without_duplicate_keys_reaches_aces_validation(self):
+        # No duplicate key, but otherwise incomplete -> ACES itself rejects
+        # it (a real ValidationError normalized), proving the preflight
+        # does not itself reject well-formed-but-incomplete documents.
+        text = "schema_version: experiment-authoring-input/v1\n"
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+
+
+class TestLoadExperimentRootByteLimit:
+    def test_rejects_a_document_over_max_root_bytes(self):
+        data = _read(
+            "experiment-core", "experiment-authoring-input-v1", "valid", "reference.json"
+        )
+        policy = AdmissionPolicy(max_root_bytes=10)
+
+        with pytest.raises(AdmissionRejection):
+            load_experiment_root(data, policy=policy)
+
+    def test_accepts_a_document_within_max_root_bytes(self):
+        data = _read(
+            "experiment-core", "experiment-authoring-input-v1", "valid", "reference.json"
+        )
+        policy = AdmissionPolicy(max_root_bytes=len(data))
+
+        load_experiment_root(data, policy=policy)  # must not raise
+
+
+class TestLoadExperimentRootInvalidUtf8AndNul:
+    def test_rejects_invalid_utf8(self):
+        with pytest.raises(AdmissionRejection):
+            load_experiment_root(b"\xff\xfe\x00\x01", policy=default_admission_policy())
+
+    def test_rejects_an_embedded_nul_byte(self):
+        text = b"schema_version: experiment-authoring-input/v1\x00\n"
+        with pytest.raises(AdmissionRejection):
+            load_experiment_root(text, policy=default_admission_policy())
+
+
+class TestLoadExperimentRootDoesNotLeakSecrets:
+    def test_a_rejected_field_value_never_appears_in_the_diagnostics(self):
+        text = (
+            "schema_version: experiment-authoring-input/v1\n"
+            "spec_id: s1\n"
+            "spec_version: v1\n"
+            "title: t\n"
+            "description: d\n"
+            f"task_ref: {{ref_kind: {SECRET}, ref_id: t1}}\n"
+            "run_plan: {}\n"
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+
+        for d in excinfo.value.diagnostics:
+            assert SECRET not in d.message
+            assert SECRET not in d.code
+            assert SECRET not in d.address
+
+
+# ---------------------------------------------------------------------------
+# load_task
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTaskHappyPath:
+    def test_loads_the_valid_corpus_fixture(self):
+        data = _read("experiment-core", "experiment-task-v1", "valid", "reference.json")
+
+        model = load_task(data, policy=default_admission_policy())
+
+        assert isinstance(model, ExperimentTaskModel)
+        assert model.task_id == "task-techvault-red-team-v1"
+
+
+class TestLoadTaskRejections:
+    def test_rejects_a_duplicate_json_member(self):
+        text = '{"schema_version": "experiment-task/v1", "task_id": "a", "task_id": "b"}'
+
+        with pytest.raises(AdmissionRejection):
+            load_task(text.encode("utf-8"), policy=default_admission_policy())
+
+    def test_rejects_over_max_artifact_bytes(self):
+        data = _read("experiment-core", "experiment-task-v1", "valid", "reference.json")
+        policy = AdmissionPolicy(max_artifact_bytes=10)
+
+        with pytest.raises(AdmissionRejection):
+            load_task(data, policy=policy)
+
+    def test_rejects_invalid_json(self):
+        with pytest.raises(AdmissionRejection):
+            load_task(b"not json at all {{{", policy=default_admission_policy())
+
+    def test_does_not_leak_a_secret_in_a_rejected_field(self):
+        payload = {
+            "schema_version": "experiment-task/v1",
+            "task_id": "t",
+            "task_version": SECRET,  # wrong type expectations aside, use a
+            # structurally-invalid field to force a validation error whose
+            # rejected value is the secret.
+        }
+        text = json.dumps(payload)
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            load_task(text.encode("utf-8"), policy=default_admission_policy())
+
+        for d in excinfo.value.diagnostics:
+            assert SECRET not in d.message
+
+
+# ---------------------------------------------------------------------------
+# load_capture_spec
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCaptureSpecHappyPath:
+    def test_loads_the_valid_corpus_fixture(self):
+        data = _read(
+            "experiment-core", "experiment-capture-spec-v1", "valid", "reference.json"
+        )
+
+        model = load_capture_spec(data, policy=default_admission_policy())
+
+        assert isinstance(model, ExperimentCaptureSpecModel)
+        assert model.capture_spec_id == "capture-techvault-evidence-v1"
+
+
+class TestLoadCaptureSpecRejections:
+    def test_rejects_a_duplicate_json_member(self):
+        text = (
+            '{"schema_version": "experiment-capture-spec/v1", '
+            '"capture_spec_id": "a", "capture_spec_id": "b"}'
+        )
+
+        with pytest.raises(AdmissionRejection):
+            load_capture_spec(text.encode("utf-8"), policy=default_admission_policy())
+
+    def test_rejects_over_max_artifact_bytes(self):
+        data = _read(
+            "experiment-core", "experiment-capture-spec-v1", "valid", "reference.json"
+        )
+        policy = AdmissionPolicy(max_artifact_bytes=10)
+
+        with pytest.raises(AdmissionRejection):
+            load_capture_spec(data, policy=policy)
+
+
+# ---------------------------------------------------------------------------
+# parse_scenario_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestParseScenarioBytesHappyPath:
+    def test_parses_the_valid_corpus_fixture(self):
+        data = _read("sdl", "sdl-yaml-v1", "valid", "minimal.yaml")
+
+        scenario, digest = parse_scenario_bytes(data, policy=default_admission_policy())
+
+        assert isinstance(scenario, Scenario)
+        assert digest.value.startswith("sha256:")
+
+    def test_canonical_digest_is_stable_across_two_parses_of_the_same_bytes(self):
+        data = _read("sdl", "sdl-yaml-v1", "valid", "core-scalars.yaml")
+
+        _, digest1 = parse_scenario_bytes(data, policy=default_admission_policy())
+        _, digest2 = parse_scenario_bytes(data, policy=default_admission_policy())
+
+        assert digest1 == digest2
+        assert digest1.value == digest2.value
+
+    def test_matches_the_aces_canonical_digest_api_directly(self):
+        data = _read("sdl", "sdl-yaml-v1", "valid", "minimal.yaml")
+
+        scenario, digest = parse_scenario_bytes(data, policy=default_admission_policy())
+
+        assert digest == canonical_sdl_digest(scenario)
+
+
+class TestParseScenarioBytesRejectsImports:
+    def test_rejects_a_scenario_that_declares_imports(self):
+        text = "name: x\nimports:\n  - path: some-module.yaml\n"
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            parse_scenario_bytes(text.encode("utf-8"), policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+
+    def test_empty_imports_list_is_not_rejected(self):
+        data = _read("sdl", "sdl-yaml-v1", "valid", "minimal.yaml")
+        scenario, _ = parse_scenario_bytes(data, policy=default_admission_policy())
+        assert scenario.imports == []
+
+
+class TestParseScenarioBytesByteLimitAndRejections:
+    def test_rejects_over_max_artifact_bytes(self):
+        data = _read("sdl", "sdl-yaml-v1", "valid", "minimal.yaml")
+        policy = AdmissionPolicy(max_artifact_bytes=2)
+
+        with pytest.raises(AdmissionRejection):
+            parse_scenario_bytes(data, policy=policy)
+
+    def test_rejects_structurally_invalid_sdl(self):
+        with pytest.raises(AdmissionRejection):
+            parse_scenario_bytes(b"not: [valid, sdl", policy=default_admission_policy())
+
+    def test_does_not_leak_a_secret_embedded_in_invalid_sdl(self):
+        text = f"name: x\nnodes:\n  {SECRET}: not-a-valid-node-shape\n"
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            parse_scenario_bytes(text.encode("utf-8"), policy=default_admission_policy())
+
+        for d in excinfo.value.diagnostics:
+            assert SECRET not in d.message
+
+
+# ---------------------------------------------------------------------------
+# validate_associated_artifacts (wiring helper)
+# ---------------------------------------------------------------------------
+
+
+def _build_valid_manifest_and_parent() -> tuple[AssociatedArtifactManifestModel, ExperimentTaskModel, bytes]:
+    task_payload = json.loads(
+        _read("experiment-core", "experiment-task-v1", "valid", "reference.json")
+    )
+    task = ExperimentTaskModel.model_validate(task_payload)
+
+    data = b"associated artifact bytes for admission wiring test"
+    digest_hex = hashlib.sha256(data).hexdigest()
+    manifest_payload = {
+        "schema_version": "associated-artifact-manifest/v1",
+        "manifest_id": "wiring-test-manifest",
+        "manifest_version": "1.0.0",
+        "canonicalization_profile": "associated-artifact-set/v1",
+        "scope": "experiment",
+        "parent_ref": {
+            "ref_kind": "task",
+            "ref_id": task.task_id,
+            "ref_version": task.task_version,
+        },
+        "artifacts": {
+            "art1": {
+                "artifact_id": "art1",
+                "role": "operator-guide",
+                "media_type": "text/plain",
+                "uri": f"urn:sha256:{digest_hex}",
+                "checksum": {"algorithm": "sha256", "value": digest_hex},
+                "size_bytes": len(data),
+                "created_at": "2026-07-12T00:00:00Z",
+                "source": "test",
+                "sensitivity": "internal",
+            }
+        },
+        "set_digest": "sha256:" + "0" * 64,
+    }
+    provisional = AssociatedArtifactManifestModel.model_validate(manifest_payload)
+    manifest_payload["set_digest"] = associated_artifact_set_digest(provisional)
+    manifest = AssociatedArtifactManifestModel.model_validate(manifest_payload)
+    return manifest, task, data
+
+
+class TestValidateAssociatedArtifacts:
+    def test_does_not_raise_when_the_manifest_and_readers_are_valid(self):
+        manifest, task, data = _build_valid_manifest_and_parent()
+
+        validate_associated_artifacts(
+            manifest,
+            parent=task,
+            artifact_readers={"art1": io.BytesIO(data)},
+            limits=AssociatedArtifactValidationLimits(),
+        )  # must not raise
+
+    def test_raises_admission_rejection_when_a_reader_binding_is_missing(self):
+        manifest, task, _ = _build_valid_manifest_and_parent()
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            validate_associated_artifacts(
+                manifest,
+                parent=task,
+                artifact_readers={},
+                limits=AssociatedArtifactValidationLimits(),
+            )
+
+        assert excinfo.value.diagnostics
+        assert all(d.is_error for d in excinfo.value.diagnostics)
+
+    def test_raises_admission_rejection_on_parent_mismatch(self):
+        manifest, _task, data = _build_valid_manifest_and_parent()
+        other_task_payload = json.loads(
+            _read("experiment-core", "experiment-task-v1", "valid", "reference.json")
+        )
+        other_task_payload["task_id"] = "a-completely-different-task"
+        other_task = ExperimentTaskModel.model_validate(other_task_payload)
+
+        with pytest.raises(AdmissionRejection):
+            validate_associated_artifacts(
+                manifest,
+                parent=other_task,
+                artifact_readers={"art1": io.BytesIO(data)},
+                limits=AssociatedArtifactValidationLimits(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Fuzz
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@pytest.mark.fuzz
+class TestFuzzDuplicateKeyDocumentsAlwaysReject:
+    @given(
+        key=st.text(alphabet="abcdefghijklmnopqrstuvwxyz_", min_size=1, max_size=12),
+        value_a=st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=12),
+        value_b=st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=12),
+    )
+    @settings(max_examples=100, deadline=1000)
+    def test_a_duplicated_top_level_key_always_rejects_the_root(self, key, value_a, value_b):
+        text = (
+            "schema_version: experiment-authoring-input/v1\n"
+            "spec_id: s1\n"
+            "spec_version: v1\n"
+            "title: t\n"
+            "description: d\n"
+            "task_ref: {ref_kind: task, ref_id: t1}\n"
+            "run_plan: {}\n"
+            f"{key}: {value_a}\n"
+            f"{key}: {value_b}\n"
+        )
+
+        with pytest.raises(AdmissionRejection):
+            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+
+    @given(
+        key=st.text(alphabet="abcdefghijklmnopqrstuvwxyz_", min_size=1, max_size=12),
+        value_a=st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=12),
+        value_b=st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=12),
+    )
+    @settings(max_examples=100, deadline=1000)
+    def test_a_duplicated_json_member_always_rejects_task_loading(self, key, value_a, value_b):
+        text = (
+            '{"schema_version": "experiment-task/v1", '
+            f'"{key}": "{value_a}", "{key}": "{value_b}"}}'
+        )
+
+        with pytest.raises(AdmissionRejection):
+            load_task(text.encode("utf-8"), policy=default_admission_policy())

--- a/tests/test_experiment_spec_loading.py
+++ b/tests/test_experiment_spec_loading.py
@@ -77,9 +77,11 @@ class TestLoadExperimentRootDuplicateKeyPreflight:
             "task_ref: {ref_kind: task, ref_id: t1}\n"
             "run_plan: {}\n"
         )
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+            load_experiment_root(data, policy=policy)
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
@@ -94,24 +96,30 @@ class TestLoadExperimentRootDuplicateKeyPreflight:
             "task_ref: {ref_kind: task, ref_id: t1, ref_id: t2}\n"
             "run_plan: {}\n"
         )
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+            load_experiment_root(data, policy=policy)
 
     def test_rejects_a_multi_document_stream(self):
         text = "schema_version: experiment-authoring-input/v1\n---\nspec_id: s1\n"
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+            load_experiment_root(data, policy=policy)
 
     def test_a_document_without_duplicate_keys_reaches_aces_validation(self):
         # No duplicate key, but otherwise incomplete -> ACES itself rejects
         # it (a real ValidationError normalized), proving the preflight
         # does not itself reject well-formed-but-incomplete documents.
         text = "schema_version: experiment-authoring-input/v1\n"
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+            load_experiment_root(data, policy=policy)
 
         assert excinfo.value.diagnostics
 
@@ -137,13 +145,15 @@ class TestLoadExperimentRootByteLimit:
 
 class TestLoadExperimentRootInvalidUtf8AndNul:
     def test_rejects_invalid_utf8(self):
+        policy = default_admission_policy()
         with pytest.raises(AdmissionRejection):
-            load_experiment_root(b"\xff\xfe\x00\x01", policy=default_admission_policy())
+            load_experiment_root(b"\xff\xfe\x00\x01", policy=policy)
 
     def test_rejects_an_embedded_nul_byte(self):
         text = b"schema_version: experiment-authoring-input/v1\x00\n"
+        policy = default_admission_policy()
         with pytest.raises(AdmissionRejection):
-            load_experiment_root(text, policy=default_admission_policy())
+            load_experiment_root(text, policy=policy)
 
 
 class TestLoadExperimentRootDoesNotLeakSecrets:
@@ -157,9 +167,11 @@ class TestLoadExperimentRootDoesNotLeakSecrets:
             f"task_ref: {{ref_kind: {SECRET}, ref_id: t1}}\n"
             "run_plan: {}\n"
         )
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+            load_experiment_root(data, policy=policy)
 
         for d in excinfo.value.diagnostics:
             assert SECRET not in d.message
@@ -185,9 +197,11 @@ class TestLoadTaskHappyPath:
 class TestLoadTaskRejections:
     def test_rejects_a_duplicate_json_member(self):
         text = '{"schema_version": "experiment-task/v1", "task_id": "a", "task_id": "b"}'
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            load_task(text.encode("utf-8"), policy=default_admission_policy())
+            load_task(data, policy=policy)
 
     def test_rejects_over_max_artifact_bytes(self):
         data = _read("experiment-core", "experiment-task-v1", "valid", "reference.json")
@@ -197,8 +211,9 @@ class TestLoadTaskRejections:
             load_task(data, policy=policy)
 
     def test_rejects_invalid_json(self):
+        policy = default_admission_policy()
         with pytest.raises(AdmissionRejection):
-            load_task(b"not json at all {{{", policy=default_admission_policy())
+            load_task(b"not json at all {{{", policy=policy)
 
     def test_does_not_leak_a_secret_in_a_rejected_field(self):
         payload = {
@@ -209,9 +224,11 @@ class TestLoadTaskRejections:
             # rejected value is the secret.
         }
         text = json.dumps(payload)
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            load_task(text.encode("utf-8"), policy=default_admission_policy())
+            load_task(data, policy=policy)
 
         for d in excinfo.value.diagnostics:
             assert SECRET not in d.message
@@ -240,9 +257,11 @@ class TestLoadCaptureSpecRejections:
             '{"schema_version": "experiment-capture-spec/v1", '
             '"capture_spec_id": "a", "capture_spec_id": "b"}'
         )
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            load_capture_spec(text.encode("utf-8"), policy=default_admission_policy())
+            load_capture_spec(data, policy=policy)
 
     def test_rejects_over_max_artifact_bytes(self):
         data = _read(
@@ -288,9 +307,11 @@ class TestParseScenarioBytesHappyPath:
 class TestParseScenarioBytesRejectsImports:
     def test_rejects_a_scenario_that_declares_imports(self):
         text = "name: x\nimports:\n  - path: some-module.yaml\n"
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            parse_scenario_bytes(text.encode("utf-8"), policy=default_admission_policy())
+            parse_scenario_bytes(data, policy=policy)
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
@@ -310,14 +331,17 @@ class TestParseScenarioBytesByteLimitAndRejections:
             parse_scenario_bytes(data, policy=policy)
 
     def test_rejects_structurally_invalid_sdl(self):
+        policy = default_admission_policy()
         with pytest.raises(AdmissionRejection):
-            parse_scenario_bytes(b"not: [valid, sdl", policy=default_admission_policy())
+            parse_scenario_bytes(b"not: [valid, sdl", policy=policy)
 
     def test_does_not_leak_a_secret_embedded_in_invalid_sdl(self):
         text = f"name: x\nnodes:\n  {SECRET}: not-a-valid-node-shape\n"
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            parse_scenario_bytes(text.encode("utf-8"), policy=default_admission_policy())
+            parse_scenario_bytes(data, policy=policy)
 
         for d in excinfo.value.diagnostics:
             assert SECRET not in d.message
@@ -381,13 +405,14 @@ class TestValidateAssociatedArtifacts:
 
     def test_raises_admission_rejection_when_a_reader_binding_is_missing(self):
         manifest, task, _ = _build_valid_manifest_and_parent()
+        limits = AssociatedArtifactValidationLimits()
 
         with pytest.raises(AdmissionRejection) as excinfo:
             validate_associated_artifacts(
                 manifest,
                 parent=task,
                 artifact_readers={},
-                limits=AssociatedArtifactValidationLimits(),
+                limits=limits,
             )
 
         assert excinfo.value.diagnostics
@@ -400,13 +425,15 @@ class TestValidateAssociatedArtifacts:
         )
         other_task_payload["task_id"] = "a-completely-different-task"
         other_task = ExperimentTaskModel.model_validate(other_task_payload)
+        reader = io.BytesIO(data)
+        limits = AssociatedArtifactValidationLimits()
 
         with pytest.raises(AdmissionRejection):
             validate_associated_artifacts(
                 manifest,
                 parent=other_task,
-                artifact_readers={"art1": io.BytesIO(data)},
-                limits=AssociatedArtifactValidationLimits(),
+                artifact_readers={"art1": reader},
+                limits=limits,
             )
 
 
@@ -438,9 +465,11 @@ class TestFuzzDuplicateKeyDocumentsAlwaysReject:
             f"{key}: {value_a}\n"
             f"{key}: {value_b}\n"
         )
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            load_experiment_root(text.encode("utf-8"), policy=default_admission_policy())
+            load_experiment_root(data, policy=policy)
 
     @given(
         key=st.text(alphabet="abcdefghijklmnopqrstuvwxyz_", min_size=1, max_size=12),
@@ -453,6 +482,8 @@ class TestFuzzDuplicateKeyDocumentsAlwaysReject:
             '{"schema_version": "experiment-task/v1", '
             f'"{key}": "{value_a}", "{key}": "{value_b}"}}'
         )
+        data = text.encode("utf-8")
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            load_task(text.encode("utf-8"), policy=default_admission_policy())
+            load_task(data, policy=policy)

--- a/tests/test_experiment_trial_plan.py
+++ b/tests/test_experiment_trial_plan.py
@@ -20,6 +20,7 @@ to exercise dict-key reordering).
 from __future__ import annotations
 
 import copy
+import dataclasses
 import inspect
 import json
 import subprocess
@@ -173,7 +174,9 @@ class TestComputeSourceSetDigest:
 
     def test_is_stable_across_calls(self):
         projection = {"task": {"ref_id": "t", "digest": "sha256:" + "0" * 64}}
-        assert compute_source_set_digest(projection) == compute_source_set_digest(projection)
+        first = compute_source_set_digest(projection)
+        second = compute_source_set_digest(projection)
+        assert first == second
 
     def test_is_independent_of_key_insertion_order(self):
         d1 = compute_source_set_digest({"a": 1, "b": 2, "c": {"x": 1, "y": 2}})
@@ -680,14 +683,14 @@ class TestImmutability:
     def test_trial_plan_is_frozen(self):
         spec = _flat_spec(target_run_count=1)
         plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
-        with pytest.raises(Exception):  # noqa: B017 - dataclass frozen raises FrozenInstanceError
+        with pytest.raises(dataclasses.FrozenInstanceError):
             plan.trials = ()  # type: ignore[misc]
 
     def test_planned_trial_is_frozen(self):
         spec = _flat_spec(target_run_count=1)
         plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
         trial = plan.trials[0]
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(dataclasses.FrozenInstanceError):
             trial.condition_id = "mutated"  # type: ignore[misc]
 
     def test_trials_is_a_tuple_not_a_list(self):
@@ -730,9 +733,10 @@ class TestUnsupportedStochasticRole:
             target_run_count=1,
             stochastic_controls=[{"control_id": "sampler", "role": "sampling", "value": 1}],
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
@@ -746,9 +750,10 @@ class TestUnsupportedStochasticRole:
                 {"control_id": "scheduler-a", "role": "scheduler", "value": "x"},
             ],
         )
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
 
 
 class TestUnsupportedAllocationMethod:
@@ -762,9 +767,10 @@ class TestUnsupportedAllocationMethod:
             allocation_method="definitely-not-a-real-method",
         )
         spec = ExperimentSpecModel.model_validate(payload)
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
@@ -783,9 +789,10 @@ class TestUnsupportedAllocationMethod:
             allocation_method="flat",
         )
         spec = ExperimentSpecModel.model_validate(payload)
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_experiment_trial_plan.py
+++ b/tests/test_experiment_trial_plan.py
@@ -491,12 +491,19 @@ class TestDeterminism:
         )
         digests = set()
         for seed in ("0", "1", "3391772699"):
+            _os = __import__("os")
+            _src = _os.path.join(
+                _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))), "src"
+            )
             result = subprocess.run(
                 [sys.executable, "-c", script],
-                env={"PYTHONHASHSEED": seed, "PATH": __import__("os").environ.get("PATH", "")},
+                env={
+                    **_os.environ,
+                    "PYTHONHASHSEED": seed,
+                    "PYTHONPATH": _src + _os.pathsep + _os.environ.get("PYTHONPATH", ""),
+                },
                 capture_output=True,
                 text=True,
-                cwd="/home/atomik/src/aptl",
                 check=True,
             )
             digests.add(result.stdout.strip())

--- a/tests/test_experiment_trial_plan.py
+++ b/tests/test_experiment_trial_plan.py
@@ -1,0 +1,865 @@
+"""Tests for ``aptl.core.experiment.trial_plan`` (ADR-047 "Deterministic
+immutable trial plan").
+
+The trial plan is a PURE expander: no I/O, no persistence (Stage 5 wires
+the result through ``LocalRunStore.create_json_once``). Determinism is the
+whole point — two expansions of the same admitted spec, regardless of
+process, host, dict-insertion order, or ``PYTHONHASHSEED``, must produce
+byte-identical ``TrialPlan.canonical_bytes`` (ADR-047 "Gotchas": no
+``hash()``, UUIDs, timestamps, ambient RNG, or set/dict traversal leaking
+into the result).
+
+Uses the installed ACES fixture corpus
+(``aces_contracts.corpus.corpus_family_root(FIXTURES)``) for a realistic
+condition allocation, plus hand-built minimal specs for flat allocation and
+for map-order-independence at the factor-level granularity (the corpus
+fixture's conditions each carry only one factor level, which is not enough
+to exercise dict-key reordering).
+"""
+
+from __future__ import annotations
+
+import copy
+import inspect
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+from aces_contracts.experiment_spec import ExperimentSpecModel
+
+from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_DOMAIN, AdmissionRejection
+from aptl.core.experiment.policy import (
+    AdmissionPolicy,
+    OrderingKind,
+    default_admission_policy,
+)
+from aptl.core.experiment import trial_plan
+from aptl.core.experiment.trial_plan import (
+    PlannedTrial,
+    TrialPlan,
+    compute_source_set_digest,
+    expand_trial_plan,
+)
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+SOURCE_SET_DIGEST = "sha256:" + "ab" * 32
+
+
+def _read_corpus_reference() -> dict:
+    path = CORPUS_ROOT / "experiment-core" / "experiment-authoring-input-v1" / "valid" / "reference.json"
+    return json.loads(path.read_text())
+
+
+def _condition_reference_spec() -> ExperimentSpecModel:
+    return ExperimentSpecModel.model_validate(_read_corpus_reference())
+
+
+def _flat_spec_payload(
+    *,
+    target_run_count: int = 5,
+    stochastic_controls: list[dict] | None = None,
+    capture_spec_refs: list[dict] | None = None,
+) -> dict:
+    payload = {
+        "schema_version": "experiment-authoring-input/v1",
+        "spec_id": "spec-flat-test-v1",
+        "spec_version": "1.0.0",
+        "title": "Flat test spec",
+        "description": "Flat allocation test fixture.",
+        "task_ref": {"ref_kind": "task", "ref_id": "task-x", "ref_version": "1.0.0"},
+        "run_plan": {
+            "stochastic_controls": (
+                stochastic_controls
+                if stochastic_controls is not None
+                else [{"control_id": "seed-a", "role": "seed", "value": 1}]
+            ),
+            "episode_control": {
+                "turn_order": "sequential",
+                "max_steps": 10,
+                "termination_rule": "fixed horizon",
+            },
+            "target_run_count": target_run_count,
+        },
+    }
+    if capture_spec_refs is not None:
+        payload["capture_spec_refs"] = capture_spec_refs
+    return payload
+
+
+def _flat_spec(**kwargs) -> ExperimentSpecModel:
+    return ExperimentSpecModel.model_validate(_flat_spec_payload(**kwargs))
+
+
+def _condition_assignment(condition_id: str, factor_levels: dict, param_value: str) -> dict:
+    return {
+        "condition_id": condition_id,
+        "factor_levels": factor_levels,
+        "required_parameters": [
+            {"name": "p", "value": param_value, "value_kind": "protocol"},
+        ],
+    }
+
+
+def _condition_spec_payload(
+    *,
+    condition_assignments: dict,
+    compared_conditions: list[str],
+    target_runs_per_condition: int = 3,
+    allocation_method: str = "balanced",
+    stochastic_controls: list[dict] | None = None,
+) -> dict:
+    return {
+        "schema_version": "experiment-authoring-input/v1",
+        "spec_id": "spec-condition-test-v1",
+        "spec_version": "1.0.0",
+        "title": "Condition test spec",
+        "description": "Condition allocation test fixture.",
+        "task_ref": {"ref_kind": "task", "ref_id": "task-x", "ref_version": "1.0.0"},
+        "run_plan": {
+            "stochastic_controls": (
+                stochastic_controls
+                if stochastic_controls is not None
+                else [{"control_id": "seed-a", "role": "seed", "value": 1}]
+            ),
+            "episode_control": {
+                "turn_order": "sequential",
+                "max_steps": 10,
+                "termination_rule": "fixed horizon",
+            },
+            "allocation": {
+                "allocation_unit": "run",
+                "allocation_method": allocation_method,
+                "compared_conditions": compared_conditions,
+                "condition_assignments": condition_assignments,
+                "target_runs_per_condition": target_runs_per_condition,
+                "replication_policy": "n independent runs",
+            },
+        },
+    }
+
+
+def _two_factor_condition_spec(*, condition_dict_order=("cond-a", "cond-b"), factor_dict_order=("factor-x", "factor-y")):
+    def _factor_levels(level_a, level_b):
+        ordered_keys = factor_dict_order
+        values = {"factor-x": level_a, "factor-y": level_b}
+        return {key: values[key] for key in ordered_keys}
+
+    assignments_in_order = {
+        "cond-a": _condition_assignment("cond-a", _factor_levels("a1", "a2"), "a1"),
+        "cond-b": _condition_assignment("cond-b", _factor_levels("b1", "b2"), "b1"),
+    }
+    condition_assignments = {key: assignments_in_order[key] for key in condition_dict_order}
+
+    payload = _condition_spec_payload(
+        condition_assignments=condition_assignments,
+        compared_conditions=["cond-a", "cond-b"],
+    )
+    return ExperimentSpecModel.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# compute_source_set_digest
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSourceSetDigest:
+    def test_returns_a_sha256_prefixed_digest(self):
+        digest = compute_source_set_digest({"a": 1, "b": 2})
+        assert digest.startswith("sha256:")
+        assert len(digest) == len("sha256:") + 64
+
+    def test_is_stable_across_calls(self):
+        projection = {"task": {"ref_id": "t", "digest": "sha256:" + "0" * 64}}
+        assert compute_source_set_digest(projection) == compute_source_set_digest(projection)
+
+    def test_is_independent_of_key_insertion_order(self):
+        d1 = compute_source_set_digest({"a": 1, "b": 2, "c": {"x": 1, "y": 2}})
+        d2 = compute_source_set_digest({"c": {"y": 2, "x": 1}, "b": 2, "a": 1})
+        assert d1 == d2
+
+    def test_different_content_yields_different_digest(self):
+        d1 = compute_source_set_digest({"a": 1})
+        d2 = compute_source_set_digest({"a": 2})
+        assert d1 != d2
+
+
+# ---------------------------------------------------------------------------
+# Flat expansion
+# ---------------------------------------------------------------------------
+
+
+class TestFlatExpansion:
+    def test_trial_count_matches_target_run_count(self):
+        spec = _flat_spec(target_run_count=7)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert len(plan.trials) == 7
+
+    def test_ordinals_are_zero_based_contiguous(self):
+        spec = _flat_spec(target_run_count=4)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert [t.replication_ordinal for t in plan.trials] == [0, 1, 2, 3]
+
+    def test_ordering_index_matches_ordinal(self):
+        spec = _flat_spec(target_run_count=4)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert [t.ordering_index for t in plan.trials] == [0, 1, 2, 3]
+
+    def test_condition_id_is_none_for_every_trial(self):
+        spec = _flat_spec(target_run_count=3)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert all(t.condition_id is None for t in plan.trials)
+
+    def test_factor_levels_and_parameter_bindings_are_empty(self):
+        spec = _flat_spec(target_run_count=2)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        for trial in plan.trials:
+            assert trial.factor_levels == ()
+            assert trial.parameter_bindings == ()
+
+    def test_ordering_kind_is_flat(self):
+        spec = _flat_spec(target_run_count=2)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert plan.ordering_kind is OrderingKind.FLAT
+
+    def test_capture_spec_refs_propagate_to_every_trial(self):
+        spec = _flat_spec(
+            target_run_count=2,
+            capture_spec_refs=[{"ref_kind": "capture-spec", "ref_id": "cap-1", "ref_version": "1.0.0"}],
+        )
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        for trial in plan.trials:
+            assert trial.capture_spec_refs == ("cap-1",)
+
+    def test_scenario_snapshot_digest_is_none_when_no_mapping_supplied(self):
+        spec = _flat_spec(target_run_count=2)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert all(t.scenario_snapshot_digest is None for t in plan.trials)
+
+
+# ---------------------------------------------------------------------------
+# Condition expansion
+# ---------------------------------------------------------------------------
+
+
+class TestConditionExpansionUsesCorpusFixture:
+    def test_total_trial_count_matches_conditions_times_replications(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        allocation = spec.run_plan.allocation
+        expected = len(allocation.compared_conditions) * allocation.target_runs_per_condition
+        assert len(plan.trials) == expected
+
+    def test_trials_follow_authored_condition_order_then_replication_ordinal(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        allocation = spec.run_plan.allocation
+
+        expected_sequence = [
+            (condition_id, ordinal)
+            for condition_id in allocation.compared_conditions
+            for ordinal in range(allocation.target_runs_per_condition)
+        ]
+        actual_sequence = [(t.condition_id, t.replication_ordinal) for t in plan.trials]
+        assert actual_sequence == expected_sequence
+
+    def test_ordering_index_is_contiguous_zero_based(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert [t.ordering_index for t in plan.trials] == list(range(len(plan.trials)))
+
+    def test_ordering_kind_is_condition_major_replication(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert plan.ordering_kind is OrderingKind.CONDITION_MAJOR_REPLICATION
+
+    def test_factor_levels_come_from_the_matching_condition_assignment(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        by_condition = {}
+        for trial in plan.trials:
+            by_condition.setdefault(trial.condition_id, trial.factor_levels)
+        assert by_condition["cond-aggressive"] == (("red-tactic", "aggressive"),)
+        assert by_condition["cond-stealthy"] == (("red-tactic", "stealthy"),)
+
+    def test_parameter_bindings_come_from_required_parameters(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        first_aggressive = next(t for t in plan.trials if t.condition_id == "cond-aggressive")
+        assert first_aggressive.parameter_bindings == (("red_tactic", "aggressive"),)
+
+    def test_scenario_snapshot_digest_from_condition_snapshot_digests(self):
+        spec = _condition_reference_spec()
+        digests = {"cond-aggressive": "sha256:" + "1" * 64, "cond-stealthy": "sha256:" + "2" * 64}
+        plan = expand_trial_plan(
+            spec,
+            source_set_digest=SOURCE_SET_DIGEST,
+            condition_snapshot_digests=digests,
+            policy=default_admission_policy(),
+        )
+        for trial in plan.trials:
+            assert trial.scenario_snapshot_digest == digests[trial.condition_id]
+
+    def test_scenario_snapshot_digest_is_none_without_a_mapping(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert all(t.scenario_snapshot_digest is None for t in plan.trials)
+
+
+# ---------------------------------------------------------------------------
+# Authored condition order (never silently sorted)
+# ---------------------------------------------------------------------------
+
+
+class TestConditionOrderIsAuthoredNotSorted:
+    """DISCRIMINATING test for the "authored order vs. silent sorted()"
+    coverage gap: every other ``compared_conditions`` fixture in this module
+    happens to already be in ascending order, so a hypothetical
+    ``sorted(allocation.compared_conditions)`` in ``_expand_condition``
+    would pass unnoticed. ``compared_conditions`` here is authored in the
+    exact REVERSE of sorted order, so this test FAILS if ``_expand_condition``
+    ever sorted instead of iterating authored order.
+    """
+
+    def test_trial_sequence_and_ordering_index_follow_authored_not_sorted_order(self):
+        payload = _condition_spec_payload(
+            condition_assignments={
+                "cond-a-second": _condition_assignment("cond-a-second", {"f": "a"}, "a"),
+                "cond-z-first": _condition_assignment("cond-z-first", {"f": "z"}, "z"),
+            },
+            # Authored order is the REVERSE of sorted(["cond-a-second",
+            # "cond-z-first"]) == ["cond-a-second", "cond-z-first"].
+            compared_conditions=["cond-z-first", "cond-a-second"],
+            target_runs_per_condition=2,
+        )
+        spec = ExperimentSpecModel.model_validate(payload)
+
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+
+        # sorted() would yield cond-a-second's trials first; authored order
+        # (the correct behavior) yields cond-z-first's trials first.
+        actual_sequence = [(t.condition_id, t.replication_ordinal) for t in plan.trials]
+        assert actual_sequence == [
+            ("cond-z-first", 0),
+            ("cond-z-first", 1),
+            ("cond-a-second", 0),
+            ("cond-a-second", 1),
+        ]
+        # ordering_index reflects the same authored-order coordinate, not a
+        # sorted one.
+        assert [t.ordering_index for t in plan.trials] == [0, 1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# max_allocation_size fail-closed
+# ---------------------------------------------------------------------------
+
+
+class TestMaxAllocationSizeFailClosed:
+    def test_flat_allocation_over_the_limit_is_rejected(self):
+        spec = _flat_spec(target_run_count=50)
+        policy = AdmissionPolicy(max_allocation_size=10)
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+        assert all(d.is_error for d in excinfo.value.diagnostics)
+
+    def test_condition_allocation_over_the_limit_is_rejected(self):
+        spec = _condition_reference_spec()  # 2 conditions * 100 replications = 200
+        policy = AdmissionPolicy(max_allocation_size=50)
+
+        with pytest.raises(AdmissionRejection):
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+    def test_allocation_within_the_limit_is_accepted(self):
+        spec = _flat_spec(target_run_count=10)
+        policy = AdmissionPolicy(max_allocation_size=10)
+
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        assert len(plan.trials) == 10
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_flat_expansion_is_byte_identical_across_two_calls(self):
+        spec = _flat_spec(target_run_count=6)
+        policy = default_admission_policy()
+        plan1 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan2 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        assert plan1.canonical_bytes == plan2.canonical_bytes
+        assert plan1.plan_digest == plan2.plan_digest
+        assert plan1.plan_id == plan2.plan_id
+
+    def test_condition_expansion_is_byte_identical_across_two_calls(self):
+        spec = _condition_reference_spec()
+        policy = default_admission_policy()
+        plan1 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan2 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        assert plan1.canonical_bytes == plan2.canonical_bytes
+        assert plan1.plan_digest == plan2.plan_digest
+        assert plan1.plan_id == plan2.plan_id
+
+    def test_plan_digest_is_the_sha256_of_canonical_bytes(self):
+        import hashlib
+
+        spec = _flat_spec(target_run_count=3)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert plan.plan_digest == "sha256:" + hashlib.sha256(plan.canonical_bytes).hexdigest()
+
+    def test_plan_id_is_filesystem_safe(self):
+        import re
+
+        spec = _flat_spec(target_run_count=3)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert re.fullmatch(r"[\w.-]+", plan.plan_id)
+        assert ".." not in plan.plan_id
+
+    def test_a_different_source_set_digest_changes_the_plan_digest(self):
+        spec = _flat_spec(target_run_count=3)
+        policy = default_admission_policy()
+        plan1 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan2 = expand_trial_plan(spec, source_set_digest="sha256:" + "ff" * 32, policy=policy)
+        assert plan1.plan_digest != plan2.plan_digest
+
+    def test_module_source_never_references_nondeterministic_primitives(self):
+        """ADR-047 Gotchas: no Python ``hash()``, UUIDs, timestamps, or
+        ambient/library RNG may influence plan bytes. A plan built with any
+        of these can look stable within one process and still drift across
+        hosts or retries."""
+        source = inspect.getsource(trial_plan)
+        forbidden_substrings = [
+            "uuid",
+            "random.",
+            "import random",
+            "time.time",
+            "datetime.now",
+            "datetime.utcnow",
+            " hash(",
+            "(hash(",
+        ]
+        for token in forbidden_substrings:
+            assert token not in source, f"forbidden nondeterministic token found: {token!r}"
+
+    def test_plan_digest_is_stable_across_separate_processes_with_different_hash_seeds(self):
+        """A same-process double-call cannot catch a stray Python ``hash()``
+        call, because ``PYTHONHASHSEED`` is fixed for the lifetime of one
+        process. Run the expansion in two subprocesses with different hash
+        seeds and confirm the digest still matches."""
+        script = textwrap.dedent(
+            """
+            from aces_contracts.experiment_spec import ExperimentSpecModel
+            from aptl.core.experiment.policy import default_admission_policy
+            from aptl.core.experiment.trial_plan import expand_trial_plan
+
+            payload = {
+                "schema_version": "experiment-authoring-input/v1",
+                "spec_id": "spec-flat-test-v1",
+                "spec_version": "1.0.0",
+                "title": "Flat test spec",
+                "description": "Flat allocation test fixture.",
+                "task_ref": {"ref_kind": "task", "ref_id": "task-x", "ref_version": "1.0.0"},
+                "run_plan": {
+                    "stochastic_controls": [
+                        {"control_id": "seed-a", "role": "seed", "value": 1},
+                        {"control_id": "seed-b", "role": "randomization", "value": 2},
+                    ],
+                    "episode_control": {
+                        "turn_order": "sequential",
+                        "max_steps": 10,
+                        "termination_rule": "fixed horizon",
+                    },
+                    "target_run_count": 6,
+                },
+            }
+            spec = ExperimentSpecModel.model_validate(payload)
+            plan = expand_trial_plan(
+                spec, source_set_digest="sha256:" + "ab" * 32, policy=default_admission_policy()
+            )
+            print(plan.plan_digest)
+            """
+        )
+        digests = set()
+        for seed in ("0", "1", "3391772699"):
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                env={"PYTHONHASHSEED": seed, "PATH": __import__("os").environ.get("PATH", "")},
+                capture_output=True,
+                text=True,
+                cwd="/home/atomik/src/aptl",
+                check=True,
+            )
+            digests.add(result.stdout.strip())
+        assert len(digests) == 1
+
+
+# ---------------------------------------------------------------------------
+# Map-order independence
+# ---------------------------------------------------------------------------
+
+
+class TestMapOrderIndependence:
+    def test_reordering_condition_assignments_dict_keys_does_not_change_canonical_bytes(self):
+        policy = default_admission_policy()
+        spec_a = _two_factor_condition_spec(condition_dict_order=("cond-a", "cond-b"))
+        spec_b = _two_factor_condition_spec(condition_dict_order=("cond-b", "cond-a"))
+
+        plan_a = expand_trial_plan(spec_a, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan_b = expand_trial_plan(spec_b, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        assert plan_a.canonical_bytes == plan_b.canonical_bytes
+        assert plan_a.plan_digest == plan_b.plan_digest
+
+    def test_reordering_factor_levels_dict_keys_does_not_change_canonical_bytes(self):
+        policy = default_admission_policy()
+        spec_a = _two_factor_condition_spec(factor_dict_order=("factor-x", "factor-y"))
+        spec_b = _two_factor_condition_spec(factor_dict_order=("factor-y", "factor-x"))
+
+        plan_a = expand_trial_plan(spec_a, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan_b = expand_trial_plan(spec_b, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        assert plan_a.canonical_bytes == plan_b.canonical_bytes
+        assert plan_a.plan_digest == plan_b.plan_digest
+
+    def test_reordering_the_reference_fixture_json_top_level_keys_does_not_change_canonical_bytes(self):
+        policy = default_admission_policy()
+        original = _read_corpus_reference()
+        reordered = dict(reversed(list(original.items())))
+        assert list(reordered.keys()) != list(original.keys())  # sanity: the reorder is real
+
+        spec_a = ExperimentSpecModel.model_validate(original)
+        spec_b = ExperimentSpecModel.model_validate(reordered)
+
+        plan_a = expand_trial_plan(spec_a, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan_b = expand_trial_plan(spec_b, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        assert plan_a.canonical_bytes == plan_b.canonical_bytes
+
+
+# ---------------------------------------------------------------------------
+# planned_trial_id uniqueness and reproducibility
+# ---------------------------------------------------------------------------
+
+
+class TestPlannedTrialIdUniquenessAndReproducibility:
+    def test_ids_are_unique_within_a_flat_plan(self):
+        spec = _flat_spec(target_run_count=25)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        ids = [t.planned_trial_id for t in plan.trials]
+        assert len(set(ids)) == len(ids)
+
+    def test_ids_are_unique_within_a_condition_plan(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        ids = [t.planned_trial_id for t in plan.trials]
+        assert len(set(ids)) == len(ids)
+
+    def test_ids_are_reproducible_across_expansions(self):
+        spec = _condition_reference_spec()
+        policy = default_admission_policy()
+        plan1 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan2 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        assert [t.planned_trial_id for t in plan1.trials] == [t.planned_trial_id for t in plan2.trials]
+
+    def test_ids_are_filesystem_safe(self):
+        import re
+
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        for trial in plan.trials:
+            assert re.fullmatch(r"[\w.-]+", trial.planned_trial_id)
+            assert ".." not in trial.planned_trial_id
+
+    def test_a_different_source_set_digest_changes_every_id(self):
+        spec = _flat_spec(target_run_count=3)
+        policy = default_admission_policy()
+        plan1 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan2 = expand_trial_plan(spec, source_set_digest="sha256:" + "ff" * 32, policy=policy)
+        ids1 = {t.planned_trial_id for t in plan1.trials}
+        ids2 = {t.planned_trial_id for t in plan2.trials}
+        assert ids1.isdisjoint(ids2)
+
+
+# ---------------------------------------------------------------------------
+# Seed determinism + domain separation
+# ---------------------------------------------------------------------------
+
+
+class TestSeedDeterminismAndDomainSeparation:
+    def test_same_coordinates_produce_the_same_seed_across_calls(self):
+        spec = _flat_spec(target_run_count=3)
+        policy = default_admission_policy()
+        plan1 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan2 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        assert [t.stochastic_seeds for t in plan1.trials] == [t.stochastic_seeds for t in plan2.trials]
+
+    def test_different_replication_ordinal_yields_a_different_seed(self):
+        spec = _flat_spec(target_run_count=3)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        seeds = [dict(t.stochastic_seeds)["seed-a"] for t in plan.trials]
+        assert len(set(seeds)) == len(seeds)
+
+    def test_different_condition_id_yields_a_different_seed(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        first_replication_by_condition = {
+            t.condition_id: dict(t.stochastic_seeds)["episode-seed"]
+            for t in plan.trials
+            if t.replication_ordinal == 0
+        }
+        seeds = list(first_replication_by_condition.values())
+        assert len(set(seeds)) == len(seeds) == 2
+
+    def test_different_control_id_yields_a_different_seed(self):
+        spec = _flat_spec(
+            target_run_count=1,
+            stochastic_controls=[
+                {"control_id": "seed-a", "role": "seed", "value": 1},
+                {"control_id": "seed-b", "role": "seed", "value": 1},
+            ],
+        )
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        seeds = dict(plan.trials[0].stochastic_seeds)
+        assert seeds["seed-a"] != seeds["seed-b"]
+
+    def test_seeds_are_sorted_by_control_id(self):
+        spec = _flat_spec(
+            target_run_count=1,
+            stochastic_controls=[
+                {"control_id": "z-seed", "role": "seed", "value": 1},
+                {"control_id": "a-seed", "role": "randomization", "value": 2},
+            ],
+        )
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        control_ids = [control_id for control_id, _ in plan.trials[0].stochastic_seeds]
+        assert control_ids == sorted(control_ids)
+
+    def test_only_seed_and_randomization_roles_get_a_derived_seed(self):
+        spec = _flat_spec(
+            target_run_count=1,
+            stochastic_controls=[
+                {"control_id": "seed-a", "role": "seed", "value": 1},
+                {"control_id": "rand-a", "role": "randomization", "value": 2},
+            ],
+        )
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        control_ids = {control_id for control_id, _ in plan.trials[0].stochastic_seeds}
+        assert control_ids == {"seed-a", "rand-a"}
+
+    def test_seed_values_look_like_hex_digests(self):
+        spec = _flat_spec(target_run_count=1)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        for _control_id, seed in plan.trials[0].stochastic_seeds:
+            assert len(seed) == 64
+            int(seed, 16)  # must be valid hex
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+class TestImmutability:
+    def test_trial_plan_is_frozen(self):
+        spec = _flat_spec(target_run_count=1)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        with pytest.raises(Exception):  # noqa: B017 - dataclass frozen raises FrozenInstanceError
+            plan.trials = ()  # type: ignore[misc]
+
+    def test_planned_trial_is_frozen(self):
+        spec = _flat_spec(target_run_count=1)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        trial = plan.trials[0]
+        with pytest.raises(Exception):  # noqa: B017
+            trial.condition_id = "mutated"  # type: ignore[misc]
+
+    def test_trials_is_a_tuple_not_a_list(self):
+        spec = _flat_spec(target_run_count=2)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert isinstance(plan.trials, tuple)
+
+    def test_per_trial_fields_are_tuples_not_lists_or_dicts(self):
+        spec = _condition_reference_spec()
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        trial = plan.trials[0]
+        assert isinstance(trial.factor_levels, tuple)
+        assert isinstance(trial.parameter_bindings, tuple)
+        assert isinstance(trial.stochastic_seeds, tuple)
+        assert isinstance(trial.capture_spec_refs, tuple)
+
+    def test_mutating_a_caller_supplied_condition_snapshot_digests_mapping_after_the_call_has_no_effect(self):
+        spec = _condition_reference_spec()
+        digests = {"cond-aggressive": "sha256:" + "1" * 64, "cond-stealthy": "sha256:" + "2" * 64}
+        original = copy.deepcopy(digests)
+
+        plan = expand_trial_plan(
+            spec, source_set_digest=SOURCE_SET_DIGEST, condition_snapshot_digests=digests, policy=default_admission_policy()
+        )
+        digests["cond-aggressive"] = "sha256:" + "9" * 64
+        digests.clear()
+
+        for trial in plan.trials:
+            assert trial.scenario_snapshot_digest == original[trial.condition_id]
+
+
+# ---------------------------------------------------------------------------
+# Unsupported stochastic role / allocation method
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedStochasticRole:
+    def test_an_unsupported_role_is_rejected(self):
+        spec = _flat_spec(
+            target_run_count=1,
+            stochastic_controls=[{"control_id": "sampler", "role": "sampling", "value": 1}],
+        )
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+        assert all(d.is_error for d in excinfo.value.diagnostics)
+
+    def test_a_supported_role_alongside_an_unsupported_role_still_rejects(self):
+        spec = _flat_spec(
+            target_run_count=1,
+            stochastic_controls=[
+                {"control_id": "seed-a", "role": "seed", "value": 1},
+                {"control_id": "scheduler-a", "role": "scheduler", "value": "x"},
+            ],
+        )
+
+        with pytest.raises(AdmissionRejection):
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+
+
+class TestUnsupportedAllocationMethod:
+    def test_an_unmapped_allocation_method_is_rejected_via_resolve_allocation_ordering(self):
+        payload = _condition_spec_payload(
+            condition_assignments={
+                "cond-a": _condition_assignment("cond-a", {"f": "1"}, "1"),
+                "cond-b": _condition_assignment("cond-b", {"f": "2"}, "2"),
+            },
+            compared_conditions=["cond-a", "cond-b"],
+            allocation_method="definitely-not-a-real-method",
+        )
+        spec = ExperimentSpecModel.model_validate(payload)
+
+        with pytest.raises(AdmissionRejection) as excinfo:
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+
+        assert excinfo.value.diagnostics
+        assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
+
+    def test_an_allocation_method_that_resolves_to_flat_is_rejected_for_a_condition_allocation(self):
+        """``allocation_method="flat"`` maps to ``OrderingKind.FLAT`` in the
+        default policy table, but a condition allocation (compared_conditions
+        + condition_assignments present) has no flat expansion algorithm —
+        this must fail closed rather than silently mis-expand."""
+        payload = _condition_spec_payload(
+            condition_assignments={
+                "cond-a": _condition_assignment("cond-a", {"f": "1"}, "1"),
+                "cond-b": _condition_assignment("cond-b", {"f": "2"}, "2"),
+            },
+            compared_conditions=["cond-a", "cond-b"],
+            allocation_method="flat",
+        )
+        spec = ExperimentSpecModel.model_validate(payload)
+
+        with pytest.raises(AdmissionRejection):
+            expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+
+
+# ---------------------------------------------------------------------------
+# Fuzz (property-based)
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@pytest.mark.fuzz
+class TestFuzzFlatExpansion:
+    @given(target_run_count=st.integers(min_value=1, max_value=500))
+    @settings(max_examples=25, deadline=None)
+    def test_contiguous_ordering_unique_ids_and_stable_repeat(self, target_run_count):
+        spec = _flat_spec(target_run_count=target_run_count)
+        policy = default_admission_policy()
+
+        plan1 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan2 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        assert [t.ordering_index for t in plan1.trials] == list(range(target_run_count))
+        ids = [t.planned_trial_id for t in plan1.trials]
+        assert len(set(ids)) == len(ids)
+        assert plan1.canonical_bytes == plan2.canonical_bytes
+
+
+@pytest.mark.fuzz
+class TestFuzzConditionExpansion:
+    @given(
+        num_conditions=st.integers(min_value=1, max_value=6),
+        target_runs_per_condition=st.integers(min_value=1, max_value=30),
+    )
+    @settings(max_examples=25, deadline=None)
+    def test_contiguous_ordering_unique_ids_and_stable_repeat(self, num_conditions, target_runs_per_condition):
+        condition_ids = [f"cond-{i}" for i in range(num_conditions)]
+        condition_assignments = {
+            cid: _condition_assignment(cid, {"f": cid}, cid) for cid in condition_ids
+        }
+        payload = _condition_spec_payload(
+            condition_assignments=condition_assignments,
+            compared_conditions=condition_ids,
+            target_runs_per_condition=target_runs_per_condition,
+        )
+        spec = ExperimentSpecModel.model_validate(payload)
+        policy = default_admission_policy()
+
+        plan1 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan2 = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        total = num_conditions * target_runs_per_condition
+        assert [t.ordering_index for t in plan1.trials] == list(range(total))
+        expected_sequence = [
+            (cid, ordinal) for cid in condition_ids for ordinal in range(target_runs_per_condition)
+        ]
+        assert [(t.condition_id, t.replication_ordinal) for t in plan1.trials] == expected_sequence
+        ids = [t.planned_trial_id for t in plan1.trials]
+        assert len(set(ids)) == len(ids)
+        assert plan1.canonical_bytes == plan2.canonical_bytes
+
+
+@pytest.mark.fuzz
+class TestFuzzDictOrderingNeverChangesCanonicalBytes:
+    @given(seed=st.integers(min_value=0, max_value=2**32 - 1))
+    @settings(max_examples=25, deadline=None)
+    def test_shuffled_condition_and_factor_dict_order_is_invariant(self, seed):
+        import random
+
+        rng = random.Random(seed)  # noqa: S311 - test-only shuffling, not plan derivation
+        condition_order = ["cond-a", "cond-b"]
+        rng.shuffle(condition_order)
+        factor_order = ["factor-x", "factor-y"]
+        rng.shuffle(factor_order)
+
+        spec_shuffled = _two_factor_condition_spec(
+            condition_dict_order=tuple(condition_order), factor_dict_order=tuple(factor_order)
+        )
+        spec_canonical = _two_factor_condition_spec()
+        policy = default_admission_policy()
+
+        plan_shuffled = expand_trial_plan(spec_shuffled, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        plan_canonical = expand_trial_plan(spec_canonical, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+
+        assert plan_shuffled.canonical_bytes == plan_canonical.canonical_bytes

--- a/tests/test_pathsafe.py
+++ b/tests/test_pathsafe.py
@@ -1,0 +1,193 @@
+"""Tests for the shared descriptor-relative, no-follow containment helper.
+
+ADR-047 "Authorized artifact resolution": resolving a path and checking its
+prefix is not enough because a symlink can change between the check and a
+later open (TOCTOU). ``aptl.utils.pathsafe`` walks an untrusted relative
+path component-by-component with ``os.open(..., O_NOFOLLOW, dir_fd=...)``
+(openat-style) and hands callers the ONE handle that was opened, so nothing
+can be swapped underneath a check.
+"""
+
+import os
+
+import pytest
+
+from aptl.utils.pathsafe import (
+    PathContainmentError,
+    open_contained_nofollow,
+    read_contained_nofollow,
+)
+
+
+class TestHappyPath:
+    def test_reads_exact_bytes_of_a_contained_file(self, tmp_path):
+        (tmp_path / "scenario.yaml").write_bytes(b"name: custom\n")
+
+        data = read_contained_nofollow(tmp_path, "scenario.yaml")
+
+        assert data == b"name: custom\n"
+
+    def test_reads_a_nested_contained_file(self, tmp_path):
+        nested = tmp_path / "scenarios" / "sub"
+        nested.mkdir(parents=True)
+        (nested / "file.txt").write_bytes(b"hello")
+
+        data = read_contained_nofollow(tmp_path, "scenarios/sub/file.txt")
+
+        assert data == b"hello"
+
+    def test_open_contained_nofollow_returns_a_closeable_binary_handle(self, tmp_path):
+        (tmp_path / "f.txt").write_bytes(b"payload")
+
+        handle = open_contained_nofollow(tmp_path, "f.txt")
+        try:
+            assert handle.read() == b"payload"
+        finally:
+            handle.close()
+        assert handle.closed
+
+    def test_usable_as_a_context_manager(self, tmp_path):
+        (tmp_path / "f.txt").write_bytes(b"payload")
+
+        with open_contained_nofollow(tmp_path, "f.txt") as handle:
+            assert handle.read() == b"payload"
+
+
+class TestRejectsAbsolutePaths:
+    def test_rejects_absolute_relative_path(self, tmp_path):
+        (tmp_path / "f.txt").write_bytes(b"x")
+
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "/etc/passwd")
+
+        assert excinfo.value.reason == "not_relative"
+
+
+class TestRejectsTraversal:
+    def test_rejects_dotdot_component(self, tmp_path):
+        outside = tmp_path.parent / "outside-pathsafe-test.txt"
+        outside.write_bytes(b"secret")
+        try:
+            with pytest.raises(PathContainmentError) as excinfo:
+                open_contained_nofollow(tmp_path, "../outside-pathsafe-test.txt")
+            assert excinfo.value.reason == "traversal"
+        finally:
+            outside.unlink()
+
+    def test_rejects_dotdot_component_in_the_middle(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "sub/../f.txt")
+        assert excinfo.value.reason == "traversal"
+
+
+class TestRejectsNulBytes:
+    def test_rejects_nul_byte_in_path(self, tmp_path):
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "foo\x00bar")
+        assert excinfo.value.reason == "nul_byte"
+
+
+class TestRejectsEmptyComponents:
+    def test_rejects_empty_string_path(self, tmp_path):
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "")
+        assert excinfo.value.reason == "empty_component"
+
+    def test_rejects_double_slash(self, tmp_path):
+        (tmp_path / "foo").mkdir()
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "foo//bar")
+        assert excinfo.value.reason == "empty_component"
+
+    def test_rejects_trailing_slash(self, tmp_path):
+        (tmp_path / "foo").write_bytes(b"x")
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "foo/")
+        assert excinfo.value.reason == "empty_component"
+
+
+class TestRejectsNonFileTargets:
+    def test_rejects_directory_leaf(self, tmp_path):
+        (tmp_path / "adir").mkdir()
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "adir")
+        assert excinfo.value.reason == "not_regular_file"
+
+    def test_rejects_missing_file(self, tmp_path):
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "missing.txt")
+        assert excinfo.value.reason == "not_found"
+
+
+class TestRejectsSymlinkedComponents:
+    def test_rejects_symlinked_directory_component(self, tmp_path):
+        outside_dir = tmp_path.parent / "pathsafe-outside-dir"
+        outside_dir.mkdir(exist_ok=True)
+        (outside_dir / "file.txt").write_bytes(b"outside contents")
+        try:
+            link_dir = tmp_path / "link_dir"
+            link_dir.symlink_to(outside_dir, target_is_directory=True)
+
+            with pytest.raises(PathContainmentError) as excinfo:
+                open_contained_nofollow(tmp_path, "link_dir/file.txt")
+            assert excinfo.value.reason == "symlink"
+        finally:
+            import shutil
+
+            shutil.rmtree(outside_dir, ignore_errors=True)
+
+    def test_rejects_symlinked_leaf(self, tmp_path):
+        target = tmp_path / "target.txt"
+        target.write_bytes(b"real content")
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path, "link.txt")
+        assert excinfo.value.reason == "symlink"
+
+    def test_symlinked_leaf_is_rejected_even_when_pointing_inside_base(self, tmp_path):
+        # A symlink pointing INSIDE base_dir is still a symlink component;
+        # no-follow rejects it regardless of where it ultimately points —
+        # the point is TOCTOU-proofing the walk itself, not the target.
+        target = tmp_path / "inside.txt"
+        target.write_bytes(b"inside content")
+        link = tmp_path / "inside-link.txt"
+        link.symlink_to(target)
+
+        with pytest.raises(PathContainmentError) as excinfo:
+            read_contained_nofollow(tmp_path, "inside-link.txt")
+        assert excinfo.value.reason == "symlink"
+
+
+class TestOneOpenIsToctouProof:
+    def test_handle_reads_original_bytes_even_after_the_path_is_swapped(self, tmp_path):
+        target = tmp_path / "f.txt"
+        target.write_bytes(b"original")
+
+        handle = open_contained_nofollow(tmp_path, "f.txt")
+        try:
+            # Simulate an attacker swapping the file's contents after the
+            # handle was opened but before the caller reads it. Because the
+            # fd already references the original inode, the swap cannot
+            # change what gets read — proving there is exactly one open.
+            os.unlink(target)
+            target.write_bytes(b"swapped-by-attacker")
+
+            assert handle.read() == b"original"
+        finally:
+            handle.close()
+
+    def test_read_convenience_returns_bytes_from_the_single_open(self, tmp_path):
+        target = tmp_path / "f.txt"
+        target.write_bytes(b"exact bytes 123")
+
+        assert read_contained_nofollow(tmp_path, "f.txt") == b"exact bytes 123"
+
+
+class TestBaseDirUnavailable:
+    def test_missing_base_dir_raises_path_containment_error(self, tmp_path):
+        with pytest.raises(PathContainmentError) as excinfo:
+            open_contained_nofollow(tmp_path / "does-not-exist", "f.txt")
+        assert excinfo.value.reason == "base_dir_unavailable"

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from aptl.utils.redaction import REDACTED, redact
+from aptl.utils.redaction import REDACTED, is_secret_shaped_value, is_sensitive_key, redact
 
 
 class TestRedactScalars:
@@ -873,3 +873,133 @@ class TestRedactorBounds:
     def test_bytes_in_container_are_redacted(self):
         out = redact({"blob": b"api_key=AKIA1234567890"})
         assert out == {"blob": f"api_key={REDACTED}"}
+
+
+class TestIsSensitiveKeyPredicate:
+    """``is_sensitive_key`` is the public yes/no wrapper around the same
+    ``_is_sensitive_key``/``_SENSITIVE_TOKENS`` table ``redact()`` uses for
+    dict keys (ADR-047 "Secret handling"). It must stay in lockstep with
+    what ``redact()`` actually does to a dict value under that key — no
+    separate token table.
+    """
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "password",
+            "passwd",
+            "passphrase",
+            "secret",
+            "token",
+            "credential",
+            "credentials",
+            "authorization",
+            "cookie",
+            "jwt",
+            "bearer",
+            "api_key",
+            "apikey",
+            "key",
+            "session",
+            "session_id",
+            "Password",
+            "API_KEY",
+            "ssl_authorization_header",
+            "oauth_token_url",
+        ],
+    )
+    def test_true_for_every_sensitive_key(self, key):
+        assert is_sensitive_key(key) is True
+
+    @pytest.mark.parametrize("key", ["name", "host", "port", "ok", "num"])
+    def test_false_for_non_sensitive_keys(self, key):
+        assert is_sensitive_key(key) is False
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "key_path",
+            "key_file",
+            "keypath",
+            "keyfile",
+            "ssh_key_path",
+            "ssh_keyfile",
+            "public_key",
+            "publickey",
+        ],
+    )
+    def test_false_for_safe_key_allowlist(self, key):
+        assert is_sensitive_key(key) is False
+
+    @pytest.mark.parametrize("key", ["ssh_key", "sshkey"])
+    def test_true_for_bare_ssh_key(self, key):
+        assert is_sensitive_key(key) is True
+
+    @pytest.mark.parametrize("key", ["password", "host", "key_path", "ssh_key"])
+    def test_agrees_with_redact_on_a_dict_value(self, key):
+        # Ground truth: is_sensitive_key(key) must predict exactly whether
+        # redact({key: "value"}) masks "value" wholesale.
+        out = redact({key: "value"})
+        assert is_sensitive_key(key) == (out[key] == REDACTED)
+
+
+class TestIsSecretShapedValuePredicate:
+    """``is_secret_shaped_value`` is the public yes/no wrapper reusing
+    ``redact()``'s own recursive core — it IS the transform, compared
+    against its input, so it cannot drift out of lockstep with what
+    ``redact()`` actually changes (ADR-047 "Secret handling": reuse
+    classification rather than copying token/regex tables).
+    """
+
+    def test_true_for_a_bare_password_string(self):
+        assert is_secret_shaped_value("password: hunter2") is True
+
+    def test_true_for_authorization_header_value(self):
+        assert is_secret_shaped_value("Authorization: Bearer abc.def.ghi") is True
+
+    def test_true_for_cli_flag_credential_value(self):
+        assert is_secret_shaped_value("--password=hunter2") is True
+
+    def test_false_for_ordinary_string(self):
+        assert is_secret_shaped_value("hello world") is False
+
+    def test_false_for_non_string_scalars(self):
+        assert is_secret_shaped_value(42) is False
+        assert is_secret_shaped_value(True) is False
+        assert is_secret_shaped_value(None) is False
+
+    def test_true_for_bytes_with_embedded_credential(self):
+        assert is_secret_shaped_value(b"token: abc") is True
+
+    def test_false_for_unmodified_bytes(self):
+        assert is_secret_shaped_value(b"just plain bytes") is False
+
+    def test_true_for_dict_with_sensitive_key(self):
+        # A container "value" is secret-shaped if redact() would touch it
+        # anywhere inside — including via a nested sensitive key.
+        assert is_secret_shaped_value({"password": "x"}) is True
+
+    def test_false_for_dict_with_no_secret_content(self):
+        assert is_secret_shaped_value({"host": "dc01", "port": 445}) is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "password: hunter2",
+            "hello world",
+            {"password": "x"},
+            {"host": "dc01"},
+            b"token: abc",
+            b"just plain bytes",
+            42,
+            None,
+        ],
+    )
+    def test_agrees_with_redact_on_arbitrary_values(self, value):
+        # Ground truth: is_secret_shaped_value(value) must predict exactly
+        # whether redact() changes `value` at all.
+        if isinstance(value, (bytes, bytearray)):
+            baseline = bytes(value).decode("utf-8", "replace")
+        else:
+            baseline = value
+        assert is_secret_shaped_value(value) == (redact(value) != baseline)

--- a/tests/test_scenario_catalog.py
+++ b/tests/test_scenario_catalog.py
@@ -138,6 +138,65 @@ scenarios:
         resolve_scenario_selection(tmp_path, scenario_id="escape")
 
 
+def test_rejects_symlinked_scenario_path(tmp_path):
+    """ADR-047 strengthens ``_resolve_project_file`` to no-follow, one-open
+    containment (``aptl.utils.pathsafe``). A symlinked scenario file is a
+    behavior change from the prior lexical ``resolve()`` +
+    ``is_relative_to()`` check, which *would* have followed it as long as
+    the resolved target stayed under ``project_dir``. That prior check was
+    TOCTOU-able (the symlink could change between check and the later
+    ``parse_sdl_file`` open), so the safer behavior is outright rejection —
+    this pins that as the new, intended contract.
+    """
+    from aptl.core.scenario_catalog import resolve_scenario_selection
+
+    (tmp_path / "scenarios").mkdir()
+    real_target = tmp_path / "scenarios" / "real.sdl.yaml"
+    real_target.write_text("name: custom\n")
+    (tmp_path / "scenarios" / "custom.sdl.yaml").symlink_to(real_target)
+    _write_catalog(
+        tmp_path,
+        """
+version: 1
+scenarios:
+  - id: custom
+    name: Custom ACES
+    path: scenarios/custom.sdl.yaml
+""",
+    )
+
+    with pytest.raises(ValueError, match="does not exist"):
+        resolve_scenario_selection(tmp_path, scenario_id="custom")
+
+
+def test_rejects_symlinked_scenario_directory_component(tmp_path):
+    """A symlinked *directory* component (not just the leaf) is rejected too."""
+    from aptl.core.scenario_catalog import resolve_scenario_selection
+
+    outside_dir = tmp_path.parent / "scenario-catalog-outside-dir"
+    outside_dir.mkdir(exist_ok=True)
+    (outside_dir / "custom.sdl.yaml").write_text("name: custom\n")
+    try:
+        (tmp_path / "scenarios").symlink_to(outside_dir, target_is_directory=True)
+        _write_catalog(
+            tmp_path,
+            """
+version: 1
+scenarios:
+  - id: custom
+    name: Custom ACES
+    path: scenarios/custom.sdl.yaml
+""",
+        )
+
+        with pytest.raises(ValueError, match="does not exist"):
+            resolve_scenario_selection(tmp_path, scenario_id="custom")
+    finally:
+        import shutil
+
+        shutil.rmtree(outside_dir, ignore_errors=True)
+
+
 def test_rejects_missing_catalog_sdl(tmp_path):
     from aptl.core.scenario_catalog import resolve_scenario_selection
 

--- a/uv.lock
+++ b/uv.lock
@@ -72,6 +72,7 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "rfc8785" },
     { name = "rich" },
     { name = "typer" },
 ]
@@ -122,6 +123,7 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rfc8785", specifier = ">=0.1.4,<0.2.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
     { name = "sse-starlette", marker = "extra == 'web'", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

Implements EXP-002, the ACES experiment-admission slice: an all-or-nothing boundary above lab lifecycle that consumes ACES experiment-authoring-input-v1 specs and their referenced task/capture/scenario artifacts through published ACES APIs, validates closed-world structure, artifact identities and digests, supported contract versions, and apparatus/capture capabilities, then expands the run allocation into a deterministic, immutable, RFC-8785-canonical trial plan with stable planned-trial IDs and domain-separated seeds, persisted create-once through the run-store containment/redaction boundary. Fail-closed throughout; nothing mutates the range until the full plan is admitted and persisted. Anchored on ADR-047 (refined to the verified aces-sdl 0.23.1 surface). A clearly-named --allow-uncertified-apparatus debug flag admits against the real aptl manifest for dev/test. No local ACES schema is defined; execution of trials stays downstream (#437/#459).

## Requirement UIDs

- `EXP-002`

## Related Issues

Closes #438

## ADR Impact

- ADR-047

## Changes

- New src/aptl/core/experiment/ package: authorized artifact resolver (offline, project-contained, no-follow one-open, digest/size verified), spec loading (byte-bound + duplicate-key preflight into published ACES loaders + canonical digests), apparatus admission (conjunctive task ∧ intent, fail-closed mutual-compat gate, planning-only reference processor), capture mapping (fail-closed; create_aptl_manifest().observation is None), deterministic immutable trial-plan expander, admission coordinator, controller, and admission diagnostics
- aptl experiment admit CLI — admission only, never mutates the range — with a --allow-uncertified-apparatus debug override (default off, warns) for dev/test against the real aptl manifest
- Shared utils/pathsafe.py no-follow descriptor-relative one-open containment helper; scenario_catalog._resolve_project_file strengthened to use it
- runstore.create_json_once: create-once canonical RFC-8785 persistence with a secret-invariant check, no-follow publication, and idempotent-identical / reject-different semantics
- redaction secret classifier exposed as reusable is_sensitive_key/is_secret_shaped_value predicates; render_aces_diagnostics stage label parameterized
- rfc8785 promoted from a transitive to a direct runtime dependency
- ADR-047 refined to the verified aces-sdl 0.23.1 API surface (parse_sdl + reference processor; stale-venv, mutual-compat, and observation-None gotchas)
- Tests: unit, property-based (fuzz marker), contract-fixture against the installed ACES corpus, and mutation-spy proving a rejected admission makes zero lab/cert/ssh/env/collector/docker/run-store calls

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: EXP-002 ← src/aptl/core/experiment/admission.py, EXP-002 ← src/aptl/core/experiment/controller.py, EXP-002 ← src/aptl/core/experiment/trial_plan.py, EXP-002 ← src/aptl/core/experiment/resolver.py, EXP-002 ← src/aptl/core/experiment/apparatus.py, EXP-002 ← src/aptl/core/experiment/spec_loading.py, EXP-002 ← src/aptl/core/experiment/capture_mapping.py, EXP-002 ← src/aptl/core/experiment/policy.py, EXP-002 ← src/aptl/cli/experiment.py
- TESTS: EXP-002 ← tests/test_experiment_admission.py, EXP-002 ← tests/test_experiment_contract.py, EXP-002 ← tests/test_experiment_trial_plan.py, EXP-002 ← tests/test_experiment_resolver.py, EXP-002 ← tests/test_experiment_apparatus.py, EXP-002 ← tests/test_experiment_spec_loading.py, EXP-002 ← tests/test_experiment_persistence.py, EXP-002 ← tests/test_experiment_cli.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
