### PR TITLE
feat: add experiment correlation identity and clock-context projection (OBS-002)

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -161,3 +161,4 @@ The victim and kali containers publish no host ports; use
 - [DEP-003 Ephemeral Lifecycle Policy](dep-003-ephemeral-lifecycle-preflight.md)
 - [GRC Boundary Surface Vocabulary](grc-boundary-surface-vocabulary-preflight.md)
 - [Issue #677 Certificate Producer Ownership](issue-677-cert-producer-ownership-preflight.md)
+- [OBS-002 Correlation Identity And Clock Context](obs-002-correlation-identity-clock-preflight.md)

--- a/docs/architecture/obs-002-correlation-identity-clock-preflight.md
+++ b/docs/architecture/obs-002-correlation-identity-clock-preflight.md
@@ -1,0 +1,214 @@
+# OBS-002 Correlation Identity And Clock Context Preflight
+
+This note is the architecture preflight for OBS-002 / issue #447. It is
+guidance, not an implementation plan. No new ADR is needed: ADR-012 owns
+OpenTelemetry integration, ADR-027 owns red-team structured logging, ADR-029
+owns secret handling and redaction, ADR-033 owns the reasoning trace boundary,
+ADR-041 and ADR-042 own Kali capture and PTY ownership, ADR-044 owns the
+ACES-aligned run record, ADR-046 owns dynamic ACES realization, and ADR-047
+owns experiment admission and trial-plan determinism.
+
+OBS-002 adds one cross-cutting rule: action-to-observation linkage must be
+auditable without treating timestamp proximity as causality. Stable identity,
+clock context, evidence source limits, and observer effects must travel through
+the existing ACES, control-plane, capture, and archive contracts rather than a
+new local tracing vocabulary.
+
+## Architecture Decisions
+
+- Reuse ACES experiment and runtime identities as the portable identities:
+  `ExperimentSpecModel.spec_id/spec_version`, task refs and task
+  `task_id/task_version`, run-plan condition/allocation identifiers,
+  `TrialPlan.plan_id`, `TrialPlan.plan_digest`,
+  `TrialPlan.source_set_digest`, `PlannedTrial.planned_trial_id`,
+  ACES participant addresses and episode IDs, participant runtime event/action
+  refs, capture spec/requirement/window refs, evidence record refs, derived
+  measure/evaluation refs, and `ExperimentRunModel.run_id`.
+- Treat APTL `trace_id`, MCP `session_id`, and sidecar capture session IDs as
+  local correlation and routing facts, not replacements for experiment, planned
+  trial, attempt/run, participant episode, action, capture, evidence, or
+  evaluator identities. They may appear as related metadata only when validated
+  and redacted according to the existing runstore/MCP policies.
+- Preserve the deterministic admission boundary. Planned identities must be
+  derived from ACES inputs through `TrialPlan` and canonical JSON hashing, not
+  from wall clock, filesystem order, UUIDs, process-global randomness, or
+  runtime ingestion order. Per-attempt identities are allowed only where the
+  surface is explicitly a run/attempt/episode result, and they must not be
+  mistaken for planned identity.
+- Represent correlation as a graph of typed associations over existing refs.
+  The minimum association methods are `explicit_identifier`, `declared_rule`,
+  `time_window_candidate`, and `gap_or_unknown`. Timestamp proximity alone is
+  never a causal link. `SourcePipelineModel.correlation_uid` is a source fact;
+  it is not automatically an APTL causal edge.
+- Record clock context per evidence source and timestamp domain. ACES already
+  provides `ExperimentClockContextModel`, run-plan `clock_intent`,
+  participant runtime `occurred_at`/`recorded_at`/`ingested_at` plus
+  `clock_authority`, source pipeline timestamp fields, participant
+  time-management contexts, capture windows, evidence `captured_at`, and
+  derived-measure `generated_at`. APTL may add archive-local projections only
+  to connect these contracts to local run files and collector outputs.
+- Disclose observer effects with the existing realized-form and augmentation
+  disclosure contracts. Injecting metadata into a range component, blue
+  telemetry source, command stream, environment, capture channel, or runtime
+  binding is an experiment augmentation unless the channel is already
+  documented as a non-secret control-plane channel.
+- Keep capture capability declarations honest. APTL may admit capture
+  requirements only when `create_aptl_manifest().observation` and
+  `SUPPORTED_CAPTURE_CAPABILITIES` describe the supported non-secret channel.
+  A collector function or sidecar path by itself is not a portable capture
+  capability claim.
+
+## Cross-Cutting Concerns To Reuse
+
+| Layer | Canonical incumbent and required behavior |
+|---|---|
+| ACES experiment contracts | Use `aces_contracts.contracts` models for experiment specs, tasks, run plans, clock contexts, capture specs, evidence records, derived measures, run traceability, realized-form disclosures, augmentation disclosures, and participant runtime envelopes. Do not mirror these schemas in APTL DTOs. |
+| Admission and planning | `src/aptl/core/experiment/spec_loading.py`, `resolver.py`, `admission.py`, `admission_steps.py`, `trial_plan.py`, `capture_mapping.py`, `apparatus.py`, and `errors.py` own bounded loading, project-contained resolution, ACES validation, deterministic planned-trial IDs, fail-closed capture support, and safe diagnostics. |
+| Runtime adapters | `src/aptl/backends/aces.py`, `aces_orchestrator.py`, `aces_evaluator.py`, `aces_participant_runtime.py`, `aces_participant_actions.py`, `aces_participant_support.py`, `aces_participant_bindings.py`, `aces_observation.py`, and `aces_repro.py` are the owners of ACES workflow, evaluation, participant, observation, and run-record projections. |
+| Run archive and persistence | `src/aptl/core/runstore.py` owns run/session ID validation, active trace lookup, `.aptl/runs/<run_id>` layout, `create_json_once`, JSON/JSONL persistence, and redacted structured writes. `src/aptl/core/exporter.py` packages archives; it is not a sanitizer or correlation builder. |
+| Telemetry and red logs | `src/aptl/core/telemetry.py`, `mcp/aptl-mcp-common/src/telemetry.ts`, `mcp/mcp-red/src/capture.ts`, and `mcp/mcp-red/src/logger.ts` own trace context, OTel attributes, MCP tool-call capture, OCSF-shaped red activity logs, and best-effort local sinks. Extend those envelopes through existing redaction/truncation paths. |
+| Capture sidecar | `containers/kali-capture/writer.py`, `mcp/aptl-mcp-common/src/runs.ts`, `captures.ts`, and `tools/handlers.ts` own ID checks, run-path resolution, PTY tee files, bounded sidecar RPC, Docker-copy harvest, and MCP result envelopes. Do not add path, command, chmod, truncate, delete, or shell execution to the sidecar for correlation. |
+| Config and environment | `src/aptl/config.py`, `src/aptl/core/config_models.py`, `src/aptl/core/env.py`, `mcp/aptl-mcp-common/src/config.ts`, `aptlShellEnv`, and ADR-025 own first-party config and explicit runtime environment binding. Add no free-form `correlation` dict or parallel env parser. |
+| Secret handling and errors | `src/aptl/core/redaction.py`, `mcp/aptl-mcp-common/src/redaction.ts`, `curl_safe`, `AdmissionRejection`, `Diagnostic`, `LabResult`, `StartupDiagnostic`, `SSHError`, and MCP `harvest_warning` own redaction and error envelopes. Correlation metadata must pass through these instead of adding a new exception hierarchy. |
+| API and web auth | `src/aptl/api/deps.py` and `src/aptl/api/middleware/bff.py` own bearer-token verification, WebSocket token handling, host/CSRF gates, and BFF session injection. OBS-002 should not add a bypass or alternate auth path. |
+| Verification workflow | `.gc/plan-rules.md`, `pytest`, `pre-commit run --all-files`, MCP package tests/builds, and existing deterministic clock seams such as timestamp factories and injected command runners are the verification and test-style incumbents. |
+
+## Security And Validation Layers
+
+- **Auth surface:** the design should add no new public endpoint, listener, or
+  remotely supplied identity authority. Any future API exposure must remain
+  behind `verify_token` and BFF host/CSRF/session gates. MCP remains local
+  stdio; the Kali sidecar remains a local Unix-socket helper.
+- **Secret-handling surface:** IDs are non-secret but replayable local
+  session/run/trace values are sensitive in analysis surfaces under ADR-029.
+  Do not log, export, or return raw tokens, credentials, private keys,
+  secret-bearing config, full commands, transcripts, or captured payload bytes
+  as correlation metadata. Use existing Python and TypeScript `redact()`
+  policies and `curl_safe`.
+- **Schema and shape validation:** ACES Pydantic models remain the portable
+  schema authority. APTL archive projections must validate incoming and
+  outgoing IDs with `LocalRunStore`/MCP/sidecar ID rules and must preserve
+  pydantic diagnostics without leaking `input`. TypeScript MCP arguments must
+  keep using JSON Schema definitions plus handler assertions.
+- **Environment binding:** correlation metadata may enter range components
+  only through existing explicit channels such as SSH environment propagation
+  and sidecar metadata frames. Any new variable must be centralized in the
+  shared MCP SSH environment construction and documented as non-secret. Do not
+  smuggle IDs through `.env`, scenario parameters, arbitrary command strings,
+  URLs, target content, or durable service config.
+- **OS/process exposure:** launch commands through argument arrays and existing
+  backend runners. Do not put secrets or unnecessary correlation IDs in process
+  argv where `ps`, shell history, audit logs, or target telemetry can observe
+  them. Do not add local shell interpolation to collectors or sidecar paths.
+- **Error envelopes:** admission, lab startup, API, MCP, and sidecar failures
+  must continue through existing diagnostic/result envelopes. Errors may name a
+  missing ref, unsupported capture capability, unknown clock context, duplicate
+  event, or unresolved evidence rule, but must not include raw ACES payloads,
+  pydantic `input`, backend stderr, command bodies, evidence bytes, or tokens.
+- **Persistence and export:** `LocalRunStore` is the archive owner. Use
+  create-once writes for identity-bearing canonical records and append-only
+  JSONL only for event streams. `exporter.py` must preserve the resulting
+  graph and disclosures but must not be relied on to redact or infer them.
+- **Observability:** OTel and red-team logs may carry bounded, redacted IDs and
+  association refs. They must not capture LLM reasoning, secrets, raw evidence,
+  or blue-detection conclusions as unqualified causal claims.
+- **Backend/runtime validation:** deployment and ACES adapters must continue to
+  use `DeploymentBackend`, ACES runtime snapshot contracts, manifest
+  capability checks, and stateful observation helpers. OBS-002 must not call
+  Docker directly or infer support from container names.
+
+## Extensibility Seam
+
+The seam is a small versioned correlation projection in the run archive whose
+nodes are existing ACES references or `LocalRunStore` evidence refs, and whose
+edges carry only:
+
+`source_ref`, `target_ref`, `association_method`, `rule_id`, `clock_context_ref`,
+`confidence_or_status`, and `disclosure_refs`.
+
+A future source should add a source adapter that emits this projection plus its
+clock metadata and capture capability row. It should not edit every controller,
+collector, exporter, and evaluator to learn a new identity concept.
+
+Clock collection needs one source-owned provider seam:
+
+`(source_kind, source_id, timestamp_domain, clock_source, synchronization_status,
+measured_offset, uncertainty, measurement_time, observer_effect_ref)`.
+
+Collectors and MCP sinks can implement that seam differently, but they should
+not scatter `datetime.now(UTC)`, `Date.now()`, UUIDs, or wall-clock parsing
+through business logic as identity or causality sources.
+
+## Whole-Repository Surface
+
+- ACES contract consumption: `aces_contracts`, `aces_sdl`, and
+  `src/aptl/backends/aces_manifest.py`.
+- Experiment admission and planning: `src/aptl/core/experiment/**`.
+- Runtime realization, participant histories, observation, evaluation, and run
+  record projection: `src/aptl/backends/aces*.py`.
+- Local control-plane state and archives: `src/aptl/core/session.py`,
+  `telemetry.py`, `runstore.py`, `lab.py`, `collectors.py`, `snapshot.py`, and
+  `exporter.py`.
+- API/web control surfaces: `src/aptl/api/**` and web BFF auth middleware when
+  correlation data is exposed to the UI.
+- MCP common and red sinks: `mcp/aptl-mcp-common/src/**`,
+  `mcp/mcp-red/src/capture.ts`, and `mcp/mcp-red/src/logger.ts`.
+- Kali capture sidecar and host/runtime layer:
+  `containers/kali-capture/writer.py`, Docker copy/exec paths, SSH
+  environment propagation, process argv, local filesystem permissions, and
+  ignored `.aptl` state.
+- Published architecture docs and workflow gates: this note,
+  `docs/architecture/index.md`, `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `.pre-commit-config.yaml`, and CI.
+
+## Gotchas And Anti-Patterns
+
+- Do not conflate `trace_id`, `run_id`, `session_id`, `episode_id`,
+  `action_instance_id`, `evaluator run_id`, planned trial ID, capture ID, and
+  evidence record ID. They answer different questions and have different
+  stability promises.
+- Do not use timestamp proximity, ingest order, sorted filenames, or sidecar
+  copy order as causal proof. At most they create `time_window_candidate`
+  associations with clock uncertainty attached.
+- Do not fabricate causal IDs for sources that cannot propagate identifiers.
+  Preserve their source timestamps, collection timestamps, offset/uncertainty,
+  and association method instead.
+- Do not collapse duplicate events, restarts, missing source timestamps, or
+  reordered ingestion into one "best" event by timestamp. Preserve the source
+  sequence/status, gap disclosure, and association method.
+- Do not create an APTL-local replacement for ACES capture, evidence,
+  derived-measure, clock, run traceability, participant runtime, or apparatus
+  context schemas.
+- Do not duplicate ID validation separately in Python, TypeScript, and the
+  sidecar. Reuse the existing run/session ID rules and add any new shared rule
+  at the boundary that owns the ID.
+- Do not silently inject identifiers into attacker-visible command text, target
+  files, blue telemetry, SIEM log fields, HTTP parameters, shell history, or
+  service config. If an experiment permits that augmentation, record the
+  observer effect and the non-secret channel used.
+- Do not treat `mcp-red` OCSF logs, OTel spans, pcap timestamps, Wazuh alert
+  times, container wall clocks, and Python/Node collection times as one clock
+  domain. Record domains and uncertainty before comparing them.
+- Do not make exporter, dashboard, or evaluator code infer missing links from
+  filenames or timestamps. Correlation belongs in the run archive projection
+  and ACES traceability/disclosure records.
+- Do not bypass capture capability admission by accepting every capture spec
+  and later writing loss notes. Unsupported capabilities must fail or be
+  explicitly disclosed at the admission/capture boundary required by ACES.
+- Do not broaden OBS-002 into a global tracing backend, database migration,
+  remote telemetry service, generic event bus, or new workflow engine.
+
+## Non-Goals And Boundaries
+
+- Do not implement OBS-002 in this preflight.
+- Do not change ACES contract models, invent portable APTL identity schemas, or
+  redesign experiment admission.
+- Do not redesign lab lifecycle, Docker topology, MCP transport, web/API auth,
+  sidecar RPC ownership, OTel deployment, exporter packaging, or runstore
+  layout except through a separately reviewed implementation.
+- Do not capture LLM reasoning traces or unredacted transcripts as evidence.
+- Do not require an always-on global tracing backend; the local single-user
+  offline run archive remains the default.
+- Do not make timestamp correlation a causal inference engine. OBS-002 records
+  explicit identifiers, declared rules, candidate windows, gaps, and clock
+  disclosures so later evaluators can reason over evidence honestly.

--- a/src/aptl/core/correlation/__init__.py
+++ b/src/aptl/core/correlation/__init__.py
@@ -1,0 +1,10 @@
+"""OBS-002 correlation package (issue #447).
+
+Intentionally empty: downstream code imports the full module paths
+(``aptl.core.correlation.models``, ``aptl.core.correlation.clock``,
+``aptl.core.correlation.identity``) rather than a package-level
+re-export surface. See ``docs/architecture/obs-002-correlation-identity-clock-preflight.md``
+for the binding design.
+"""
+
+from __future__ import annotations

--- a/src/aptl/core/correlation/_assemble.py
+++ b/src/aptl/core/correlation/_assemble.py
@@ -1,0 +1,558 @@
+"""Internal graph-assembly helpers for the OBS-002 correlation builder (#447).
+
+Split out of :mod:`aptl.core.correlation.builder` to keep each module within
+the repo's per-file line budget (SonarCloud ``python:S104``). Not a public
+API — the only supported entry point is
+:func:`aptl.core.correlation.builder.build_correlation_projection`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from aptl.core.correlation.clock import ClockProvider
+from aptl.core.correlation.identity import bind_attempt_ref, stable_ref
+from aptl.core.correlation.models import (
+    AssociationMethod,
+    ClockContext,
+    CorrelationEdge,
+    CorrelationNode,
+)
+from aptl.core.correlation.rules import (
+    ADMITTED_PLAN_BINDING,
+    MANIFEST_SNAPSHOT_MEMBERSHIP,
+    ORCHESTRATION_ADDRESS_GROUPING,
+    RUN_PATH_BINDING,
+    CorrelationRuleSet,
+)
+
+# ---------------------------------------------------------------------------
+# Domain separation for content-derived refs (identity.stable_ref). Distinct
+# per source category so a byte-identical dict from two different sources
+# (e.g. a behavior event and an orchestration history event that happen to
+# serialize the same way) can never collide into the same node ref.
+# ---------------------------------------------------------------------------
+
+_BEHAVIOR_EVIDENCE_DOMAIN = b"aptl.correlation.builder.behavior-evidence/v1"
+_ORCHESTRATION_EVIDENCE_DOMAIN = b"aptl.correlation.builder.orchestration-evidence/v1"
+_EXTERNAL_EVIDENCE_DOMAIN = b"aptl.correlation.builder.external-evidence/v1"
+_CLOCK_CONTEXT_REF_DOMAIN = b"aptl.correlation.builder.clock-context/v1"
+
+
+# ---------------------------------------------------------------------------
+# Content-derived, order-independent, duplicate-preserving refs.
+# ---------------------------------------------------------------------------
+
+
+def _content_signature(payload: object) -> str:
+    """Canonical string signature for grouping byte-identical raw dicts.
+
+    Sorted keys make signature independent of a dict's own key order;
+    list *values* are left as-is because their order is meaningful
+    source content (e.g. ``shared_state_refs``), not incidental
+    ingestion order.
+    """
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+def _derive_distinct_refs(items: Sequence[object], *, domain: bytes) -> list[str]:
+    """Return one ref per item, positionally aligned with ``items``.
+
+    Each ref is derived from the item's own content plus how many
+    *identical* items were already counted (an occurrence index within
+    the content-keyed multiset) — never from list position. Re-ordering
+    ``items`` (simulating reordered ingestion) therefore produces the
+    identical *set* of refs, while two genuinely duplicate (byte-for-byte
+    identical) items still resolve to two distinct refs rather than
+    collapsing into one (preflight: "Do not collapse duplicate events ...
+    into one 'best' event").
+    """
+    occurrence_counts: dict[str, int] = {}
+    refs: list[str] = []
+    for item in items:
+        signature = _content_signature(item)
+        occurrence = occurrence_counts.get(signature, 0)
+        occurrence_counts[signature] = occurrence + 1
+        refs.append(stable_ref(signature, str(occurrence), domain=domain))
+    return refs
+
+
+# ---------------------------------------------------------------------------
+# Timestamp parsing / window overlap (never used to assert an explicit or
+# declared edge — only ever to justify a TIME_WINDOW_CANDIDATE, and always
+# paired with a clock_context_ref).
+# ---------------------------------------------------------------------------
+
+
+def _parse_rfc3339(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _events_window(events: Sequence[Mapping[str, object]]) -> tuple[datetime, datetime] | None:
+    """Return ``(earliest, latest)`` parsed timestamps among ``events``, or
+    ``None`` when none of them carry a parseable timestamp (a missing
+    source timestamp is a gap, never fabricated)."""
+    timestamps = [ts for ts in (_parse_rfc3339(e.get("timestamp")) for e in events) if ts is not None]
+    if not timestamps:
+        return None
+    return min(timestamps), max(timestamps)
+
+
+def _evaluator_window(payload: Mapping[str, object]) -> tuple[datetime, datetime] | None:
+    started = _parse_rfc3339(payload.get("started_at"))
+    updated = _parse_rfc3339(payload.get("updated_at"))
+    if started is None and updated is None:
+        return None
+    started = started if started is not None else updated
+    updated = updated if updated is not None else started
+    assert started is not None and updated is not None  # narrowed above
+    return (started, updated) if started <= updated else (updated, started)
+
+
+def _windows_overlap(a: tuple[datetime, datetime], b: tuple[datetime, datetime]) -> bool:
+    return a[0] <= b[1] and b[0] <= a[1]
+
+
+# ---------------------------------------------------------------------------
+# Run-record extraction helpers (best-effort: EXP-002/REP-001 do not thread
+# planned_trial_id or augmentation disclosures into the run record today —
+# these read a handful of plausible paths and are silently absent, never
+# fabricated, when the field truly is not there).
+# ---------------------------------------------------------------------------
+
+
+def _runtime_snapshot(run_record: Mapping[str, object]) -> Mapping[str, object]:
+    aces_section = run_record.get("aces")
+    if not isinstance(aces_section, Mapping):
+        return {}
+    snapshot = aces_section.get("runtime_snapshot")
+    return snapshot if isinstance(snapshot, Mapping) else {}
+
+
+def _find_planned_trial_id(run_record: Mapping[str, object]) -> str | None:
+    candidates: list[object] = [run_record.get("planned_trial_id")]
+    aces_section = run_record.get("aces")
+    if isinstance(aces_section, Mapping):
+        candidates.append(aces_section.get("planned_trial_id"))
+        realization = aces_section.get("realization")
+        if isinstance(realization, Mapping):
+            candidates.append(realization.get("planned_trial_id"))
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def _find_disclosure_refs(run_record: Mapping[str, object]) -> tuple[str, ...]:
+    aces_section = run_record.get("aces")
+    if not isinstance(aces_section, Mapping):
+        return ()
+    realization = aces_section.get("realization")
+    if not isinstance(realization, Mapping):
+        return ()
+    for key in ("disclosure_refs", "augmentation_disclosure_refs"):
+        raw = realization.get(key)
+        if isinstance(raw, list) and raw:
+            return tuple(str(item) for item in raw if isinstance(item, str) and item)
+    return ()
+
+
+def _external_evidence_references(run_record: Mapping[str, object]) -> list[Mapping[str, object]]:
+    backend_evidence = run_record.get("backend_evidence")
+    if not isinstance(backend_evidence, Mapping):
+        return []
+    refs = backend_evidence.get("evidence_references")
+    if not isinstance(refs, list):
+        return []
+    return [item for item in refs if isinstance(item, Mapping)]
+
+
+def _flatten_behavior_events(runtime_snapshot: Mapping[str, object]) -> list[dict[str, object]]:
+    behavior_history = runtime_snapshot.get("participant_behavior_history")
+    events: list[dict[str, object]] = []
+    if not isinstance(behavior_history, Mapping):
+        return events
+    for event_list in behavior_history.values():
+        if not isinstance(event_list, list):
+            continue
+        events.extend(dict(event) for event in event_list if isinstance(event, Mapping))
+    return events
+
+
+def _collect_episode_ids(
+    runtime_snapshot: Mapping[str, object], behavior_events: Sequence[Mapping[str, object]]
+) -> set[str]:
+    episode_ids: set[str] = set()
+    results = runtime_snapshot.get("participant_episode_results")
+    if isinstance(results, Mapping):
+        for payload in results.values():
+            if isinstance(payload, Mapping) and isinstance(payload.get("episode_id"), str):
+                episode_ids.add(payload["episode_id"])
+    history = runtime_snapshot.get("participant_episode_history")
+    if isinstance(history, Mapping):
+        for event_list in history.values():
+            if not isinstance(event_list, list):
+                continue
+            for event in event_list:
+                if isinstance(event, Mapping) and isinstance(event.get("episode_id"), str):
+                    episode_ids.add(event["episode_id"])
+    for event in behavior_events:
+        episode_id = event.get("episode_id")
+        if isinstance(episode_id, str) and episode_id:
+            episode_ids.add(episode_id)
+    return episode_ids
+
+
+def _collect_action_ids(behavior_events: Sequence[Mapping[str, object]]) -> set[str]:
+    return {
+        event["action_instance_id"]
+        for event in behavior_events
+        if isinstance(event.get("action_instance_id"), str) and event["action_instance_id"]
+    }
+
+
+def _map_action_to_episode(behavior_events: Sequence[Mapping[str, object]]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for event in behavior_events:
+        action_id = event.get("action_instance_id")
+        episode_id = event.get("episode_id")
+        if isinstance(action_id, str) and action_id and isinstance(episode_id, str) and episode_id:
+            mapping.setdefault(action_id, episode_id)
+    return mapping
+
+
+def _map_action_to_events(
+    behavior_events: Sequence[Mapping[str, object]],
+) -> dict[str, list[Mapping[str, object]]]:
+    mapping: dict[str, list[Mapping[str, object]]] = {}
+    for event in behavior_events:
+        action_id = event.get("action_instance_id")
+        if isinstance(action_id, str) and action_id:
+            mapping.setdefault(action_id, []).append(event)
+    return mapping
+
+
+# ---------------------------------------------------------------------------
+# Mutable accumulator: nodes/edges/clock-contexts are all order-independent
+# sets (Stage 1's CorrelationProjection canonicalizes by sorting), so the
+# accumulator only needs to guard against a ref being redeclared under a
+# conflicting ref_kind and against a clock source being read twice.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Accumulator:
+    clock_provider: ClockProvider
+    rules: CorrelationRuleSet
+    nodes: dict[str, CorrelationNode] = field(default_factory=dict)
+    edges: list[CorrelationEdge] = field(default_factory=list)
+    clock_contexts: dict[tuple[str, str], ClockContext] = field(default_factory=dict)
+
+    def add_node(self, ref: str, ref_kind: str) -> str:
+        existing = self.nodes.get(ref)
+        if existing is not None and existing.ref_kind != ref_kind:
+            raise ValueError(
+                f"correlation ref {ref!r} redeclared with a conflicting "
+                f"ref_kind ({existing.ref_kind!r} vs {ref_kind!r})"
+            )
+        self.nodes[ref] = CorrelationNode(ref=ref, ref_kind=ref_kind)
+        return ref
+
+    def add_edge(
+        self,
+        source_ref: str,
+        target_ref: str,
+        association_method: AssociationMethod,
+        *,
+        rule_id: str | None = None,
+        clock_context_ref: str | None = None,
+        confidence_or_status: str | None = None,
+        disclosure_refs: tuple[str, ...] = (),
+    ) -> None:
+        self.edges.append(
+            CorrelationEdge(
+                source_ref=source_ref,
+                target_ref=target_ref,
+                association_method=association_method,
+                rule_id=rule_id,
+                clock_context_ref=clock_context_ref,
+                confidence_or_status=confidence_or_status,
+                disclosure_refs=disclosure_refs,
+            )
+        )
+
+    def clock_context_for(
+        self, source_kind: str, source_id: str, *, observer_effect_ref: str | None = None
+    ) -> ClockContext:
+        """Return the (cached) ClockContext for this exact ``(source_kind,
+        source_id)`` — one ClockContext per source, never merged across
+        sources even when they share a provider."""
+        key = (source_kind, source_id)
+        ctx = self.clock_contexts.get(key)
+        if ctx is None:
+            ctx = self.clock_provider.clock_context(
+                source_kind=source_kind, source_id=source_id, observer_effect_ref=observer_effect_ref
+            )
+            self.clock_contexts[key] = ctx
+        return ctx
+
+    @staticmethod
+    def clock_ref(ctx: ClockContext) -> str:
+        """Stable ref for a ClockContext (its ``clock_context_ref`` in edges)."""
+        return stable_ref(
+            ctx.source_kind, ctx.source_id, ctx.timestamp_domain, domain=_CLOCK_CONTEXT_REF_DOMAIN
+        )
+
+    def clock_ref_for(
+        self, source_kind: str, source_id: str, *, observer_effect_ref: str | None = None
+    ) -> str:
+        return self.clock_ref(
+            self.clock_context_for(source_kind, source_id, observer_effect_ref=observer_effect_ref)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section builders — each owns one concern and stays small (ruff C901 gate).
+# ---------------------------------------------------------------------------
+
+
+def _add_run_node(acc: _Accumulator, run_ref: str) -> None:
+    acc.add_node(run_ref, "attempt-run")
+
+
+def _add_planned_trial(acc: _Accumulator, run_record: Mapping[str, object], run_ref: str) -> None:
+    planned_trial_id = _find_planned_trial_id(run_record)
+    if planned_trial_id is None:
+        return
+    planned_ref = bind_attempt_ref(planned_trial_id)
+    acc.add_node(planned_ref, "planned-trial")
+    acc.add_edge(
+        planned_ref,
+        run_ref,
+        AssociationMethod.DECLARED_RULE,
+        rule_id=acc.rules.require(ADMITTED_PLAN_BINDING.rule_id),
+    )
+
+
+def _add_episodes(acc: _Accumulator, episode_ids: set[str], run_ref: str) -> None:
+    for episode_id in episode_ids:
+        episode_ref = bind_attempt_ref(episode_id)
+        acc.add_node(episode_ref, "participant-episode")
+        acc.add_edge(
+            episode_ref,
+            run_ref,
+            AssociationMethod.DECLARED_RULE,
+            rule_id=acc.rules.require(MANIFEST_SNAPSHOT_MEMBERSHIP.rule_id),
+        )
+
+
+def _add_actions(
+    acc: _Accumulator,
+    action_ids: set[str],
+    action_to_episode: Mapping[str, str],
+    run_ref: str,
+) -> None:
+    for action_id in action_ids:
+        action_ref = bind_attempt_ref(action_id)
+        acc.add_node(action_ref, "action")
+        acc.add_edge(
+            action_ref,
+            run_ref,
+            AssociationMethod.DECLARED_RULE,
+            rule_id=acc.rules.require(MANIFEST_SNAPSHOT_MEMBERSHIP.rule_id),
+        )
+        episode_id = action_to_episode.get(action_id)
+        if episode_id:
+            acc.add_edge(
+                action_ref, bind_attempt_ref(episode_id), AssociationMethod.EXPLICIT_IDENTIFIER
+            )
+
+
+def _add_behavior_evidence(acc: _Accumulator, behavior_events: Sequence[Mapping[str, object]]) -> None:
+    evidence_refs = _derive_distinct_refs(behavior_events, domain=_BEHAVIOR_EVIDENCE_DOMAIN)
+    for event, evidence_ref in zip(behavior_events, evidence_refs, strict=True):
+        acc.add_node(evidence_ref, "evidence")
+        action_id = event.get("action_instance_id")
+        if isinstance(action_id, str) and action_id:
+            acc.add_edge(
+                evidence_ref, bind_attempt_ref(action_id), AssociationMethod.EXPLICIT_IDENTIFIER
+            )
+        episode_id = event.get("episode_id")
+        if isinstance(episode_id, str) and episode_id:
+            acc.add_edge(
+                evidence_ref, bind_attempt_ref(episode_id), AssociationMethod.EXPLICIT_IDENTIFIER
+            )
+        participant_address = event.get("participant_address")
+        if isinstance(participant_address, str) and participant_address and event.get("timestamp"):
+            acc.clock_ref_for("participant", participant_address)
+
+
+def _add_orchestration_address(
+    acc: _Accumulator, address: str, payload: Mapping[str, object], run_ref: str
+) -> str:
+    address_ref = bind_attempt_ref(address)
+    acc.add_node(address_ref, "action")
+    acc.add_edge(
+        address_ref,
+        run_ref,
+        AssociationMethod.DECLARED_RULE,
+        rule_id=acc.rules.require(RUN_PATH_BINDING.rule_id),
+    )
+    result = payload.get("result")
+    if isinstance(result, Mapping) and (result.get("started_at") or result.get("updated_at")):
+        acc.clock_ref_for("orchestration", address)
+    return address_ref
+
+
+def _add_orchestration_history(
+    acc: _Accumulator, address_ref: str, history: Sequence[Mapping[str, object]]
+) -> None:
+    history_refs = _derive_distinct_refs(history, domain=_ORCHESTRATION_EVIDENCE_DOMAIN)
+    for history_ref in history_refs:
+        acc.add_node(history_ref, "evidence")
+        acc.add_edge(
+            history_ref,
+            address_ref,
+            AssociationMethod.DECLARED_RULE,
+            rule_id=acc.rules.require(ORCHESTRATION_ADDRESS_GROUPING.rule_id),
+        )
+
+
+def _add_orchestration(
+    acc: _Accumulator, orchestration: Mapping[str, Mapping[str, object]], run_ref: str
+) -> None:
+    for address, payload in orchestration.items():
+        if not isinstance(payload, Mapping):
+            continue
+        address_ref = _add_orchestration_address(acc, address, payload, run_ref)
+        history = payload.get("history")
+        if isinstance(history, list):
+            events = [event for event in history if isinstance(event, Mapping)]
+            _add_orchestration_history(acc, address_ref, events)
+
+
+def _participant_address_of(events: Sequence[Mapping[str, object]]) -> str | None:
+    for event in events:
+        addr = event.get("participant_address")
+        if isinstance(addr, str) and addr:
+            return addr
+    return None
+
+
+def _clocks_reconcilable(a: ClockContext, b: ClockContext) -> bool:
+    """Whether two clock contexts' timestamps can be honestly compared.
+
+    Only when they share a timestamp domain (the same clock) — comparing raw
+    timestamps across DIFFERENT domains with no known measured offset would
+    fabricate clock-qualified precision that does not exist. This is the
+    OBS-002 gate that stops timestamp proximity in one domain from
+    masquerading as a cross-domain temporal association.
+    """
+    return a.timestamp_domain == b.timestamp_domain
+
+
+def _add_evaluator_result_candidates(
+    acc: _Accumulator,
+    address_ref: str,
+    eval_window: tuple[datetime, datetime],
+    eval_ctx: ClockContext,
+    action_ids: set[str],
+    action_to_events: Mapping[str, Sequence[Mapping[str, object]]],
+) -> None:
+    """Associate an evaluator result with actions, honestly reconciling both
+    sources' clocks BEFORE claiming any temporal candidate.
+
+    The evaluator and participant clocks are distinct sources. Their windows
+    are only comparable when they share a timestamp domain: then an overlap
+    is a ``TIME_WINDOW_CANDIDATE`` (never EXPLICIT/DECLARED — no ACES contract
+    propagates a shared id across the evaluation/participant namespaces). When
+    the domains differ and no offset reconciles them, overlap cannot be
+    established, so the edge is an explicit ``GAP_OR_UNKNOWN`` disclosing the
+    unreconciled clocks rather than a candidate that merely *looks*
+    clock-qualified. Every emitted edge names BOTH clock inputs — the
+    evaluator via ``clock_context_ref``, the participant via
+    ``disclosure_refs`` — so the comparison basis is auditable.
+    """
+    eval_clock_ref = acc.clock_ref(eval_ctx)
+    for action_id in action_ids:
+        events = action_to_events.get(action_id, ())
+        participant_address = _participant_address_of(events)
+        if participant_address is None:
+            continue
+        part_ctx = acc.clock_context_for("participant", participant_address)
+        part_clock_ref = acc.clock_ref(part_ctx)
+        if not _clocks_reconcilable(eval_ctx, part_ctx):
+            acc.add_edge(
+                address_ref,
+                bind_attempt_ref(action_id),
+                AssociationMethod.GAP_OR_UNKNOWN,
+                confidence_or_status="cross_domain_clock_unreconciled",
+                disclosure_refs=(eval_clock_ref, part_clock_ref),
+            )
+            continue
+        action_window = _events_window(events)
+        if action_window is None or not _windows_overlap(eval_window, action_window):
+            continue
+        acc.add_edge(
+            address_ref,
+            bind_attempt_ref(action_id),
+            AssociationMethod.TIME_WINDOW_CANDIDATE,
+            clock_context_ref=eval_clock_ref,
+            confidence_or_status="overlapping_window_reconciled_domain",
+            disclosure_refs=(part_clock_ref,),
+        )
+
+
+def _add_evaluator_results(
+    acc: _Accumulator,
+    runtime_snapshot: Mapping[str, object],
+    run_ref: str,
+    action_ids: set[str],
+    action_to_events: Mapping[str, Sequence[Mapping[str, object]]],
+) -> None:
+    evaluation_results = runtime_snapshot.get("evaluation_results")
+    if not isinstance(evaluation_results, Mapping):
+        return
+    for address, payload in evaluation_results.items():
+        if not isinstance(payload, Mapping):
+            continue
+        address_ref = bind_attempt_ref(address)
+        acc.add_node(address_ref, "evaluator-result")
+        acc.add_edge(
+            address_ref,
+            run_ref,
+            AssociationMethod.DECLARED_RULE,
+            rule_id=acc.rules.require(MANIFEST_SNAPSHOT_MEMBERSHIP.rule_id),
+        )
+        eval_window = _evaluator_window(payload)
+        if eval_window is None:
+            continue
+        eval_ctx = acc.clock_context_for("evaluator", address)
+        _add_evaluator_result_candidates(
+            acc, address_ref, eval_window, eval_ctx, action_ids, action_to_events
+        )
+
+
+def _add_external_evidence(acc: _Accumulator, run_record: Mapping[str, object], run_ref: str) -> None:
+    """External evidence references (e.g. ``backend_evidence.evidence_references``)
+    carry no participant/episode/action/run identifier at all — GAP_OR_UNKNOWN
+    is the only honest association method (preflight: "an external evidence
+    source with no id propagation on the Python side")."""
+    references = _external_evidence_references(run_record)
+    refs = _derive_distinct_refs(references, domain=_EXTERNAL_EVIDENCE_DOMAIN)
+    for evidence_ref in refs:
+        acc.add_node(evidence_ref, "evidence")
+        acc.add_edge(
+            evidence_ref,
+            run_ref,
+            AssociationMethod.GAP_OR_UNKNOWN,
+            confidence_or_status="no_propagated_identifier",
+        )

--- a/src/aptl/core/correlation/_assemble.py
+++ b/src/aptl/core/correlation/_assemble.py
@@ -1,18 +1,28 @@
-"""Internal graph-assembly helpers for the OBS-002 correlation builder (#447).
+"""Correlation-graph assembly for the OBS-002 builder (#447).
 
-Split out of :mod:`aptl.core.correlation.builder` to keep each module within
-the repo's per-file line budget (SonarCloud ``python:S104``). Not a public
-API — the only supported entry point is
-:func:`aptl.core.correlation.builder.build_correlation_projection`.
+The mutable :class:`_Accumulator` plus one small section-builder per concern
+(nodes/edges for the run, planned trial, participant episodes/actions, behavior
+evidence, orchestration, evaluator results, external evidence). Split from the
+public :mod:`aptl.core.correlation.builder` and the read-only
+:mod:`aptl.core.correlation._extract` helpers to keep each module within the
+per-file line budget (SonarCloud ``python:S104``). Not a public API.
 """
 
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from aptl.core.correlation._extract import (
+    _derive_distinct_refs,
+    _events_window,
+    _evaluator_window,
+    _external_evidence_references,
+    _find_planned_trial_id,
+    _participant_address_of,
+    _windows_overlap,
+)
 from aptl.core.correlation.clock import ClockProvider
 from aptl.core.correlation.identity import bind_attempt_ref, stable_ref
 from aptl.core.correlation.models import (
@@ -29,227 +39,25 @@ from aptl.core.correlation.rules import (
     CorrelationRuleSet,
 )
 
-# ---------------------------------------------------------------------------
 # Domain separation for content-derived refs (identity.stable_ref). Distinct
-# per source category so a byte-identical dict from two different sources
-# (e.g. a behavior event and an orchestration history event that happen to
-# serialize the same way) can never collide into the same node ref.
-# ---------------------------------------------------------------------------
-
+# per source category so a byte-identical dict from two different sources can
+# never collide into the same node ref.
 _BEHAVIOR_EVIDENCE_DOMAIN = b"aptl.correlation.builder.behavior-evidence/v1"
 _ORCHESTRATION_EVIDENCE_DOMAIN = b"aptl.correlation.builder.orchestration-evidence/v1"
 _EXTERNAL_EVIDENCE_DOMAIN = b"aptl.correlation.builder.external-evidence/v1"
 _CLOCK_CONTEXT_REF_DOMAIN = b"aptl.correlation.builder.clock-context/v1"
 
 
-# ---------------------------------------------------------------------------
-# Content-derived, order-independent, duplicate-preserving refs.
-# ---------------------------------------------------------------------------
-
-
-def _content_signature(payload: object) -> str:
-    """Canonical string signature for grouping byte-identical raw dicts.
-
-    Sorted keys make signature independent of a dict's own key order;
-    list *values* are left as-is because their order is meaningful
-    source content (e.g. ``shared_state_refs``), not incidental
-    ingestion order.
-    """
-    return json.dumps(payload, sort_keys=True, default=str)
-
-
-def _derive_distinct_refs(items: Sequence[object], *, domain: bytes) -> list[str]:
-    """Return one ref per item, positionally aligned with ``items``.
-
-    Each ref is derived from the item's own content plus how many
-    *identical* items were already counted (an occurrence index within
-    the content-keyed multiset) — never from list position. Re-ordering
-    ``items`` (simulating reordered ingestion) therefore produces the
-    identical *set* of refs, while two genuinely duplicate (byte-for-byte
-    identical) items still resolve to two distinct refs rather than
-    collapsing into one (preflight: "Do not collapse duplicate events ...
-    into one 'best' event").
-    """
-    occurrence_counts: dict[str, int] = {}
-    refs: list[str] = []
-    for item in items:
-        signature = _content_signature(item)
-        occurrence = occurrence_counts.get(signature, 0)
-        occurrence_counts[signature] = occurrence + 1
-        refs.append(stable_ref(signature, str(occurrence), domain=domain))
-    return refs
-
-
-# ---------------------------------------------------------------------------
-# Timestamp parsing / window overlap (never used to assert an explicit or
-# declared edge — only ever to justify a TIME_WINDOW_CANDIDATE, and always
-# paired with a clock_context_ref).
-# ---------------------------------------------------------------------------
-
-
-def _parse_rfc3339(value: object) -> datetime | None:
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def _events_window(events: Sequence[Mapping[str, object]]) -> tuple[datetime, datetime] | None:
-    """Return ``(earliest, latest)`` parsed timestamps among ``events``, or
-    ``None`` when none of them carry a parseable timestamp (a missing
-    source timestamp is a gap, never fabricated)."""
-    timestamps = [ts for ts in (_parse_rfc3339(e.get("timestamp")) for e in events) if ts is not None]
-    if not timestamps:
-        return None
-    return min(timestamps), max(timestamps)
-
-
-def _evaluator_window(payload: Mapping[str, object]) -> tuple[datetime, datetime] | None:
-    started = _parse_rfc3339(payload.get("started_at"))
-    updated = _parse_rfc3339(payload.get("updated_at"))
-    if started is None and updated is None:
-        return None
-    started = started if started is not None else updated
-    updated = updated if updated is not None else started
-    assert started is not None and updated is not None  # narrowed above
-    return (started, updated) if started <= updated else (updated, started)
-
-
-def _windows_overlap(a: tuple[datetime, datetime], b: tuple[datetime, datetime]) -> bool:
-    return a[0] <= b[1] and b[0] <= a[1]
-
-
-# ---------------------------------------------------------------------------
-# Run-record extraction helpers (best-effort: EXP-002/REP-001 do not thread
-# planned_trial_id or augmentation disclosures into the run record today —
-# these read a handful of plausible paths and are silently absent, never
-# fabricated, when the field truly is not there).
-# ---------------------------------------------------------------------------
-
-
-def _runtime_snapshot(run_record: Mapping[str, object]) -> Mapping[str, object]:
-    aces_section = run_record.get("aces")
-    if not isinstance(aces_section, Mapping):
-        return {}
-    snapshot = aces_section.get("runtime_snapshot")
-    return snapshot if isinstance(snapshot, Mapping) else {}
-
-
-def _find_planned_trial_id(run_record: Mapping[str, object]) -> str | None:
-    candidates: list[object] = [run_record.get("planned_trial_id")]
-    aces_section = run_record.get("aces")
-    if isinstance(aces_section, Mapping):
-        candidates.append(aces_section.get("planned_trial_id"))
-        realization = aces_section.get("realization")
-        if isinstance(realization, Mapping):
-            candidates.append(realization.get("planned_trial_id"))
-    for candidate in candidates:
-        if isinstance(candidate, str) and candidate:
-            return candidate
-    return None
-
-
-def _find_disclosure_refs(run_record: Mapping[str, object]) -> tuple[str, ...]:
-    aces_section = run_record.get("aces")
-    if not isinstance(aces_section, Mapping):
-        return ()
-    realization = aces_section.get("realization")
-    if not isinstance(realization, Mapping):
-        return ()
-    for key in ("disclosure_refs", "augmentation_disclosure_refs"):
-        raw = realization.get(key)
-        if isinstance(raw, list) and raw:
-            return tuple(str(item) for item in raw if isinstance(item, str) and item)
-    return ()
-
-
-def _external_evidence_references(run_record: Mapping[str, object]) -> list[Mapping[str, object]]:
-    backend_evidence = run_record.get("backend_evidence")
-    if not isinstance(backend_evidence, Mapping):
-        return []
-    refs = backend_evidence.get("evidence_references")
-    if not isinstance(refs, list):
-        return []
-    return [item for item in refs if isinstance(item, Mapping)]
-
-
-def _flatten_behavior_events(runtime_snapshot: Mapping[str, object]) -> list[dict[str, object]]:
-    behavior_history = runtime_snapshot.get("participant_behavior_history")
-    events: list[dict[str, object]] = []
-    if not isinstance(behavior_history, Mapping):
-        return events
-    for event_list in behavior_history.values():
-        if not isinstance(event_list, list):
-            continue
-        events.extend(dict(event) for event in event_list if isinstance(event, Mapping))
-    return events
-
-
-def _collect_episode_ids(
-    runtime_snapshot: Mapping[str, object], behavior_events: Sequence[Mapping[str, object]]
-) -> set[str]:
-    episode_ids: set[str] = set()
-    results = runtime_snapshot.get("participant_episode_results")
-    if isinstance(results, Mapping):
-        for payload in results.values():
-            if isinstance(payload, Mapping) and isinstance(payload.get("episode_id"), str):
-                episode_ids.add(payload["episode_id"])
-    history = runtime_snapshot.get("participant_episode_history")
-    if isinstance(history, Mapping):
-        for event_list in history.values():
-            if not isinstance(event_list, list):
-                continue
-            for event in event_list:
-                if isinstance(event, Mapping) and isinstance(event.get("episode_id"), str):
-                    episode_ids.add(event["episode_id"])
-    for event in behavior_events:
-        episode_id = event.get("episode_id")
-        if isinstance(episode_id, str) and episode_id:
-            episode_ids.add(episode_id)
-    return episode_ids
-
-
-def _collect_action_ids(behavior_events: Sequence[Mapping[str, object]]) -> set[str]:
-    return {
-        event["action_instance_id"]
-        for event in behavior_events
-        if isinstance(event.get("action_instance_id"), str) and event["action_instance_id"]
-    }
-
-
-def _map_action_to_episode(behavior_events: Sequence[Mapping[str, object]]) -> dict[str, str]:
-    mapping: dict[str, str] = {}
-    for event in behavior_events:
-        action_id = event.get("action_instance_id")
-        episode_id = event.get("episode_id")
-        if isinstance(action_id, str) and action_id and isinstance(episode_id, str) and episode_id:
-            mapping.setdefault(action_id, episode_id)
-    return mapping
-
-
-def _map_action_to_events(
-    behavior_events: Sequence[Mapping[str, object]],
-) -> dict[str, list[Mapping[str, object]]]:
-    mapping: dict[str, list[Mapping[str, object]]] = {}
-    for event in behavior_events:
-        action_id = event.get("action_instance_id")
-        if isinstance(action_id, str) and action_id:
-            mapping.setdefault(action_id, []).append(event)
-    return mapping
-
-
-# ---------------------------------------------------------------------------
-# Mutable accumulator: nodes/edges/clock-contexts are all order-independent
-# sets (Stage 1's CorrelationProjection canonicalizes by sorting), so the
-# accumulator only needs to guard against a ref being redeclared under a
-# conflicting ref_kind and against a clock source being read twice.
-# ---------------------------------------------------------------------------
-
-
 @dataclass
 class _Accumulator:
+    """Mutable node/edge/clock-context collector for one projection build.
+
+    Nodes/edges/clock-contexts are order-independent sets (the
+    ``CorrelationProjection`` canonicalizes by sorting), so this only guards
+    against a ref being redeclared under a conflicting ref_kind and caches one
+    ClockContext per distinct source.
+    """
+
     clock_provider: ClockProvider
     rules: CorrelationRuleSet
     nodes: dict[str, CorrelationNode] = field(default_factory=dict)
@@ -257,6 +65,7 @@ class _Accumulator:
     clock_contexts: dict[tuple[str, str], ClockContext] = field(default_factory=dict)
 
     def add_node(self, ref: str, ref_kind: str) -> str:
+        """Register ``ref`` as a node, rejecting a conflicting ref_kind for it."""
         existing = self.nodes.get(ref)
         if existing is not None and existing.ref_kind != ref_kind:
             raise ValueError(
@@ -277,6 +86,7 @@ class _Accumulator:
         confidence_or_status: str | None = None,
         disclosure_refs: tuple[str, ...] = (),
     ) -> None:
+        """Append one typed correlation edge."""
         self.edges.append(
             CorrelationEdge(
                 source_ref=source_ref,
@@ -314,21 +124,20 @@ class _Accumulator:
     def clock_ref_for(
         self, source_kind: str, source_id: str, *, observer_effect_ref: str | None = None
     ) -> str:
+        """Record (if new) and return the clock ref for a ``(source_kind, source_id)``."""
         return self.clock_ref(
             self.clock_context_for(source_kind, source_id, observer_effect_ref=observer_effect_ref)
         )
 
 
-# ---------------------------------------------------------------------------
-# Section builders — each owns one concern and stays small (ruff C901 gate).
-# ---------------------------------------------------------------------------
-
-
 def _add_run_node(acc: _Accumulator, run_ref: str) -> None:
+    """Add the top-level attempt/run node."""
     acc.add_node(run_ref, "attempt-run")
 
 
 def _add_planned_trial(acc: _Accumulator, run_record: Mapping[str, object], run_ref: str) -> None:
+    """Add a planned-trial node bound to the run by the admitted-plan rule,
+    when the run record carries a planned-trial id."""
     planned_trial_id = _find_planned_trial_id(run_record)
     if planned_trial_id is None:
         return
@@ -343,6 +152,8 @@ def _add_planned_trial(acc: _Accumulator, run_record: Mapping[str, object], run_
 
 
 def _add_episodes(acc: _Accumulator, episode_ids: set[str], run_ref: str) -> None:
+    """Add participant-episode nodes, each bound to the run by manifest
+    containment (the record carries no run_id of its own — DECLARED_RULE)."""
     for episode_id in episode_ids:
         episode_ref = bind_attempt_ref(episode_id)
         acc.add_node(episode_ref, "participant-episode")
@@ -360,6 +171,9 @@ def _add_actions(
     action_to_episode: Mapping[str, str],
     run_ref: str,
 ) -> None:
+    """Add action nodes: bound to the run by manifest containment
+    (DECLARED_RULE), and to their episode by the shared episode id
+    (EXPLICIT_IDENTIFIER) when known."""
     for action_id in action_ids:
         action_ref = bind_attempt_ref(action_id)
         acc.add_node(action_ref, "action")
@@ -377,6 +191,9 @@ def _add_actions(
 
 
 def _add_behavior_evidence(acc: _Accumulator, behavior_events: Sequence[Mapping[str, object]]) -> None:
+    """Add one evidence node per behavior event, explicitly linked to the
+    action/episode ids the event itself carries, and record the participant
+    clock when the event has a timestamp."""
     evidence_refs = _derive_distinct_refs(behavior_events, domain=_BEHAVIOR_EVIDENCE_DOMAIN)
     for event, evidence_ref in zip(behavior_events, evidence_refs, strict=True):
         acc.add_node(evidence_ref, "evidence")
@@ -398,6 +215,8 @@ def _add_behavior_evidence(acc: _Accumulator, behavior_events: Sequence[Mapping[
 def _add_orchestration_address(
     acc: _Accumulator, address: str, payload: Mapping[str, object], run_ref: str
 ) -> str:
+    """Add an orchestration-address node bound to the run by the run-path rule
+    (its own workflow run_id is a distinct, workflow-internal identity)."""
     address_ref = bind_attempt_ref(address)
     acc.add_node(address_ref, "action")
     acc.add_edge(
@@ -415,6 +234,8 @@ def _add_orchestration_address(
 def _add_orchestration_history(
     acc: _Accumulator, address_ref: str, history: Sequence[Mapping[str, object]]
 ) -> None:
+    """Add one evidence node per workflow history event, grouped under its
+    address by the orchestration-address-grouping rule."""
     history_refs = _derive_distinct_refs(history, domain=_ORCHESTRATION_EVIDENCE_DOMAIN)
     for history_ref in history_refs:
         acc.add_node(history_ref, "evidence")
@@ -429,6 +250,7 @@ def _add_orchestration_history(
 def _add_orchestration(
     acc: _Accumulator, orchestration: Mapping[str, Mapping[str, object]], run_ref: str
 ) -> None:
+    """Add every orchestration address and its history events."""
     for address, payload in orchestration.items():
         if not isinstance(payload, Mapping):
             continue
@@ -437,26 +259,6 @@ def _add_orchestration(
         if isinstance(history, list):
             events = [event for event in history if isinstance(event, Mapping)]
             _add_orchestration_history(acc, address_ref, events)
-
-
-def _participant_address_of(events: Sequence[Mapping[str, object]]) -> str | None:
-    for event in events:
-        addr = event.get("participant_address")
-        if isinstance(addr, str) and addr:
-            return addr
-    return None
-
-
-def _clocks_reconcilable(a: ClockContext, b: ClockContext) -> bool:
-    """Whether two clock contexts' timestamps can be honestly compared.
-
-    Only when they share a timestamp domain (the same clock) — comparing raw
-    timestamps across DIFFERENT domains with no known measured offset would
-    fabricate clock-qualified precision that does not exist. This is the
-    OBS-002 gate that stops timestamp proximity in one domain from
-    masquerading as a cross-domain temporal association.
-    """
-    return a.timestamp_domain == b.timestamp_domain
 
 
 def _add_evaluator_result_candidates(
@@ -471,15 +273,15 @@ def _add_evaluator_result_candidates(
     sources' clocks BEFORE claiming any temporal candidate.
 
     The evaluator and participant clocks are distinct sources. Their windows
-    are only comparable when they share a timestamp domain: then an overlap
-    is a ``TIME_WINDOW_CANDIDATE`` (never EXPLICIT/DECLARED — no ACES contract
+    are only comparable when they share a timestamp domain: then an overlap is
+    a ``TIME_WINDOW_CANDIDATE`` (never EXPLICIT/DECLARED — no ACES contract
     propagates a shared id across the evaluation/participant namespaces). When
     the domains differ and no offset reconciles them, overlap cannot be
     established, so the edge is an explicit ``GAP_OR_UNKNOWN`` disclosing the
     unreconciled clocks rather than a candidate that merely *looks*
-    clock-qualified. Every emitted edge names BOTH clock inputs — the
-    evaluator via ``clock_context_ref``, the participant via
-    ``disclosure_refs`` — so the comparison basis is auditable.
+    clock-qualified. Every emitted edge names BOTH clock inputs — the evaluator
+    via ``clock_context_ref``, the participant via ``disclosure_refs`` — so the
+    comparison basis is auditable.
     """
     eval_clock_ref = acc.clock_ref(eval_ctx)
     for action_id in action_ids:
@@ -489,7 +291,7 @@ def _add_evaluator_result_candidates(
             continue
         part_ctx = acc.clock_context_for("participant", participant_address)
         part_clock_ref = acc.clock_ref(part_ctx)
-        if not _clocks_reconcilable(eval_ctx, part_ctx):
+        if part_ctx.timestamp_domain != eval_ctx.timestamp_domain:
             acc.add_edge(
                 address_ref,
                 bind_attempt_ref(action_id),
@@ -518,6 +320,8 @@ def _add_evaluator_results(
     action_ids: set[str],
     action_to_events: Mapping[str, Sequence[Mapping[str, object]]],
 ) -> None:
+    """Add evaluator-result nodes (bound to the run by manifest containment)
+    and their reconciled time-window candidate/gap edges to actions."""
     evaluation_results = runtime_snapshot.get("evaluation_results")
     if not isinstance(evaluation_results, Mapping):
         return
@@ -542,10 +346,10 @@ def _add_evaluator_results(
 
 
 def _add_external_evidence(acc: _Accumulator, run_record: Mapping[str, object], run_ref: str) -> None:
-    """External evidence references (e.g. ``backend_evidence.evidence_references``)
-    carry no participant/episode/action/run identifier at all — GAP_OR_UNKNOWN
-    is the only honest association method (preflight: "an external evidence
-    source with no id propagation on the Python side")."""
+    """Add external evidence reference nodes. These carry no
+    participant/episode/action/run identifier, so ``GAP_OR_UNKNOWN`` is the
+    only honest association method (preflight: "no id propagation on the
+    Python side")."""
     references = _external_evidence_references(run_record)
     refs = _derive_distinct_refs(references, domain=_EXTERNAL_EVIDENCE_DOMAIN)
     for evidence_ref in refs:

--- a/src/aptl/core/correlation/_extract.py
+++ b/src/aptl/core/correlation/_extract.py
@@ -1,0 +1,257 @@
+"""Run-archive parsing/extraction helpers for the OBS-002 correlation builder.
+
+Split out of :mod:`aptl.core.correlation._assemble` to keep each module within
+the repo's per-file line budget (SonarCloud ``python:S104``). Pure, read-only
+helpers over the already-parsed ``aptl.run-record/v1`` manifest and the ACES
+orchestrator's ``orchestration/<addr>/*`` payloads — no I/O, no wall clock, no
+identity minting. Best-effort throughout: EXP-002/REP-001 do not thread
+``planned_trial_id`` or augmentation disclosures into the run record today, so
+these read a handful of plausible paths and are silently absent (never
+fabricated) when a field truly is not there.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+
+from aptl.core.correlation.identity import stable_ref
+from aptl.core.correlation.models import ClockContext
+
+
+def _content_signature(payload: object) -> str:
+    """Canonical string signature for grouping byte-identical raw dicts.
+
+    Sorted keys make the signature independent of a dict's own key order;
+    list *values* are left as-is because their order is meaningful source
+    content (e.g. ``shared_state_refs``), not incidental ingestion order.
+    """
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+def _derive_distinct_refs(items: Sequence[object], *, domain: bytes) -> list[str]:
+    """Return one content-derived ref per item, positionally aligned with ``items``.
+
+    Each ref is derived from the item's own content plus how many *identical*
+    items were already counted (an occurrence index within the content-keyed
+    multiset) — never from list position. Re-ordering ``items`` (reordered
+    ingestion) yields the identical *set* of refs, while two genuinely
+    byte-identical items still resolve to two distinct refs rather than
+    collapsing into one (preflight: "Do not collapse duplicate events").
+    """
+    occurrence_counts: dict[str, int] = {}
+    refs: list[str] = []
+    for item in items:
+        signature = _content_signature(item)
+        occurrence = occurrence_counts.get(signature, 0)
+        occurrence_counts[signature] = occurrence + 1
+        refs.append(stable_ref(signature, str(occurrence), domain=domain))
+    return refs
+
+
+def _parse_rfc3339(value: object) -> datetime | None:
+    """Parse an RFC-3339 timestamp string, or ``None`` when absent/unparseable."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _events_window(events: Sequence[Mapping[str, object]]) -> tuple[datetime, datetime] | None:
+    """Return ``(earliest, latest)`` parsed timestamps among ``events``, or
+    ``None`` when none carry a parseable timestamp (a missing source timestamp
+    is a gap, never fabricated)."""
+    timestamps = [ts for ts in (_parse_rfc3339(e.get("timestamp")) for e in events) if ts is not None]
+    if not timestamps:
+        return None
+    return min(timestamps), max(timestamps)
+
+
+def _evaluator_window(payload: Mapping[str, object]) -> tuple[datetime, datetime] | None:
+    """Return an evaluator result's ``(earliest, latest)`` window from its
+    ``started_at``/``updated_at`` fields, or ``None`` when neither is a
+    parseable timestamp."""
+    started = _parse_rfc3339(payload.get("started_at"))
+    updated = _parse_rfc3339(payload.get("updated_at"))
+    if started is None:
+        started = updated
+    if updated is None:
+        updated = started
+    if started is None or updated is None:
+        return None
+    return (started, updated) if started <= updated else (updated, started)
+
+
+def _windows_overlap(a: tuple[datetime, datetime], b: tuple[datetime, datetime]) -> bool:
+    """Whether two closed time windows overlap (endpoints inclusive)."""
+    return a[0] <= b[1] and b[0] <= a[1]
+
+
+def _clocks_reconcilable(a: ClockContext, b: ClockContext) -> bool:
+    """Whether two clock contexts' timestamps can be honestly compared.
+
+    Only when they share a timestamp domain (the same clock) — comparing raw
+    timestamps across DIFFERENT domains with no known measured offset would
+    fabricate clock-qualified precision that does not exist. This is the
+    OBS-002 gate that stops timestamp proximity in one domain from
+    masquerading as a cross-domain temporal association.
+    """
+    return a.timestamp_domain == b.timestamp_domain
+
+
+def _runtime_snapshot(run_record: Mapping[str, object]) -> Mapping[str, object]:
+    """Return the embedded ``aces.runtime_snapshot`` mapping, or ``{}``."""
+    aces_section = run_record.get("aces")
+    if not isinstance(aces_section, Mapping):
+        return {}
+    snapshot = aces_section.get("runtime_snapshot")
+    return snapshot if isinstance(snapshot, Mapping) else {}
+
+
+def _find_planned_trial_id(run_record: Mapping[str, object]) -> str | None:
+    """Best-effort planned-trial id from the run record, or ``None`` when the
+    field is not threaded through (the common case today) — never fabricated."""
+    candidates: list[object] = [run_record.get("planned_trial_id")]
+    aces_section = run_record.get("aces")
+    if isinstance(aces_section, Mapping):
+        candidates.append(aces_section.get("planned_trial_id"))
+        realization = aces_section.get("realization")
+        if isinstance(realization, Mapping):
+            candidates.append(realization.get("planned_trial_id"))
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def _find_disclosure_refs(run_record: Mapping[str, object]) -> tuple[str, ...]:
+    """Observer-effect / augmentation disclosure refs from the run record's
+    realization section (best-effort; empty when absent — never fabricated)."""
+    realization: object = {}
+    aces_section = run_record.get("aces")
+    if isinstance(aces_section, Mapping):
+        realization = aces_section.get("realization")
+    result: tuple[str, ...] = ()
+    if isinstance(realization, Mapping):
+        for key in ("disclosure_refs", "augmentation_disclosure_refs"):
+            raw = realization.get(key)
+            if isinstance(raw, list) and raw:
+                result = tuple(str(item) for item in raw if isinstance(item, str) and item)
+                break
+    return result
+
+
+def _external_evidence_references(run_record: Mapping[str, object]) -> list[Mapping[str, object]]:
+    """External evidence reference dicts from ``backend_evidence`` (or ``[]``)."""
+    backend_evidence = run_record.get("backend_evidence")
+    if not isinstance(backend_evidence, Mapping):
+        return []
+    refs = backend_evidence.get("evidence_references")
+    if not isinstance(refs, list):
+        return []
+    return [item for item in refs if isinstance(item, Mapping)]
+
+
+def _flatten_behavior_events(runtime_snapshot: Mapping[str, object]) -> list[dict[str, object]]:
+    """Flatten ``participant_behavior_history`` (address → event list) into a
+    single ordered list of event dicts."""
+    behavior_history = runtime_snapshot.get("participant_behavior_history")
+    events: list[dict[str, object]] = []
+    if not isinstance(behavior_history, Mapping):
+        return events
+    for event_list in behavior_history.values():
+        if not isinstance(event_list, list):
+            continue
+        events.extend(dict(event) for event in event_list if isinstance(event, Mapping))
+    return events
+
+
+def _episode_ids_from_results(runtime_snapshot: Mapping[str, object]) -> set[str]:
+    """Episode ids declared in ``participant_episode_results``."""
+    out: set[str] = set()
+    results = runtime_snapshot.get("participant_episode_results")
+    if isinstance(results, Mapping):
+        for payload in results.values():
+            if isinstance(payload, Mapping) and isinstance(payload.get("episode_id"), str):
+                out.add(payload["episode_id"])
+    return out
+
+
+def _episode_ids_from_history(runtime_snapshot: Mapping[str, object]) -> set[str]:
+    """Episode ids appearing across ``participant_episode_history`` event lists."""
+    out: set[str] = set()
+    history = runtime_snapshot.get("participant_episode_history")
+    if not isinstance(history, Mapping):
+        return out
+    for event_list in history.values():
+        if not isinstance(event_list, list):
+            continue
+        for event in event_list:
+            if isinstance(event, Mapping) and isinstance(event.get("episode_id"), str):
+                out.add(event["episode_id"])
+    return out
+
+
+def _episode_ids_from_events(behavior_events: Sequence[Mapping[str, object]]) -> set[str]:
+    """Episode ids stamped on behavior-history events."""
+    return {
+        event["episode_id"]
+        for event in behavior_events
+        if isinstance(event.get("episode_id"), str) and event["episode_id"]
+    }
+
+
+def _collect_episode_ids(
+    runtime_snapshot: Mapping[str, object], behavior_events: Sequence[Mapping[str, object]]
+) -> set[str]:
+    """Union of every participant episode id present anywhere in the snapshot
+    (results, history, and behavior events)."""
+    return (
+        _episode_ids_from_results(runtime_snapshot)
+        | _episode_ids_from_history(runtime_snapshot)
+        | _episode_ids_from_events(behavior_events)
+    )
+
+
+def _collect_action_ids(behavior_events: Sequence[Mapping[str, object]]) -> set[str]:
+    """Distinct ``action_instance_id`` values across behavior events."""
+    return {
+        event["action_instance_id"]
+        for event in behavior_events
+        if isinstance(event.get("action_instance_id"), str) and event["action_instance_id"]
+    }
+
+
+def _map_action_to_episode(behavior_events: Sequence[Mapping[str, object]]) -> dict[str, str]:
+    """Map each action instance id to the episode id it was first seen under."""
+    mapping: dict[str, str] = {}
+    for event in behavior_events:
+        action_id = event.get("action_instance_id")
+        episode_id = event.get("episode_id")
+        if isinstance(action_id, str) and action_id and isinstance(episode_id, str) and episode_id:
+            mapping.setdefault(action_id, episode_id)
+    return mapping
+
+
+def _map_action_to_events(
+    behavior_events: Sequence[Mapping[str, object]],
+) -> dict[str, list[Mapping[str, object]]]:
+    """Group behavior events by their ``action_instance_id``."""
+    mapping: dict[str, list[Mapping[str, object]]] = {}
+    for event in behavior_events:
+        action_id = event.get("action_instance_id")
+        if isinstance(action_id, str) and action_id:
+            mapping.setdefault(action_id, []).append(event)
+    return mapping
+
+
+def _participant_address_of(events: Sequence[Mapping[str, object]]) -> str | None:
+    """First non-empty ``participant_address`` among ``events``, or ``None``."""
+    for event in events:
+        addr = event.get("participant_address")
+        if isinstance(addr, str) and addr:
+            return addr
+    return None

--- a/src/aptl/core/correlation/builder.py
+++ b/src/aptl/core/correlation/builder.py
@@ -1,0 +1,129 @@
+"""Correlation-graph builder (OBS-002, issue #447).
+
+Builds a :class:`~aptl.core.correlation.models.CorrelationProjection` from
+already-parsed APTL run-archive inputs — the ``aptl.run-record/v1`` manifest
+(whose embedded ``RuntimeSnapshot`` carries participant episode/behavior
+history and evaluator results) and the ACES orchestrator's
+``orchestration/<addr>/{result.json,history.jsonl}`` files. Pure: no I/O,
+no wall clock, no UUIDs, no process-random ordering dependence — see
+:mod:`aptl.core.correlation.persistence` for the archive-reading/writing
+boundary that feeds this module. The graph-assembly machinery lives in the
+private :mod:`aptl.core.correlation._assemble` module and the named
+``DECLARED_RULE`` vocabulary in :mod:`aptl.core.correlation.rules` (split out
+to keep each module within the repo's per-file line budget).
+
+Reality this module is built against (verified live against
+``aces-sdl==0.23.1`` and the APTL adapters, not the aspirational ACES
+archival contracts EXP-002/REP-001 do not yet wire in):
+
+- Participant events are the *lightweight*
+  ``ParticipantBehaviorHistoryEventModel`` (a single ``timestamp``, no
+  ``occurred_at``/``recorded_at``/``ingested_at``/``clock_authority`` to
+  read) — see :mod:`aptl.backends.aces_participant_actions`.
+- ``run_id`` is threaded only into the ACES orchestrator adapter
+  (:mod:`aptl.backends.aces_orchestrator`); its persisted
+  ``WorkflowExecutionState.run_id`` is the *workflow's own* internal
+  execution id (an opaque ``uuid4().hex`` minted by
+  :class:`aptl.core.runtime.workflow_engine.WorkflowEngine`), never the
+  APTL run id, and ``WorkflowHistoryEvent`` payloads do not carry the
+  workflow address as a field at all. That is why an orchestration node
+  binds to the run via a ``DECLARED_RULE`` edge (``RUN_PATH_BINDING``)
+  rather than an ``EXPLICIT_IDENTIFIER`` one, while participant
+  episodes/actions/evaluator results — all read from the *same*
+  ``manifest.json`` document, which does carry an explicit top-level
+  ``run_id`` field equal to the run identity — bind via
+  ``EXPLICIT_IDENTIFIER``.
+- No ACES archival contract (``ExperimentEvidenceRecordModel``,
+  ``ParticipantAttributionEdgeModel``, ``ExperimentAugmentationDisclosureModel``,
+  ...) is wired into APTL yet. A ``planned_trial_id``/plan ref and
+  augmentation-disclosure refs are read from ``run_record`` on a
+  best-effort basis (a handful of plausible key paths) and simply omitted
+  when absent — never fabricated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from aptl.core.correlation._assemble import (
+    _Accumulator,
+    _add_actions,
+    _add_behavior_evidence,
+    _add_episodes,
+    _add_evaluator_results,
+    _add_external_evidence,
+    _add_orchestration,
+    _add_planned_trial,
+    _add_run_node,
+    _collect_action_ids,
+    _collect_episode_ids,
+    _find_disclosure_refs,
+    _flatten_behavior_events,
+    _map_action_to_episode,
+    _map_action_to_events,
+    _runtime_snapshot,
+)
+from aptl.core.correlation.clock import ClockProvider
+from aptl.core.correlation.identity import bind_attempt_ref
+from aptl.core.correlation.models import CorrelationProjection
+from aptl.core.correlation.rules import (
+    ADMITTED_PLAN_BINDING,
+    DEFAULT_RULE_SET,
+    ORCHESTRATION_ADDRESS_GROUPING,
+    RUN_PATH_BINDING,
+    CorrelationRule,
+    CorrelationRuleSet,
+)
+
+__all__ = [
+    "ADMITTED_PLAN_BINDING",
+    "DEFAULT_RULE_SET",
+    "ORCHESTRATION_ADDRESS_GROUPING",
+    "RUN_PATH_BINDING",
+    "CorrelationRule",
+    "CorrelationRuleSet",
+    "build_correlation_projection",
+]
+
+
+def build_correlation_projection(
+    *,
+    run_id: str,
+    run_record: Mapping[str, object],
+    orchestration: Mapping[str, Mapping[str, object]],
+    clock_provider: ClockProvider,
+    rules: CorrelationRuleSet | None = None,
+) -> CorrelationProjection:
+    """Build a :class:`CorrelationProjection` from already-parsed run-archive
+    inputs. Pure and deterministic: the result depends only on the content
+    of ``run_record``/``orchestration``, never on their input ordering, wall
+    clock, or process-random state (:func:`ClockProvider.clock_context`
+    supplies clock *disclosures* attached to candidate edges, never node/edge
+    identity — see the module docstring for the exact reality this reads).
+    """
+    acc = _Accumulator(clock_provider=clock_provider, rules=rules or DEFAULT_RULE_SET)
+    run_ref = bind_attempt_ref(run_id)
+    _add_run_node(acc, run_ref)
+    _add_planned_trial(acc, run_record, run_ref)
+
+    runtime_snapshot = _runtime_snapshot(run_record)
+    behavior_events = _flatten_behavior_events(runtime_snapshot)
+    episode_ids = _collect_episode_ids(runtime_snapshot, behavior_events)
+    action_ids = _collect_action_ids(behavior_events)
+    action_to_episode = _map_action_to_episode(behavior_events)
+    action_to_events = _map_action_to_events(behavior_events)
+
+    _add_episodes(acc, episode_ids, run_ref)
+    _add_actions(acc, action_ids, action_to_episode, run_ref)
+    _add_behavior_evidence(acc, behavior_events)
+    _add_orchestration(acc, orchestration, run_ref)
+    _add_evaluator_results(acc, runtime_snapshot, run_ref, action_ids, action_to_events)
+    _add_external_evidence(acc, run_record, run_ref)
+
+    return CorrelationProjection(
+        run_id=run_ref,
+        nodes=tuple(acc.nodes.values()),
+        edges=tuple(acc.edges),
+        clock_contexts=tuple(acc.clock_contexts.values()),
+        disclosures=_find_disclosure_refs(run_record),
+    )

--- a/src/aptl/core/correlation/builder.py
+++ b/src/aptl/core/correlation/builder.py
@@ -55,6 +55,8 @@ from aptl.core.correlation._assemble import (
     _add_orchestration,
     _add_planned_trial,
     _add_run_node,
+)
+from aptl.core.correlation._extract import (
     _collect_action_ids,
     _collect_episode_ids,
     _find_disclosure_refs,

--- a/src/aptl/core/correlation/clock.py
+++ b/src/aptl/core/correlation/clock.py
@@ -1,0 +1,131 @@
+"""Clock-provider seam (OBS-002 Stage 1, issue #447).
+
+Implements the preflight's "Clock collection needs one source-owned
+provider seam" seam:
+``(source_kind, source_id, timestamp_domain, clock_source,
+synchronization_status, measured_offset, uncertainty, measurement_time,
+observer_effect_ref)``. Collectors and MCP sinks can implement this
+seam differently, but must not scatter ``datetime.now(UTC)``,
+``Date.now()``, UUIDs, or wall-clock parsing through business logic as an
+identity or causality source (preflight "Gotchas").
+
+:func:`utc_now` is the single canonical UTC RFC3339 formatter — a future
+stage rewires the three duplicated backend call sites that currently
+format ``datetime.now(UTC)`` locally to import this instead, so the
+formatting logic has exactly one owner.
+
+Identity is deliberately out of scope here: this module only ever
+reports *when* and *how confidently* a source's clock was read. Stable
+correlation identity comes from ``aptl.core.correlation.identity``, never
+from a clock reading.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+from aptl.core.correlation.models import ClockContext
+
+__all__ = [
+    "ClockContext",
+    "ClockProvider",
+    "FixedClockProvider",
+    "SystemClockProvider",
+    "utc_now",
+]
+
+
+def utc_now() -> str:
+    """Return the current UTC time as an RFC3339 string (``...Z`` suffix).
+
+    The single canonical UTC formatter for the whole codebase — callers
+    must import this rather than formatting ``datetime.now(UTC)``
+    locally, so there is exactly one place that owns the format.
+    """
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+class ClockProvider(Protocol):
+    """Source-owned clock seam. A future collector implements this
+    differently per source (e.g. reading an NTP-disciplined offset)
+    without any caller needing to learn a new identity concept."""
+
+    def clock_context(
+        self,
+        *,
+        source_kind: str,
+        source_id: str,
+        observer_effect_ref: str | None = None,
+    ) -> ClockContext: ...
+
+    def now(self) -> str: ...
+
+
+class SystemClockProvider(ClockProvider):
+    """Default provider backed by the host system clock.
+
+    Honest about what a bare system clock can claim: no measured offset
+    or uncertainty band (the host has not been NTP-audited by this
+    provider), and ``synchronization_status="unknown"`` rather than a
+    fabricated "synchronized" claim.
+    """
+
+    def now(self) -> str:
+        return utc_now()
+
+    def clock_context(
+        self,
+        *,
+        source_kind: str,
+        source_id: str,
+        observer_effect_ref: str | None = None,
+    ) -> ClockContext:
+        return ClockContext(
+            source_kind=source_kind,
+            source_id=source_id,
+            timestamp_domain="host-utc",
+            clock_source="system",
+            synchronization_status="unknown",
+            measured_offset=None,
+            uncertainty=None,
+            measurement_time=self.now(),
+            observer_effect_ref=observer_effect_ref,
+        )
+
+
+@dataclass(frozen=True)
+class FixedClockProvider(ClockProvider):
+    """Test-friendly injectable provider: every field is fixed at
+    construction, so both :meth:`now` and :meth:`clock_context` are
+    fully deterministic across calls."""
+
+    measurement_time: str
+    clock_source: str = "fixed"
+    timestamp_domain: str = "host-utc"
+    synchronization_status: str = "unknown"
+    measured_offset: str | None = None
+    uncertainty: str | None = None
+
+    def now(self) -> str:
+        return self.measurement_time
+
+    def clock_context(
+        self,
+        *,
+        source_kind: str,
+        source_id: str,
+        observer_effect_ref: str | None = None,
+    ) -> ClockContext:
+        return ClockContext(
+            source_kind=source_kind,
+            source_id=source_id,
+            timestamp_domain=self.timestamp_domain,
+            clock_source=self.clock_source,
+            synchronization_status=self.synchronization_status,
+            measured_offset=self.measured_offset,
+            uncertainty=self.uncertainty,
+            measurement_time=self.measurement_time,
+            observer_effect_ref=observer_effect_ref,
+        )

--- a/src/aptl/core/correlation/identity.py
+++ b/src/aptl/core/correlation/identity.py
@@ -1,0 +1,93 @@
+"""Deterministic, non-secret identity helpers (OBS-002 Stage 1, issue #447).
+
+Reuses the domain-separated SHA-256 pattern EXP-002 established in
+``aptl.core.experiment.trial_plan``: stable identity comes from hashing a
+fixed, versioned domain-separation prefix plus canonical parts — never
+from an ambient wall clock, a process-random or universally-unique
+identifier, or the order evidence happened to arrive in (preflight
+"Extensibility Seam" / "Gotchas And Anti-Patterns": planned identity must
+be derived from ACES inputs, never minted from time or ingestion order).
+
+Two distinct identity shapes:
+
+- **Planned** identity (:func:`derive_planned_ref`) is deterministic —
+  the same ACES/plan inputs always derive the same ref, on any host, in
+  any process, regardless of the interpreter's hash-randomization seed.
+- **Attempt** identity (:func:`bind_attempt_ref`) accepts an externally
+  supplied run/episode/action id (e.g. an experiment run's own run id)
+  and validates it at the serialization boundary rather than deriving
+  it — an attempt result is never minted here, only bound and checked,
+  so it can never be mistaken for planned identity.
+
+Every id this module produces or accepts is validated through
+:func:`aptl.core.correlation.models.validate_correlation_id` before it is
+returned.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from aptl.core.correlation.models import assert_non_secret, validate_correlation_id
+
+#: ASCII unit separator (0x1F) joining hash-input fields. Mirrors
+#: ``aptl.core.experiment.trial_plan``'s ``_FIELD_SEP``: not a legal
+#: character in any authored ACES identifier, so it cannot be abused to
+#: fabricate a cross-field collision (e.g. by embedding the separator
+#: inside one part to make two distinct part tuples hash to the same
+#: input bytes).
+_FIELD_SEP = b"\x1f"
+
+
+def stable_ref(*parts: str, domain: bytes) -> str:
+    """Return a filesystem-safe, non-secret, collision-resistant id.
+
+    Derived via domain-separated SHA-256 over ``parts``: the exact same
+    ``domain`` plus the exact same ``parts``, in the exact same order,
+    always yields the exact same id — on any host, in any process,
+    regardless of the interpreter's hash-randomization seed. Nothing
+    here reads the system clock, mints a universally-unique token, draws
+    on ambient process entropy, or depends on the order callers happened
+    to invoke this in.
+
+    Raises ``ValueError`` if ``domain`` or ``parts`` is empty. Raises
+    ``TypeError`` if any part is not a ``str``.
+    """
+    if not domain:
+        raise ValueError("stable_ref requires a non-empty domain")
+    if not parts:
+        raise ValueError("stable_ref requires at least one part")
+    digest_input = domain
+    for part in parts:
+        if not isinstance(part, str):
+            raise TypeError(f"stable_ref parts must be str, got {type(part)!r}")
+        digest_input += _FIELD_SEP + part.encode("utf-8")
+    digest_hex = hashlib.sha256(digest_input).hexdigest()
+    return validate_correlation_id(digest_hex)
+
+
+def derive_planned_ref(*parts: str, domain: bytes) -> str:
+    """Deterministic *planned* identity: derive a ref purely from
+    caller-supplied ACES/plan inputs (never an attempt/run result).
+
+    A thin, deliberately distinct name for :func:`stable_ref` so a
+    planned-identity call site can never be confused with an
+    attempt-identity call site (:func:`bind_attempt_ref`) at a glance.
+    """
+    return stable_ref(*parts, domain=domain)
+
+
+def bind_attempt_ref(external_id: str) -> str:
+    """*Attempt* identity: bind an externally-supplied run/episode/action
+    id as a correlation ref.
+
+    Unlike :func:`derive_planned_ref`, nothing is hashed or derived here
+    — an attempt id is supplied by the surface that actually executed
+    (e.g. an experiment run's own run id, or a participant episode id),
+    and this function only validates it (id-shaped and non-secret) at
+    the serialization boundary. Keeping this a validate-only path —
+    never a derive-and-hash path — means an attempt ref can never
+    silently drift into looking like a deterministic planned ref.
+    """
+    ref = validate_correlation_id(external_id)
+    return assert_non_secret(ref, field_name="external_id")

--- a/src/aptl/core/correlation/models.py
+++ b/src/aptl/core/correlation/models.py
@@ -1,0 +1,402 @@
+"""Typed correlation models (OBS-002 Stage 1, issue #447).
+
+Implements the "Extensibility Seam" from
+``docs/architecture/obs-002-correlation-identity-clock-preflight.md``: a
+small versioned correlation projection whose nodes are existing ACES or
+``LocalRunStore`` references and whose edges carry only ``source_ref``,
+``target_ref``, ``association_method``, ``rule_id``, ``clock_context_ref``,
+``confidence_or_status``, and ``disclosure_refs``. Timestamp proximity is
+never a causal claim on its own: a ``TIME_WINDOW_CANDIDATE`` edge must
+carry a ``clock_context_ref`` so its uncertainty travels with the claim,
+and a ``DECLARED_RULE`` edge must name the ``rule_id`` that produced it.
+
+Reuses two incumbents rather than re-deriving their policy locally
+(preflight "Gotchas": "Do not duplicate ID validation separately"):
+
+- ID/filesystem-safety validation delegates to the exact rule
+  ``aptl.core.runstore`` already enforces for run/session/trace ids
+  (:func:`validate_correlation_id`), so a correlation ref can never
+  validate under a second, drifting definition.
+- Non-secret validation delegates to the shared
+  ``aptl.utils.redaction`` classification (:func:`assert_non_secret`),
+  so an identity-bearing value that :func:`aptl.utils.redaction.redact`
+  would alter is rejected at construction instead of silently persisted
+  and redacted later.
+
+Determinism and canonicalization follow
+``aptl.core.experiment.trial_plan``'s pattern: RFC 8785 canonical JSON
+over a projection dict, SHA-256 over the canonical bytes, immutable
+frozen dataclasses, tuples (never lists) for every sequence field. Nodes,
+edges, clock contexts, and the top-level disclosure list are graph-shaped
+(semantically unordered) rather than an authored execution sequence, so
+:meth:`CorrelationProjection.to_canonical_dict` sorts each of them before
+hashing — two projections built from the same content in different
+input order must still hash identically.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+
+import rfc8785
+
+from aptl.core.runstore import _validate_id as _runstore_validate_id
+from aptl.utils.redaction import is_secret_shaped_value, is_sensitive_key
+
+#: Versioned identity for the canonical projection shape itself (distinct
+#: from any ACES ``schema_version`` literal — this is an APTL-internal
+#: archive projection, never an ACES contract).
+_PROJECTION_SCHEMA_VERSION = "aptl-correlation/v1"
+
+#: Controlled vocabulary for :attr:`CorrelationNode.ref_kind`. Every entry
+#: names an existing ACES or ``LocalRunStore`` identity kind (preflight
+#: "Represent correlation as a graph of typed associations over existing
+#: refs") — this package must never invent a new local tracing vocabulary.
+_REF_KINDS: frozenset[str] = frozenset(
+    {
+        "experiment-spec",
+        "task",
+        "condition",
+        "planned-trial",
+        "attempt-run",
+        "participant-episode",
+        "action",
+        "capture",
+        "evidence",
+        "evaluator-result",
+    }
+)
+
+
+class AssociationMethod(str, Enum):
+    """The minimum association methods a correlation edge may claim
+    (preflight: "The minimum association methods are ``explicit_identifier``,
+    ``declared_rule``, ``time_window_candidate``, and ``gap_or_unknown``.
+    Timestamp proximity alone is never a causal link.")."""
+
+    EXPLICIT_IDENTIFIER = "explicit_identifier"
+    DECLARED_RULE = "declared_rule"
+    TIME_WINDOW_CANDIDATE = "time_window_candidate"
+    GAP_OR_UNKNOWN = "gap_or_unknown"
+
+
+def validate_correlation_id(value: str) -> str:
+    """Validate ``value`` as a correlation ref/id.
+
+    Delegates to the exact ``LocalRunStore`` id-validation rule
+    (:func:`aptl.core.runstore._validate_id`) — the single source of
+    truth for the filesystem-safe id contract used throughout the run
+    archive — instead of a second, locally-defined pattern. Raises
+    ``ValueError`` on an invalid id; returns ``value`` unchanged
+    otherwise.
+    """
+    return _runstore_validate_id(value, "correlation_id")
+
+
+def assert_non_secret(value: str, *, field_name: str) -> str:
+    """Reject an identity-bearing ``value`` that the shared redaction
+    policy would treat as sensitive.
+
+    Two independent checks, both backed by
+    :mod:`aptl.utils.redaction` (never a second, locally-defined
+    classification):
+
+    - ``field_name`` itself reads as a sensitive key
+      (:func:`aptl.utils.redaction.is_sensitive_key`) — e.g. a caller
+      accidentally wiring a ``password``-named field through a
+      correlation ref.
+    - ``value`` is secret-shaped content
+      (:func:`aptl.utils.redaction.is_secret_shaped_value`) — i.e.
+      :func:`aptl.utils.redaction.redact` would alter it.
+
+    Raises ``ValueError`` on either hit; returns ``value`` unchanged
+    otherwise.
+    """
+    if is_sensitive_key(field_name):
+        raise ValueError(
+            f"{field_name!r} reads as a sensitive field name; "
+            "correlation identities must be non-secret"
+        )
+    if is_secret_shaped_value(value):
+        raise ValueError(
+            f"{field_name} value is secret-shaped; correlation identities must be non-secret"
+        )
+    return value
+
+
+def _validate_non_empty(field_name: str, value: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+
+def _validate_ref(value: str, *, field_name: str) -> None:
+    """Validate a required ref: id-shaped AND non-secret."""
+    validate_correlation_id(value)
+    assert_non_secret(value, field_name=field_name)
+
+
+def _validate_optional_ref(value: str | None, *, field_name: str) -> None:
+    """Validate an optional ref: ``None`` is always accepted; a present
+    value must be id-shaped AND non-secret."""
+    if value is None:
+        return
+    _validate_ref(value, field_name=field_name)
+
+
+@dataclass(frozen=True)
+class ClockContext:
+    """APTL archive-local projection of one source's clock context.
+
+    ACES's own ``ExperimentClockContextModel`` carries only ``clock_id``,
+    ``authority``, ``time_domain``, and an optional free-text
+    ``synchronization`` string — no structured offset or uncertainty.
+    This type fills that gap: a per-source, per-timestamp-domain clock
+    reading that can carry a measured offset and uncertainty band
+    alongside the observer-effect disclosure that documents any injected
+    metadata (preflight "Record clock context per evidence source and
+    timestamp domain").
+    """
+
+    source_kind: str
+    source_id: str
+    timestamp_domain: str
+    clock_source: str
+    synchronization_status: str
+    measured_offset: str | None
+    uncertainty: str | None
+    measurement_time: str
+    observer_effect_ref: str | None
+
+    def __post_init__(self) -> None:
+        _validate_non_empty("source_kind", self.source_kind)
+        _validate_non_empty("timestamp_domain", self.timestamp_domain)
+        _validate_non_empty("clock_source", self.clock_source)
+        _validate_non_empty("synchronization_status", self.synchronization_status)
+        _validate_non_empty("measurement_time", self.measurement_time)
+        _validate_ref(self.source_id, field_name="source_id")
+        _validate_optional_ref(self.observer_effect_ref, field_name="observer_effect_ref")
+
+
+@dataclass(frozen=True)
+class CorrelationNode:
+    """One ACES/``LocalRunStore`` reference in the correlation graph.
+
+    ``ref`` is an existing ACES or run-store identity — never a new
+    APTL-local tracing concept; ``ref_kind`` names which controlled
+    vocabulary entry (:data:`_REF_KINDS`) it is.
+    """
+
+    ref: str
+    ref_kind: str
+
+    def __post_init__(self) -> None:
+        _validate_ref(self.ref, field_name="ref")
+        if self.ref_kind not in _REF_KINDS:
+            raise ValueError(f"unknown ref_kind: {self.ref_kind!r}")
+
+
+@dataclass(frozen=True)
+class CorrelationEdge:
+    """One typed association between two declared :class:`CorrelationNode` refs.
+
+    Never a bare causal claim from timestamp proximity alone: a
+    ``TIME_WINDOW_CANDIDATE`` edge MUST carry a ``clock_context_ref`` so
+    its uncertainty travels with the claim, and a ``DECLARED_RULE`` edge
+    MUST name the ``rule_id`` that produced it.
+    """
+
+    source_ref: str
+    target_ref: str
+    association_method: AssociationMethod
+    rule_id: str | None
+    clock_context_ref: str | None
+    confidence_or_status: str | None
+    disclosure_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _validate_ref(self.source_ref, field_name="source_ref")
+        _validate_ref(self.target_ref, field_name="target_ref")
+        _validate_optional_ref(self.rule_id, field_name="rule_id")
+        _validate_optional_ref(self.clock_context_ref, field_name="clock_context_ref")
+        for ref in self.disclosure_refs:
+            _validate_ref(ref, field_name="disclosure_refs")
+        if self.association_method is AssociationMethod.DECLARED_RULE and self.rule_id is None:
+            raise ValueError("a DECLARED_RULE edge requires rule_id")
+        if (
+            self.association_method is AssociationMethod.TIME_WINDOW_CANDIDATE
+            and self.clock_context_ref is None
+        ):
+            raise ValueError(
+                "a TIME_WINDOW_CANDIDATE edge requires clock_context_ref "
+                "(uncertainty must be attached — never a bare causal claim)"
+            )
+
+
+def _node_projection(node: CorrelationNode) -> dict[str, object]:
+    return {"ref": node.ref, "ref_kind": node.ref_kind}
+
+
+def _node_sort_key(node: CorrelationNode) -> tuple[str, str]:
+    return (node.ref, node.ref_kind)
+
+
+def _edge_projection(edge: CorrelationEdge) -> dict[str, object]:
+    return {
+        "source_ref": edge.source_ref,
+        "target_ref": edge.target_ref,
+        "association_method": edge.association_method.value,
+        "rule_id": edge.rule_id,
+        "clock_context_ref": edge.clock_context_ref,
+        "confidence_or_status": edge.confidence_or_status,
+        # Sorted: disclosure_refs is an unordered set of disclosure
+        # documents attached to this edge, not an authored sequence.
+        "disclosure_refs": sorted(edge.disclosure_refs),
+    }
+
+
+def _edge_sort_key(edge: CorrelationEdge) -> tuple[str, str, str, str, str, str, str]:
+    return (
+        edge.source_ref,
+        edge.target_ref,
+        edge.association_method.value,
+        edge.rule_id or "",
+        edge.clock_context_ref or "",
+        edge.confidence_or_status or "",
+        ",".join(sorted(edge.disclosure_refs)),
+    )
+
+
+def _clock_context_projection(ctx: ClockContext) -> dict[str, object]:
+    return {
+        "source_kind": ctx.source_kind,
+        "source_id": ctx.source_id,
+        "timestamp_domain": ctx.timestamp_domain,
+        "clock_source": ctx.clock_source,
+        "synchronization_status": ctx.synchronization_status,
+        "measured_offset": ctx.measured_offset,
+        "uncertainty": ctx.uncertainty,
+        "measurement_time": ctx.measurement_time,
+        "observer_effect_ref": ctx.observer_effect_ref,
+    }
+
+
+def _clock_context_sort_key(ctx: ClockContext) -> tuple[str, str, str]:
+    return (ctx.source_kind, ctx.source_id, ctx.measurement_time)
+
+
+def _clock_context_from_dict(data: Mapping[str, object]) -> ClockContext:
+    return ClockContext(
+        source_kind=data["source_kind"],
+        source_id=data["source_id"],
+        timestamp_domain=data["timestamp_domain"],
+        clock_source=data["clock_source"],
+        synchronization_status=data["synchronization_status"],
+        measured_offset=data["measured_offset"],
+        uncertainty=data["uncertainty"],
+        measurement_time=data["measurement_time"],
+        observer_effect_ref=data["observer_effect_ref"],
+    )
+
+
+def _edge_from_dict(data: Mapping[str, object]) -> CorrelationEdge:
+    return CorrelationEdge(
+        source_ref=data["source_ref"],
+        target_ref=data["target_ref"],
+        association_method=AssociationMethod(data["association_method"]),
+        rule_id=data["rule_id"],
+        clock_context_ref=data["clock_context_ref"],
+        confidence_or_status=data["confidence_or_status"],
+        disclosure_refs=tuple(data["disclosure_refs"]),
+    )
+
+
+def _node_from_dict(data: Mapping[str, object]) -> CorrelationNode:
+    return CorrelationNode(ref=data["ref"], ref_kind=data["ref_kind"])
+
+
+@dataclass(frozen=True)
+class CorrelationProjection:
+    """The full versioned correlation projection for one run archive.
+
+    Immutable: :attr:`canonical_bytes` (RFC 8785 canonical JSON of
+    :meth:`to_canonical_dict`) and :attr:`projection_digest`
+    (``sha256:<hex>`` of those bytes) are computed once at construction
+    and never accepted as constructor input — a caller cannot pass a
+    ``canonical_bytes`` that disagrees with the actual field content.
+
+    Every edge endpoint (``source_ref``/``target_ref``) must reference a
+    node declared in :attr:`nodes`; construction rejects a dangling edge
+    rather than silently admitting it.
+    """
+
+    run_id: str
+    nodes: tuple[CorrelationNode, ...]
+    edges: tuple[CorrelationEdge, ...]
+    clock_contexts: tuple[ClockContext, ...]
+    disclosures: tuple[str, ...]
+    schema_version: str = _PROJECTION_SCHEMA_VERSION
+    canonical_bytes: bytes = field(init=False)
+    projection_digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        _validate_non_empty("schema_version", self.schema_version)
+        _validate_ref(self.run_id, field_name="run_id")
+        declared_refs = {node.ref for node in self.nodes}
+        for edge in self.edges:
+            if edge.source_ref not in declared_refs:
+                raise ValueError(f"edge source_ref is not a declared node: {edge.source_ref!r}")
+            if edge.target_ref not in declared_refs:
+                raise ValueError(f"edge target_ref is not a declared node: {edge.target_ref!r}")
+        for ref in self.disclosures:
+            _validate_ref(ref, field_name="disclosures")
+
+        canonical = rfc8785.dumps(self.to_canonical_dict())
+        object.__setattr__(self, "canonical_bytes", canonical)
+        object.__setattr__(
+            self, "projection_digest", f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+        )
+
+    def to_canonical_dict(self) -> dict[str, object]:
+        """Project to a canonical-JSON-ready dict.
+
+        Nodes, edges, clock contexts, and disclosures are graph-shaped
+        (semantically unordered) rather than an authored execution
+        sequence, so each is sorted here — two projections built from the
+        same content in different input order produce the identical
+        dict, and therefore identical :attr:`canonical_bytes` /
+        :attr:`projection_digest`. Excludes any wall-clock/host-path
+        administrative metadata: every value below is authored content
+        (a source's own recorded ``measurement_time`` is payload, not
+        build-time provenance).
+        """
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "nodes": [_node_projection(n) for n in sorted(self.nodes, key=_node_sort_key)],
+            "edges": [_edge_projection(e) for e in sorted(self.edges, key=_edge_sort_key)],
+            "clock_contexts": [
+                _clock_context_projection(c)
+                for c in sorted(self.clock_contexts, key=_clock_context_sort_key)
+            ],
+            "disclosures": sorted(self.disclosures),
+        }
+
+    @classmethod
+    def from_canonical_dict(cls, data: Mapping[str, object]) -> "CorrelationProjection":
+        """Reconstruct a :class:`CorrelationProjection` from
+        :meth:`to_canonical_dict`'s output (or an equivalently-shaped
+        mapping, e.g. after a JSON round-trip)."""
+        nodes: Sequence[Mapping[str, object]] = data["nodes"]
+        edges: Sequence[Mapping[str, object]] = data["edges"]
+        clock_contexts: Sequence[Mapping[str, object]] = data["clock_contexts"]
+        return cls(
+            run_id=data["run_id"],
+            nodes=tuple(_node_from_dict(n) for n in nodes),
+            edges=tuple(_edge_from_dict(e) for e in edges),
+            clock_contexts=tuple(_clock_context_from_dict(c) for c in clock_contexts),
+            disclosures=tuple(data["disclosures"]),
+            schema_version=data.get("schema_version", _PROJECTION_SCHEMA_VERSION),
+        )

--- a/src/aptl/core/correlation/models.py
+++ b/src/aptl/core/correlation/models.py
@@ -128,6 +128,7 @@ def assert_non_secret(value: str, *, field_name: str) -> str:
 
 
 def _validate_non_empty(field_name: str, value: str) -> None:
+    """Raise ``ValueError`` if ``value`` is not a non-empty string."""
     if not isinstance(value, str) or not value:
         raise ValueError(f"{field_name} must be a non-empty string")
 
@@ -236,14 +237,17 @@ class CorrelationEdge:
 
 
 def _node_projection(node: CorrelationNode) -> dict[str, object]:
+    """Canonical dict projection of a node."""
     return {"ref": node.ref, "ref_kind": node.ref_kind}
 
 
 def _node_sort_key(node: CorrelationNode) -> tuple[str, str]:
+    """Sort key for deterministic node ordering."""
     return (node.ref, node.ref_kind)
 
 
 def _edge_projection(edge: CorrelationEdge) -> dict[str, object]:
+    """Canonical dict projection of an edge (disclosure_refs sorted)."""
     return {
         "source_ref": edge.source_ref,
         "target_ref": edge.target_ref,
@@ -258,6 +262,7 @@ def _edge_projection(edge: CorrelationEdge) -> dict[str, object]:
 
 
 def _edge_sort_key(edge: CorrelationEdge) -> tuple[str, str, str, str, str, str, str]:
+    """Sort key for deterministic edge ordering."""
     return (
         edge.source_ref,
         edge.target_ref,
@@ -270,6 +275,7 @@ def _edge_sort_key(edge: CorrelationEdge) -> tuple[str, str, str, str, str, str,
 
 
 def _clock_context_projection(ctx: ClockContext) -> dict[str, object]:
+    """Canonical dict projection of a clock context."""
     return {
         "source_kind": ctx.source_kind,
         "source_id": ctx.source_id,
@@ -284,10 +290,12 @@ def _clock_context_projection(ctx: ClockContext) -> dict[str, object]:
 
 
 def _clock_context_sort_key(ctx: ClockContext) -> tuple[str, str, str]:
+    """Sort key for deterministic clock-context ordering."""
     return (ctx.source_kind, ctx.source_id, ctx.measurement_time)
 
 
 def _clock_context_from_dict(data: Mapping[str, object]) -> ClockContext:
+    """Reconstruct a ClockContext from its canonical dict projection."""
     return ClockContext(
         source_kind=data["source_kind"],
         source_id=data["source_id"],
@@ -302,6 +310,7 @@ def _clock_context_from_dict(data: Mapping[str, object]) -> ClockContext:
 
 
 def _edge_from_dict(data: Mapping[str, object]) -> CorrelationEdge:
+    """Reconstruct a CorrelationEdge from its canonical dict projection."""
     return CorrelationEdge(
         source_ref=data["source_ref"],
         target_ref=data["target_ref"],
@@ -314,6 +323,7 @@ def _edge_from_dict(data: Mapping[str, object]) -> CorrelationEdge:
 
 
 def _node_from_dict(data: Mapping[str, object]) -> CorrelationNode:
+    """Reconstruct a CorrelationNode from its canonical dict projection."""
     return CorrelationNode(ref=data["ref"], ref_kind=data["ref_kind"])
 
 

--- a/src/aptl/core/correlation/persistence.py
+++ b/src/aptl/core/correlation/persistence.py
@@ -1,0 +1,231 @@
+"""Correlation-projection persistence (OBS-002 Stage 2, issue #447).
+
+Reads the run archive's ``manifest.json`` and ``orchestration/*/{result.json,
+history.jsonl}`` files through the ``LocalRunStore`` path API, builds a
+:class:`~aptl.core.correlation.models.CorrelationProjection` via
+:func:`aptl.core.correlation.builder.build_correlation_projection`, and
+persists it back into the *same* run directory as
+``<run_id>/correlation.json``.
+
+Persisting anywhere else is a real, previously-confirmed bug class here:
+``aptl.core.exporter.export_local`` tars only ``<base_dir>/<run_id>/``
+(``rglob`` + ``tar.add(run_path, ...)``); ``LocalRunStore.create_json_once``
+writes to ``<base_dir>/<namespace>/<name>.json`` — a *sibling* of the run
+tree, invisible to both ``list_runs()`` and the exporter. So this module
+always writes through ``run_store.write_json(run_id, ...)``, never
+``create_json_once``, and the persistence test asserts the exported tar
+actually contains ``correlation.json`` end to end.
+
+Every failure normalizes into the existing ADR-047 fail-closed diagnostic
+shape (:class:`aces_contracts.diagnostics.Diagnostic` /
+:class:`aptl.core.experiment.errors.AdmissionRejection`) rather than a new
+exception hierarchy — a missing/corrupt manifest, an unreadable
+orchestration file, or a builder ``ValueError`` (e.g. an invalid/secret-
+shaped ref) all surface the same way callers already handle admission
+failures.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+
+from aptl.core.correlation.builder import CorrelationRuleSet, build_correlation_projection
+from aptl.core.correlation.clock import ClockProvider, SystemClockProvider
+from aptl.core.correlation.models import CorrelationProjection
+from aptl.core.experiment.errors import AdmissionRejection
+from aptl.core.runstore import RunStorageBackend
+from aptl.utils.logging import get_logger
+from aptl.utils.redaction import redact
+
+__all__ = ["build_and_persist_correlation", "persist_run_correlation_best_effort"]
+
+_log = get_logger("obs-002-correlation")
+
+_CORRELATION_DOMAIN = "obs-002-correlation"
+_CORRELATION_RELATIVE_PATH = "correlation.json"
+
+
+def _diagnostic(code: str, address: str, message: str) -> Diagnostic:
+    """Build one redacted correlation-persistence diagnostic.
+
+    Mirrors ``aptl.core.experiment.errors.diagnostic()``'s exact shape
+    (same ``Diagnostic``/``Severity`` types, same ``redact()`` pass on the
+    message) but under this module's own domain — correlation persistence
+    is not the experiment-admission boundary that module's constant names.
+    """
+    return Diagnostic(
+        code=code,
+        domain=_CORRELATION_DOMAIN,
+        address=address,
+        message=redact(message),
+        severity=Severity.ERROR,
+    )
+
+
+def _read_manifest(run_store: RunStorageBackend, run_id: str) -> dict[str, object]:
+    try:
+        return run_store.get_run_manifest(run_id)
+    except FileNotFoundError as exc:
+        raise AdmissionRejection(
+            (_diagnostic("aptl.correlation.manifest-missing", run_id, "run manifest.json not found"),)
+        ) from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AdmissionRejection(
+            (
+                _diagnostic(
+                    "aptl.correlation.manifest-unreadable",
+                    run_id,
+                    "run manifest.json could not be read or parsed",
+                ),
+            )
+        ) from exc
+
+
+def _read_orchestration_result(address_dir: Path, run_id: str, address: str) -> dict[str, object]:
+    result_path = address_dir / "result.json"
+    if not result_path.is_file():
+        return {}
+    try:
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AdmissionRejection(
+            (
+                _diagnostic(
+                    "aptl.correlation.orchestration-result-unreadable",
+                    run_id,
+                    f"orchestration result.json unreadable for address {address!r}",
+                ),
+            )
+        ) from exc
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_orchestration_history(address_dir: Path, run_id: str, address: str) -> list[dict[str, object]]:
+    history_path = address_dir / "history.jsonl"
+    if not history_path.is_file():
+        return []
+    events: list[dict[str, object]] = []
+    try:
+        lines = history_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise AdmissionRejection(
+            (
+                _diagnostic(
+                    "aptl.correlation.orchestration-history-unreadable",
+                    run_id,
+                    f"orchestration history.jsonl unreadable for address {address!r}",
+                ),
+            )
+        ) from exc
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise AdmissionRejection(
+                (
+                    _diagnostic(
+                        "aptl.correlation.orchestration-history-invalid",
+                        run_id,
+                        f"orchestration history.jsonl has a malformed line for address {address!r}",
+                    ),
+                )
+            ) from exc
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def _read_orchestration(run_store: RunStorageBackend, run_id: str) -> dict[str, dict[str, object]]:
+    orchestration_dir = run_store.get_run_path(run_id) / "orchestration"
+    orchestration: dict[str, dict[str, object]] = {}
+    if not orchestration_dir.is_dir():
+        return orchestration
+    for address_dir in sorted(orchestration_dir.iterdir()):
+        if not address_dir.is_dir():
+            continue
+        address = address_dir.name
+        orchestration[address] = {
+            "result": _read_orchestration_result(address_dir, run_id, address),
+            "history": _read_orchestration_history(address_dir, run_id, address),
+        }
+    return orchestration
+
+
+def build_and_persist_correlation(
+    *,
+    run_id: str,
+    run_store: RunStorageBackend,
+    clock_provider: ClockProvider,
+    rules: CorrelationRuleSet | None = None,
+) -> CorrelationProjection:
+    """Read ``<run_id>``'s archive, build its correlation projection, and
+    persist it as ``<run_id>/correlation.json``.
+
+    Returns the built :class:`CorrelationProjection`. Raises
+    :class:`AdmissionRejection` (never a raw exception) on a missing/
+    unreadable archive or an invalid projection — every diagnostic message
+    passes through :func:`aptl.utils.redaction.redact` and names no raw
+    ACES payload content.
+    """
+    manifest = _read_manifest(run_store, run_id)
+    orchestration = _read_orchestration(run_store, run_id)
+    try:
+        projection = build_correlation_projection(
+            run_id=run_id,
+            run_record=manifest,
+            orchestration=orchestration,
+            clock_provider=clock_provider,
+            rules=rules,
+        )
+    except ValueError as exc:
+        raise AdmissionRejection(
+            (
+                _diagnostic(
+                    "aptl.correlation.build-failed",
+                    run_id,
+                    "correlation projection construction failed validation",
+                ),
+            )
+        ) from exc
+    run_store.write_json(run_id, _CORRELATION_RELATIVE_PATH, projection.to_canonical_dict())
+    return projection
+
+
+def persist_run_correlation_best_effort(
+    *,
+    run_id: str,
+    run_store: RunStorageBackend,
+    clock_provider: ClockProvider | None = None,
+    rules: CorrelationRuleSet | None = None,
+) -> CorrelationProjection | None:
+    """Run-finalization hook: build + persist the correlation projection,
+    returning ``None`` (and logging a redacted warning) on any failure so a
+    correlation problem never fails the run itself.
+
+    OBS-002's projection is auditing metadata layered over an already-sealed
+    run record; a missing evaluator field or an unreadable orchestration file
+    must degrade the *audit trail*, never turn a successful run into a failed
+    one. The logged message names only the run id and the diagnostic
+    *codes* (already redacted, no payload/timestamp content).
+    """
+    provider = clock_provider if clock_provider is not None else SystemClockProvider()
+    try:
+        return build_and_persist_correlation(
+            run_id=run_id, run_store=run_store, clock_provider=provider, rules=rules
+        )
+    except AdmissionRejection as exc:
+        codes = ", ".join(diag.code for diag in exc.diagnostics) or "unknown"
+        _log.warning(
+            "OBS-002: correlation projection not persisted for run %s (%s)", run_id, codes
+        )
+        return None
+    except Exception:  # defensive: an OBS-002 audit projection is never fatal to the run
+        _log.warning(
+            "OBS-002: correlation projection not persisted for run %s (unexpected error)", run_id
+        )
+        return None

--- a/src/aptl/core/correlation/persistence.py
+++ b/src/aptl/core/correlation/persistence.py
@@ -66,6 +66,8 @@ def _diagnostic(code: str, address: str, message: str) -> Diagnostic:
 
 
 def _read_manifest(run_store: RunStorageBackend, run_id: str) -> dict[str, object]:
+    """Read ``<run_id>/manifest.json``, raising a redacted AdmissionRejection
+    on a missing or unparseable manifest."""
     try:
         return run_store.get_run_manifest(run_id)
     except FileNotFoundError as exc:
@@ -85,6 +87,8 @@ def _read_manifest(run_store: RunStorageBackend, run_id: str) -> dict[str, objec
 
 
 def _read_orchestration_result(address_dir: Path, run_id: str, address: str) -> dict[str, object]:
+    """Read one orchestration address's ``result.json`` (``{}`` when absent;
+    AdmissionRejection when present but unreadable)."""
     result_path = address_dir / "result.json"
     if not result_path.is_file():
         return {}
@@ -104,6 +108,8 @@ def _read_orchestration_result(address_dir: Path, run_id: str, address: str) -> 
 
 
 def _read_orchestration_history(address_dir: Path, run_id: str, address: str) -> list[dict[str, object]]:
+    """Read one orchestration address's ``history.jsonl`` events (``[]`` when
+    absent; AdmissionRejection on an unreadable or malformed file)."""
     history_path = address_dir / "history.jsonl"
     if not history_path.is_file():
         return []
@@ -141,6 +147,8 @@ def _read_orchestration_history(address_dir: Path, run_id: str, address: str) ->
 
 
 def _read_orchestration(run_store: RunStorageBackend, run_id: str) -> dict[str, dict[str, object]]:
+    """Read every ``<run_id>/orchestration/<address>/`` result + history into
+    the ``{address: {result, history}}`` shape the builder consumes."""
     orchestration_dir = run_store.get_run_path(run_id) / "orchestration"
     orchestration: dict[str, dict[str, object]] = {}
     if not orchestration_dir.is_dir():
@@ -224,7 +232,8 @@ def persist_run_correlation_best_effort(
             "OBS-002: correlation projection not persisted for run %s (%s)", run_id, codes
         )
         return None
-    except Exception:  # defensive: an OBS-002 audit projection is never fatal to the run
+    # Defensive: an OBS-002 audit projection is never fatal to the run.
+    except Exception:
         _log.warning(
             "OBS-002: correlation projection not persisted for run %s (unexpected error)", run_id
         )

--- a/src/aptl/core/correlation/rules.py
+++ b/src/aptl/core/correlation/rules.py
@@ -1,0 +1,98 @@
+"""Named ``DECLARED_RULE`` vocabulary for the OBS-002 correlation builder (#447).
+
+The correlation builder may only cite a ``DECLARED_RULE`` edge with a
+``rule_id`` declared here — free-form rule ids are never evaluated (OBS-002
+preflight: "Define a small versioned CorrelationRuleSet of named rules; free
+form is never evaluated"). Split out of :mod:`aptl.core.correlation.builder`
+so that module stays within the repo's per-file line budget (SonarCloud
+``python:S104``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CorrelationRule:
+    """One named, documented ``DECLARED_RULE`` rule."""
+
+    rule_id: str
+    description: str
+
+
+RUN_PATH_BINDING = CorrelationRule(
+    rule_id="run-path-binding",
+    description=(
+        "An orchestration workflow address (and its history events) is "
+        "associated with this run only because LocalRunStore wrote/read "
+        "its result.json and history.jsonl under "
+        "<run_id>/orchestration/<address>/ — the workflow's own internal "
+        "run_id field (WorkflowExecutionState.run_id) is a distinct, "
+        "workflow-scoped identity and is never treated as the APTL run_id."
+    ),
+)
+
+ADMITTED_PLAN_BINDING = CorrelationRule(
+    rule_id="admitted-plan-binding",
+    description=(
+        "A planned trial is associated with the run admitted from it by "
+        "the experiment-admission plan-to-attempt binding, not by any "
+        "literal identifier field shared between the plan and the run "
+        "record."
+    ),
+)
+
+ORCHESTRATION_ADDRESS_GROUPING = CorrelationRule(
+    rule_id="orchestration-address-grouping",
+    description=(
+        "A workflow history event is associated with its workflow address "
+        "because LocalRunStore grouped it under that address's "
+        "history.jsonl — WorkflowHistoryEvent payloads carry no address "
+        "field of their own."
+    ),
+)
+
+MANIFEST_SNAPSHOT_MEMBERSHIP = CorrelationRule(
+    rule_id="manifest-snapshot-membership",
+    description=(
+        "A participant episode, action, or evaluator result is associated "
+        "with the run because it was read from the RuntimeSnapshot embedded "
+        "in that run's manifest.json — the record carries no run_id field of "
+        "its own, so this is a declared containment rule (the same honest "
+        "provenance the orchestration files get), not a shared explicit "
+        "identifier on the record itself."
+    ),
+)
+
+
+@dataclass(frozen=True)
+class CorrelationRuleSet:
+    """Small, versioned, closed set of named ``DECLARED_RULE`` rules.
+
+    Never free-form: :meth:`require` raises rather than letting a caller
+    (or a typo) invent a ``rule_id`` that was never declared here.
+    """
+
+    version: str = "aptl-correlation-rules/v1"
+    rules: tuple[CorrelationRule, ...] = (
+        RUN_PATH_BINDING,
+        ADMITTED_PLAN_BINDING,
+        ORCHESTRATION_ADDRESS_GROUPING,
+        MANIFEST_SNAPSHOT_MEMBERSHIP,
+    )
+
+    def __post_init__(self) -> None:
+        ids = [rule.rule_id for rule in self.rules]
+        if len(ids) != len(set(ids)):
+            raise ValueError("CorrelationRuleSet rule_ids must be unique")
+
+    def require(self, rule_id: str) -> str:
+        """Return ``rule_id`` if it is declared in this rule set, else raise."""
+        for rule in self.rules:
+            if rule.rule_id == rule_id:
+                return rule.rule_id
+        raise ValueError(f"undeclared correlation rule: {rule_id!r}")
+
+
+DEFAULT_RULE_SET = CorrelationRuleSet()

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -1880,6 +1880,14 @@ def _write_run_record(ctx: _LabStartContext) -> None:
     store.write_json(run_id, "manifest.json", record)
     log.info("REP-001: Run record written to run archive (run_id=%s)", run_id)
 
+    # OBS-002: layer the correlation-identity + clock-context projection over
+    # the now-sealed run archive so an action can be traced end-to-end and
+    # every source's clock is disclosed. Best-effort by contract — an audit
+    # projection must never turn a successful run into a failed one.
+    from aptl.core.correlation.persistence import persist_run_correlation_best_effort
+
+    persist_run_correlation_best_effort(run_id=run_id, run_store=store)
+
 
 # Evidence artifact subtrees scanned for the REP-001 record (GAP 3). Each
 # existing file under these directories is referenced by its relative path;

--- a/tests/test_correlation_builder.py
+++ b/tests/test_correlation_builder.py
@@ -304,13 +304,10 @@ class TestCorrelationRuleSet:
     def test_rejects_duplicate_rule_ids(self):
         from aptl.core.correlation.builder import CorrelationRule
 
+        dup_a = CorrelationRule(rule_id="dup", description="a")
+        dup_b = CorrelationRule(rule_id="dup", description="b")
         with pytest.raises(ValueError, match="unique"):
-            CorrelationRuleSet(
-                rules=(
-                    CorrelationRule(rule_id="dup", description="a"),
-                    CorrelationRule(rule_id="dup", description="b"),
-                )
-            )
+            CorrelationRuleSet(rules=(dup_a, dup_b))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_correlation_builder.py
+++ b/tests/test_correlation_builder.py
@@ -1,0 +1,870 @@
+"""Tests for ``aptl.core.correlation.builder`` (OBS-002 Stage 2, issue #447).
+
+Fixtures mirror the REAL APTL run-archive shapes read from
+``aptl.backends.aces_repro`` (the ``aptl.run-record/v1`` manifest and its
+embedded ``RuntimeSnapshot``), ``aptl.backends.aces_participant_actions``
+(``ParticipantBehaviorHistoryEventModel``-shaped behavior events), and
+``aptl.backends.aces_orchestrator``/``aptl.core.runtime.workflow_engine``
+(``WorkflowExecutionState``/``WorkflowHistoryEvent``-shaped orchestration
+records) — not an invented local schema.
+
+Covers: each of the four association methods produced in the right
+circumstance; clock skew across distinct domains never collapsing into an
+explicit/causal edge; a missing source timestamp recorded as an honest gap
+rather than a fabricated candidate; duplicate (byte-identical) events kept
+as distinct nodes; episode restarts preserved as distinct episode nodes;
+reordered ingestion producing an identical projection; timestamp proximity
+never yielding an EXPLICIT_IDENTIFIER edge; an end-to-end connected typed
+path from an action through red/blue evidence to an evaluator result and
+the run; and determinism (repeat build byte-identical, input-order
+independent).
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from aptl.core.correlation.builder import (
+    ADMITTED_PLAN_BINDING,
+    ORCHESTRATION_ADDRESS_GROUPING,
+    RUN_PATH_BINDING,
+    CorrelationRuleSet,
+    build_correlation_projection,
+)
+from aptl.core.correlation.clock import ClockProvider, FixedClockProvider
+from aptl.core.correlation.identity import bind_attempt_ref
+from aptl.core.correlation.models import AssociationMethod, ClockContext
+
+# ---------------------------------------------------------------------------
+# Fixture builders — shaped like the real ACES/APTL archive records.
+# ---------------------------------------------------------------------------
+
+_PARTICIPANT_ADDRESS = "participant.behavior.techvault.kali-victim-ssh-probe"
+_ACTION_CONTRACT_ADDRESS = "participant.action-contract.aptl.kali-victim-ssh-probe"
+_OBSERVATION_BOUNDARY_ADDRESS = "participant.observation-boundary.aptl.kali-victim-ssh-probe"
+
+
+def _behavior_event(
+    *,
+    event_type: str,
+    timestamp: str,
+    participant_address: str = _PARTICIPANT_ADDRESS,
+    episode_id: str,
+    action_instance_id: str,
+    **overrides: object,
+) -> dict[str, object]:
+    """Build a dict shaped like ``ParticipantBehaviorHistoryEventModel``
+    (verified fields: ``aces_contracts.contracts.py:1433``)."""
+    base: dict[str, object] = {
+        "event_type": event_type,
+        "timestamp": timestamp,
+        "participant_address": participant_address,
+        "episode_id": episode_id,
+        "action_instance_id": action_instance_id,
+        "action_contract_address": _ACTION_CONTRACT_ADDRESS,
+        "observation_boundary_address": None,
+        "observation_status": None,
+        "actor_provenance": "codex-cli",
+        "lifecycle_phase": None,
+        "phase_realization": None,
+        "admission_disposition": None,
+        "operation_ref": None,
+        "operation_state": None,
+        "state_transition_kind": None,
+        "post_state_digest": None,
+        "joint_action_set_id": None,
+        "realized_order": None,
+        "interaction_ref": None,
+        "interaction_class": "shared_state_change",
+        "shared_state_refs": ["container:aptl-kali"],
+        "details": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def _attempted_and_observed(
+    *, episode_id: str, action_instance_id: str, attempted_at: str, observed_at: str
+) -> tuple[dict[str, object], dict[str, object]]:
+    """One red-team-attempted / blue-observed event pair for one action —
+    mirrors ``_action_attempted_event``/``_observation_event`` in
+    ``aces_participant_actions.py``."""
+    attempted = _behavior_event(
+        event_type="action_attempted",
+        timestamp=attempted_at,
+        episode_id=episode_id,
+        action_instance_id=action_instance_id,
+        lifecycle_phase="execution_attempt",
+        phase_realization="runtime_mediated",
+        operation_ref="container_exec:aptl-kali",
+        operation_state="running",
+    )
+    observed = _behavior_event(
+        event_type="observation_emitted",
+        timestamp=observed_at,
+        episode_id=episode_id,
+        action_instance_id=action_instance_id,
+        observation_boundary_address=_OBSERVATION_BOUNDARY_ADDRESS,
+        observation_status="terminal",
+        lifecycle_phase="observation_emission",
+        phase_realization="observed",
+        post_state_digest="sha256:" + "a" * 64,
+    )
+    return attempted, observed
+
+
+def _runtime_snapshot(
+    *,
+    behavior_history: dict[str, list[dict[str, object]]] | None = None,
+    episode_results: dict[str, dict[str, object]] | None = None,
+    episode_history: dict[str, list[dict[str, object]]] | None = None,
+    evaluation_results: dict[str, dict[str, object]] | None = None,
+) -> dict[str, object]:
+    """Build a dict shaped like ``_snapshot_payload(RuntimeSnapshot)``
+    (verified: ``aces_runtime.control_plane_store._snapshot_payload``)."""
+    return {
+        "participant_episode_results": episode_results or {},
+        "participant_episode_history": episode_history or {},
+        "participant_behavior_history": behavior_history or {},
+        "evaluation_results": evaluation_results or {},
+    }
+
+
+def _manifest(
+    *,
+    run_id: str,
+    runtime_snapshot: dict[str, object],
+    evidence_references: list[dict[str, object]] | None = None,
+    planned_trial_id: str | None = None,
+    disclosure_refs: list[str] | None = None,
+) -> dict[str, object]:
+    """Build a dict shaped like the ``aptl.run-record/v1`` manifest
+    (verified: ``aces_repro.build_reproducibility_record``)."""
+    realization: dict[str, object] = {}
+    if planned_trial_id is not None:
+        realization["planned_trial_id"] = planned_trial_id
+    if disclosure_refs is not None:
+        realization["disclosure_refs"] = list(disclosure_refs)
+    return {
+        "schema_version": "aptl.run-record/v1",
+        "run_id": run_id,
+        "aces": {"runtime_snapshot": runtime_snapshot, "realization": realization},
+        "backend_evidence": {"evidence_references": evidence_references or []},
+    }
+
+
+def _workflow_history_event(
+    *, event_type: str, timestamp: str, **overrides: object
+) -> dict[str, object]:
+    """Build a dict shaped like ``WorkflowHistoryEvent.to_payload()``."""
+    base: dict[str, object] = {
+        "event_type": event_type,
+        "timestamp": timestamp,
+        "step_name": None,
+        "branch_name": None,
+        "join_step": None,
+        "outcome": None,
+        "details": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def _orchestration_record(
+    *,
+    address: str,
+    started_at: str,
+    updated_at: str,
+    history: list[dict[str, object]] | None = None,
+    workflow_status: str = "succeeded",
+) -> dict[str, object]:
+    """Build a dict shaped like ``{"result": ..., "history": [...]}`` read
+    from ``orchestration/<address>/{result.json,history.jsonl}``. The
+    result's own ``run_id`` is a *workflow-internal* id
+    (``WorkflowEngine.register_pending`` mints ``uuid4().hex``) —
+    deliberately NOT the APTL run id, to catch a builder that naively
+    trusts it."""
+    return {
+        "result": {
+            "state_schema_version": "aces-workflow-state/v1",
+            "workflow_status": workflow_status,
+            "run_id": "workflow-internal-deadbeefdeadbeefdeadbeefdeadbeef",
+            "started_at": started_at,
+            "updated_at": updated_at,
+            "terminal_reason": "completed" if workflow_status == "succeeded" else None,
+            "compensation_status": "not_required",
+            "compensation_started_at": None,
+            "compensation_updated_at": None,
+            "compensation_failures": [],
+            "steps": {},
+        },
+        "history": history or [],
+    }
+
+
+def _edges_by_method(proj, method: AssociationMethod):
+    return [e for e in proj.edges if e.association_method is method]
+
+
+def _node_refs(proj) -> set[str]:
+    return {n.ref for n in proj.nodes}
+
+
+def _connected_component(proj, start_ref: str) -> set[str]:
+    """Undirected reachability over the projection's edges, from `start_ref`."""
+    adjacency: dict[str, set[str]] = {}
+    for edge in proj.edges:
+        adjacency.setdefault(edge.source_ref, set()).add(edge.target_ref)
+        adjacency.setdefault(edge.target_ref, set()).add(edge.source_ref)
+    visited = {start_ref}
+    frontier = [start_ref]
+    while frontier:
+        current = frontier.pop()
+        for neighbor in adjacency.get(current, ()):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                frontier.append(neighbor)
+    return visited
+
+
+# ---------------------------------------------------------------------------
+# A minimal, complete, one-action run: shared across several tests.
+# ---------------------------------------------------------------------------
+
+_RUN_ID = "run-e2e-1"
+_EPISODE_ID = "episode-e2e-1"
+_ACTION_ID = "participant.behavior.techvault.kali-victim-ssh-probe.aaaa1111"
+
+
+def _minimal_run(**evaluation_kwargs) -> tuple[dict[str, object], dict[str, dict[str, object]]]:
+    attempted, observed = _attempted_and_observed(
+        episode_id=_EPISODE_ID,
+        action_instance_id=_ACTION_ID,
+        attempted_at="2026-01-01T00:00:00Z",
+        observed_at="2026-01-01T00:00:05Z",
+    )
+    evaluation_results = evaluation_kwargs.get("evaluation_results")
+    if evaluation_results is None:
+        evaluation_results = {
+            "evaluation.objective.techvault.foothold": {
+                "outcome": "succeeded",
+                "started_at": "2026-01-01T00:00:01Z",
+                "updated_at": "2026-01-01T00:00:06Z",
+            }
+        }
+    snapshot = _runtime_snapshot(
+        behavior_history={_PARTICIPANT_ADDRESS: [attempted, observed]},
+        episode_results={
+            _PARTICIPANT_ADDRESS: {"episode_id": _EPISODE_ID, "status": "running"}
+        },
+        evaluation_results=evaluation_results,
+    )
+    manifest = _manifest(run_id=_RUN_ID, runtime_snapshot=snapshot)
+    orchestration = _orchestration_record(
+        address="runtime_apply_orchestration",
+        started_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:02Z",
+        history=[
+            _workflow_history_event(event_type="workflow_started", timestamp="2026-01-01T00:00:00Z"),
+            _workflow_history_event(event_type="workflow_completed", timestamp="2026-01-01T00:00:02Z"),
+        ],
+    )
+    return manifest, {"runtime_apply_orchestration": orchestration}
+
+
+def _build(manifest, orchestration, *, clock_provider=None, rules=None):
+    return build_correlation_projection(
+        run_id=_RUN_ID,
+        run_record=manifest,
+        orchestration=orchestration,
+        clock_provider=clock_provider or FixedClockProvider(measurement_time="2026-01-01T00:10:00Z"),
+        rules=rules,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CorrelationRuleSet
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationRuleSet:
+    def test_default_rule_set_declares_the_named_rules(self):
+        ruleset = CorrelationRuleSet()
+        assert ruleset.require(RUN_PATH_BINDING.rule_id) == "run-path-binding"
+        assert ruleset.require(ADMITTED_PLAN_BINDING.rule_id) == "admitted-plan-binding"
+        assert ruleset.require(ORCHESTRATION_ADDRESS_GROUPING.rule_id) == "orchestration-address-grouping"
+
+    def test_require_rejects_an_undeclared_rule_id(self):
+        ruleset = CorrelationRuleSet()
+        with pytest.raises(ValueError, match="undeclared"):
+            ruleset.require("free-form-not-a-real-rule")
+
+    def test_rejects_duplicate_rule_ids(self):
+        from aptl.core.correlation.builder import CorrelationRule
+
+        with pytest.raises(ValueError, match="unique"):
+            CorrelationRuleSet(
+                rules=(
+                    CorrelationRule(rule_id="dup", description="a"),
+                    CorrelationRule(rule_id="dup", description="b"),
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# The four association methods, each in its documented circumstance.
+# ---------------------------------------------------------------------------
+
+
+class TestAssociationMethods:
+    def test_explicit_identifier_links_action_to_episode_via_shared_episode_id(self):
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        action_ref = bind_attempt_ref(_ACTION_ID)
+        episode_ref = bind_attempt_ref(_EPISODE_ID)
+        explicit = _edges_by_method(proj, AssociationMethod.EXPLICIT_IDENTIFIER)
+        assert any(e.source_ref == action_ref and e.target_ref == episode_ref for e in explicit)
+
+    def test_declared_rule_binds_manifest_scoped_nodes_to_run_not_explicit_identity(self):
+        """Episode/action/evaluator-result records carry NO run_id field of
+        their own — they belong to the run only because they were read from
+        the RuntimeSnapshot embedded in that run's manifest.json. That is a
+        declared containment rule (the same honest provenance orchestration
+        files get), NEVER an EXPLICIT_IDENTIFIER: the record has no shared
+        literal identifier to point at."""
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        run_ref = bind_attempt_ref(_RUN_ID)
+        episode_ref = bind_attempt_ref(_EPISODE_ID)
+        action_ref = bind_attempt_ref(_ACTION_ID)
+        eval_ref = bind_attempt_ref("evaluation.objective.techvault.foothold")
+        declared = {
+            (e.source_ref, e.target_ref): e
+            for e in _edges_by_method(proj, AssociationMethod.DECLARED_RULE)
+        }
+        explicit_targets = {
+            (e.source_ref, e.target_ref)
+            for e in _edges_by_method(proj, AssociationMethod.EXPLICIT_IDENTIFIER)
+        }
+        for src in (episode_ref, action_ref, eval_ref):
+            assert (src, run_ref) in declared
+            assert declared[(src, run_ref)].rule_id == "manifest-snapshot-membership"
+            assert (src, run_ref) not in explicit_targets
+
+    def test_declared_rule_links_orchestration_address_to_run_not_via_its_own_run_id_field(self):
+        """The orchestration result's own `run_id` field is a DIFFERENT,
+        workflow-internal identity (see `_orchestration_record`), so this
+        can only be a DECLARED_RULE (archive-layout convention), never an
+        EXPLICIT_IDENTIFIER."""
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        run_ref = bind_attempt_ref(_RUN_ID)
+        address_ref = bind_attempt_ref("runtime_apply_orchestration")
+        declared = _edges_by_method(proj, AssociationMethod.DECLARED_RULE)
+        matches = [e for e in declared if e.source_ref == address_ref and e.target_ref == run_ref]
+        assert len(matches) == 1
+        assert matches[0].rule_id == "run-path-binding"
+        # And it must NOT also appear as an EXPLICIT_IDENTIFIER edge.
+        explicit = _edges_by_method(proj, AssociationMethod.EXPLICIT_IDENTIFIER)
+        assert not any(e.source_ref == address_ref and e.target_ref == run_ref for e in explicit)
+
+    def test_declared_rule_links_orchestration_history_events_to_their_address(self):
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        address_ref = bind_attempt_ref("runtime_apply_orchestration")
+        declared = _edges_by_method(proj, AssociationMethod.DECLARED_RULE)
+        history_edges = [e for e in declared if e.target_ref == address_ref]
+        assert len(history_edges) == 2  # workflow_started + workflow_completed
+        assert all(e.rule_id == "orchestration-address-grouping" for e in history_edges)
+
+    def test_declared_rule_links_planned_trial_to_run_when_present(self):
+        manifest, orchestration = _minimal_run()
+        manifest["aces"]["realization"]["planned_trial_id"] = "planned-trial-1"
+        proj = _build(manifest, orchestration)
+        run_ref = bind_attempt_ref(_RUN_ID)
+        planned_ref = bind_attempt_ref("planned-trial-1")
+        declared = _edges_by_method(proj, AssociationMethod.DECLARED_RULE)
+        matches = [e for e in declared if e.source_ref == planned_ref and e.target_ref == run_ref]
+        assert len(matches) == 1
+        assert matches[0].rule_id == "admitted-plan-binding"
+        assert any(n.ref == planned_ref and n.ref_kind == "planned-trial" for n in proj.nodes)
+
+    def test_no_planned_trial_node_when_absent_from_the_run_record(self):
+        """EXP-002/REP-001 do not thread planned_trial_id into the run
+        record today (verified reality) — absence must not fabricate one."""
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        assert not any(n.ref_kind == "planned-trial" for n in proj.nodes)
+
+    def test_time_window_candidate_links_overlapping_evaluator_result_to_action(self):
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        eval_ref = bind_attempt_ref("evaluation.objective.techvault.foothold")
+        action_ref = bind_attempt_ref(_ACTION_ID)
+        candidates = _edges_by_method(proj, AssociationMethod.TIME_WINDOW_CANDIDATE)
+        matches = [e for e in candidates if e.source_ref == eval_ref and e.target_ref == action_ref]
+        assert len(matches) == 1
+        assert matches[0].clock_context_ref is not None
+
+    def test_time_window_candidate_is_absent_when_windows_do_not_overlap(self):
+        manifest, orchestration = _minimal_run(
+            evaluation_results={
+                "evaluation.objective.techvault.foothold": {
+                    "outcome": "succeeded",
+                    "started_at": "2030-01-01T00:00:00Z",
+                    "updated_at": "2030-01-01T00:00:01Z",
+                }
+            }
+        )
+        proj = _build(manifest, orchestration)
+        candidates = _edges_by_method(proj, AssociationMethod.TIME_WINDOW_CANDIDATE)
+        assert candidates == []
+
+    def test_gap_or_unknown_links_external_evidence_reference_with_no_propagated_id(self):
+        manifest, orchestration = _minimal_run()
+        manifest["backend_evidence"]["evidence_references"] = [
+            {"kind": "pcap", "path": "captures/eth0.pcap"}
+        ]
+        proj = _build(manifest, orchestration)
+        run_ref = bind_attempt_ref(_RUN_ID)
+        gaps = _edges_by_method(proj, AssociationMethod.GAP_OR_UNKNOWN)
+        assert len(gaps) == 1
+        assert gaps[0].target_ref == run_ref
+        gap_node = next(n for n in proj.nodes if n.ref == gaps[0].source_ref)
+        assert gap_node.ref_kind == "evidence"
+
+    def test_timestamp_proximity_never_yields_an_explicit_identifier_edge(self):
+        """The evaluator-result <-> action link is time-window-only in
+        current APTL reality (no shared id field between the two
+        namespaces) — even though their windows overlap, it must never be
+        promoted to EXPLICIT_IDENTIFIER or DECLARED_RULE."""
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        eval_ref = bind_attempt_ref("evaluation.objective.techvault.foothold")
+        action_ref = bind_attempt_ref(_ACTION_ID)
+        for method in (AssociationMethod.EXPLICIT_IDENTIFIER, AssociationMethod.DECLARED_RULE):
+            edges = _edges_by_method(proj, method)
+            assert not any(e.source_ref == eval_ref and e.target_ref == action_ref for e in edges)
+
+
+# ---------------------------------------------------------------------------
+# Clock contexts / clock skew.
+# ---------------------------------------------------------------------------
+
+
+class _SkewClockProvider(ClockProvider):
+    """Test-only provider: distinct clock_source/timestamp_domain/offset
+    per source_kind, so distinct sources never collapse into one clock
+    domain (preflight: "Different sources = DIFFERENT domains")."""
+
+    _PROFILES = {
+        "participant": ("host-utc", "system", None, None),
+        "evaluator": ("evaluator-utc", "evaluator-process-clock", "+120ms", "50ms"),
+        "orchestration": ("workflow-engine-utc", "workflow-engine-clock", "-50ms", "20ms"),
+    }
+
+    def now(self) -> str:
+        return "2026-01-01T00:10:00Z"
+
+    def clock_context(self, *, source_kind, source_id, observer_effect_ref=None):
+        domain, source, offset, uncertainty = self._PROFILES.get(
+            source_kind, ("host-utc", "system", None, None)
+        )
+        return ClockContext(
+            source_kind=source_kind,
+            source_id=source_id,
+            timestamp_domain=domain,
+            clock_source=source,
+            synchronization_status="unknown",
+            measured_offset=offset,
+            uncertainty=uncertainty,
+            measurement_time=self.now(),
+            observer_effect_ref=observer_effect_ref,
+        )
+
+
+class TestClockHandling:
+    def test_distinct_sources_record_distinct_clock_domains_and_offsets(self):
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration, clock_provider=_SkewClockProvider())
+        by_kind = {ctx.source_kind: ctx for ctx in proj.clock_contexts}
+        assert by_kind["participant"].timestamp_domain == "host-utc"
+        assert by_kind["participant"].measured_offset is None
+        assert by_kind["evaluator"].timestamp_domain == "evaluator-utc"
+        assert by_kind["evaluator"].measured_offset == "+120ms"
+        assert by_kind["orchestration"].timestamp_domain == "workflow-engine-utc"
+        assert by_kind["orchestration"].measured_offset == "-50ms"
+
+    def test_skewed_clock_contexts_are_never_used_for_explicit_or_declared_edges(self):
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration, clock_provider=_SkewClockProvider())
+        for method in (AssociationMethod.EXPLICIT_IDENTIFIER, AssociationMethod.DECLARED_RULE):
+            for edge in _edges_by_method(proj, method):
+                assert edge.clock_context_ref is None
+
+    def test_only_time_window_candidate_edges_carry_a_clock_context_ref(self):
+        # Same-domain clocks (default provider) → the evaluator/action windows
+        # are reconcilable, so an overlap is a real TIME_WINDOW_CANDIDATE that
+        # carries a clock_context_ref; no other method carries one.
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        candidates = _edges_by_method(proj, AssociationMethod.TIME_WINDOW_CANDIDATE)
+        assert candidates
+        assert all(e.clock_context_ref is not None for e in candidates)
+        for method in (
+            AssociationMethod.EXPLICIT_IDENTIFIER,
+            AssociationMethod.DECLARED_RULE,
+            AssociationMethod.GAP_OR_UNKNOWN,
+        ):
+            assert all(e.clock_context_ref is None for e in _edges_by_method(proj, method))
+
+    def test_cross_domain_evaluator_action_comparison_is_a_disclosed_gap_not_a_candidate(self):
+        """OBS-002 clock reconciliation: timestamps from DIFFERENT clock
+        domains cannot be compared for overlap without a known offset, so a
+        skewed evaluator/participant pair yields an explicit GAP_OR_UNKNOWN
+        that discloses BOTH clock inputs — never a clock-qualified-looking
+        TIME_WINDOW_CANDIDATE built on an unreconciled comparison."""
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration, clock_provider=_SkewClockProvider())
+        eval_ref = bind_attempt_ref("evaluation.objective.techvault.foothold")
+        action_ref = bind_attempt_ref(_ACTION_ID)
+        candidates = _edges_by_method(proj, AssociationMethod.TIME_WINDOW_CANDIDATE)
+        assert not any(e.source_ref == eval_ref and e.target_ref == action_ref for e in candidates)
+        gaps = [
+            e
+            for e in _edges_by_method(proj, AssociationMethod.GAP_OR_UNKNOWN)
+            if e.source_ref == eval_ref and e.target_ref == action_ref
+        ]
+        assert len(gaps) == 1
+        assert gaps[0].confidence_or_status == "cross_domain_clock_unreconciled"
+        assert gaps[0].clock_context_ref is None
+        # Both clock inputs (evaluator + participant) are named for audit.
+        assert len(gaps[0].disclosure_refs) == 2
+
+    def test_participant_clock_context_is_recorded_honestly_as_unknown_sync(self):
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        participant_ctx = next(c for c in proj.clock_contexts if c.source_kind == "participant")
+        assert participant_ctx.synchronization_status == "unknown"
+        assert participant_ctx.measured_offset is None
+
+
+# ---------------------------------------------------------------------------
+# Missing source timestamps.
+# ---------------------------------------------------------------------------
+
+
+class TestMissingSourceTimestamp:
+    def test_evaluator_result_without_any_timestamp_gets_no_fabricated_candidate_edge(self):
+        manifest, orchestration = _minimal_run(
+            evaluation_results={
+                "evaluation.objective.techvault.foothold": {"outcome": "succeeded"}
+            }
+        )
+        proj = _build(manifest, orchestration)
+        eval_ref = bind_attempt_ref("evaluation.objective.techvault.foothold")
+        candidates = _edges_by_method(proj, AssociationMethod.TIME_WINDOW_CANDIDATE)
+        assert not any(e.source_ref == eval_ref for e in candidates)
+        # It is still a real node, still bound to the run by manifest
+        # containment: a missing timestamp is a time-correlation gap, not a
+        # missing node.
+        assert eval_ref in _node_refs(proj)
+        run_ref = bind_attempt_ref(_RUN_ID)
+        declared = _edges_by_method(proj, AssociationMethod.DECLARED_RULE)
+        assert any(
+            e.source_ref == eval_ref
+            and e.target_ref == run_ref
+            and e.rule_id == "manifest-snapshot-membership"
+            for e in declared
+        )
+
+    def test_orchestration_result_without_timestamps_does_not_crash_and_records_no_clock_context(self):
+        manifest, orchestration = _minimal_run()
+        orchestration["runtime_apply_orchestration"]["result"]["started_at"] = ""
+        orchestration["runtime_apply_orchestration"]["result"]["updated_at"] = ""
+        proj = _build(manifest, orchestration)
+        assert not any(c.source_kind == "orchestration" for c in proj.clock_contexts)
+        # The address node and its DECLARED_RULE binding to run must still exist.
+        address_ref = bind_attempt_ref("runtime_apply_orchestration")
+        assert address_ref in _node_refs(proj)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate events.
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateEvents:
+    def test_two_byte_identical_attempted_events_produce_two_distinct_evidence_nodes(self):
+        attempted, observed = _attempted_and_observed(
+            episode_id=_EPISODE_ID,
+            action_instance_id=_ACTION_ID,
+            attempted_at="2026-01-01T00:00:00Z",
+            observed_at="2026-01-01T00:00:05Z",
+        )
+        # A byte-identical duplicate of `attempted` (e.g. a retried emission).
+        duplicate_attempted = dict(attempted)
+        snapshot = _runtime_snapshot(
+            behavior_history={_PARTICIPANT_ADDRESS: [attempted, duplicate_attempted, observed]},
+        )
+        manifest = _manifest(run_id=_RUN_ID, runtime_snapshot=snapshot)
+        proj = _build(manifest, {})
+        evidence_nodes = [n for n in proj.nodes if n.ref_kind == "evidence"]
+        # 2 distinct attempted-event nodes + 1 observed-event node = 3.
+        assert len(evidence_nodes) == 3
+        assert len({n.ref for n in evidence_nodes}) == 3
+
+    def test_duplicate_events_are_not_collapsed_regardless_of_which_copy_appears_first(self):
+        attempted, observed = _attempted_and_observed(
+            episode_id=_EPISODE_ID,
+            action_instance_id=_ACTION_ID,
+            attempted_at="2026-01-01T00:00:00Z",
+            observed_at="2026-01-01T00:00:05Z",
+        )
+        duplicate_attempted = dict(attempted)
+        forward = _runtime_snapshot(
+            behavior_history={_PARTICIPANT_ADDRESS: [attempted, duplicate_attempted, observed]}
+        )
+        backward = _runtime_snapshot(
+            behavior_history={_PARTICIPANT_ADDRESS: [duplicate_attempted, attempted, observed]}
+        )
+        proj_forward = _build(_manifest(run_id=_RUN_ID, runtime_snapshot=forward), {})
+        proj_backward = _build(_manifest(run_id=_RUN_ID, runtime_snapshot=backward), {})
+        assert proj_forward.projection_digest == proj_backward.projection_digest
+
+
+# ---------------------------------------------------------------------------
+# Restarts.
+# ---------------------------------------------------------------------------
+
+
+class TestRestarts:
+    def test_a_restarted_episode_produces_two_distinct_episode_nodes(self):
+        episode_1 = "episode-restart-1"
+        episode_2 = "episode-restart-2"
+        action_1 = "participant.behavior.techvault.kali-victim-ssh-probe.1111"
+        action_2 = "participant.behavior.techvault.kali-victim-ssh-probe.2222"
+        attempted_1, observed_1 = _attempted_and_observed(
+            episode_id=episode_1,
+            action_instance_id=action_1,
+            attempted_at="2026-01-01T00:00:00Z",
+            observed_at="2026-01-01T00:00:05Z",
+        )
+        attempted_2, observed_2 = _attempted_and_observed(
+            episode_id=episode_2,
+            action_instance_id=action_2,
+            attempted_at="2026-01-01T00:01:00Z",
+            observed_at="2026-01-01T00:01:05Z",
+        )
+        snapshot = _runtime_snapshot(
+            behavior_history={
+                _PARTICIPANT_ADDRESS: [attempted_1, observed_1, attempted_2, observed_2]
+            },
+            episode_results={
+                # Only the LATEST episode survives in participant_episode_results
+                # (a single envelope per address) — restarts are only visible
+                # through the behavior history's own episode_id fields.
+                _PARTICIPANT_ADDRESS: {
+                    "episode_id": episode_2,
+                    "previous_episode_id": episode_1,
+                    "status": "running",
+                }
+            },
+        )
+        manifest = _manifest(run_id=_RUN_ID, runtime_snapshot=snapshot)
+        proj = _build(manifest, {})
+        episode_refs = {n.ref for n in proj.nodes if n.ref_kind == "participant-episode"}
+        assert episode_refs == {bind_attempt_ref(episode_1), bind_attempt_ref(episode_2)}
+        # Each action still binds to its OWN episode, never merged.
+        explicit = _edges_by_method(proj, AssociationMethod.EXPLICIT_IDENTIFIER)
+        assert (bind_attempt_ref(action_1), bind_attempt_ref(episode_1)) in {
+            (e.source_ref, e.target_ref) for e in explicit
+        }
+        assert (bind_attempt_ref(action_2), bind_attempt_ref(episode_2)) in {
+            (e.source_ref, e.target_ref) for e in explicit
+        }
+
+
+# ---------------------------------------------------------------------------
+# Reordered ingestion.
+# ---------------------------------------------------------------------------
+
+
+class TestReorderedIngestion:
+    def test_reordering_the_behavior_event_list_does_not_change_the_digest(self):
+        manifest, orchestration = _minimal_run()
+        events = manifest["aces"]["runtime_snapshot"]["participant_behavior_history"][
+            _PARTICIPANT_ADDRESS
+        ]
+        proj_forward = _build(manifest, orchestration)
+        reversed_manifest = _manifest(
+            run_id=_RUN_ID,
+            runtime_snapshot=_runtime_snapshot(
+                behavior_history={_PARTICIPANT_ADDRESS: list(reversed(events))},
+                episode_results=manifest["aces"]["runtime_snapshot"]["participant_episode_results"],
+                evaluation_results=manifest["aces"]["runtime_snapshot"]["evaluation_results"],
+            ),
+        )
+        proj_backward = _build(reversed_manifest, orchestration)
+        assert proj_forward.projection_digest == proj_backward.projection_digest
+
+    def test_reordering_the_orchestration_address_dict_does_not_change_the_digest(self):
+        manifest, _ = _minimal_run()
+        orch_a = _orchestration_record(
+            address="address-a", started_at="2026-01-01T00:00:00Z", updated_at="2026-01-01T00:00:01Z"
+        )
+        orch_b = _orchestration_record(
+            address="address-b", started_at="2026-01-01T00:00:02Z", updated_at="2026-01-01T00:00:03Z"
+        )
+        forward = {"address-a": orch_a, "address-b": orch_b}
+        backward = {"address-b": orch_b, "address-a": orch_a}
+        proj_forward = _build(manifest, forward)
+        proj_backward = _build(manifest, backward)
+        assert proj_forward.projection_digest == proj_backward.projection_digest
+
+    def test_reordering_orchestration_history_events_does_not_change_the_digest(self):
+        manifest, _ = _minimal_run()
+        events = [
+            _workflow_history_event(event_type="workflow_started", timestamp="2026-01-01T00:00:00Z"),
+            _workflow_history_event(event_type="step_started", timestamp="2026-01-01T00:00:01Z", step_name="s1"),
+            _workflow_history_event(event_type="workflow_completed", timestamp="2026-01-01T00:00:02Z"),
+        ]
+        forward = {
+            "runtime_apply_orchestration": _orchestration_record(
+                address="runtime_apply_orchestration",
+                started_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:02Z",
+                history=events,
+            )
+        }
+        backward = {
+            "runtime_apply_orchestration": _orchestration_record(
+                address="runtime_apply_orchestration",
+                started_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:02Z",
+                history=list(reversed(events)),
+            )
+        }
+        proj_forward = _build(manifest, forward)
+        proj_backward = _build(manifest, backward)
+        assert proj_forward.projection_digest == proj_backward.projection_digest
+
+
+# ---------------------------------------------------------------------------
+# End-to-end connected typed path.
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndTrace:
+    def test_action_red_evidence_blue_observation_evaluator_result_and_run_are_connected(self):
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+
+        action_ref = bind_attempt_ref(_ACTION_ID)
+        run_ref = bind_attempt_ref(_RUN_ID)
+        eval_ref = bind_attempt_ref("evaluation.objective.techvault.foothold")
+
+        # The two behavior-history evidence nodes (red attempted / blue
+        # observed) both derive from content, so look them up by ref_kind
+        # + edge participation instead of a literal id.
+        evidence_refs = {
+            e.source_ref
+            for e in proj.edges
+            if e.association_method is AssociationMethod.EXPLICIT_IDENTIFIER and e.target_ref == action_ref
+        }
+        assert len(evidence_refs) == 2  # attempted + observed
+
+        component = _connected_component(proj, run_ref)
+        assert action_ref in component
+        assert eval_ref in component
+        for evidence_ref in evidence_refs:
+            assert evidence_ref in component
+
+    def test_typed_path_uses_only_documented_association_methods(self):
+        manifest, orchestration = _minimal_run()
+        proj = _build(manifest, orchestration)
+        methods = {e.association_method for e in proj.edges}
+        assert methods <= set(AssociationMethod)
+        assert AssociationMethod.EXPLICIT_IDENTIFIER in methods
+        assert AssociationMethod.DECLARED_RULE in methods
+        assert AssociationMethod.TIME_WINDOW_CANDIDATE in methods
+
+
+# ---------------------------------------------------------------------------
+# Determinism.
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_repeated_build_is_byte_identical(self):
+        manifest, orchestration = _minimal_run()
+        proj1 = _build(manifest, orchestration)
+        proj2 = _build(manifest, orchestration)
+        assert proj1.canonical_bytes == proj2.canonical_bytes
+        assert proj1.projection_digest == proj2.projection_digest
+
+    def test_digest_is_independent_of_manifest_dict_key_order(self):
+        manifest, orchestration = _minimal_run()
+        reordered = dict(reversed(list(manifest.items())))
+        proj1 = _build(manifest, orchestration)
+        proj2 = _build(reordered, orchestration)
+        assert proj1.projection_digest == proj2.projection_digest
+
+    def test_build_never_uses_wall_clock_for_node_or_edge_identity(self):
+        """Two builds against two DIFFERENT clock_provider `now()` values
+        (only used for candidate-edge clock disclosures, never identity)
+        must still produce identical node/edge sets."""
+        manifest, orchestration = _minimal_run()
+        proj_a = _build(
+            manifest, orchestration, clock_provider=FixedClockProvider(measurement_time="2026-01-01T00:00:00Z")
+        )
+        proj_b = _build(
+            manifest, orchestration, clock_provider=FixedClockProvider(measurement_time="2099-12-31T23:59:59Z")
+        )
+        assert {n.ref for n in proj_a.nodes} == {n.ref for n in proj_b.nodes}
+        assert {(e.source_ref, e.target_ref, e.association_method) for e in proj_a.edges} == {
+            (e.source_ref, e.target_ref, e.association_method) for e in proj_b.edges
+        }
+
+
+# ---------------------------------------------------------------------------
+# Fuzz (property-based) — determinism / order-independence.
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@pytest.mark.fuzz
+class TestFuzzOrderIndependence:
+    @given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+    @settings(max_examples=25, deadline=None)
+    def test_shuffled_behavior_events_and_orchestration_addresses_preserve_digest(self, seed):
+        rng = random.Random(seed)
+        manifest, orchestration = _minimal_run()
+        events = list(
+            manifest["aces"]["runtime_snapshot"]["participant_behavior_history"][_PARTICIPANT_ADDRESS]
+        )
+        shuffled_events = list(events)
+        rng.shuffle(shuffled_events)
+        shuffled_manifest = _manifest(
+            run_id=_RUN_ID,
+            runtime_snapshot=_runtime_snapshot(
+                behavior_history={_PARTICIPANT_ADDRESS: shuffled_events},
+                episode_results=manifest["aces"]["runtime_snapshot"]["participant_episode_results"],
+                evaluation_results=manifest["aces"]["runtime_snapshot"]["evaluation_results"],
+            ),
+        )
+        baseline = _build(manifest, orchestration)
+        shuffled = _build(shuffled_manifest, orchestration)
+        assert baseline.projection_digest == shuffled.projection_digest
+
+    @given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+    @settings(max_examples=25, deadline=None)
+    def test_repeated_build_is_always_byte_identical(self, seed):
+        manifest, orchestration = _minimal_run()
+        first = _build(manifest, orchestration)
+        second = _build(manifest, orchestration)
+        assert first.canonical_bytes == second.canonical_bytes

--- a/tests/test_correlation_clock.py
+++ b/tests/test_correlation_clock.py
@@ -1,0 +1,215 @@
+"""Tests for ``aptl.core.correlation.clock`` (OBS-002 Stage 1, issue #447).
+
+Covers: ``SystemClockProvider`` reports an honest (not fabricated)
+domain/sync/source; ``FixedClockProvider`` is fully deterministic and
+injectable; ``utc_now()`` returns an RFC3339 UTC string; and a
+source-scan test forbidding ``datetime.now``/``uuid``/``random`` tokens
+in ``identity.py`` (identity must never be derived from the clock or
+ambient randomness).
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from datetime import UTC, datetime
+
+import pytest
+
+from aptl.core.correlation import identity as identity_module
+from aptl.core.correlation.clock import (
+    ClockProvider,
+    FixedClockProvider,
+    SystemClockProvider,
+    utc_now,
+)
+from aptl.core.correlation.models import ClockContext
+
+_RFC3339_UTC_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$"
+)
+
+
+# ---------------------------------------------------------------------------
+# utc_now
+# ---------------------------------------------------------------------------
+
+
+class TestUtcNow:
+    def test_returns_an_rfc3339_utc_string(self):
+        value = utc_now()
+        assert _RFC3339_UTC_RE.match(value), value
+
+    def test_is_parseable_and_close_to_the_real_current_time(self):
+        before = datetime.now(UTC)
+        value = utc_now()
+        after = datetime.now(UTC)
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        assert before <= parsed <= after
+
+    def test_two_calls_are_monotonic_non_decreasing(self):
+        # Parse rather than compare raw strings: `datetime.isoformat()`
+        # omits the fractional-second component entirely when
+        # microsecond == 0, so two RFC3339 strings that are both valid
+        # can have different lengths and are not safe to compare
+        # lexicographically.
+        first = datetime.fromisoformat(utc_now().replace("Z", "+00:00"))
+        second = datetime.fromisoformat(utc_now().replace("Z", "+00:00"))
+        assert first <= second
+
+
+# ---------------------------------------------------------------------------
+# SystemClockProvider
+# ---------------------------------------------------------------------------
+
+
+class TestSystemClockProvider:
+    def test_satisfies_the_clock_provider_protocol(self):
+        provider: ClockProvider = SystemClockProvider()
+        assert hasattr(provider, "now")
+        assert hasattr(provider, "clock_context")
+
+    def test_now_returns_rfc3339_utc(self):
+        provider = SystemClockProvider()
+        assert _RFC3339_UTC_RE.match(provider.now())
+
+    def test_clock_context_reports_honest_unknown_synchronization(self):
+        """A bare system clock has not been NTP-audited by this provider,
+        so it must not fabricate a "synchronized" claim."""
+        provider = SystemClockProvider()
+        ctx = provider.clock_context(source_kind="kali-session", source_id="sess-1")
+        assert ctx.synchronization_status == "unknown"
+
+    def test_clock_context_reports_no_measured_offset_or_uncertainty(self):
+        provider = SystemClockProvider()
+        ctx = provider.clock_context(source_kind="kali-session", source_id="sess-1")
+        assert ctx.measured_offset is None
+        assert ctx.uncertainty is None
+
+    def test_clock_context_reports_system_clock_source_and_host_utc_domain(self):
+        provider = SystemClockProvider()
+        ctx = provider.clock_context(source_kind="kali-session", source_id="sess-1")
+        assert ctx.clock_source == "system"
+        assert ctx.timestamp_domain == "host-utc"
+
+    def test_clock_context_carries_through_source_kind_and_source_id(self):
+        provider = SystemClockProvider()
+        ctx = provider.clock_context(source_kind="wazuh", source_id="alert-stream")
+        assert ctx.source_kind == "wazuh"
+        assert ctx.source_id == "alert-stream"
+
+    def test_clock_context_defaults_observer_effect_ref_to_none(self):
+        provider = SystemClockProvider()
+        ctx = provider.clock_context(source_kind="kali-session", source_id="sess-1")
+        assert ctx.observer_effect_ref is None
+
+    def test_clock_context_accepts_an_observer_effect_ref(self):
+        provider = SystemClockProvider()
+        ctx = provider.clock_context(
+            source_kind="kali-session", source_id="sess-1", observer_effect_ref="disc-1"
+        )
+        assert ctx.observer_effect_ref == "disc-1"
+
+    def test_clock_context_returns_a_clock_context_instance(self):
+        provider = SystemClockProvider()
+        ctx = provider.clock_context(source_kind="kali-session", source_id="sess-1")
+        assert isinstance(ctx, ClockContext)
+
+    def test_measurement_time_matches_rfc3339_shape(self):
+        provider = SystemClockProvider()
+        ctx = provider.clock_context(source_kind="kali-session", source_id="sess-1")
+        assert _RFC3339_UTC_RE.match(ctx.measurement_time)
+
+
+# ---------------------------------------------------------------------------
+# FixedClockProvider
+# ---------------------------------------------------------------------------
+
+
+class TestFixedClockProvider:
+    def test_now_returns_the_injected_measurement_time(self):
+        provider = FixedClockProvider(measurement_time="2026-01-01T00:00:00Z")
+        assert provider.now() == "2026-01-01T00:00:00Z"
+
+    def test_now_is_stable_across_repeated_calls(self):
+        provider = FixedClockProvider(measurement_time="2026-01-01T00:00:00Z")
+        assert provider.now() == provider.now() == provider.now()
+
+    def test_clock_context_uses_the_injected_measurement_time(self):
+        provider = FixedClockProvider(measurement_time="2026-06-15T12:00:00Z")
+        ctx = provider.clock_context(source_kind="kali-session", source_id="sess-1")
+        assert ctx.measurement_time == "2026-06-15T12:00:00Z"
+
+    def test_clock_context_uses_injected_defaults(self):
+        provider = FixedClockProvider(measurement_time="2026-01-01T00:00:00Z")
+        ctx = provider.clock_context(source_kind="kali-session", source_id="sess-1")
+        assert ctx.clock_source == "fixed"
+        assert ctx.timestamp_domain == "host-utc"
+        assert ctx.synchronization_status == "unknown"
+        assert ctx.measured_offset is None
+        assert ctx.uncertainty is None
+
+    def test_clock_context_honors_overridden_fields(self):
+        provider = FixedClockProvider(
+            measurement_time="2026-01-01T00:00:00Z",
+            clock_source="ntp",
+            timestamp_domain="pcap-monotonic",
+            synchronization_status="synchronized",
+            measured_offset="3ms",
+            uncertainty="1ms",
+        )
+        ctx = provider.clock_context(source_kind="pcap", source_id="eth0")
+        assert ctx.clock_source == "ntp"
+        assert ctx.timestamp_domain == "pcap-monotonic"
+        assert ctx.synchronization_status == "synchronized"
+        assert ctx.measured_offset == "3ms"
+        assert ctx.uncertainty == "1ms"
+
+    def test_two_providers_with_the_same_fields_are_equal(self):
+        provider1 = FixedClockProvider(measurement_time="2026-01-01T00:00:00Z")
+        provider2 = FixedClockProvider(measurement_time="2026-01-01T00:00:00Z")
+        assert provider1 == provider2
+
+    def test_is_frozen(self):
+        import dataclasses
+
+        provider = FixedClockProvider(measurement_time="2026-01-01T00:00:00Z")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            provider.measurement_time = "mutated"  # type: ignore[misc]
+
+    def test_repeated_clock_context_calls_are_byte_identical(self):
+        provider = FixedClockProvider(measurement_time="2026-01-01T00:00:00Z")
+        ctx1 = provider.clock_context(source_kind="k", source_id="s")
+        ctx2 = provider.clock_context(source_kind="k", source_id="s")
+        assert ctx1 == ctx2
+
+
+# ---------------------------------------------------------------------------
+# identity.py must never derive from the clock or ambient randomness
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityModuleForbidsNondeterministicPrimitives:
+    """OBS-002 preflight "Gotchas": identity must not be minted from wall
+    clock, UUIDs, or ambient/library RNG. A stray ``datetime.now(UTC)``,
+    ``uuid4()``, or ``random.random()`` call inside ``identity.py`` would
+    make planned refs silently host- or run-dependent."""
+
+    def test_identity_module_source_never_references_forbidden_tokens(self):
+        source = inspect.getsource(identity_module)
+        forbidden_substrings = [
+            "uuid",
+            "random.",
+            "import random",
+            "time.time",
+            "datetime.now",
+            "datetime.utcnow",
+            " hash(",
+            "(hash(",
+        ]
+        for token in forbidden_substrings:
+            assert token not in source, f"forbidden nondeterministic token found in identity.py: {token!r}"
+
+    def test_identity_module_does_not_import_uuid_or_random(self):
+        assert not hasattr(identity_module, "uuid")
+        assert not hasattr(identity_module, "random")

--- a/tests/test_correlation_identity.py
+++ b/tests/test_correlation_identity.py
@@ -1,0 +1,235 @@
+"""Tests for ``aptl.core.correlation.identity`` (OBS-002 Stage 1, issue #447).
+
+Covers: ``stable_ref`` deterministic across calls AND across subprocesses
+with different ``PYTHONHASHSEED`` (mirrors
+``tests/test_experiment_trial_plan.py``'s
+``test_plan_digest_is_stable_across_separate_processes_with_different_hash_seeds``);
+different inputs yield different ids; every produced/accepted id
+validates through ``aptl.core.correlation.models.validate_correlation_id``;
+``derive_planned_ref`` is a deterministic alias of ``stable_ref``;
+``bind_attempt_ref`` validates (never derives) an externally-supplied id.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from aptl.core.correlation.identity import bind_attempt_ref, derive_planned_ref, stable_ref
+from aptl.core.correlation.models import validate_correlation_id
+
+_DOMAIN = b"aptl.correlation.test/v1"
+_OTHER_DOMAIN = b"aptl.correlation.test-other/v1"
+
+
+# ---------------------------------------------------------------------------
+# stable_ref
+# ---------------------------------------------------------------------------
+
+
+class TestStableRef:
+    def test_is_deterministic_across_calls(self):
+        first = stable_ref("a", "b", domain=_DOMAIN)
+        second = stable_ref("a", "b", domain=_DOMAIN)
+        assert first == second
+
+    def test_returns_a_validated_id(self):
+        ref = stable_ref("a", "b", domain=_DOMAIN)
+        assert validate_correlation_id(ref) == ref
+
+    def test_looks_like_a_hex_sha256_digest(self):
+        ref = stable_ref("a", "b", domain=_DOMAIN)
+        assert re.fullmatch(r"[0-9a-f]{64}", ref)
+
+    def test_different_parts_yield_different_ids(self):
+        ref1 = stable_ref("a", "b", domain=_DOMAIN)
+        ref2 = stable_ref("a", "c", domain=_DOMAIN)
+        assert ref1 != ref2
+
+    def test_different_part_order_yields_different_ids(self):
+        ref1 = stable_ref("a", "b", domain=_DOMAIN)
+        ref2 = stable_ref("b", "a", domain=_DOMAIN)
+        assert ref1 != ref2
+
+    def test_different_domain_yields_different_ids_for_the_same_parts(self):
+        ref1 = stable_ref("a", "b", domain=_DOMAIN)
+        ref2 = stable_ref("a", "b", domain=_OTHER_DOMAIN)
+        assert ref1 != ref2
+
+    def test_a_single_part_is_accepted(self):
+        ref = stable_ref("only-one", domain=_DOMAIN)
+        assert validate_correlation_id(ref) == ref
+
+    def test_many_parts_are_accepted(self):
+        ref = stable_ref("a", "b", "c", "d", "e", domain=_DOMAIN)
+        assert validate_correlation_id(ref) == ref
+
+    def test_rejects_an_empty_domain(self):
+        with pytest.raises(ValueError):
+            stable_ref("a", domain=b"")
+
+    def test_rejects_no_parts(self):
+        with pytest.raises(ValueError):
+            stable_ref(domain=_DOMAIN)
+
+    def test_rejects_a_non_string_part(self):
+        with pytest.raises(TypeError):
+            stable_ref("a", 123, domain=_DOMAIN)  # type: ignore[arg-type]
+
+    def test_field_separator_cannot_be_used_to_forge_a_collision(self):
+        """Concatenating parts across a field boundary must not collide
+        with hashing them as two separate parts (domain separation via
+        the 0x1F unit separator prevents ``("ab", "c")`` colliding with
+        ``("a", "bc")``)."""
+        ref1 = stable_ref("ab", "c", domain=_DOMAIN)
+        ref2 = stable_ref("a", "bc", domain=_DOMAIN)
+        assert ref1 != ref2
+
+
+# ---------------------------------------------------------------------------
+# derive_planned_ref
+# ---------------------------------------------------------------------------
+
+
+class TestDerivePlannedRef:
+    def test_matches_stable_ref_for_the_same_inputs(self):
+        assert derive_planned_ref("a", "b", domain=_DOMAIN) == stable_ref("a", "b", domain=_DOMAIN)
+
+    def test_is_deterministic_across_calls(self):
+        first = derive_planned_ref("cond-1", "0", domain=_DOMAIN)
+        second = derive_planned_ref("cond-1", "0", domain=_DOMAIN)
+        assert first == second
+
+    def test_different_inputs_yield_different_refs(self):
+        ref1 = derive_planned_ref("cond-1", "0", domain=_DOMAIN)
+        ref2 = derive_planned_ref("cond-1", "1", domain=_DOMAIN)
+        assert ref1 != ref2
+
+    def test_returns_a_validated_id(self):
+        ref = derive_planned_ref("cond-1", "0", domain=_DOMAIN)
+        assert validate_correlation_id(ref) == ref
+
+
+# ---------------------------------------------------------------------------
+# bind_attempt_ref
+# ---------------------------------------------------------------------------
+
+
+class TestBindAttemptRef:
+    def test_returns_the_external_id_unchanged_when_valid(self):
+        assert bind_attempt_ref("run-abc123") == "run-abc123"
+
+    def test_rejects_an_invalid_external_id(self):
+        with pytest.raises(ValueError):
+            bind_attempt_ref("not a valid id")
+
+    def test_rejects_a_secret_shaped_external_id(self):
+        with pytest.raises(ValueError):
+            bind_attempt_ref("password=hunter2")
+
+    def test_does_not_derive_a_new_value_it_only_validates(self):
+        """Unlike `derive_planned_ref`, this must not hash the input —
+        the returned ref is exactly the externally-supplied id."""
+        external_id = "episode-99"
+        assert bind_attempt_ref(external_id) == external_id
+
+
+# ---------------------------------------------------------------------------
+# Determinism across processes / hash seeds
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminismAcrossProcesses:
+    def test_stable_ref_is_stable_across_separate_processes_with_different_hash_seeds(self):
+        """A same-process double-call cannot catch a stray Python
+        ``hash()`` call, because ``PYTHONHASHSEED`` is fixed for the
+        lifetime of one process. Run the derivation in subprocesses with
+        different hash seeds and confirm the id still matches."""
+        script = textwrap.dedent(
+            """
+            from aptl.core.correlation.identity import stable_ref
+
+            print(stable_ref("cond-a", "0", "seed-a", domain=b"aptl.correlation.test/v1"))
+            """
+        )
+        refs = set()
+        repo_src = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src"
+        )
+        for seed in ("0", "1", "3391772699"):
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                env={
+                    **os.environ,
+                    "PYTHONHASHSEED": seed,
+                    "PYTHONPATH": repo_src + os.pathsep + os.environ.get("PYTHONPATH", ""),
+                },
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            refs.add(result.stdout.strip())
+        assert len(refs) == 1
+
+    def test_derive_planned_ref_is_stable_across_separate_processes_with_different_hash_seeds(self):
+        script = textwrap.dedent(
+            """
+            from aptl.core.correlation.identity import derive_planned_ref
+
+            print(derive_planned_ref("cond-a", "0", domain=b"aptl.correlation.test/v1"))
+            """
+        )
+        refs = set()
+        repo_src = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src"
+        )
+        for seed in ("0", "2", "4242424242"):
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                env={
+                    **os.environ,
+                    "PYTHONHASHSEED": seed,
+                    "PYTHONPATH": repo_src + os.pathsep + os.environ.get("PYTHONPATH", ""),
+                },
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            refs.add(result.stdout.strip())
+        assert len(refs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fuzz (property-based)
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+_PART_TEXT = st.text(min_size=1, max_size=40)
+
+
+@pytest.mark.fuzz
+class TestFuzzStableRef:
+    @given(parts=st.lists(_PART_TEXT, min_size=1, max_size=6))
+    @settings(max_examples=50, deadline=None)
+    def test_random_parts_always_produce_a_stable_valid_id(self, parts):
+        ref1 = stable_ref(*parts, domain=_DOMAIN)
+        ref2 = stable_ref(*parts, domain=_DOMAIN)
+        assert ref1 == ref2
+        assert validate_correlation_id(ref1) == ref1
+        assert re.fullmatch(r"[0-9a-f]{64}", ref1)
+
+    @given(parts_a=st.lists(_PART_TEXT, min_size=1, max_size=6), parts_b=st.lists(_PART_TEXT, min_size=1, max_size=6))
+    @settings(max_examples=50, deadline=None)
+    def test_different_part_lists_are_extremely_unlikely_to_collide(self, parts_a, parts_b):
+        if parts_a == parts_b:
+            return
+        ref_a = stable_ref(*parts_a, domain=_DOMAIN)
+        ref_b = stable_ref(*parts_b, domain=_DOMAIN)
+        assert ref_a != ref_b

--- a/tests/test_correlation_identity.py
+++ b/tests/test_correlation_identity.py
@@ -208,7 +208,7 @@ class TestDeterminismAcrossProcesses:
 # Fuzz (property-based)
 # ---------------------------------------------------------------------------
 
-from hypothesis import given, settings  # noqa: E402
+from hypothesis import assume, given, settings  # noqa: E402
 from hypothesis import strategies as st  # noqa: E402
 
 _PART_TEXT = st.text(min_size=1, max_size=40)
@@ -228,8 +228,7 @@ class TestFuzzStableRef:
     @given(parts_a=st.lists(_PART_TEXT, min_size=1, max_size=6), parts_b=st.lists(_PART_TEXT, min_size=1, max_size=6))
     @settings(max_examples=50, deadline=None)
     def test_different_part_lists_are_extremely_unlikely_to_collide(self, parts_a, parts_b):
-        if parts_a == parts_b:
-            return
+        assume(parts_a != parts_b)
         ref_a = stable_ref(*parts_a, domain=_DOMAIN)
         ref_b = stable_ref(*parts_b, domain=_DOMAIN)
         assert ref_a != ref_b

--- a/tests/test_correlation_models.py
+++ b/tests/test_correlation_models.py
@@ -333,22 +333,24 @@ class TestCorrelationProjection:
 
     def test_rejects_an_edge_whose_source_ref_is_not_a_declared_node(self):
         node_b = _node("task-1", "task")
+        bad_edge = _edge(source_ref="missing-node", target_ref="task-1")
         with pytest.raises(ValueError, match="source_ref"):
             CorrelationProjection(
                 run_id="run-1",
                 nodes=(node_b,),
-                edges=(_edge(source_ref="missing-node", target_ref="task-1"),),
+                edges=(bad_edge,),
                 clock_contexts=(),
                 disclosures=(),
             )
 
     def test_rejects_an_edge_whose_target_ref_is_not_a_declared_node(self):
         node_a = _node("exp-spec-1", "experiment-spec")
+        bad_edge = _edge(source_ref="exp-spec-1", target_ref="missing-node")
         with pytest.raises(ValueError, match="target_ref"):
             CorrelationProjection(
                 run_id="run-1",
                 nodes=(node_a,),
-                edges=(_edge(source_ref="exp-spec-1", target_ref="missing-node"),),
+                edges=(bad_edge,),
                 clock_contexts=(),
                 disclosures=(),
             )

--- a/tests/test_correlation_models.py
+++ b/tests/test_correlation_models.py
@@ -1,0 +1,528 @@
+"""Tests for ``aptl.core.correlation.models`` (OBS-002 Stage 1, issue #447).
+
+Covers: enum values; construction and frozen immutability of
+``ClockContext``/``CorrelationNode``/``CorrelationEdge``/
+``CorrelationProjection``; the two edge invariants (``DECLARED_RULE``
+requires ``rule_id``; ``TIME_WINDOW_CANDIDATE`` requires
+``clock_context_ref``); edge endpoints must reference a declared node;
+id validation rejects a bad/secret-shaped id at construction;
+``projection_digest`` stability across two builds of the same content
+AND independence from node/edge/clock-context/disclosure input ordering;
+and ``assert_non_secret`` rejecting a secret-shaped identity-bearing
+value directly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+
+import pytest
+
+from aptl.core.correlation.models import (
+    AssociationMethod,
+    ClockContext,
+    CorrelationEdge,
+    CorrelationNode,
+    CorrelationProjection,
+    assert_non_secret,
+    validate_correlation_id,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _clock_context(**overrides) -> ClockContext:
+    fields = {
+        "source_kind": "kali-session",
+        "source_id": "sess-1",
+        "timestamp_domain": "host-utc",
+        "clock_source": "system",
+        "synchronization_status": "unknown",
+        "measured_offset": None,
+        "uncertainty": None,
+        "measurement_time": "2026-01-01T00:00:00Z",
+        "observer_effect_ref": None,
+    }
+    fields.update(overrides)
+    return ClockContext(**fields)
+
+
+def _node(ref: str = "exp-spec-1", ref_kind: str = "experiment-spec") -> CorrelationNode:
+    return CorrelationNode(ref=ref, ref_kind=ref_kind)
+
+
+def _edge(**overrides) -> CorrelationEdge:
+    fields = {
+        "source_ref": "exp-spec-1",
+        "target_ref": "task-1",
+        "association_method": AssociationMethod.EXPLICIT_IDENTIFIER,
+        "rule_id": None,
+        "clock_context_ref": None,
+        "confidence_or_status": "high",
+        "disclosure_refs": (),
+    }
+    fields.update(overrides)
+    return CorrelationEdge(**fields)
+
+
+def _projection(**overrides) -> CorrelationProjection:
+    node_a = _node("exp-spec-1", "experiment-spec")
+    node_b = _node("task-1", "task")
+    fields = {
+        "run_id": "run-1",
+        "nodes": (node_a, node_b),
+        "edges": (_edge(),),
+        "clock_contexts": (_clock_context(),),
+        "disclosures": (),
+    }
+    fields.update(overrides)
+    return CorrelationProjection(**fields)
+
+
+# ---------------------------------------------------------------------------
+# AssociationMethod
+# ---------------------------------------------------------------------------
+
+
+class TestAssociationMethod:
+    def test_values_match_the_preflight_controlled_vocabulary(self):
+        assert AssociationMethod.EXPLICIT_IDENTIFIER.value == "explicit_identifier"
+        assert AssociationMethod.DECLARED_RULE.value == "declared_rule"
+        assert AssociationMethod.TIME_WINDOW_CANDIDATE.value == "time_window_candidate"
+        assert AssociationMethod.GAP_OR_UNKNOWN.value == "gap_or_unknown"
+
+    def test_is_a_str_enum(self):
+        assert AssociationMethod.EXPLICIT_IDENTIFIER == "explicit_identifier"
+        assert isinstance(AssociationMethod.EXPLICIT_IDENTIFIER, str)
+
+
+# ---------------------------------------------------------------------------
+# validate_correlation_id / assert_non_secret
+# ---------------------------------------------------------------------------
+
+
+class TestValidateCorrelationId:
+    def test_accepts_a_well_formed_id(self):
+        assert validate_correlation_id("run-abc123") == "run-abc123"
+
+    def test_rejects_an_id_with_illegal_characters(self):
+        with pytest.raises(ValueError):
+            validate_correlation_id("bad id with spaces")
+
+    def test_rejects_path_traversal(self):
+        with pytest.raises(ValueError):
+            validate_correlation_id("../escape")
+
+    def test_rejects_kv_shaped_secret_text(self):
+        with pytest.raises(ValueError):
+            validate_correlation_id("password=hunter2")
+
+
+class TestAssertNonSecret:
+    def test_returns_the_value_unchanged_when_safe(self):
+        assert assert_non_secret("safe-value-1", field_name="ref") == "safe-value-1"
+
+    def test_rejects_a_secret_shaped_value(self):
+        with pytest.raises(ValueError):
+            assert_non_secret("token=abc123def456", field_name="notes")
+
+    def test_rejects_a_sensitive_field_name_even_with_a_bland_value(self):
+        with pytest.raises(ValueError):
+            assert_non_secret("bland-value", field_name="password")
+
+    def test_rejects_an_authorization_bearer_shaped_value(self):
+        with pytest.raises(ValueError):
+            assert_non_secret("Bearer abc.def.ghi", field_name="notes")
+
+
+# ---------------------------------------------------------------------------
+# ClockContext
+# ---------------------------------------------------------------------------
+
+
+class TestClockContext:
+    def test_constructs_with_valid_fields(self):
+        ctx = _clock_context()
+        assert ctx.source_kind == "kali-session"
+        assert ctx.clock_source == "system"
+
+    def test_is_frozen(self):
+        ctx = _clock_context()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ctx.source_kind = "mutated"  # type: ignore[misc]
+
+    def test_rejects_empty_source_kind(self):
+        with pytest.raises(ValueError):
+            _clock_context(source_kind="")
+
+    def test_rejects_empty_measurement_time(self):
+        with pytest.raises(ValueError):
+            _clock_context(measurement_time="")
+
+    def test_rejects_a_bad_source_id(self):
+        with pytest.raises(ValueError):
+            _clock_context(source_id="bad id")
+
+    def test_rejects_a_secret_shaped_source_id(self):
+        with pytest.raises(ValueError):
+            _clock_context(source_id="password=hunter2")
+
+    def test_accepts_none_for_optional_fields(self):
+        ctx = _clock_context(measured_offset=None, uncertainty=None, observer_effect_ref=None)
+        assert ctx.measured_offset is None
+        assert ctx.uncertainty is None
+        assert ctx.observer_effect_ref is None
+
+    def test_accepts_present_optional_fields(self):
+        ctx = _clock_context(measured_offset="12ms", uncertainty="5ms", observer_effect_ref="disc-1")
+        assert ctx.measured_offset == "12ms"
+        assert ctx.observer_effect_ref == "disc-1"
+
+    def test_rejects_an_invalid_observer_effect_ref(self):
+        with pytest.raises(ValueError):
+            _clock_context(observer_effect_ref="not a valid ref")
+
+
+# ---------------------------------------------------------------------------
+# CorrelationNode
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationNode:
+    def test_constructs_with_a_known_ref_kind(self):
+        node = _node("evidence-1", "evidence")
+        assert node.ref == "evidence-1"
+        assert node.ref_kind == "evidence"
+
+    def test_is_frozen(self):
+        node = _node()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            node.ref = "mutated"  # type: ignore[misc]
+
+    def test_rejects_an_unknown_ref_kind(self):
+        with pytest.raises(ValueError):
+            _node(ref_kind="not-a-controlled-kind")
+
+    def test_rejects_a_bad_ref(self):
+        with pytest.raises(ValueError):
+            _node(ref="bad ref with spaces")
+
+    def test_rejects_a_secret_shaped_ref(self):
+        with pytest.raises(ValueError):
+            _node(ref="password=hunter2")
+
+    @pytest.mark.parametrize(
+        "ref_kind",
+        [
+            "experiment-spec",
+            "task",
+            "condition",
+            "planned-trial",
+            "attempt-run",
+            "participant-episode",
+            "action",
+            "capture",
+            "evidence",
+            "evaluator-result",
+        ],
+    )
+    def test_accepts_every_controlled_ref_kind(self, ref_kind):
+        node = _node(ref="ref-1", ref_kind=ref_kind)
+        assert node.ref_kind == ref_kind
+
+
+# ---------------------------------------------------------------------------
+# CorrelationEdge
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationEdge:
+    def test_constructs_a_minimal_explicit_identifier_edge(self):
+        edge = _edge()
+        assert edge.association_method is AssociationMethod.EXPLICIT_IDENTIFIER
+
+    def test_is_frozen(self):
+        edge = _edge()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            edge.source_ref = "mutated"  # type: ignore[misc]
+
+    def test_disclosure_refs_is_a_tuple(self):
+        edge = _edge(disclosure_refs=("disc-1", "disc-2"))
+        assert isinstance(edge.disclosure_refs, tuple)
+
+    def test_rejects_a_bad_source_ref(self):
+        with pytest.raises(ValueError):
+            _edge(source_ref="bad ref")
+
+    def test_rejects_a_bad_target_ref(self):
+        with pytest.raises(ValueError):
+            _edge(target_ref="bad ref")
+
+    def test_rejects_a_secret_shaped_disclosure_ref(self):
+        with pytest.raises(ValueError):
+            _edge(disclosure_refs=("password=hunter2",))
+
+    def test_declared_rule_requires_rule_id(self):
+        with pytest.raises(ValueError, match="DECLARED_RULE"):
+            _edge(association_method=AssociationMethod.DECLARED_RULE, rule_id=None)
+
+    def test_declared_rule_with_rule_id_succeeds(self):
+        edge = _edge(association_method=AssociationMethod.DECLARED_RULE, rule_id="rule-1")
+        assert edge.rule_id == "rule-1"
+
+    def test_time_window_candidate_requires_clock_context_ref(self):
+        with pytest.raises(ValueError, match="TIME_WINDOW_CANDIDATE"):
+            _edge(
+                association_method=AssociationMethod.TIME_WINDOW_CANDIDATE,
+                clock_context_ref=None,
+            )
+
+    def test_time_window_candidate_with_clock_context_ref_succeeds(self):
+        edge = _edge(
+            association_method=AssociationMethod.TIME_WINDOW_CANDIDATE,
+            clock_context_ref="clock-ctx-1",
+        )
+        assert edge.clock_context_ref == "clock-ctx-1"
+
+    def test_explicit_identifier_does_not_require_rule_id_or_clock_context_ref(self):
+        edge = _edge(
+            association_method=AssociationMethod.EXPLICIT_IDENTIFIER,
+            rule_id=None,
+            clock_context_ref=None,
+        )
+        assert edge.rule_id is None
+        assert edge.clock_context_ref is None
+
+    def test_gap_or_unknown_does_not_require_rule_id_or_clock_context_ref(self):
+        edge = _edge(
+            association_method=AssociationMethod.GAP_OR_UNKNOWN,
+            rule_id=None,
+            clock_context_ref=None,
+        )
+        assert edge.association_method is AssociationMethod.GAP_OR_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# CorrelationProjection
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationProjection:
+    def test_constructs_with_valid_nodes_and_edges(self):
+        proj = _projection()
+        assert proj.run_id == "run-1"
+        assert proj.schema_version == "aptl-correlation/v1"
+
+    def test_is_frozen(self):
+        proj = _projection()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            proj.run_id = "mutated"  # type: ignore[misc]
+
+    def test_canonical_bytes_and_digest_are_populated(self):
+        proj = _projection()
+        assert isinstance(proj.canonical_bytes, bytes)
+        assert proj.projection_digest.startswith("sha256:")
+
+    def test_projection_digest_is_the_sha256_of_canonical_bytes(self):
+        proj = _projection()
+        expected = f"sha256:{hashlib.sha256(proj.canonical_bytes).hexdigest()}"
+        assert proj.projection_digest == expected
+
+    def test_rejects_an_edge_whose_source_ref_is_not_a_declared_node(self):
+        node_b = _node("task-1", "task")
+        with pytest.raises(ValueError, match="source_ref"):
+            CorrelationProjection(
+                run_id="run-1",
+                nodes=(node_b,),
+                edges=(_edge(source_ref="missing-node", target_ref="task-1"),),
+                clock_contexts=(),
+                disclosures=(),
+            )
+
+    def test_rejects_an_edge_whose_target_ref_is_not_a_declared_node(self):
+        node_a = _node("exp-spec-1", "experiment-spec")
+        with pytest.raises(ValueError, match="target_ref"):
+            CorrelationProjection(
+                run_id="run-1",
+                nodes=(node_a,),
+                edges=(_edge(source_ref="exp-spec-1", target_ref="missing-node"),),
+                clock_contexts=(),
+                disclosures=(),
+            )
+
+    def test_rejects_a_bad_run_id(self):
+        with pytest.raises(ValueError):
+            _projection(run_id="bad run id")
+
+    def test_rejects_a_secret_shaped_run_id(self):
+        with pytest.raises(ValueError):
+            _projection(run_id="password=hunter2")
+
+    def test_rejects_a_secret_shaped_disclosure(self):
+        with pytest.raises(ValueError):
+            _projection(disclosures=("password=hunter2",))
+
+    def test_accepts_an_empty_graph(self):
+        proj = CorrelationProjection(
+            run_id="run-empty", nodes=(), edges=(), clock_contexts=(), disclosures=()
+        )
+        assert proj.nodes == ()
+        assert proj.edges == ()
+
+    # -- digest stability -----------------------------------------------
+
+    def test_digest_is_stable_across_two_builds_of_the_same_content(self):
+        proj1 = _projection()
+        proj2 = _projection()
+        assert proj1.canonical_bytes == proj2.canonical_bytes
+        assert proj1.projection_digest == proj2.projection_digest
+
+    def test_digest_is_independent_of_node_input_order(self):
+        node_a = _node("exp-spec-1", "experiment-spec")
+        node_b = _node("task-1", "task")
+        edge = _edge()
+        proj_ab = CorrelationProjection(
+            run_id="run-1", nodes=(node_a, node_b), edges=(edge,), clock_contexts=(), disclosures=()
+        )
+        proj_ba = CorrelationProjection(
+            run_id="run-1", nodes=(node_b, node_a), edges=(edge,), clock_contexts=(), disclosures=()
+        )
+        assert proj_ab.canonical_bytes == proj_ba.canonical_bytes
+        assert proj_ab.projection_digest == proj_ba.projection_digest
+
+    def test_digest_is_independent_of_edge_input_order(self):
+        node_a = _node("exp-spec-1", "experiment-spec")
+        node_b = _node("task-1", "task")
+        node_c = _node("action-1", "action")
+        edge1 = _edge(source_ref="exp-spec-1", target_ref="task-1")
+        edge2 = _edge(source_ref="task-1", target_ref="action-1")
+        proj_12 = CorrelationProjection(
+            run_id="run-1",
+            nodes=(node_a, node_b, node_c),
+            edges=(edge1, edge2),
+            clock_contexts=(),
+            disclosures=(),
+        )
+        proj_21 = CorrelationProjection(
+            run_id="run-1",
+            nodes=(node_a, node_b, node_c),
+            edges=(edge2, edge1),
+            clock_contexts=(),
+            disclosures=(),
+        )
+        assert proj_12.canonical_bytes == proj_21.canonical_bytes
+        assert proj_12.projection_digest == proj_21.projection_digest
+
+    def test_digest_is_independent_of_clock_context_input_order(self):
+        node_a = _node("exp-spec-1", "experiment-spec")
+        ctx1 = _clock_context(source_id="sess-1", measurement_time="2026-01-01T00:00:00Z")
+        ctx2 = _clock_context(source_id="sess-2", measurement_time="2026-01-01T00:00:01Z")
+        proj_12 = CorrelationProjection(
+            run_id="run-1", nodes=(node_a,), edges=(), clock_contexts=(ctx1, ctx2), disclosures=()
+        )
+        proj_21 = CorrelationProjection(
+            run_id="run-1", nodes=(node_a,), edges=(), clock_contexts=(ctx2, ctx1), disclosures=()
+        )
+        assert proj_12.canonical_bytes == proj_21.canonical_bytes
+        assert proj_12.projection_digest == proj_21.projection_digest
+
+    def test_digest_is_independent_of_disclosure_input_order(self):
+        node_a = _node("exp-spec-1", "experiment-spec")
+        proj_ab = CorrelationProjection(
+            run_id="run-1",
+            nodes=(node_a,),
+            edges=(),
+            clock_contexts=(),
+            disclosures=("disc-a", "disc-b"),
+        )
+        proj_ba = CorrelationProjection(
+            run_id="run-1",
+            nodes=(node_a,),
+            edges=(),
+            clock_contexts=(),
+            disclosures=("disc-b", "disc-a"),
+        )
+        assert proj_ab.canonical_bytes == proj_ba.canonical_bytes
+        assert proj_ab.projection_digest == proj_ba.projection_digest
+
+    def test_digest_is_independent_of_edge_disclosure_refs_order(self):
+        node_a = _node("exp-spec-1", "experiment-spec")
+        node_b = _node("task-1", "task")
+        edge_ab = _edge(disclosure_refs=("disc-a", "disc-b"))
+        edge_ba = _edge(disclosure_refs=("disc-b", "disc-a"))
+        proj_ab = CorrelationProjection(
+            run_id="run-1", nodes=(node_a, node_b), edges=(edge_ab,), clock_contexts=(), disclosures=()
+        )
+        proj_ba = CorrelationProjection(
+            run_id="run-1", nodes=(node_a, node_b), edges=(edge_ba,), clock_contexts=(), disclosures=()
+        )
+        assert proj_ab.canonical_bytes == proj_ba.canonical_bytes
+
+    def test_different_content_yields_a_different_digest(self):
+        proj1 = _projection()
+        proj2 = _projection(run_id="run-2")
+        assert proj1.projection_digest != proj2.projection_digest
+
+    # -- roundtrip ---------------------------------------------------------
+
+    def test_to_canonical_dict_from_canonical_dict_roundtrip_preserves_digest(self):
+        proj = _projection()
+        rebuilt = CorrelationProjection.from_canonical_dict(proj.to_canonical_dict())
+        assert rebuilt.projection_digest == proj.projection_digest
+        assert rebuilt.canonical_bytes == proj.canonical_bytes
+
+    def test_to_canonical_dict_is_json_shaped(self):
+        proj = _projection()
+        d = proj.to_canonical_dict()
+        assert d["run_id"] == "run-1"
+        assert isinstance(d["nodes"], list)
+        assert isinstance(d["edges"], list)
+        assert isinstance(d["clock_contexts"], list)
+        assert isinstance(d["disclosures"], list)
+
+
+# ---------------------------------------------------------------------------
+# Fuzz (property-based)
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+_ID_ALPHABET = st.text(
+    alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd"), whitelist_characters="-_"),
+    min_size=1,
+    max_size=20,
+).filter(lambda s: s[0].isalnum() or s[0] in "_")
+
+
+@pytest.mark.fuzz
+class TestFuzzProjectionOrderingInvariance:
+    @given(
+        node_refs=st.lists(_ID_ALPHABET, min_size=1, max_size=8, unique=True),
+        seed=st.integers(min_value=0, max_value=2**32 - 1),
+    )
+    @settings(max_examples=25, deadline=None)
+    def test_shuffled_node_order_never_changes_the_digest(self, node_refs, seed):
+        import random
+
+        rng = random.Random(seed)  # noqa: S311 - test-only shuffling
+        nodes = tuple(_node(ref=r, ref_kind="task") for r in node_refs)
+        shuffled = list(nodes)
+        rng.shuffle(shuffled)
+
+        proj_original = CorrelationProjection(
+            run_id="run-fuzz", nodes=nodes, edges=(), clock_contexts=(), disclosures=()
+        )
+        proj_shuffled = CorrelationProjection(
+            run_id="run-fuzz", nodes=tuple(shuffled), edges=(), clock_contexts=(), disclosures=()
+        )
+        assert proj_original.canonical_bytes == proj_shuffled.canonical_bytes
+        assert proj_original.projection_digest == proj_shuffled.projection_digest
+
+    @given(ref=_ID_ALPHABET)
+    @settings(max_examples=25, deadline=None)
+    def test_valid_ids_always_round_trip_through_validate_correlation_id(self, ref):
+        assert validate_correlation_id(ref) == ref

--- a/tests/test_correlation_persistence.py
+++ b/tests/test_correlation_persistence.py
@@ -1,0 +1,375 @@
+"""Tests for ``aptl.core.correlation.persistence`` (OBS-002 Stage 2, issue #447).
+
+Uses a real ``LocalRunStore`` against a ``tmp_path`` archive (not a fake).
+Covers: ``build_and_persist_correlation`` reads ``manifest.json`` and
+``orchestration/*/{result.json,history.jsonl}`` through the store's path
+API, persists ``<run_id>/correlation.json`` under the run directory (never
+``create_json_once``'s sibling namespace — the confirmed exporter gotcha),
+round-trips the persisted content back to an equal projection, redacts a
+secret-shaped value carried in a raw input, and that
+``aptl.core.exporter.export_local``'s tar actually contains
+``correlation.json`` end to end. Also covers the ADR-047 fail-closed
+diagnostic shape for a missing/corrupt archive.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from aptl.core.correlation.clock import FixedClockProvider
+from aptl.core.correlation.models import CorrelationProjection
+from aptl.core.correlation.persistence import (
+    build_and_persist_correlation,
+    persist_run_correlation_best_effort,
+)
+from aptl.core.experiment.errors import AdmissionRejection
+from aptl.core.exporter import export_local
+from aptl.core.runstore import LocalRunStore
+
+_PARTICIPANT_ADDRESS = "participant.behavior.techvault.kali-victim-ssh-probe"
+
+
+def _behavior_event(*, event_type: str, timestamp: str, episode_id: str, action_instance_id: str, **overrides):
+    base = {
+        "event_type": event_type,
+        "timestamp": timestamp,
+        "participant_address": _PARTICIPANT_ADDRESS,
+        "episode_id": episode_id,
+        "action_instance_id": action_instance_id,
+        "action_contract_address": "participant.action-contract.aptl.kali-victim-ssh-probe",
+        "observation_boundary_address": None,
+        "observation_status": None,
+        "actor_provenance": "codex-cli",
+        "lifecycle_phase": None,
+        "phase_realization": None,
+        "admission_disposition": None,
+        "operation_ref": None,
+        "operation_state": None,
+        "state_transition_kind": None,
+        "post_state_digest": None,
+        "joint_action_set_id": None,
+        "realized_order": None,
+        "interaction_ref": None,
+        "interaction_class": "shared_state_change",
+        "shared_state_refs": ["container:aptl-kali"],
+        "details": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_run_archive(
+    store: LocalRunStore,
+    run_id: str,
+    *,
+    evidence_references: list[dict[str, object]] | None = None,
+    write_orchestration: bool = True,
+) -> None:
+    store.create_run(run_id)
+    episode_id = "episode-persist-1"
+    action_id = "participant.behavior.techvault.kali-victim-ssh-probe.persist1"
+    attempted = _behavior_event(
+        event_type="action_attempted",
+        timestamp="2026-01-01T00:00:00Z",
+        episode_id=episode_id,
+        action_instance_id=action_id,
+    )
+    observed = _behavior_event(
+        event_type="observation_emitted",
+        timestamp="2026-01-01T00:00:05Z",
+        episode_id=episode_id,
+        action_instance_id=action_id,
+    )
+    runtime_snapshot = {
+        "participant_episode_results": {
+            _PARTICIPANT_ADDRESS: {"episode_id": episode_id, "status": "running"}
+        },
+        "participant_episode_history": {},
+        "participant_behavior_history": {_PARTICIPANT_ADDRESS: [attempted, observed]},
+        "evaluation_results": {
+            "evaluation.objective.techvault.foothold": {
+                "outcome": "succeeded",
+                "started_at": "2026-01-01T00:00:01Z",
+                "updated_at": "2026-01-01T00:00:06Z",
+            }
+        },
+    }
+    manifest = {
+        "schema_version": "aptl.run-record/v1",
+        "run_id": run_id,
+        "aces": {"runtime_snapshot": runtime_snapshot, "realization": {}},
+        "backend_evidence": {"evidence_references": evidence_references or []},
+    }
+    store.write_json(run_id, "manifest.json", manifest)
+
+    if write_orchestration:
+        result = {
+            "state_schema_version": "aces-workflow-state/v1",
+            "workflow_status": "succeeded",
+            "run_id": "workflow-internal-deadbeefdeadbeefdeadbeefdeadbeef",
+            "started_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:02Z",
+            "terminal_reason": "completed",
+            "compensation_status": "not_required",
+            "compensation_started_at": None,
+            "compensation_updated_at": None,
+            "compensation_failures": [],
+            "steps": {},
+        }
+        store.write_json(run_id, "orchestration/runtime_apply_orchestration/result.json", result)
+        history_events = [
+            {
+                "event_type": "workflow_started",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "step_name": None,
+                "branch_name": None,
+                "join_step": None,
+                "outcome": None,
+                "details": {},
+            },
+            {
+                "event_type": "workflow_completed",
+                "timestamp": "2026-01-01T00:00:02Z",
+                "step_name": None,
+                "branch_name": None,
+                "join_step": None,
+                "outcome": None,
+                "details": {"reason": "completed"},
+            },
+        ]
+        for event in history_events:
+            store.append_jsonl(run_id, "orchestration/runtime_apply_orchestration/history.jsonl", [event])
+
+
+def _clock_provider() -> FixedClockProvider:
+    return FixedClockProvider(measurement_time="2026-01-01T00:10:00Z")
+
+
+# ---------------------------------------------------------------------------
+# build_and_persist_correlation — happy path.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAndPersistCorrelation:
+    def test_persists_correlation_json_under_the_run_directory(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-1"
+        _write_run_archive(store, run_id)
+
+        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+
+        correlation_path = tmp_path / "runs" / run_id / "correlation.json"
+        assert correlation_path.is_file()
+
+    def test_does_not_use_create_json_once_sibling_namespace(self, tmp_path):
+        """The confirmed exporter gotcha: `create_json_once` writes to
+        `<base_dir>/<namespace>/...`, a SIBLING of the run tree, not under
+        it. Assert nothing new landed outside `<base_dir>/<run_id>/`."""
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-2"
+        _write_run_archive(store, run_id)
+        base_dir = tmp_path / "runs"
+        before = {p.relative_to(base_dir) for p in base_dir.rglob("*") if p.is_file()}
+
+        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+
+        after = {p.relative_to(base_dir) for p in base_dir.rglob("*") if p.is_file()}
+        new_files = after - before
+        assert new_files == {Path(run_id) / "correlation.json"}
+
+    def test_returned_projection_matches_the_persisted_file(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-3"
+        _write_run_archive(store, run_id)
+
+        projection = build_and_persist_correlation(
+            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+        )
+
+        correlation_path = tmp_path / "runs" / run_id / "correlation.json"
+        persisted = json.loads(correlation_path.read_text(encoding="utf-8"))
+        assert persisted == projection.to_canonical_dict()
+
+    def test_persisted_content_round_trips_to_an_equal_projection(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-4"
+        _write_run_archive(store, run_id)
+
+        projection = build_and_persist_correlation(
+            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+        )
+
+        correlation_path = tmp_path / "runs" / run_id / "correlation.json"
+        persisted = json.loads(correlation_path.read_text(encoding="utf-8"))
+        reloaded = CorrelationProjection.from_canonical_dict(persisted)
+
+        assert reloaded.projection_digest == projection.projection_digest
+        assert reloaded.canonical_bytes == projection.canonical_bytes
+        assert set(reloaded.nodes) == set(projection.nodes)
+        assert set(reloaded.edges) == set(projection.edges)
+
+    def test_finds_the_expected_association_methods_from_a_real_archive(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-5"
+        _write_run_archive(store, run_id)
+
+        projection = build_and_persist_correlation(
+            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+        )
+        methods = {e.association_method.value for e in projection.edges}
+        assert "explicit_identifier" in methods
+        assert "declared_rule" in methods
+        assert "time_window_candidate" in methods
+
+
+# ---------------------------------------------------------------------------
+# Redaction.
+# ---------------------------------------------------------------------------
+
+
+class TestRedaction:
+    def test_secret_shaped_value_in_an_external_evidence_reference_is_absent_from_the_persisted_file(
+        self, tmp_path
+    ):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-secret-1"
+        _write_run_archive(
+            store,
+            run_id,
+            evidence_references=[
+                {"kind": "pcap", "note": "password=hunter2-super-secret-value"}
+            ],
+        )
+
+        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+
+        correlation_path = tmp_path / "runs" / run_id / "correlation.json"
+        raw_text = correlation_path.read_text(encoding="utf-8")
+        assert "hunter2-super-secret-value" not in raw_text
+        assert "password=" not in raw_text
+
+
+# ---------------------------------------------------------------------------
+# Export sweep.
+# ---------------------------------------------------------------------------
+
+
+class TestExportIncludesCorrelation:
+    def test_exported_tar_contains_correlation_json(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-export-1"
+        _write_run_archive(store, run_id)
+        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+
+        output_dir = tmp_path / "exports"
+        archive_path = export_local(store, run_id, output_dir)
+
+        with tarfile.open(archive_path, "r:gz") as tar:
+            names = tar.getnames()
+        assert f"{run_id}/correlation.json" in names
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed diagnostics.
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosedDiagnostics:
+    def test_missing_manifest_raises_admission_rejection(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-missing-1"
+        store.create_run(run_id)  # no manifest.json written
+
+        with pytest.raises(AdmissionRejection) as exc_info:
+            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+        assert len(exc_info.value.diagnostics) == 1
+        assert exc_info.value.diagnostics[0].domain == "obs-002-correlation"
+
+    def test_malformed_orchestration_history_raises_admission_rejection(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-malformed-1"
+        _write_run_archive(store, run_id, write_orchestration=False)
+        run_dir = tmp_path / "runs" / run_id
+        (run_dir / "orchestration" / "runtime_apply_orchestration").mkdir(parents=True)
+        (run_dir / "orchestration" / "runtime_apply_orchestration" / "history.jsonl").write_text(
+            "{not valid json\n"
+        )
+
+        with pytest.raises(AdmissionRejection):
+            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+
+    def test_diagnostic_message_never_leaks_a_secret_shaped_value(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-persist-missing-2"
+        store.create_run(run_id)
+
+        with pytest.raises(AdmissionRejection) as exc_info:
+            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+        for diag in exc_info.value.diagnostics:
+            assert "password=" not in diag.message
+
+
+# ---------------------------------------------------------------------------
+# Fuzz (property-based) — persistence-layer determinism.
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@pytest.mark.fuzz
+class TestFuzzPersistenceDeterminism:
+    @given(run_suffix=st.integers(min_value=0, max_value=10_000))
+    @settings(max_examples=15, deadline=None)
+    def test_repeated_persist_of_the_same_archive_is_byte_identical(self, tmp_path_factory, run_suffix):
+        tmp_path = tmp_path_factory.mktemp(f"persist-fuzz-{run_suffix}")
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = f"run-fuzz-{run_suffix}"
+        _write_run_archive(store, run_id)
+
+        first = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+        second = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+
+        assert first.canonical_bytes == second.canonical_bytes
+
+
+class TestPersistRunCorrelationBestEffort:
+    """The run-finalization wiring (lab.py `_write_run_record`): build+persist
+    is best-effort — it emits ``<run_id>/correlation.json`` on success and
+    NEVER raises (returns None) when the archive is missing/unreadable, so an
+    audit-projection failure can never fail the run itself (OBS-002:
+    correlation is layered over the already-sealed run record)."""
+
+    def test_success_emits_correlation_json_and_returns_projection(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-besteffort-ok"
+        _write_run_archive(store, run_id)
+        projection = persist_run_correlation_best_effort(
+            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+        )
+        assert isinstance(projection, CorrelationProjection)
+        assert (store.get_run_path(run_id) / "correlation.json").is_file()
+
+    def test_missing_manifest_returns_none_and_does_not_raise(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-besteffort-nomanifest"
+        store.create_run(run_id)  # no manifest.json written
+        # build_and_persist_correlation would raise AdmissionRejection here;
+        # the best-effort wrapper must swallow it and return None instead.
+        result = persist_run_correlation_best_effort(
+            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+        )
+        assert result is None
+        assert not (store.get_run_path(run_id) / "correlation.json").exists()
+
+    def test_defaults_to_system_clock_when_none_supplied(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_id = "run-besteffort-defaultclock"
+        _write_run_archive(store, run_id)
+        projection = persist_run_correlation_best_effort(run_id=run_id, run_store=store)
+        assert isinstance(projection, CorrelationProjection)
+        assert (store.get_run_path(run_id) / "correlation.json").is_file()

--- a/tests/test_correlation_persistence.py
+++ b/tests/test_correlation_persistence.py
@@ -149,6 +149,11 @@ def _clock_provider() -> FixedClockProvider:
     return FixedClockProvider(measurement_time="2026-01-01T00:10:00Z")
 
 
+# Shared instance so a call does not sit inside a `with pytest.raises(...)` block
+# (SonarCloud S5778: only one throwing invocation per exception test).
+_FIXED_CLOCK = _clock_provider()
+
+
 # ---------------------------------------------------------------------------
 # build_and_persist_correlation — happy path.
 # ---------------------------------------------------------------------------
@@ -160,7 +165,7 @@ class TestBuildAndPersistCorrelation:
         run_id = "run-persist-1"
         _write_run_archive(store, run_id)
 
-        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
 
         correlation_path = tmp_path / "runs" / run_id / "correlation.json"
         assert correlation_path.is_file()
@@ -175,7 +180,7 @@ class TestBuildAndPersistCorrelation:
         base_dir = tmp_path / "runs"
         before = {p.relative_to(base_dir) for p in base_dir.rglob("*") if p.is_file()}
 
-        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
 
         after = {p.relative_to(base_dir) for p in base_dir.rglob("*") if p.is_file()}
         new_files = after - before
@@ -187,7 +192,7 @@ class TestBuildAndPersistCorrelation:
         _write_run_archive(store, run_id)
 
         projection = build_and_persist_correlation(
-            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+            run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK
         )
 
         correlation_path = tmp_path / "runs" / run_id / "correlation.json"
@@ -200,7 +205,7 @@ class TestBuildAndPersistCorrelation:
         _write_run_archive(store, run_id)
 
         projection = build_and_persist_correlation(
-            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+            run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK
         )
 
         correlation_path = tmp_path / "runs" / run_id / "correlation.json"
@@ -218,7 +223,7 @@ class TestBuildAndPersistCorrelation:
         _write_run_archive(store, run_id)
 
         projection = build_and_persist_correlation(
-            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+            run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK
         )
         methods = {e.association_method.value for e in projection.edges}
         assert "explicit_identifier" in methods
@@ -245,7 +250,7 @@ class TestRedaction:
             ],
         )
 
-        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
 
         correlation_path = tmp_path / "runs" / run_id / "correlation.json"
         raw_text = correlation_path.read_text(encoding="utf-8")
@@ -263,7 +268,7 @@ class TestExportIncludesCorrelation:
         store = LocalRunStore(tmp_path / "runs")
         run_id = "run-persist-export-1"
         _write_run_archive(store, run_id)
-        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+        build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
 
         output_dir = tmp_path / "exports"
         archive_path = export_local(store, run_id, output_dir)
@@ -285,7 +290,7 @@ class TestFailClosedDiagnostics:
         store.create_run(run_id)  # no manifest.json written
 
         with pytest.raises(AdmissionRejection) as exc_info:
-            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
         assert len(exc_info.value.diagnostics) == 1
         assert exc_info.value.diagnostics[0].domain == "obs-002-correlation"
 
@@ -300,7 +305,7 @@ class TestFailClosedDiagnostics:
         )
 
         with pytest.raises(AdmissionRejection):
-            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
 
     def test_diagnostic_message_never_leaks_a_secret_shaped_value(self, tmp_path):
         store = LocalRunStore(tmp_path / "runs")
@@ -308,7 +313,7 @@ class TestFailClosedDiagnostics:
         store.create_run(run_id)
 
         with pytest.raises(AdmissionRejection) as exc_info:
-            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+            build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
         for diag in exc_info.value.diagnostics:
             assert "password=" not in diag.message
 
@@ -331,8 +336,8 @@ class TestFuzzPersistenceDeterminism:
         run_id = f"run-fuzz-{run_suffix}"
         _write_run_archive(store, run_id)
 
-        first = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
-        second = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_clock_provider())
+        first = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
+        second = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
 
         assert first.canonical_bytes == second.canonical_bytes
 
@@ -349,7 +354,7 @@ class TestPersistRunCorrelationBestEffort:
         run_id = "run-besteffort-ok"
         _write_run_archive(store, run_id)
         projection = persist_run_correlation_best_effort(
-            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+            run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK
         )
         assert isinstance(projection, CorrelationProjection)
         assert (store.get_run_path(run_id) / "correlation.json").is_file()
@@ -361,7 +366,7 @@ class TestPersistRunCorrelationBestEffort:
         # build_and_persist_correlation would raise AdmissionRejection here;
         # the best-effort wrapper must swallow it and return None instead.
         result = persist_run_correlation_best_effort(
-            run_id=run_id, run_store=store, clock_provider=_clock_provider()
+            run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK
         )
         assert result is None
         assert not (store.get_run_path(run_id) / "correlation.json").exists()


### PR DESCRIPTION
## Summary

Implements OBS-002: a small, versioned experiment correlation-identity + clock-context projection built over the existing run archive, so an action can be traced end-to-end (participant history → red evidence → blue observation → evaluator result → sealed run record) without ever treating timestamp proximity as causality. New src/aptl/core/correlation/ package assembles typed nodes from ACES-derived identities and typed edges — explicit-identifier only for a genuinely shared id, declared-rule for manifest/run-path containment, time-window-candidate only across a reconciled shared clock domain (else a disclosed gap), gap-or-unknown for un-propagated sources — and records each evidence source's clock domain/sync/offset/uncertainty. Persisted create-once as <run_id>/correlation.json (swept by the exporter) and wired best-effort into run finalization so an audit-projection failure never fails the run. No ACES contract changes; no injection into range components. Un-propagated sources (MCP-red, collectors) are honestly recorded as typed associations + clock uncertainty — the documented extension seam for later per-source explicit-id propagation.

## Requirement UIDs

- `OBS-002`

## Related Issues

Closes #447

## ADR Impact

- ADR-044
- ADR-047

## Changes

- New src/aptl/core/correlation/ package: models.py (frozen AssociationMethod / ClockContext / CorrelationNode / CorrelationEdge / CorrelationProjection with order-independent canonical bytes + serialization-boundary ID validation reusing the run-store ID rule), clock.py (source-owned ClockProvider seam + SystemClockProvider/FixedClockProvider + shared utc_now), identity.py (deterministic RFC-8785+SHA-256 stable refs; no wall-clock/UUID/RNG), rules.py (closed versioned DECLARED_RULE vocabulary), _assemble.py (graph assembly), builder.py (pure build_correlation_projection), persistence.py (archive read + create-once persist under <run_id>/ + best-effort wrapper)
- Wired into src/aptl/core/lab.py `_write_run_record` (best-effort, never fatal) so every run emits <run_id>/correlation.json
- Honest edge classification: manifest-scoped episode/action/evaluator nodes bind to the run via a manifest-snapshot-membership DECLARED_RULE (they carry no run_id of their own), not an overstated explicit identifier; evaluator/participant temporal comparison reconciles clock domains first and discloses both clock inputs, emitting a gap across unreconciled domains
- Tests: unit + property-based (fuzz) + a full end-to-end connected-path trace + clock skew / missing timestamps / duplicate events / restarts / reordered-ingestion + export-sweep verification (~2200 lines across 5 test files)
- No new ADR (per the OBS-002 preflight note added under docs/architecture/); builds on ADR-044 run record + ADR-047 admission identities

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: OBS-002 ← src/aptl/core/correlation/models.py, OBS-002 ← src/aptl/core/correlation/clock.py, OBS-002 ← src/aptl/core/correlation/identity.py, OBS-002 ← src/aptl/core/correlation/rules.py, OBS-002 ← src/aptl/core/correlation/_assemble.py, OBS-002 ← src/aptl/core/correlation/builder.py, OBS-002 ← src/aptl/core/correlation/persistence.py, OBS-002 ← src/aptl/core/lab.py
- TESTS: OBS-002 ← tests/test_correlation_models.py, OBS-002 ← tests/test_correlation_clock.py, OBS-002 ← tests/test_correlation_identity.py, OBS-002 ← tests/test_correlation_builder.py, OBS-002 ← tests/test_correlation_persistence.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
