### PR TITLE
fix: harden Suricata seed ownership-repair helper container

### DIFF
--- a/src/aptl/core/suricata_seed.py
+++ b/src/aptl/core/suricata_seed.py
@@ -23,6 +23,7 @@ from aptl.core.credentials import (
     _canonical_generated_path,
     _resolve_within_project,
 )
+from aptl.core.deployment._compose_seed_safety import redacted_stderr_hint
 from aptl.core.seed_spec import NamedVolumeSeed, SeedFile
 from aptl.utils.logging import get_logger
 
@@ -127,6 +128,12 @@ def _restore_via_container(
         perm_result = subprocess.run(
             [
                 "docker", "run", "--rm",
+                # Harden the throwaway repair helper: no network namespace
+                # (it only chowns local bind-mounted files — zero egress
+                # surface), and an explicit root identity so the chown works
+                # regardless of the seeder image's default user.
+                "--network", "none",
+                "--user", "0:0",
                 "--entrypoint", "chown",
                 "-v", f"{project_dir}:/project",
                 seeder_image,
@@ -147,11 +154,14 @@ def _restore_via_container(
         )
 
     if perm_result.returncode != 0:
+        # Route container stderr through the canonical seed-path redactor
+        # rather than surfacing it verbatim, so a leaked host path or secret
+        # in the tool's output never reaches the error string or logs.
         return SuricataSourceOwnershipResult(
             success=False,
             error=(
-                perm_result.stderr.strip()
-                or "Suricata config ownership restore failed"
+                "Suricata config ownership restore failed"
+                + redacted_stderr_hint(perm_result.stderr)
             ),
         )
 

--- a/src/aptl/core/suricata_seed.py
+++ b/src/aptl/core/suricata_seed.py
@@ -23,7 +23,6 @@ from aptl.core.credentials import (
     _canonical_generated_path,
     _resolve_within_project,
 )
-from aptl.core.deployment._compose_seed_safety import redacted_stderr_hint
 from aptl.core.seed_spec import NamedVolumeSeed, SeedFile
 from aptl.utils.logging import get_logger
 
@@ -121,6 +120,14 @@ def _restore_via_container(
     runs as root and chowns the bind-mounted files to the invoking user.
     Reuses the Suricata seeder image, which is already present at this step.
     """
+    # Import at point of use, not module scope: importing anything from
+    # ``aptl.core.deployment`` runs that package's __init__ (docker_compose →
+    # … → cryptography), which the lightweight ``suricata-config-source-
+    # ownership`` pre-commit hook environment does not install. This repair
+    # path only runs on a native-Linux host with the full deps present, so the
+    # heavy import is safe here while keeping module import lightweight.
+    from aptl.core.deployment._compose_seed_safety import redacted_stderr_hint
+
     rel_targets = [
         f"/project/{p.relative_to(project_dir).as_posix()}" for p in still_foreign
     ]

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -898,6 +898,12 @@ class TestEnsureSuricataConfigSourceOwnership:
         assert "run" in calls[0] and "--entrypoint" in calls[0] and "chown" in calls[0]
         assert "sudo" not in calls[0]
         assert self._IMAGE in calls[0]
+        # #678 hardening: the throwaway helper has no network and runs as an
+        # explicit root, so it can chown regardless of the image default user
+        # while offering no egress.
+        cmd = calls[0]
+        assert cmd[cmd.index("--network") + 1] == "none"
+        assert cmd[cmd.index("--user") + 1] == "0:0"
 
     def test_reports_error_when_container_repair_fails(self, tmp_path, monkeypatch):
         from aptl.core.suricata_seed import ensure_suricata_config_source_ownership
@@ -920,14 +926,30 @@ class TestEnsureSuricataConfigSourceOwnership:
             lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError()),
         )
 
+        # Credential-shaped fragment so the assertions below exercise the
+        # actual redact() pass, not just the message envelope: a regression
+        # to interpolating raw perm_result.stderr would leak this token.
+        secret = "s3cr3tLEAK123"
+
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 1, "", "chown: operation not permitted")
+            return subprocess.CompletedProcess(
+                cmd, 1, "", f"chown: operation not permitted; token={secret}"
+            )
 
         monkeypatch.setattr(subprocess, "run", fake_run)
 
         result = ensure_suricata_config_source_ownership(tmp_path, self._IMAGE)
         assert result.success is False
-        assert "not permitted" in result.error
+        # #678 hardening: container stderr is routed through the canonical
+        # redaction helper (fixed base message + " — stderr: …"), never
+        # returned verbatim.
+        assert result.error.startswith("Suricata config ownership restore failed")
+        assert "stderr:" in result.error
+        # The secret is stripped and marked, while a benign portion of the
+        # same stderr survives — proving redact() actually ran on it.
+        assert secret not in result.error
+        assert "[REDACTED]" in result.error
+        assert "operation not permitted" in result.error
         assert "sudo" not in result.error
 
 


### PR DESCRIPTION
## Summary

Harden the throwaway container that repairs Suricata seed-source ownership on native-Linux Docker hosts. #678's original acceptance (no host sudo, linux-native-gated repair, Windows-safe uid/gid) already shipped in commit 4cc3987; this PR adds the architecture-preflight-identified hardening to that helper: the chown `docker run` now uses `--network none` (no egress) and an explicit `--user 0:0` (root-to-chown regardless of the image default), and its failure path routes container stderr through the canonical `redacted_stderr_hint()` instead of returning it verbatim.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #678

## ADR Impact

- ADR-043

## Changes

- `src/aptl/core/suricata_seed.py`: `_restore_via_container` adds `--network none` and explicit `--user 0:0` to the chown `docker run` argv; the returncode!=0 branch now builds the error from a fixed base message + `redacted_stderr_hint(perm_result.stderr)` rather than the raw stderr.
- `tests/test_credentials.py`: extend the two container tests to pin `--network none`/`--user 0:0` in the argv, and drive `redact()` with a credential-shaped stderr fragment, asserting the secret is stripped (`[REDACTED]`) while a benign portion survives.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Full non-integration suite 2341 passed / 92 skipped; integration static gate 2/2; pre-commit all green (incl. the Suricata ownership hook). Codex core+security pre-push review: ship, 0 findings. Test-quality review: 1 finding (redaction had message-shape coverage only) fixed by exercising real redaction.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.
