### PR TITLE
feat(experiment): admit capture requirements via a code-owned collector registry

### DIFF
--- a/docs/architecture/exp-010-capture-admission-evidence-preflight.md
+++ b/docs/architecture/exp-010-capture-admission-evidence-preflight.md
@@ -1,0 +1,309 @@
+# EXP-010 Capture Admission And Evidence Acquisition Preflight
+
+This note is the architecture preflight for EXP-010 / issue #752. It is
+guidance, not an implementation plan. No new ADR is needed: ADR-047 owns ACES
+experiment admission and deterministic trial planning, OBS-002 owns correlation
+identity and clock context, ADR-029 owns secret handling, ADR-041 and ADR-042
+own Kali capture and PTY boundaries, and ADR-044 owns the ACES-aligned run
+record. This note fixes how EXP-010 crosses those boundaries without creating a
+parallel workflow, evidence schema, persistence system, or plugin loader.
+
+## Architecture Decisions And Guardrails
+
+### One declaration, one admitted binding
+
+- Evolve the empty, code-owned `SUPPORTED_CAPTURE_CAPABILITIES` table and its
+  `CaptureCapability` in `src/aptl/core/experiment/capture_mapping.py` into one
+  versioned collector registry. A registration has a stable non-executable ID,
+  implementation version, static capability declaration, trusted factory
+  wiring, and a conformance fixture. The ID is not an import path, class name,
+  command, URL, host path, credential selector, or arbitrary configuration key.
+- The registry is the sole detailed source of truth for capture support. Its
+  declarations cover the ACES contract version, channel identity and version,
+  capture kind, scope, window semantics, media types, required artifact roles,
+  sensitivity and redaction support, integrity and sealing support, retention
+  policy IDs, loss disclosure, visibility class, and size/count/time limits.
+  The backend `ObservationCapabilities` manifest is an aggregate projection of
+  the same declarations, not a second hand-maintained capability matrix.
+- Admission must match every authored requirement field deterministically and
+  return an immutable binding, not the current owner string. Unknown contract
+  versions, channel versions, policy vocabulary, or requirement values fail
+  closed. Function existence, container presence, or a sidecar path does not
+  constitute declared support.
+- Persist each binding in the canonical, immutable trial-plan bytes before
+  mutation. It pins the capture/requirement/window refs, collector registration
+  and implementation version, public effective-config digest, expected
+  artifact and media contract, limits, clock policy, visibility, and accepted
+  failure/limitation policy. Runtime verifies the pinned registration and
+  digest and never re-matches against a changed registry.
+- The capture plan is an internal execution projection within or referenced by
+  `TrialPlan`; it is not a local replacement for
+  `ExperimentCaptureSpecModel`, `ExperimentEvidenceRecordModel`, or
+  `ExperimentRunModel`. Capture-plan IDs, planned-trial IDs, attempt/run IDs,
+  trace IDs, sidecar session IDs, evidence-record IDs, and run-record IDs remain
+  distinct concepts.
+
+ACES capture-spec v1 has no general `required` flag. Treat authored capture
+requirements as required by default. A trusted admission policy may explicitly
+accept a stable limitation code and comparability disclosure for a supported
+degradation; the acceptance must be persisted in the plan and default to
+empty. Never infer optionality from notes, validity text, an empty result, or a
+collector's historical best-effort behavior.
+
+### Narrow collector boundary
+
+- A collector receives only an immutable admitted context: planned-trial and
+  run/attempt IDs, its pinned binding and window, a deadline and limits, a
+  `ClockProvider`, and the narrow source adapter it needs. It does not receive
+  `ExperimentController`, the full ACES runtime target, `LocalRunStore`, raw
+  filesystem paths, `EnvVars`, the complete application config, or generic
+  command/HTTP clients.
+- Built-ins remain behind their existing authority boundaries:
+  `DeploymentBackend` for container operations, established SOC clients and
+  `curl_safe` for authenticated services, the MCP result envelope for MCP
+  activity, and the ADR-041/ADR-042 sidecar for Kali PTY/packet sources. Trusted
+  composition code injects those narrow adapters; experiment input never
+  chooses their executable implementation or secret-bearing configuration.
+- The coordinator owns deadlines, cancellation, quotas, clock observations,
+  path allocation, hashing, redaction, media checks, persistence, diagnostics,
+  and ACES record construction. A collector can report source bytes/chunks and
+  typed counters or failures; it cannot choose archive paths or directly
+  create portable evidence records.
+- `src/aptl/core/collectors.py`, red MCP logs, and sidecar harvesters are useful
+  source adapters but currently have best-effort/empty-on-error semantics. Do
+  not reinterpret an empty list or a successful harvest call as successful
+  required capture. A conformant adapter must preserve startup failure,
+  mid-run loss/drop, truncation, timeout, source disappearance, and finalization
+  failure as distinct outcomes.
+
+The extension seam is the registry registration plus this narrow lifecycle
+protocol. Adding a reasonable next built-in source should require one adapter,
+one static declaration, and its conformance fixture; it must not require edits
+to the experiment controller, manifest logic, persistence layout, or evidence
+schema. Untrusted or out-of-process third-party collectors require a separate
+authorization and sandboxing design and are outside this boundary.
+
+### Lifecycle and terminal semantics
+
+The ordering is a correctness contract:
+
+1. Load ACES artifacts, validate all cross-artifact refs, match every capture
+   requirement, compile the immutable plan, and persist it before any range
+   mutation.
+2. Provision through the existing ACES/deployment lifecycle. Start admitted
+   collectors after their sources are ready but before participant actions or
+   orchestrator workflows can begin.
+3. Stop collectors in reverse order from a `finally` boundary, even when the
+   trial or another collector fails.
+4. Bound, classify, redact where required, media-check, hash, and persist the
+   captured bytes; then construct ACES evidence records and explicit evidence
+   references.
+5. Only a successfully finalized result is ready for the sealing work owned by
+   issue #444. Capture authorization and artifact presence are not proof of a
+   successful seal.
+
+`RuntimeManager.apply` in `src/aptl/backends/aces.py` currently drives
+orchestrator workflows before returning. The execution design therefore needs
+a narrow seam between successful provisioning/registration and
+`_drive_orchestrator_workflows`; wrapping capture around the return from
+`apply` starts too late. Reuse the existing provisioning and workflow owners
+rather than cloning either lifecycle.
+
+Unsupported or missing declared capability is an admission rejection and must
+cause zero range mutation. A declared source that becomes unavailable at
+runtime or a collector startup failure aborts the attempt before participant
+action and still runs cleanup. Required mid-run loss, unacceptable truncation
+or clock uncertainty, and required finalization failure produce an unsealed,
+invalidated/inconclusive result. An explicitly accepted optional degradation
+may produce a completed/partial result only with loss, limitation, and
+comparability disclosures. Stable diagnostic/reason codes must distinguish
+missing source, startup failure, loss, truncation, clock skew, timeout, and
+finalization failure even where ACES terminal statuses coincide.
+
+Use `ExperimentRunModel` status/outcome, its deviations and disclosures, and
+safe ACES diagnostics for experiment outcomes. Do not create a second
+controller state machine or overload `LabResult` startup readiness to describe
+capture success. Collector failures are typed outcome data projected into those
+diagnostics; normalize internal exceptions instead of exposing a second public
+exception hierarchy.
+
+### Evidence ownership and persistence
+
+- Use public models from `aces_contracts.contracts` as the portable schema:
+  `ExperimentEvidenceRecordModel`, `ExperimentArtifactRefModel`,
+  `ParticipantObservationEnvelopeModel`, `SourcePipelineModel`,
+  `RawDataIntegrityModel`, experiment clock context, and run
+  augmentation/realized-form disclosures. An internal collector receipt may be
+  an adapter result, but it is not another portable evidence record.
+- Extend the existing `RunStorageBackend` boundary narrowly for streamed,
+  content-addressed blob insertion and run-scoped create-once canonical JSON.
+  Do not add an evidence repository beside `LocalRunStore`. The coordinator
+  derives fixed locations from validated IDs and the computed digest; plugins
+  never supply a relative or absolute destination.
+- Content insertion must be descriptor-relative/no-follow and create-exclusive,
+  reuse `src/aptl/utils/pathsafe.py`, use restrictive permissions, enforce
+  byte/count/time limits while streaming, and recompute size, digest, and media
+  type from the stored object. A repeated digest is idempotent only when the
+  existing bytes agree; a conflict fails closed.
+- Checksums in ACES artifact/evidence references identify the bytes actually
+  retained. When policy permits redaction or truncation, retain safe original
+  digest/size observations separately where available and record the stored
+  digest/size, redaction state, and mandatory loss disclosure. Never fabricate
+  evidence content for a failed collection.
+- Structured material must pass the shared Python/TypeScript redactors before
+  persistence. Opaque control-plane secrets are rejected or excluded. Designed
+  target secrets may be captured only through an explicit source/path and
+  sensitivity policy under ADR-029. `APTL_EXPERIMENT_NO_REDACT`, direct
+  `write_file`/`copy_file`, a harvested file, or an exporter pass is not a
+  final-evidence sanitation decision.
+- Build an explicit verified evidence ledger. The current run-directory scan
+  for orchestration, MCP-side, and Kali-side files is useful legacy inventory,
+  but path presence without digest, source outcome, and record validation is
+  not evidence truth and cannot satisfy the seal gate.
+- `src/aptl/core/lab.py` writes the existing reproducibility run record during
+  lab startup. That record is not a final `ExperimentRunModel` and must not be
+  stretched into the experiment evidence ledger or issue #444 seal. Feed
+  verified references into the later experiment result through the existing
+  run/correlation projection boundaries.
+- Evidence-record identity must derive from stable run/planned-trial,
+  capture-spec, requirement, window, collector-config, and retained-content
+  identity. `captured_at`, filesystem order, or ingestion order must not define
+  identity. Preserve each source's clock domain, offset/uncertainty, and
+  observer-effect disclosure using the OBS-002 clock/correlation seams.
+
+Participant visibility is a separate projection from capture authorization.
+Reuse the participant-visible/disclosed/evaluator-only partition in
+`src/aptl/backends/aces_participant_actions.py` and ACES participant observation
+envelopes. Hidden or evaluator-only evidence remains absent from participant
+responses, logs, and future API projections even when the collector is
+authorized to retain it.
+
+## Cross-Cutting Incumbents To Reuse
+
+| Concern | Canonical incumbent and required use |
+|---|---|
+| ACES schema and conformance | Public `aces_contracts.contracts` loaders/models, the installed fixture corpus, and `aces_conformance` observability diagnostics. Do not copy schemas or fixture payloads into APTL. |
+| Admission and planning | `src/aptl/core/experiment/{resolver,spec_loading,admission,admission_artifacts,capture_mapping,trial_plan,policy,errors}.py` for bounded loading, public contract parsing, deterministic projection, policy, canonical hashing, persistence-before-mutation, and safe `AdmissionRejection`. |
+| Backend capability manifest | `src/aptl/backends/aces_manifest.py` and ACES `ObservationCapabilities`. Generate observation claims from conformant registry declarations. |
+| Runtime seams | `src/aptl/backends/aces.py`, `aces_orchestrator.py`, `aces_participant_runtime.py`, `aces_participant_actions.py`, `aces_observation.py`, and `aces_repro.py` for provisioning, workflow/action boundaries, visibility, and run projection. |
+| Source ownership | `DeploymentBackend`, `src/aptl/core/collectors.py`, established SOC clients/`curl_safe`, `mcp/aptl-mcp-common`, `mcp/mcp-red`, and `containers/kali-capture/writer.py`. Adapt; do not bypass their safety boundaries with Docker/shell/HTTP duplicates. |
+| Persistence and path safety | `RunStorageBackend`/`LocalRunStore`, RFC 8785 canonical JSON, `src/aptl/utils/pathsafe.py`, run/session ID validators, restrictive creation, and `src/aptl/core/exporter.py`. Export remains packaging, not validation or sanitation. |
+| Secrets and logs | ADR-029, `src/aptl/utils/redaction.py`, TypeScript redaction parity, `src/aptl/utils/logging.py`, bounded ACES diagnostics, `LabResult` diagnostics, and MCP `harvest_warning`. Log stable IDs, stages, codes, counts, and durations only. |
+| Identity and clocks | `src/aptl/core/correlation`, its `ClockProvider`, `TrialPlan` identities, ACES run/participant/source identities, and OBS-002 association and clock rules. |
+| Configuration | Strict `src/aptl/core/config.py`, `src/aptl/core/env.py`, ADR-025 first-party config, and shared MCP config/environment binding. Durable operator knobs require a typed field and a real consumer; experiment documents do not become config. |
+| Auth and projection | `src/aptl/api/deps.py`, BFF host/CSRF/session middleware, existing local MCP stdio authority, sidecar peer checks, and participant visibility filtering. EXP-010 adds no auth bypass or endpoint. |
+| Workflow and tests | `.ground-control.yaml`, `.gc/plan-rules.md`, pytest, pre-commit, MCP package tests/builds, injected clocks/runners, and ACES corpus/conformance fixtures. Compose/container/config changes retain the clean-lab validation gate. |
+
+## Security And Validation Passage
+
+The intended design must pass every applicable layer below; passing only the
+collector's local input checks is insufficient.
+
+| Layer | Required passage |
+|---|---|
+| Authentication/authority | No new network endpoint. Future API access inherits bearer verification plus BFF host/CSRF/session gates. MCP remains local stdio; the sidecar remains a peer-checked local socket. A capture grant identifies allowed sources and visibility, not general controller authority. |
+| ACES shape validation | Parse capture specs and emit evidence/run artifacts only through public ACES models. Preserve bounded diagnostics without pydantic `input`, arbitrary metadata, or source payloads. |
+| Cross-artifact admission | Existing resolver/spec-loading and ADR-047 validate project containment, artifact kinds/versions, references, task joins, and apparatus compatibility before mutation. Capture matching then checks every requirement axis and policy vocabulary. |
+| Registry/policy validation | Enforce unique stable registration IDs, supported contract/channel versions, deterministic selection, public-config digest, explicit limits, visibility, and accepted limitation codes. No dynamic import, fallback collector, or notes-driven policy. |
+| Config/environment binding | `AptlConfig` remains strict and `EnvVars` remains the environment authority. Secret-bearing clients are injected after admission; their values are excluded from config digests, plans, manifests, logs, and evidence metadata. No experiment-provided env keys. |
+| OS/process/URL exposure | Use backend argument arrays and existing runners/timeouts. No shell command construction, executable name, host path, arbitrary URL, credential, or token from experiment input. Secrets must not appear in argv, query strings, process listings, diagnostic text, or child environment except through an incumbent explicitly designed for that secret. |
+| Source boundary | Built-ins use only their narrow deployment/SOC/MCP/sidecar adapters. Enforce start/stop deadlines and cancellation outside plugin code; distinguish source failure from legitimate zero events. |
+| Filesystem and persistence | Validate IDs; derive destinations internally; reject traversal, absolute paths, symlinks, special files, and replacement races; enforce quotas during streaming; verify digest/size/media after storage; create records once. |
+| Secret/media boundary | Classify before structured persistence, redact with shared helpers, reject prohibited secrets and media mismatches, and disclose every allowed redaction/truncation/loss. Never make global redaction weaker for a fixture. |
+| Visibility boundary | Project participant-visible, disclosed, hidden, and evaluator-only observations server-side using existing partitioning. Storage or evaluator authorization never implies participant visibility. |
+| Error/log envelope | Convert untrusted/backend exceptions to stage-specific safe diagnostics. Do not return or log raw exception strings, backend stderr, host paths, URLs, headers, queries, hostile metadata, captured bytes, credentials, or full commands. |
+| Seal/export boundary | Validate ACES records and conformance, explicit references, retained digests, required capture outcomes, clock/observer disclosures, and finalization state before declaring ready to seal. Export does not repair or sanitize an invalid archive. |
+
+An important manifest guardrail follows from the ACES contract: declaring
+`ObservationCapabilities` requires the backend's top-level supported contract
+versions to cover the capture spec, evidence record, derived measure, and
+experiment run contracts. Do not turn on `create_aptl_manifest().observation`
+until that whole claim is true and conformance-tested. Claim only implemented
+sealing modes; a content digest or immutable local object is not a signed
+attestation or complete chain of custody.
+
+## Verification Guardrails
+
+- Pin deterministic, contract-version-aware matching across all requirement
+  axes, registry order, and equivalent input ordering. Assert unsupported
+  capture causes no backend, environment, sidecar, collector, session, or
+  run-directory mutation.
+- Give every registration a shared conformance fixture for start, stop,
+  deadlines, empty success, source unavailable, startup failure, mid-run
+  drop/loss, truncation, clock uncertainty, and finalization failure. Validate
+  the emitted record with the installed ACES corpus/conformance APIs.
+- Exercise traversal, absolute paths, symlinks and replacement races, hostile
+  filenames/metadata/media types, oversized streams and artifact counts,
+  stuck collectors, partial writes, digest collisions/conflicts, and concurrent
+  finalization. Quotas must be enforced during reads, not after buffering.
+- Use target-secret and control-plane-secret fixtures to prove intended target
+  evidence is classified/disclosed while credentials and operator secrets do
+  not enter plan bytes, argv, logs, records, CAS objects, or exports.
+- The representative integration must bind red action, container, network, and
+  defensive sources to one planned trial/run with explicit clock context and
+  ACES-valid evidence references. Tests must prove participant-hidden and
+  evaluator-only material never enters the participant projection.
+- Follow `.gc/plan-rules.md`: Python behavior gets pytest coverage; MCP common
+  changes rebuild and test every dependent MCP; web changes get web tests; and
+  compose, container-Dockerfile, or `config/` changes require a clean
+  `aptl lab stop -v && aptl lab start` validation on a fresh machine.
+
+## Gotchas And Anti-Patterns
+
+- Do not turn `capture_owner` into `importlib`, `getattr`, a command dispatcher,
+  or a plugin-supplied factory locator.
+- Do not duplicate ACES capture/evidence/run DTOs, validators, diagnostics,
+  retention/redaction vocabularies, or terminal-state workflows.
+- Do not discard admitted mapping output, re-select collectors at runtime, or
+  let a mutable registry/config silently change a persisted plan.
+- Do not conflate plan, collector receipt, raw blob, artifact reference,
+  evidence record, run record, correlation edge, trace, or sealed archive.
+- Do not treat best-effort empty results, file presence, successful `docker cp`,
+  telemetry spans, or a path scan as proof of evidence fidelity.
+- Do not let collectors write archive paths, follow symlinks, buffer unbounded
+  streams, decide redaction, construct ACES records, or receive the full
+  controller/backend/runtime target.
+- Do not use free-text notes as executable failure, retention, redaction, or
+  comparability policy; do not silently downgrade an authored requirement.
+- Do not infer causality or record identity from timestamp proximity, and do
+  not collapse source/host/container clocks into one synchronized clock.
+- Do not log raw exception text or preserve secrets through argv, URLs, env,
+  metadata, diagnostic contexts, opaque writes, or the no-redact test switch.
+- Do not seal before required collectors finalize, or translate a capture
+  failure into a harmless lab-start warning.
+
+## Non-Goals And Boundaries
+
+- This preflight does not implement EXP-010 or prescribe task sequencing.
+- It does not change ACES schemas, add a local capture DSL, or make APTL the
+  authority for portable experiment/evidence contracts.
+- It does not design arbitrary third-party discovery, dynamic plugin loading,
+  untrusted code sandboxing, remote collector installation, or arbitrary URI
+  acquisition. The first boundary is trusted, code-owned registrations.
+- It does not redesign `DeploymentBackend`, lab provisioning, SOC services,
+  MCP transport, the Kali PTY/packet ownership model, OpenTelemetry, or the
+  existing red-action logs; those are source boundaries to adapt.
+- It does not implement derived measures, statistical evaluation, participant
+  UI/API access, or issue #444 sealing. It produces validated, explicit,
+  ready-to-seal evidence inputs and prevents sealing when required capture is
+  incomplete.
+- It does not broaden participant visibility or convert evaluator-only data
+  into participant-observable state.
+
+## Whole-Repository Surface
+
+The design crosses the experiment modules and tests under
+`src/aptl/core/experiment/` and `tests/test_experiment_*`; ACES manifest/runtime
+adapters under `src/aptl/backends/`; `src/aptl/core/{lab,lab_types,runstore,
+collectors,config,env}.py`; `src/aptl/core/correlation/`; path, logging, and
+redaction utilities under `src/aptl/utils/`; MCP common and red-team packages;
+the Kali capture sidecar; SOC client boundaries; API/BFF auth if evidence is
+later exposed; exporter/run archives; ACES fixture/conformance packages; and
+the repo workflow gates in `.ground-control.yaml` and `.gc/plan-rules.md`.
+
+At runtime, the affected host/OS surfaces are container engines reached only
+through `DeploymentBackend`, process argv/environment, local Unix sockets,
+container filesystems and evidence mounts, SOC HTTPS/TLS clients, host run
+storage permissions and symlink behavior, clocks across host/container/source
+domains, and archive/export readers. None may receive authority merely because
+an experiment document requested a capture.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -162,3 +162,4 @@ The victim and kali containers publish no host ports; use
 - [GRC Boundary Surface Vocabulary](grc-boundary-surface-vocabulary-preflight.md)
 - [Issue #677 Certificate Producer Ownership](issue-677-cert-producer-ownership-preflight.md)
 - [OBS-002 Correlation Identity And Clock Context](obs-002-correlation-identity-clock-preflight.md)
+- [EXP-010 Capture Admission And Evidence Acquisition](exp-010-capture-admission-evidence-preflight.md)

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -45,6 +45,10 @@ except ImportError:
     BACKEND_SUPPORTED_CONTRACT_IDS = ()
 
 from aptl.backends.aces_participant_runtime import PARTICIPANT_ACTION_ADDRESS
+from aptl.core.experiment.capture_registry import (
+    DEFAULT_COLLECTOR_REGISTRY,
+    OBSERVATION_EVIDENCE_CONTRACTS,
+)
 
 APTL_ACES_TARGET_NAME = "aptl"
 APTL_ACES_TARGET_VERSION = "0.1.0"
@@ -216,11 +220,29 @@ _CONCEPT_BINDINGS = (
 
 
 def create_aptl_manifest() -> BackendManifest:
-    """Return APTL's canonical full remote-control-plane backend manifest."""
+    """Return APTL's canonical full remote-control-plane backend manifest.
+
+    The ``observation`` capability is an aggregate projection of the code-owned
+    collector registry (EXP-010 / issue #752), NOT a hand-maintained matrix.
+    :data:`~aptl.core.experiment.capture_registry.DEFAULT_COLLECTOR_REGISTRY`
+    is empty until a capture capability is genuinely backed end-to-end, so the
+    projection is ``None`` and no observation is declared — the honest EXP-002
+    posture. When (EXP-010 PR 2) real registrations turn the projection on, the
+    ACES ``observation_capability_contract_gaps`` invariant requires the
+    capture-spec/evidence-record/derived-measure/experiment-run contracts in
+    ``supported_contract_versions``, so they are added exactly then and never
+    speculatively.
+    """
+    observation = DEFAULT_COLLECTOR_REGISTRY.observation_projection()
+    supported_contract_versions = _SUPPORTED_CONTRACT_VERSIONS
+    capability_options: dict[str, object] = {}
+    if observation is not None:
+        supported_contract_versions = supported_contract_versions | OBSERVATION_EVIDENCE_CONTRACTS
+        capability_options["observation"] = observation
     return BackendManifest(
         name=APTL_ACES_TARGET_NAME,
         version=APTL_ACES_TARGET_VERSION,
-        supported_contract_versions=_SUPPORTED_CONTRACT_VERSIONS,
+        supported_contract_versions=supported_contract_versions,
         compatible_processors=_COMPATIBLE_PROCESSORS,
         realization_support=_REALIZATION_SUPPORT,
         concept_bindings=_CONCEPT_BINDINGS,
@@ -228,4 +250,5 @@ def create_aptl_manifest() -> BackendManifest:
         orchestrator=_ORCHESTRATOR,
         evaluator=_EVALUATOR,
         participant_runtime=_PARTICIPANT_RUNTIME,
+        **capability_options,
     )

--- a/src/aptl/core/experiment/admission.py
+++ b/src/aptl/core/experiment/admission.py
@@ -85,7 +85,8 @@ from aptl.core.experiment.admission_steps import (
     _resolve_capture_specs,
 )
 from aptl.core.experiment.apparatus import check_apparatus_admission
-from aptl.core.experiment.capture_mapping import map_capture_requirements
+from aptl.core.experiment.capture_mapping import bind_capture_requirements
+from aptl.core.experiment.capture_registry import DEFAULT_COLLECTOR_REGISTRY, CollectorRegistry
 from aptl.core.experiment.errors import AdmissionRejection, diagnostic
 from aptl.core.experiment.policy import AdmissionPolicy
 from aptl.core.experiment.resolver import ResolvedArtifact
@@ -220,6 +221,7 @@ def _admit_experiment_inner(
     policy: AdmissionPolicy,
     backend_manifest: BackendManifest,
     processor_manifest: ProcessorManifest,
+    capture_registry: CollectorRegistry,
 ) -> AdmissionResult:
     """Run the full admission sequence once; raises AdmissionRejection on any fail-closed gap."""
     # Step 1: root.
@@ -248,8 +250,12 @@ def _admit_experiment_inner(
         policy=policy,
     )
 
-    # Step 5: capture-requirement mapping (fail-closed; empty w/o refs).
-    map_capture_requirements(capture_specs, backend_manifest=backend_manifest, policy=policy)
+    # Step 5: capture-requirement binding against the collector registry
+    # (fail-closed; empty w/o refs). The immutable bindings are pinned into
+    # the trial plan at Step 8 so runtime never re-matches a changed registry.
+    capture_bindings = bind_capture_requirements(
+        capture_specs, registry=capture_registry, policy=policy
+    )
 
     # Step 6: per-condition planning-only feasibility + snapshot digests.
     condition_snapshot_digests, flat_instantiated_digest = _plan_conditions(
@@ -270,11 +276,12 @@ def _admit_experiment_inner(
     )
     source_set_digest = compute_source_set_digest(source_set_projection)
 
-    # Step 8: pure trial-plan expansion.
+    # Step 8: pure trial-plan expansion, pinning the admitted capture bindings.
     plan = expand_trial_plan(
         spec,
         source_set_digest=source_set_digest,
         condition_snapshot_digests=condition_snapshot_digests or None,
+        capture_bindings=capture_bindings,
         policy=policy,
     )
 
@@ -299,6 +306,7 @@ def admit_experiment(
     policy: AdmissionPolicy,
     backend_manifest: BackendManifest | None = None,
     processor_manifest: ProcessorManifest | None = None,
+    capture_registry: CollectorRegistry = DEFAULT_COLLECTOR_REGISTRY,
 ) -> AdmissionResult:
     """Run ADR-047 admission for one experiment-authoring-input document.
 
@@ -330,6 +338,7 @@ def admit_experiment(
             policy=policy,
             backend_manifest=resolved_backend,
             processor_manifest=resolved_processor,
+            capture_registry=capture_registry,
         )
     except AdmissionRejection as exc:
         return AdmissionResult.rejected(exc.diagnostics)

--- a/src/aptl/core/experiment/capture_mapping.py
+++ b/src/aptl/core/experiment/capture_mapping.py
@@ -1,147 +1,115 @@
-"""ACES capture-requirement terms -> APTL capture-owner mapping (ADR-047
-"Apparatus and capture capability admission").
+"""ACES capture-requirement admission via the collector registry (ADR-047
+"Apparatus and capture capability admission"; EXP-010 / issue #752).
 
-This is the ONE code-owned mapping from ``ExperimentCaptureRequirementModel``
-terms (``capture_kind``, ``capture_scope``, ``expected_media_types``,
-``integrity_requirements``) to an existing APTL capture owner
-(``collectors.py``, MCP/Kali capture, runtime snapshots, orchestration/
-evaluation history). Admission and later execution share it. It describes
-SUPPORT only — it never replaces the ACES capture-spec model, and it never
-maps an unknown term to a collector name, import, backend method, or shell
-command (ADR-047 "Apparatus capability admission").
+EXP-002 shipped an empty ``SUPPORTED_CAPTURE_CAPABILITIES`` table here. EXP-010
+evolves that into the single versioned :class:`~aptl.core.experiment.
+capture_registry.CollectorRegistry` (its own module), and this module becomes
+the thin admission entry point that binds every authored capture requirement
+against that registry.
 
-FAIL-CLOSED BASELINE (the load-bearing rule for #438 / EXP-002): a capture
-requirement is admitted ONLY when :data:`SUPPORTED_CAPTURE_CAPABILITIES`
-declares evidence-backed support AND the resolved backend manifest's
-``observation`` capability actually declares the matching channel/media/
-sealing vocabulary. The mere existence of a best-effort collector function
-is NEVER evidence of support — ``aptl.core.collectors`` collectors are
-best-effort primitives that often collapse failure into an empty result
-(ADR-047 Gotchas), and admitting on their presence would silently promise
-evidence collection never verified end-to-end.
+FAIL-CLOSED BASELINE (unchanged from #438): a capture requirement is admitted
+ONLY when a trusted registration in the resolved registry deterministically
+covers every requirement axis (contract version, channel identity/version,
+capture kind/scope, window semantics, media types, artifact roles, sensitivity,
+integrity, redaction, retention, loss disclosure). The mere existence of a
+best-effort collector function is never evidence of support. The production
+:data:`~aptl.core.experiment.capture_registry.DEFAULT_COLLECTOR_REGISTRY` is
+EMPTY, so every capture-bearing input still fails closed until EXP-010 PR 2
+lands real registrations together with their acquisition adapters.
 
-``create_aptl_manifest().observation`` is currently ``None`` (verified live
-against aces-sdl 0.23.1 — see the ACES API reference consulted for Stage 3,
-section 11). Because of that, :data:`SUPPORTED_CAPTURE_CAPABILITIES` is
-EMPTY for #438: there is no honest backend observation declaration yet for
-any entry to point at. EXP-010 (#752) is the extension seam — it must add
-BOTH an honest ``create_aptl_manifest().observation`` declaration (naming
-the real, verified channel/media/sealing vocabulary APTL's capture owners
-actually provide) AND the corresponding :class:`CaptureCapability` entries
-here, together. Adding one without the other is exactly the failure mode
-this module exists to prevent.
+Admission is all-or-nothing: the moment ANY requirement across ANY spec is
+unbound, admission is rejected (naming the unsupported ``capture_kind`` /
+``capture_scope``) — never a partial binding. Authored requirements are
+required by default; a degradation is admitted only when
+``policy.accepted_capture_limitations`` explicitly accepts it, and that
+acceptance is annotated onto the bound requirement's plan binding (never
+inferred).
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+import dataclasses
+from collections.abc import Iterable
 
-from aces_backend_protocols.manifest import BackendManifest
-from aces_contracts.contracts import ExperimentCaptureRequirementModel, ExperimentCaptureSpecModel
+from aces_contracts.contracts import ExperimentCaptureSpecModel
 
-from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.capture_registry import (
+    DEFAULT_COLLECTOR_REGISTRY,
+    CaptureBinding,
+    CollectorRegistry,
+)
 from aptl.core.experiment.errors import AdmissionRejection, diagnostic
 from aptl.core.experiment.policy import AdmissionPolicy
 
 _CODE_CAPTURE_UNSUPPORTED = "aptl.experiment-admission.capture-requirement-unsupported"
 
 
-@dataclass(frozen=True)
-class CaptureCapability:
-    """One evidence-backed ``(capture_kind, capture_scope)`` -> APTL owner entry.
+def _apply_limitation(
+    binding: CaptureBinding, *, capture_spec_id: str, policy: AdmissionPolicy
+) -> CaptureBinding:
+    """Return binding annotated with any policy-accepted degradation, else unchanged.
 
-    ``media_types``/``integrity_requirements`` further narrow support: a
-    requirement is only covered when its ``expected_media_types`` and
-    ``integrity_requirements`` are each a SUBSET of what this entry
-    declares (never the reverse — a requirement asking for MORE than the
-    entry covers is not admitted by it). ``capture_owner`` is a stable,
-    human-readable identifier for the APTL capture owner (e.g. a
-    ``module.function`` path in ``collectors.py`` or an MCP/Kali capture
-    owner name) — never something admission itself resolves to an import,
-    exec, or shell command.
+    The acceptance is keyed by the fully-qualified
+    ``"{capture_spec_id}.{requirement_id}"``; when present its stable
+    limitation code and comparability disclosure are pinned onto the binding so
+    the degradation travels in the plan bytes and is auditable.
     """
-
-    capture_kind: str
-    capture_scope: str
-    media_types: frozenset[str]
-    integrity_requirements: frozenset[str]
-    capture_owner: str
-
-
-#: Versioned, evidence-backed support table. EMPTY for #438 — see the
-#: module docstring. EXP-010 (#752) is the only authorized place to add an
-#: entry, and only alongside an honest, verified
-#: ``create_aptl_manifest().observation`` declaration.
-SUPPORTED_CAPTURE_CAPABILITIES: tuple[CaptureCapability, ...] = ()
+    key = f"{capture_spec_id}.{binding.requirement_id}"
+    acceptance = policy.accepted_capture_limitations.get(key)
+    if acceptance is None:
+        return binding
+    return dataclasses.replace(
+        binding,
+        accepted_limitation=acceptance.limitation_code,
+        comparability_disclosure_ref=acceptance.comparability_disclosure_ref,
+    )
 
 
-def _resolve_capture_owner(
-    requirement: ExperimentCaptureRequirementModel, backend_manifest: BackendManifest
-) -> str | None:
-    """Return the evidence-backed capture owner for requirement, or None if unsupported."""
-    observation = backend_manifest.observation
-    if observation is None:
-        return None
-    requirement_media_types = frozenset(requirement.expected_media_types)
-    requirement_integrity = frozenset(requirement.integrity_requirements)
-    for capability in SUPPORTED_CAPTURE_CAPABILITIES:
-        if capability.capture_kind != requirement.capture_kind:
-            continue
-        if capability.capture_scope != requirement.capture_scope:
-            continue
-        if not requirement_media_types.issubset(capability.media_types):
-            continue
-        if not requirement_integrity.issubset(capability.integrity_requirements):
-            continue
-        if capability.capture_kind not in observation.supported_capture_kinds:
-            continue
-        if not requirement_media_types.issubset(observation.supported_media_types):
-            continue
-        return capability.capture_owner
-    return None
-
-
-def map_capture_requirements(
+def bind_capture_requirements(
     capture_specs: Iterable[ExperimentCaptureSpecModel],
     *,
-    backend_manifest: BackendManifest | None = None,
+    registry: CollectorRegistry = DEFAULT_COLLECTOR_REGISTRY,
     policy: AdmissionPolicy,
-) -> Mapping[str, str]:
-    """Map every capture requirement in ``capture_specs`` to its APTL owner.
+) -> tuple[CaptureBinding, ...]:
+    """Bind every capture requirement in ``capture_specs`` to an immutable binding.
+
+    Returns the tuple of :class:`CaptureBinding` values, sorted by stable
+    identity ``(capture_spec_id, requirement_id)`` so the ACES
+    ``capture_requirements`` dict's iteration order (a semantically unordered
+    map) never leaks into the pinned plan digest (ADR-047 "sort semantically
+    unordered maps/sets"). They are pinned in the canonical trial-plan bytes
+    before any range mutation.
 
     Raises :class:`~aptl.core.experiment.errors.AdmissionRejection` (fail
-    closed, naming the unsupported ``capture_kind``/``capture_scope``) the
-    moment ANY requirement across ANY spec is not evidence-backed —
-    admission is all-or-nothing, never a partial mapping. An empty
-    ``capture_specs`` iterable (no capture spec resolved at all) maps to an
-    empty result without rejecting; ``ExperimentCaptureSpecModel`` itself
-    requires at least one entry in ``capture_requirements``, so an
-    individual resolved spec can never itself be "empty".
+    closed, naming the unsupported ``capture_kind`` / ``capture_scope``) the
+    moment ANY requirement is not covered by a trusted registration — admission
+    is all-or-nothing, never a partial binding. An empty ``capture_specs``
+    iterable (no capture spec resolved at all) returns an empty tuple without
+    rejecting; ``ExperimentCaptureSpecModel`` itself requires at least one
+    entry in ``capture_requirements``, so an individual resolved spec can never
+    be "empty".
     """
-    # reserved: no capture-specific limit exists yet.
-    del policy
-
-    manifest = backend_manifest if backend_manifest is not None else create_aptl_manifest()
-    result: dict[str, str] = {}
+    bindings: list[CaptureBinding] = []
     diagnostics = []
     for spec in capture_specs:
         for requirement_id, requirement in spec.capture_requirements.items():
-            address = f"capture_spec.{spec.capture_spec_id}.capture_requirements.{requirement_id}"
-            owner = _resolve_capture_owner(requirement, manifest)
-            if owner is None:
+            binding = registry.match(spec, requirement)
+            if binding is None:
+                address = f"capture_spec.{spec.capture_spec_id}.capture_requirements.{requirement_id}"
                 diagnostics.append(
                     diagnostic(
                         _CODE_CAPTURE_UNSUPPORTED,
                         address,
                         "capture requirement (capture_kind="
                         f"{requirement.capture_kind!r}, capture_scope={requirement.capture_scope!r}) "
-                        "is not evidence-backed by a declared backend observation capability",
+                        "is not covered by a declared collector registration",
                     )
                 )
                 continue
-            result[f"{spec.capture_spec_id}.{requirement_id}"] = owner
+            bindings.append(
+                _apply_limitation(binding, capture_spec_id=spec.capture_spec_id, policy=policy)
+            )
 
     if diagnostics:
         raise AdmissionRejection(tuple(diagnostics))
-    return result
+    return tuple(sorted(bindings, key=lambda binding: (binding.capture_spec_id, binding.requirement_id)))

--- a/src/aptl/core/experiment/capture_mapping.py
+++ b/src/aptl/core/experiment/capture_mapping.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Iterable
+from typing import cast
 
 from aces_contracts.contracts import ExperimentCaptureSpecModel
 
@@ -58,10 +59,16 @@ def _apply_limitation(
     acceptance = policy.accepted_capture_limitations.get(key)
     if acceptance is None:
         return binding
-    return dataclasses.replace(
-        binding,
-        accepted_limitation=acceptance.limitation_code,
-        comparability_disclosure_ref=acceptance.comparability_disclosure_ref,
+    # ``dataclasses.replace`` is typed to return ``DataclassInstance``; cast
+    # back to the concrete type so the annotation matches without a pointless
+    # temporary (avoids both the loose-return and declare-then-return smells).
+    return cast(
+        CaptureBinding,
+        dataclasses.replace(
+            binding,
+            accepted_limitation=acceptance.limitation_code,
+            comparability_disclosure_ref=acceptance.comparability_disclosure_ref,
+        ),
     )
 
 

--- a/src/aptl/core/experiment/capture_registry.py
+++ b/src/aptl/core/experiment/capture_registry.py
@@ -1,0 +1,462 @@
+"""The versioned, code-owned collector registry (ADR-047 "Apparatus and
+capture capability admission"; EXP-010 / issue #752 preflight
+``docs/architecture/exp-010-capture-admission-evidence-preflight.md``).
+
+This module evolves EXP-002's ``CaptureCapability`` /
+``SUPPORTED_CAPTURE_CAPABILITIES`` table (formerly in
+:mod:`aptl.core.experiment.capture_mapping`) into ONE versioned registry that
+is the **single source of truth** for capture support. Everything downstream
+projects from it:
+
+* admission matches an authored ``ExperimentCaptureRequirementModel`` against
+  the registry and returns an immutable :class:`CaptureBinding` (never the old
+  free-text owner string) — deterministic across every requirement axis and
+  contract version, fail-closed on any unknown;
+* the backend ``ObservationCapabilities`` manifest is an **aggregate
+  projection** of the same declarations (:meth:`CollectorRegistry.
+  observation_projection`), never a second hand-maintained capability matrix;
+* the acquisition coordinator (EXP-010 PR 2) consumes the pinned binding to
+  drive a narrow collector without re-matching a changed registry.
+
+FAIL-CLOSED / HONESTY BASELINE. :data:`DEFAULT_COLLECTOR_REGISTRY` is EMPTY:
+there is no honest end-to-end backed capture capability yet, so the production
+manifest keeps ``observation=None`` (exactly as EXP-002 shipped). A capability
+is added ONLY together with its collector adapter, conformance fixture, and a
+turned-on manifest observation (EXP-010 PR 2) — adding a registration without
+the acquisition path is the failure mode this registry exists to prevent.
+
+A ``registration_id`` is a stable, NON-EXECUTABLE identifier
+(:func:`validate_registration_id`): never an import path, class name, command,
+URL, host path, credential/environment selector, or arbitrary configuration
+key. Admission never resolves it to code (ADR-047 "no input controls imports,
+commands, collectors, backend methods, environment names, or filesystem
+roots").
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+
+from aces_backend_protocols.capabilities import ObservationCapabilities
+from aces_contracts.contracts import ExperimentCaptureRequirementModel, ExperimentCaptureSpecModel
+
+from aptl.core.experiment.trial_plan import compute_source_set_digest
+
+#: Versioned identity of the registry declaration shape itself. A change to
+#: the fields a registration declares, or to how the observation projection or
+#: binding is computed, bumps this so a persisted plan records which registry
+#: shape admitted it.
+REGISTRY_SCHEMA_VERSION = "aptl-collector-registry/v1"
+
+#: Fixed ``ObservationCapabilities.name`` for APTL's aggregate declaration.
+_OBSERVATION_NAME = "aptl-observation"
+
+#: The ACES evidence/run contract set a declared observation capability emits.
+#: ``observation_capability_contract_gaps`` additionally requires these be
+#: present in the manifest's top-level ``supported_contract_versions`` — the
+#: manifest builder adds them whenever the projection is non-None.
+OBSERVATION_EVIDENCE_CONTRACTS: frozenset[str] = frozenset(
+    {
+        "experiment-capture-spec-v1",
+        "experiment-evidence-record-v1",
+        "experiment-derived-measure-v1",
+        "experiment-run-v1",
+    }
+)
+
+#: A ``registration_id`` is a lowercase dotted/hyphenated slug: it starts with
+#: a letter and joins alphanumeric segments with single ``.`` or ``-``. That
+#: deliberately rejects uppercase (class names), ``/`` and ``\`` (paths),
+#: ``://`` (URLs), ``:`` (schemes/host:port), ``..`` (traversal), whitespace,
+#: and every shell/argv metacharacter — so a registration ID can never be
+#: mistaken for something admission could execute or resolve.
+_REGISTRATION_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$")
+
+#: Upper bound on a registration ID's length (defense against absurd inputs in
+#: a future dynamically-built registry; the built-ins are far shorter).
+_MAX_REGISTRATION_ID_LEN = 128
+
+
+class CaptureVisibility(str, Enum):
+    """Controlled visibility class of a collector's evidence (preflight
+    "Visibility boundary").
+
+    Capture authorization is a SEPARATE projection from participant
+    visibility: an ``EVALUATOR_ONLY`` or ``APPARATUS_ONLY`` collector may be
+    authorized to retain evidence that must never enter a participant
+    response. The binding carries this class so the acquisition coordinator
+    (EXP-010 PR 2) can project it server-side.
+    """
+
+    PARTICIPANT_VISIBLE = "participant-visible"
+    DISCLOSED = "disclosed"
+    EVALUATOR_ONLY = "evaluator-only"
+    APPARATUS_ONLY = "apparatus-only"
+
+
+class RegistrationIdError(ValueError):
+    """Raised when a ``registration_id`` is not a safe non-executable slug."""
+
+
+def validate_registration_id(value: str) -> str:
+    """Return ``value`` if it is a safe, non-executable registration ID; else raise.
+
+    The rule is intentionally strict (see :data:`_REGISTRATION_ID_RE`): the ID
+    identifies a trusted built-in registration and must never be resolvable to
+    an import path, class, command, URL, host path, or config key.
+    """
+    if not isinstance(value, str) or not value:
+        raise RegistrationIdError("registration_id must be a non-empty string")
+    if len(value) > _MAX_REGISTRATION_ID_LEN:
+        raise RegistrationIdError("registration_id exceeds the maximum length")
+    if _REGISTRATION_ID_RE.fullmatch(value) is None:
+        raise RegistrationIdError("registration_id is not a safe non-executable slug")
+    return value
+
+
+@dataclass(frozen=True)
+class CaptureLimits:
+    """Immutable size/count/time bounds a collector is admitted under.
+
+    The coordinator (EXP-010 PR 2) enforces these while streaming — a
+    collector never buffers unbounded or exceeds its admitted budget.
+    """
+
+    max_bytes: int
+    max_artifact_count: int
+    max_duration_s: int
+
+
+@dataclass(frozen=True)
+class CollectorRegistration:
+    """One trusted, code-owned collector's static capability declaration.
+
+    This is the whole capability surface admission and the observation
+    projection read (preflight "One declaration, one admitted binding"): the
+    supported ACES capture-spec contract version, the observation channel kind
+    (a governed ``observation-channel-kinds`` term), capture kind/scope, window
+    semantics, media types, required artifact roles, sensitivities,
+    redaction/integrity/sealing/chain-of-custody/retention support, loss
+    disclosure, visibility class, and limits. It carries NO factory, import
+    path, or executable reference — the trusted adapter wiring is composed
+    separately (EXP-010 PR 2).
+
+    ``channel_kind``, ``capture_kind``, and ``sealing_modes`` MUST be governed
+    controlled-vocabulary terms (``observation-channel-kinds`` /
+    ``observation-capture-kinds`` / ``observation-sealing-modes``); the
+    observation projection validates them against ACES's catalog, so a
+    registration with an ungoverned term fails when the manifest is built.
+    """
+
+    registration_id: str
+    implementation_version: str
+    contract_version: str
+    channel_kind: str
+    capture_kind: str
+    capture_scope: str
+    window_kinds: frozenset[str]
+    media_types: frozenset[str]
+    required_artifact_roles: frozenset[str]
+    supported_sensitivities: frozenset[str]
+    supports_redaction: bool
+    integrity_modes: frozenset[str]
+    sealing_modes: frozenset[str]
+    supports_chain_of_custody: bool
+    supports_retention: bool
+    supports_loss_disclosure: bool
+    visibility_class: CaptureVisibility
+    limits: CaptureLimits
+
+    def __post_init__(self) -> None:
+        """Validate the registration ID is a safe non-executable slug at construction."""
+        validate_registration_id(self.registration_id)
+
+    def declaration_projection(self) -> dict[str, object]:
+        """Return the canonical-JSON-ready projection of this registration's declaration.
+
+        Sets are emitted as sorted lists so the RFC 8785 digest is
+        order-independent; this projection is what
+        :attr:`CaptureBinding.effective_config_digest` pins.
+        """
+        return {
+            "registry_schema": REGISTRY_SCHEMA_VERSION,
+            "registration_id": self.registration_id,
+            "implementation_version": self.implementation_version,
+            "contract_version": self.contract_version,
+            "channel_kind": self.channel_kind,
+            "capture_kind": self.capture_kind,
+            "capture_scope": self.capture_scope,
+            "window_kinds": sorted(self.window_kinds),
+            "media_types": sorted(self.media_types),
+            "required_artifact_roles": sorted(self.required_artifact_roles),
+            "supported_sensitivities": sorted(self.supported_sensitivities),
+            "supports_redaction": self.supports_redaction,
+            "integrity_modes": sorted(self.integrity_modes),
+            "sealing_modes": sorted(self.sealing_modes),
+            "supports_chain_of_custody": self.supports_chain_of_custody,
+            "supports_retention": self.supports_retention,
+            "supports_loss_disclosure": self.supports_loss_disclosure,
+            "visibility_class": self.visibility_class.value,
+            "max_bytes": self.limits.max_bytes,
+            "max_artifact_count": self.limits.max_artifact_count,
+            "max_duration_s": self.limits.max_duration_s,
+        }
+
+    def effective_config_digest(self) -> str:
+        """Return ``sha256:<hex>`` of this registration's canonical declaration.
+
+        Pins the exact capability version a plan admitted, so runtime can
+        verify the registration has not silently changed (preflight: "Runtime
+        verifies the pinned registration and digest and never re-matches").
+        """
+        return compute_source_set_digest(self.declaration_projection())
+
+
+@dataclass(frozen=True)
+class CaptureBinding:
+    """The immutable result of admitting one capture requirement.
+
+    Everything runtime needs to acquire the evidence without re-matching a
+    (possibly changed) registry is pinned here and, via
+    :meth:`binding_projection`, folded into the canonical trial-plan bytes
+    before any range mutation. ``channel_ref_*`` records the AUTHOR's
+    measurement channel the evidence satisfies; ``registration_id`` /
+    ``channel_kind`` record which trusted APTL collector produces it.
+    ``accepted_limitation`` / ``comparability_disclosure_ref`` are ``None``
+    unless a trusted policy explicitly accepted a supported degradation (never
+    inferred).
+    """
+
+    capture_spec_id: str
+    requirement_id: str
+    window_refs: tuple[str, ...]
+    registration_id: str
+    implementation_version: str
+    contract_version: str
+    effective_config_digest: str
+    channel_ref_id: str
+    channel_ref_version: str | None
+    channel_kind: str
+    capture_kind: str
+    capture_scope: str
+    expected_media_types: tuple[str, ...]
+    required_artifact_roles: tuple[str, ...]
+    sensitivity: str
+    redaction_required: bool
+    integrity_requirements: tuple[str, ...]
+    retention_policy: str | None
+    loss_disclosure_required: bool
+    visibility_class: CaptureVisibility
+    limits: CaptureLimits
+    accepted_limitation: str | None = None
+    comparability_disclosure_ref: str | None = None
+
+    def binding_projection(self) -> dict[str, object]:
+        """Return the canonical-JSON-ready projection pinned into the trial plan.
+
+        The requirement's set-valued axes (``window_refs``,
+        ``expected_media_types``, ``required_artifact_roles``,
+        ``integrity_requirements``) are semantically unordered, so they are
+        SORTED here — ADR-047 "sort semantically unordered maps/sets": two
+        requirements identical up to authored list order must yield the same
+        plan digest, so incidental ACES-document ordering never leaks into
+        identity. The projection excludes nothing identity-bearing, so the plan
+        digest changes iff a binding meaningfully changes.
+        """
+        return {
+            "capture_spec_id": self.capture_spec_id,
+            "requirement_id": self.requirement_id,
+            "window_refs": sorted(self.window_refs),
+            "registration_id": self.registration_id,
+            "implementation_version": self.implementation_version,
+            "contract_version": self.contract_version,
+            "effective_config_digest": self.effective_config_digest,
+            "channel_ref_id": self.channel_ref_id,
+            "channel_ref_version": self.channel_ref_version,
+            "channel_kind": self.channel_kind,
+            "capture_kind": self.capture_kind,
+            "capture_scope": self.capture_scope,
+            "expected_media_types": sorted(self.expected_media_types),
+            "required_artifact_roles": sorted(self.required_artifact_roles),
+            "sensitivity": self.sensitivity,
+            "redaction_required": self.redaction_required,
+            "integrity_requirements": sorted(self.integrity_requirements),
+            "retention_policy": self.retention_policy,
+            "loss_disclosure_required": self.loss_disclosure_required,
+            "visibility_class": self.visibility_class.value,
+            "max_bytes": self.limits.max_bytes,
+            "max_artifact_count": self.limits.max_artifact_count,
+            "max_duration_s": self.limits.max_duration_s,
+            "accepted_limitation": self.accepted_limitation,
+            "comparability_disclosure_ref": self.comparability_disclosure_ref,
+        }
+
+
+def _window_kinds_by_ref(spec: ExperimentCaptureSpecModel) -> Mapping[str, str]:
+    """Return a map from each capture-window ID to its window kind for spec."""
+    return {window.window_id: window.window_kind for window in spec.capture_windows}
+
+
+def _windows_supported(
+    window_refs: Sequence[str],
+    window_kinds_by_ref: Mapping[str, str],
+    supported_window_kinds: frozenset[str],
+) -> bool:
+    """Return whether every referenced window resolves to a supported window kind.
+
+    A window ref that does not resolve to a declared spec window is treated as
+    unsupported (fail closed) rather than skipped.
+    """
+    for window_ref in window_refs:
+        kind = window_kinds_by_ref.get(window_ref)
+        if kind is None or kind not in supported_window_kinds:
+            return False
+    return True
+
+
+def _registration_covers(
+    registration: CollectorRegistration,
+    requirement: ExperimentCaptureRequirementModel,
+    *,
+    contract_version: str,
+    window_kinds_by_ref: Mapping[str, str],
+) -> bool:
+    """Return whether registration deterministically covers requirement on every axis.
+
+    Every authored requirement axis is checked (preflight "Registry/policy
+    validation"): contract version, capture kind/scope, window semantics, media
+    types, artifact roles, sensitivity, integrity, redaction, retention, and
+    loss disclosure. Subset axes require the requirement to be a SUBSET of what
+    the registration declares — a requirement asking for more than a
+    registration covers is not matched by it. The author's ``channel_ref`` is
+    NOT a match axis: it names an author-defined measurement channel APTL
+    cannot pre-enumerate; it is recorded on the binding for traceability
+    instead. Collected as one boolean list so this stays a single return.
+    """
+    checks = (
+        registration.contract_version == contract_version,
+        registration.capture_kind == requirement.capture_kind,
+        registration.capture_scope == requirement.capture_scope,
+        _windows_supported(requirement.window_refs, window_kinds_by_ref, registration.window_kinds),
+        frozenset(requirement.expected_media_types) <= registration.media_types,
+        frozenset(requirement.required_artifact_roles) <= registration.required_artifact_roles,
+        requirement.sensitivity in registration.supported_sensitivities,
+        frozenset(requirement.integrity_requirements) <= registration.integrity_modes,
+        registration.supports_redaction or requirement.redaction_policy is None,
+        registration.supports_retention or requirement.retention_policy is None,
+        registration.supports_loss_disclosure or not requirement.loss_disclosure_required,
+    )
+    return all(checks)
+
+
+@dataclass(frozen=True)
+class CollectorRegistry:
+    """An immutable set of trusted collector registrations, keyed by ID.
+
+    Construction rejects duplicate registration IDs. The registry is the sole
+    detailed source of truth: :meth:`match` binds a requirement and
+    :meth:`observation_projection` aggregates the same declarations into the
+    backend manifest's observation capability.
+    """
+
+    registrations: tuple[CollectorRegistration, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Reject duplicate registration IDs at construction."""
+        ids = [registration.registration_id for registration in self.registrations]
+        if len(set(ids)) != len(ids):
+            raise ValueError("CollectorRegistry contains duplicate registration IDs")
+
+    def _ordered(self) -> tuple[CollectorRegistration, ...]:
+        """Return registrations in a deterministic (ID-sorted) order for selection."""
+        return tuple(sorted(self.registrations, key=lambda registration: registration.registration_id))
+
+    def match(
+        self,
+        spec: ExperimentCaptureSpecModel,
+        requirement: ExperimentCaptureRequirementModel,
+    ) -> CaptureBinding | None:
+        """Return the immutable binding for requirement, or ``None`` if unsupported.
+
+        Selection is deterministic: registrations are scanned in ID-sorted
+        order and the first that covers every axis is bound, so registration
+        insertion order never affects the result. ``None`` (fail closed) means
+        no trusted registration covers the requirement — the caller rejects
+        admission; it is never a silent skip.
+        """
+        window_kinds_by_ref = _window_kinds_by_ref(spec)
+        for registration in self._ordered():
+            if _registration_covers(
+                registration,
+                requirement,
+                contract_version=spec.schema_version,
+                window_kinds_by_ref=window_kinds_by_ref,
+            ):
+                return _bind(spec, requirement, registration)
+        return None
+
+    def observation_projection(self) -> ObservationCapabilities | None:
+        """Return the aggregate ``ObservationCapabilities``, or ``None`` when empty.
+
+        ``None`` for an empty registry keeps the manifest honestly declaring no
+        observation capability (``create_aptl_manifest().observation is None``)
+        until a real capability is genuinely backed. Otherwise every scalar
+        support flag is the OR across registrations and every vocabulary set is
+        their union; ``supported_evidence_contracts`` is the fixed
+        :data:`OBSERVATION_EVIDENCE_CONTRACTS` the observation emits.
+        """
+        if not self.registrations:
+            return None
+        return ObservationCapabilities(
+            name=_OBSERVATION_NAME,
+            supported_capture_kinds=frozenset(r.capture_kind for r in self.registrations),
+            supported_channel_kinds=frozenset(r.channel_kind for r in self.registrations),
+            supported_evidence_contracts=OBSERVATION_EVIDENCE_CONTRACTS,
+            supported_media_types=frozenset().union(*(r.media_types for r in self.registrations)),
+            supported_sealing_modes=frozenset().union(*(r.sealing_modes for r in self.registrations)),
+            supports_redaction=any(r.supports_redaction for r in self.registrations),
+            supports_loss_disclosure=any(r.supports_loss_disclosure for r in self.registrations),
+            supports_chain_of_custody=any(r.supports_chain_of_custody for r in self.registrations),
+        )
+
+
+def _bind(
+    spec: ExperimentCaptureSpecModel,
+    requirement: ExperimentCaptureRequirementModel,
+    registration: CollectorRegistration,
+) -> CaptureBinding:
+    """Build the immutable :class:`CaptureBinding` for a covered requirement."""
+    return CaptureBinding(
+        capture_spec_id=spec.capture_spec_id,
+        requirement_id=requirement.requirement_id,
+        window_refs=tuple(requirement.window_refs),
+        registration_id=registration.registration_id,
+        implementation_version=registration.implementation_version,
+        contract_version=registration.contract_version,
+        effective_config_digest=registration.effective_config_digest(),
+        channel_ref_id=requirement.channel_ref.ref_id,
+        channel_ref_version=requirement.channel_ref.ref_version,
+        channel_kind=registration.channel_kind,
+        capture_kind=requirement.capture_kind,
+        capture_scope=requirement.capture_scope,
+        expected_media_types=tuple(requirement.expected_media_types),
+        required_artifact_roles=tuple(requirement.required_artifact_roles),
+        sensitivity=requirement.sensitivity,
+        redaction_required=requirement.redaction_policy is not None,
+        integrity_requirements=tuple(requirement.integrity_requirements),
+        retention_policy=requirement.retention_policy,
+        loss_disclosure_required=requirement.loss_disclosure_required,
+        visibility_class=registration.visibility_class,
+        limits=registration.limits,
+    )
+
+
+#: The production registry. EMPTY by design (see the module docstring): no
+#: capture capability is honestly backed end-to-end yet, so the manifest keeps
+#: ``observation=None`` and every capture requirement fails closed. EXP-010
+#: PR 2 populates real registrations together with their acquisition adapters,
+#: conformance fixtures, and a turned-on observation projection.
+DEFAULT_COLLECTOR_REGISTRY = CollectorRegistry()

--- a/src/aptl/core/experiment/policy.py
+++ b/src/aptl/core/experiment/policy.py
@@ -15,6 +15,7 @@ expansion (a later stage) is that consumer's home, not this one.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from types import MappingProxyType
@@ -25,6 +26,24 @@ from aptl.core.experiment.errors import AdmissionRejection, diagnostic
 #: policy revision (e.g. a new supported allocation method) bumps this
 #: string so a persisted plan can record exactly which policy admitted it.
 _POLICY_VERSION = "aptl-admission/v1"
+
+
+@dataclass(frozen=True)
+class CaptureLimitationAcceptance:
+    """A trusted operator's explicit acceptance of one supported capture degradation.
+
+    ADR-047 / EXP-010 preflight ("One declaration, one admitted binding"): ACES
+    capture-spec v1 has no general ``required`` flag, so authored capture
+    requirements are **required by default**. A degradation is admitted ONLY
+    when the policy carries an explicit acceptance here — a stable
+    ``limitation_code`` plus the ``comparability_disclosure_ref`` that discloses
+    its effect on comparability — and that acceptance is persisted into the
+    plan binding. Optionality is NEVER inferred from notes, validity text, an
+    empty collector result, or historical best-effort behavior.
+    """
+
+    limitation_code: str
+    comparability_disclosure_ref: str
 
 
 class OrderingKind(str, Enum):
@@ -111,6 +130,17 @@ class AdmissionPolicy:
     #: regardless of this flag — it narrows exactly one documented,
     #: structural gap, never the whole admission surface.
     allow_uncertified_apparatus: bool = False
+
+    #: Explicit per-requirement capture-degradation acceptances, keyed by the
+    #: fully-qualified ``"{capture_spec_id}.{requirement_id}"`` (EXP-010
+    #: preflight). Empty by default: with no entry, every authored capture
+    #: requirement is required and an unbound requirement fails closed. An
+    #: entry annotates its bound requirement's plan binding with the accepted
+    #: limitation + comparability disclosure so the degradation is auditable,
+    #: never silent.
+    accepted_capture_limitations: Mapping[str, CaptureLimitationAcceptance] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
 
     supported_allocation_methods: MappingProxyType[str, OrderingKind] = field(
         default_factory=lambda: _DEFAULT_SUPPORTED_ALLOCATION_METHODS

--- a/src/aptl/core/experiment/trial_plan.py
+++ b/src/aptl/core/experiment/trial_plan.py
@@ -32,14 +32,21 @@ stochastic control ID).
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import rfc8785
 from aces_contracts.experiment_spec import ExperimentSpecModel
 
 from aptl.core.experiment.errors import AdmissionRejection, diagnostic
 from aptl.core.experiment.policy import AdmissionPolicy, OrderingKind, resolve_allocation_ordering
+
+if TYPE_CHECKING:
+    # Typing-only import: at runtime ``capture_registry`` imports from THIS
+    # module, so a runtime import here would cycle. ``expand_trial_plan`` only
+    # calls ``binding_projection()`` structurally, needing no runtime import.
+    from aptl.core.experiment.capture_registry import CaptureBinding
 
 # ---------------------------------------------------------------------------
 # Domain-separation constants
@@ -81,10 +88,11 @@ _SEED_BEARING_ROLES = frozenset({"seed", "randomization"})
 _PLAN_ID_PREFIX = "plan-"
 _TRIAL_ID_PREFIX = "trial-"
 
-#: Versioned identity for the canonical plan projection shape itself
-#: (distinct from any ACES ``schema_version`` literal — this is an
-#: APTL-internal journal format, never an ACES contract).
-_PLAN_PROJECTION_SCHEMA = "aptl-experiment-trial-plan/v1"
+#: Versioned identity for the canonical plan projection shape (an APTL-internal
+#: journal format, never an ACES contract). Bumped to v2 by EXP-010 (#752): the
+#: projection now pins the admitted capture bindings, changing the shape and
+#: digest, so old v1 bytes cannot silently reinterpret under it.
+_PLAN_PROJECTION_SCHEMA = "aptl-experiment-trial-plan/v2"
 
 _ADDRESS_RUN_PLAN = "run_plan"
 _ADDRESS_STOCHASTIC_CONTROLS = "run_plan.stochastic_controls"
@@ -129,6 +137,7 @@ class TrialPlan:
     source_set_digest: str
     ordering_kind: OrderingKind
     trials: tuple[PlannedTrial, ...]
+    capture_bindings: tuple[CaptureBinding, ...]
     canonical_bytes: bytes
     plan_digest: str
 
@@ -393,6 +402,7 @@ def _canonicalize(
     source_set_digest: str,
     ordering_kind: OrderingKind,
     trials: tuple[PlannedTrial, ...],
+    capture_bindings: Sequence[CaptureBinding],
 ) -> tuple[bytes, str, str]:
     """Canonicalize the plan projection to RFC 8785 bytes and derive (canonical_bytes, plan_digest, plan_id)."""
     projection = {
@@ -403,6 +413,9 @@ def _canonicalize(
         # The trial sequence itself is an authored-meaningful ordered list
         # (execution order) and stays a JSON array.
         "trials": [_trial_projection(trial) for trial in trials],
+        # The admitted capture bindings, pinned so runtime executes exactly
+        # these. Always present (``[]`` w/o capture spec) for a stable shape.
+        "capture_bindings": [binding.binding_projection() for binding in capture_bindings],
     }
     canonical_bytes = rfc8785.dumps(projection)
     digest_hex = hashlib.sha256(canonical_bytes).hexdigest()
@@ -416,13 +429,16 @@ def expand_trial_plan(
     *,
     source_set_digest: str,
     condition_snapshot_digests: Mapping[str, str] | None = None,
+    capture_bindings: Sequence[CaptureBinding] = (),
     policy: AdmissionPolicy,
 ) -> TrialPlan:
     """Pure expansion of an admitted spec's ``run_plan`` into an immutable :class:`TrialPlan`.
 
-    ``source_set_digest`` and ``condition_snapshot_digests`` are supplied by
-    the caller (a later admission stage) — this function does no artifact
-    resolution or digesting of its own beyond the plan projection itself.
+    ``source_set_digest``, ``condition_snapshot_digests``, and
+    ``capture_bindings`` are supplied by the caller (a later admission stage) —
+    this function does no artifact resolution, capability matching, or
+    digesting of its own. The bindings are pinned verbatim into the canonical
+    bytes so runtime executes exactly the admitted capture.
 
     Raises :class:`AdmissionRejection` when the planned trial count would
     exceed ``policy.max_allocation_size``, a stochastic control's role does
@@ -461,11 +477,14 @@ def expand_trial_plan(
     if len(set(ids)) != len(ids):
         raise AssertionError("planned_trial_id collision within one trial plan")
 
+    # Bindings arrive pre-sorted by stable identity (``bind_capture_requirements``).
+    capture_bindings_tuple = tuple(capture_bindings)
     canonical_bytes, plan_digest, plan_id = _canonicalize(
         policy_version=policy.policy_version,
         source_set_digest=source_set_digest,
         ordering_kind=ordering_kind,
         trials=trials,
+        capture_bindings=capture_bindings_tuple,
     )
 
     return TrialPlan(
@@ -474,6 +493,7 @@ def expand_trial_plan(
         source_set_digest=source_set_digest,
         ordering_kind=ordering_kind,
         trials=trials,
+        capture_bindings=capture_bindings_tuple,
         canonical_bytes=canonical_bytes,
         plan_digest=plan_digest,
     )

--- a/tests/test_capture_registry.py
+++ b/tests/test_capture_registry.py
@@ -167,9 +167,10 @@ class TestImmutability:
             binding.registration_id = "other"
 
     def test_registry_rejects_duplicate_registration_ids(self):
-        registration = _covering_registration()
+        first = _covering_registration()
+        second = _covering_registration()
         with pytest.raises(ValueError, match="duplicate registration IDs"):
-            CollectorRegistry((registration, _covering_registration()))
+            CollectorRegistry((first, second))
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +289,9 @@ class TestMatchIsDeterministic:
 
 class TestConfigDigest:
     def test_two_identical_registrations_share_a_digest(self):
-        assert _covering_registration().effective_config_digest() == _covering_registration().effective_config_digest()
+        left = _covering_registration().effective_config_digest()
+        right = _covering_registration().effective_config_digest()
+        assert left == right
 
     def test_changing_any_declared_field_changes_the_digest(self):
         base = _covering_registration().effective_config_digest()

--- a/tests/test_capture_registry.py
+++ b/tests/test_capture_registry.py
@@ -1,0 +1,400 @@
+"""Tests for the code-owned collector registry (ADR-047 "Apparatus and
+capture capability admission"; EXP-010 / issue #752).
+
+The registry is the single source of truth for capture support: admission
+matches an authored ``ExperimentCaptureRequirementModel`` against it and
+returns an immutable :class:`CaptureBinding`, and the backend
+``ObservationCapabilities`` manifest is an aggregate projection of the same
+declarations. These tests prove the matching is deterministic across every
+requirement axis, fails closed on any unknown, keeps ``registration_id``
+non-executable, and that the observation projection is honest (``None`` while
+the registry is empty).
+
+Uses the installed ACES fixture corpus as the contract test source (ADR-047
+testing contract), never a copied-in schema.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+from aces_backend_protocols.capabilities import observation_capability_contract_gaps
+from aces_contracts.contracts import ExperimentCaptureSpecModel
+from aces_contracts.corpus import FIXTURES, corpus_family_root
+
+from aptl.core.experiment.capture_registry import (
+    DEFAULT_COLLECTOR_REGISTRY,
+    OBSERVATION_EVIDENCE_CONTRACTS,
+    CaptureBinding,
+    CaptureLimits,
+    CaptureVisibility,
+    CollectorRegistration,
+    CollectorRegistry,
+    RegistrationIdError,
+    validate_registration_id,
+)
+
+CORPUS_ROOT = corpus_family_root(FIXTURES)
+
+_LIMITS = CaptureLimits(max_bytes=1_048_576, max_artifact_count=100, max_duration_s=300)
+
+
+def _read(*parts: str) -> bytes:
+    """Read a byte payload from the installed ACES fixture corpus."""
+    path = CORPUS_ROOT
+    for part in parts:
+        path = path / part
+    return path.read_bytes()
+
+
+def _reference_spec_payload() -> dict:
+    """Return the parsed reference capture-spec fixture payload (single requirement)."""
+    return json.loads(_read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json"))
+
+
+def _spec_with(**requirement_overrides: object) -> ExperimentCaptureSpecModel:
+    """Build a one-requirement capture spec from the corpus reference, overriding fields.
+
+    The reference ``network-trace`` requirement is the fully-covered baseline
+    every miss test deviates from by exactly one field.
+    """
+    payload = _reference_spec_payload()
+    requirement = next(iter(payload["capture_requirements"].values()))
+    requirement.update(requirement_overrides)
+    payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
+    return ExperimentCaptureSpecModel.model_validate(payload)
+
+
+def _covering_registration(**overrides: object) -> CollectorRegistration:
+    """Return a registration that covers the reference ``network-trace`` requirement.
+
+    Every miss test overrides exactly one field so that, if the corresponding
+    match guard were deleted, the requirement would wrongly bind.
+    """
+    fields: dict[str, object] = {
+        "registration_id": "aptl.collector.network-trace",
+        "implementation_version": "1.0.0",
+        "contract_version": "experiment-capture-spec/v1",
+        "channel_kind": "evaluation-history",
+        "capture_kind": "trace",
+        "capture_scope": "network",
+        "window_kinds": frozenset({"run"}),
+        "media_types": frozenset({"application/json"}),
+        "required_artifact_roles": frozenset({"observation"}),
+        "supported_sensitivities": frozenset({"internal", "public"}),
+        "supports_redaction": True,
+        "integrity_modes": frozenset({"sha256-digest"}),
+        "sealing_modes": frozenset({"digest"}),
+        "supports_chain_of_custody": False,
+        "supports_retention": True,
+        "supports_loss_disclosure": True,
+        "visibility_class": CaptureVisibility.EVALUATOR_ONLY,
+        "limits": _LIMITS,
+    }
+    fields.update(overrides)
+    return CollectorRegistration(**fields)
+
+
+def _bind_reference(registration: CollectorRegistration, **requirement_overrides: object) -> CaptureBinding | None:
+    """Match the reference requirement (with overrides) against a single-registration registry."""
+    spec = _spec_with(**requirement_overrides)
+    requirement = next(iter(spec.capture_requirements.values()))
+    return CollectorRegistry((registration,)).match(spec, requirement)
+
+
+# ---------------------------------------------------------------------------
+# registration_id — non-executable slug
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationIdValidation:
+    @pytest.mark.parametrize(
+        "value",
+        ["aptl.collector.wazuh-alerts", "x", "a-b.c-d", "trace1", "a1-b2.c3"],
+    )
+    def test_safe_slugs_are_accepted(self, value):
+        assert validate_registration_id(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Foo.Bar",  # class name (uppercase)
+            "aptl/collector",  # path separator
+            "a\\b",  # windows path separator
+            "http://example",  # URL scheme
+            "a..b",  # traversal
+            "../escape",  # traversal
+            "a b",  # whitespace
+            "a;rm -rf",  # shell metachar
+            "a:b",  # scheme / host:port
+            "a__b",  # underscore not in the slug alphabet
+            "a.",  # trailing separator
+            ".a",  # leading separator
+            "",  # empty
+            "aptl.collector.$evil",  # shell expansion char
+        ],
+    )
+    def test_executable_or_unsafe_ids_are_rejected(self, value):
+        with pytest.raises(RegistrationIdError):
+            validate_registration_id(value)
+
+    def test_a_registration_validates_its_id_at_construction(self):
+        with pytest.raises(RegistrationIdError):
+            _covering_registration(registration_id="Not/A/Slug")
+
+    def test_an_over_long_id_is_rejected(self):
+        with pytest.raises(RegistrationIdError):
+            validate_registration_id("a" + "-b" * 200)
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+class TestImmutability:
+    def test_registration_is_frozen(self):
+        registration = _covering_registration()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            registration.capture_kind = "log"
+
+    def test_binding_is_frozen(self):
+        binding = _bind_reference(_covering_registration())
+        assert binding is not None
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            binding.registration_id = "other"
+
+    def test_registry_rejects_duplicate_registration_ids(self):
+        registration = _covering_registration()
+        with pytest.raises(ValueError, match="duplicate registration IDs"):
+            CollectorRegistry((registration, _covering_registration()))
+
+
+# ---------------------------------------------------------------------------
+# Deterministic match — the covered baseline binds, one miss per axis does not
+# ---------------------------------------------------------------------------
+
+
+class TestMatchSuccessBaseline:
+    def test_the_covered_reference_requirement_binds(self):
+        binding = _bind_reference(_covering_registration())
+
+        assert binding is not None
+        assert binding.registration_id == "aptl.collector.network-trace"
+        assert binding.requirement_id == "network-trace"
+        assert binding.capture_kind == "trace"
+        assert binding.capture_scope == "network"
+
+    def test_the_binding_records_the_author_channel_ref_and_provider_channel_kind(self):
+        binding = _bind_reference(_covering_registration())
+
+        assert binding is not None
+        # The AUTHOR's measurement channel the evidence satisfies...
+        assert binding.channel_ref_id == "evaluation-history-channel"
+        assert binding.channel_ref_version == "1.0.0"
+        # ...and the provider (registration) channel kind.
+        assert binding.channel_kind == "evaluation-history"
+
+    def test_the_binding_pins_the_registration_config_digest(self):
+        registration = _covering_registration()
+        binding = _bind_reference(registration)
+
+        assert binding is not None
+        assert binding.effective_config_digest == registration.effective_config_digest()
+        assert binding.effective_config_digest.startswith("sha256:")
+
+    def test_the_binding_carries_free_text_retention_verbatim(self):
+        binding = _bind_reference(_covering_registration())
+
+        assert binding is not None
+        assert binding.retention_policy is not None
+        assert "Retain raw evidence" in binding.retention_policy
+
+
+class TestMatchOneMissPerAxisFailsClosed:
+    """Each test deviates from the covered baseline on exactly one axis; the
+    guard for that axis must make the match return ``None``."""
+
+    def test_contract_version_mismatch(self):
+        assert _bind_reference(_covering_registration(contract_version="experiment-capture-spec/v2")) is None
+
+    def test_capture_kind_mismatch(self):
+        assert _bind_reference(_covering_registration(capture_kind="log")) is None
+
+    def test_capture_scope_mismatch(self):
+        assert _bind_reference(_covering_registration(capture_scope="service")) is None
+
+    def test_window_kind_not_supported(self):
+        assert _bind_reference(_covering_registration(window_kinds=frozenset({"task"}))) is None
+
+    def test_media_type_not_a_subset(self):
+        assert _bind_reference(_covering_registration(media_types=frozenset({"text/plain"}))) is None
+
+    def test_required_artifact_role_not_a_subset(self):
+        assert _bind_reference(_covering_registration(required_artifact_roles=frozenset({"report"}))) is None
+
+    def test_sensitivity_not_supported(self):
+        assert _bind_reference(_covering_registration(supported_sensitivities=frozenset({"public"}))) is None
+
+    def test_integrity_mode_not_a_subset(self):
+        assert _bind_reference(_covering_registration(integrity_modes=frozenset({"sha512-digest"}))) is None
+
+    def test_redaction_required_but_unsupported(self):
+        registration = _covering_registration(supports_redaction=False)
+        assert _bind_reference(registration, redaction_policy="redact-secrets") is None
+
+    def test_retention_required_but_unsupported(self):
+        registration = _covering_registration(supports_retention=False)
+        assert _bind_reference(registration, retention_policy="retain-30d") is None
+
+    def test_loss_disclosure_required_but_unsupported(self):
+        registration = _covering_registration(supports_loss_disclosure=False)
+        assert _bind_reference(registration, loss_disclosure_required=True) is None
+
+    def test_an_unmatched_optional_axis_still_binds(self):
+        # A requirement that does NOT require redaction/retention/loss binds
+        # against a registration that also does not support them — the guards
+        # are "required implies supported", not "supported implies required".
+        registration = _covering_registration(
+            supports_redaction=False, supports_retention=False, supports_loss_disclosure=False
+        )
+        binding = _bind_reference(
+            registration, redaction_policy=None, retention_policy=None, loss_disclosure_required=False
+        )
+        assert binding is not None
+
+
+class TestMatchIsDeterministic:
+    def test_selection_is_id_sorted_not_insertion_ordered(self):
+        first = _covering_registration(registration_id="aptl.collector.aaa")
+        second = _covering_registration(registration_id="aptl.collector.bbb")
+        spec = _spec_with()
+        requirement = next(iter(spec.capture_requirements.values()))
+
+        forward = CollectorRegistry((first, second)).match(spec, requirement)
+        reverse = CollectorRegistry((second, first)).match(spec, requirement)
+
+        assert forward is not None and reverse is not None
+        # Both cover; ID-sorted selection picks "aaa" regardless of insertion order.
+        assert forward.registration_id == reverse.registration_id == "aptl.collector.aaa"
+
+
+# ---------------------------------------------------------------------------
+# effective_config_digest — stable and sensitive
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDigest:
+    def test_two_identical_registrations_share_a_digest(self):
+        assert _covering_registration().effective_config_digest() == _covering_registration().effective_config_digest()
+
+    def test_changing_any_declared_field_changes_the_digest(self):
+        base = _covering_registration().effective_config_digest()
+        changed = _covering_registration(implementation_version="2.0.0").effective_config_digest()
+        assert base != changed
+
+
+# ---------------------------------------------------------------------------
+# observation projection — honest and vocabulary-valid
+# ---------------------------------------------------------------------------
+
+
+class TestObservationProjection:
+    def test_empty_registry_projects_no_observation(self):
+        assert DEFAULT_COLLECTOR_REGISTRY.observation_projection() is None
+        assert CollectorRegistry().observation_projection() is None
+
+    def test_populated_registry_aggregates_declarations(self):
+        registry = CollectorRegistry(
+            (
+                _covering_registration(registration_id="aptl.collector.a", capture_kind="trace"),
+                _covering_registration(
+                    registration_id="aptl.collector.b",
+                    capture_kind="log",
+                    channel_kind="backend-log",
+                    media_types=frozenset({"text/plain"}),
+                ),
+            )
+        )
+        observation = registry.observation_projection()
+
+        assert observation is not None
+        assert observation.supported_capture_kinds == frozenset({"trace", "log"})
+        assert observation.supported_channel_kinds == frozenset({"evaluation-history", "backend-log"})
+        assert observation.supported_media_types == frozenset({"application/json", "text/plain"})
+        assert observation.supported_evidence_contracts == OBSERVATION_EVIDENCE_CONTRACTS
+
+    def test_projection_uses_governed_vocabulary_terms(self):
+        # ObservationCapabilities validates channel/capture/sealing terms
+        # against the ACES controlled-vocabulary catalog at construction, so a
+        # successful projection proves the declared terms are governed.
+        registry = CollectorRegistry((_covering_registration(),))
+        observation = registry.observation_projection()
+        assert observation is not None
+        assert observation.supports_loss_disclosure is True
+
+
+# ---------------------------------------------------------------------------
+# Fuzz — determinism and order-independence
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@pytest.mark.fuzz
+class TestFuzzRegistry:
+    @given(version=st.text(alphabet="0123456789.", min_size=1, max_size=8))
+    @settings(max_examples=40, deadline=2000)
+    def test_config_digest_is_stable_across_reconstruction(self, version):
+        left = _covering_registration(implementation_version=version).effective_config_digest()
+        right = _covering_registration(implementation_version=version).effective_config_digest()
+        assert left == right
+
+    @given(shuffle=st.permutations([f"aptl.collector.c{i}" for i in range(4)]))
+    @settings(max_examples=40, deadline=2000)
+    def test_match_selection_is_insertion_order_independent(self, shuffle):
+        registrations = tuple(_covering_registration(registration_id=rid) for rid in shuffle)
+        spec = _spec_with()
+        requirement = next(iter(spec.capture_requirements.values()))
+        binding = CollectorRegistry(registrations).match(spec, requirement)
+        assert binding is not None
+        assert binding.registration_id == "aptl.collector.c0"
+
+
+# ---------------------------------------------------------------------------
+# Canonical identity — insertion order never leaks into the projection
+# ---------------------------------------------------------------------------
+
+
+class TestProjectionIsOrderCanonical:
+    """ADR-047: semantically unordered requirement axes must be sorted in the
+    identity-bearing binding projection so authored list order never changes
+    the plan digest."""
+
+    def test_set_valued_axes_are_sorted_in_the_projection(self):
+        registration = _covering_registration(
+            media_types=frozenset({"application/json", "text/plain"}),
+            integrity_modes=frozenset({"sha256-digest", "blake3-digest"}),
+            required_artifact_roles=frozenset({"observation", "report"}),
+        )
+        binding = _bind_reference(
+            registration,
+            expected_media_types=["text/plain", "application/json"],
+            integrity_requirements=["sha256-digest", "blake3-digest"],
+            required_artifact_roles=["report", "observation"],
+        )
+        assert binding is not None
+        projection = binding.binding_projection()
+        assert projection["expected_media_types"] == ["application/json", "text/plain"]
+        assert projection["integrity_requirements"] == ["blake3-digest", "sha256-digest"]
+        assert projection["required_artifact_roles"] == ["observation", "report"]
+
+    def test_authored_axis_order_does_not_change_the_projection(self):
+        registration = _covering_registration(media_types=frozenset({"application/json", "text/plain"}))
+        forward = _bind_reference(registration, expected_media_types=["application/json", "text/plain"])
+        reverse = _bind_reference(registration, expected_media_types=["text/plain", "application/json"])
+        assert forward is not None and reverse is not None
+        assert forward.binding_projection() == reverse.binding_projection()

--- a/tests/test_experiment_admission.py
+++ b/tests/test_experiment_admission.py
@@ -50,6 +50,12 @@ from aptl.core.experiment.admission import (
     admit_experiment,
     build_associated_artifact_source,
 )
+from aptl.core.experiment.capture_registry import (
+    CaptureLimits,
+    CaptureVisibility,
+    CollectorRegistration,
+    CollectorRegistry,
+)
 from aptl.core.experiment.errors import AdmissionRejection
 from aptl.core.experiment.policy import default_admission_policy
 from aptl.core.experiment.resolver import ResolvedArtifact
@@ -1212,3 +1218,93 @@ class TestBuildAssociatedArtifactSource:
             build_associated_artifact_source(tmp_path, "associated-artifact-manifest.json", spec, policy)
 
         assert excinfo.value.diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Admitted-capture path — a covering registry binds and pins into the plan
+# ---------------------------------------------------------------------------
+
+
+def _covering_registration() -> CollectorRegistration:
+    """Return a registration covering the corpus reference ``network-trace`` requirement."""
+    return CollectorRegistration(
+        registration_id="aptl.collector.network-trace",
+        implementation_version="1.0.0",
+        contract_version="experiment-capture-spec/v1",
+        channel_kind="evaluation-history",
+        capture_kind="trace",
+        capture_scope="network",
+        window_kinds=frozenset({"run"}),
+        media_types=frozenset({"application/json"}),
+        required_artifact_roles=frozenset({"observation"}),
+        supported_sensitivities=frozenset({"internal", "public"}),
+        supports_redaction=True,
+        integrity_modes=frozenset({"sha256-digest"}),
+        sealing_modes=frozenset({"digest"}),
+        supports_chain_of_custody=False,
+        supports_retention=True,
+        supports_loss_disclosure=True,
+        visibility_class=CaptureVisibility.EVALUATOR_ONLY,
+        limits=CaptureLimits(max_bytes=1_048_576, max_artifact_count=100, max_duration_s=300),
+    )
+
+
+def _capture_bearing_bundle():
+    """Build a capability-only bundle whose spec references the corpus capture spec."""
+    backend, processor = _synthetic_manifests()
+    declared = sorted(backend.supported_contract_versions)[0]
+    task_payload = _capability_only_task_payload(declared_capability=declared)
+    capture_payload = _read_corpus_capture_spec_payload()
+    capture_payload["capture_spec_id"] = "capture-minimal"
+    capture_payload["spec_version"] = "1.0.0"
+    capture_payload["scope_refs"] = [
+        {"ref_kind": "task", "ref_id": task_payload["task_id"], "ref_version": task_payload["task_version"]}
+    ]
+    spec_payload = _flat_spec_payload(
+        capture_spec_refs=[{"ref_kind": "capture-spec", "ref_id": "capture-minimal", "ref_version": "1.0.0"}]
+    )
+    bundle = _Bundle(task_payload=task_payload, spec_payload=spec_payload, capture_spec_payload=capture_payload)
+    return bundle, backend, processor
+
+
+class TestAdmitExperimentWithCoveringRegistry:
+    def test_a_covered_capture_spec_admits_and_pins_the_binding(self, tmp_path):
+        bundle, backend, processor = _capture_bearing_bundle()
+        registry = CollectorRegistry((_covering_registration(),))
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+            capture_registry=registry,
+        )
+
+        assert result.admitted is True, [d.code for d in result.diagnostics]
+        assert result.plan is not None
+        assert len(result.plan.capture_bindings) == 1
+        binding = result.plan.capture_bindings[0]
+        assert binding.registration_id == "aptl.collector.network-trace"
+        assert binding.requirement_id == "network-trace"
+        # The binding travelled into the persisted canonical bytes.
+        assert b"aptl.collector.network-trace" in result.plan.canonical_bytes
+
+    def test_the_same_registry_missing_the_capability_still_fails_closed(self, tmp_path):
+        bundle, backend, processor = _capture_bearing_bundle()
+        store = LocalRunStore(tmp_path / "store")
+
+        result = admit_experiment(
+            experiment_root=bundle.experiment_root,
+            artifact_source=bundle.artifact_source,
+            run_store=store,
+            policy=default_admission_policy(),
+            backend_manifest=backend,
+            processor_manifest=processor,
+            capture_registry=CollectorRegistry(),
+        )
+
+        assert result.admitted is False
+        assert any("capture-requirement-unsupported" in d.code for d in result.diagnostics)

--- a/tests/test_experiment_capture_mapping.py
+++ b/tests/test_experiment_capture_mapping.py
@@ -89,18 +89,20 @@ def _covering_registration(**overrides: object) -> CollectorRegistration:
 class TestBindCaptureRequirementsFailsClosed:
     def test_the_realistic_corpus_capture_spec_is_rejected_by_default(self):
         spec = _load_reference_capture_spec()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            bind_capture_requirements([spec], policy=default_admission_policy())
+            bind_capture_requirements([spec], policy=policy)
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
 
     def test_the_rejection_names_the_unsupported_capture_kind_and_scope(self):
         spec = _load_reference_capture_spec()
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            bind_capture_requirements([spec], policy=default_admission_policy())
+            bind_capture_requirements([spec], policy=policy)
 
         messages = " ".join(d.message + " " + d.address for d in excinfo.value.diagnostics)
         assert "trace" in messages
@@ -113,9 +115,10 @@ class TestBindCaptureRequirementsFailsClosed:
         assert callable(collect_traces)
         spec = _load_reference_capture_spec()
         assert spec.capture_requirements["network-trace"].capture_kind == "trace"
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            bind_capture_requirements([spec], policy=default_admission_policy())
+            bind_capture_requirements([spec], policy=policy)
 
 
 # ---------------------------------------------------------------------------
@@ -155,9 +158,10 @@ class TestBindCaptureRequirementsSuccess:
         requirement["capture_kind"] = "log"
         payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
         uncovered = ExperimentCaptureSpecModel.model_validate(payload)
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            bind_capture_requirements([covered, uncovered], registry=registry, policy=default_admission_policy())
+            bind_capture_requirements([covered, uncovered], registry=registry, policy=policy)
 
 
 # ---------------------------------------------------------------------------
@@ -235,6 +239,7 @@ class TestFuzzCaptureRequirementsFailClosed:
         requirement["capture_scope"] = capture_scope
         payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
         spec = ExperimentCaptureSpecModel.model_validate(payload)
+        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            bind_capture_requirements([spec], policy=default_admission_policy())
+            bind_capture_requirements([spec], policy=policy)

--- a/tests/test_experiment_capture_mapping.py
+++ b/tests/test_experiment_capture_mapping.py
@@ -1,46 +1,48 @@
 """Tests for ``aptl.core.experiment.capture_mapping`` (ADR-047 "Apparatus and
-capture capability admission" + the ``observation=None`` gotcha).
+capture capability admission"; EXP-010 / issue #752).
 
-``create_aptl_manifest().observation`` is currently ``None`` (Stage 3 /
-EXP-002), and the existing capture collectors (``aptl.core.collectors``) are
-best-effort primitives that often collapse failure into an empty result.
-Per ADR-047's Gotchas: "Do not admit a capture requirement merely because a
-collector function exists." This module's ``SUPPORTED_CAPTURE_CAPABILITIES``
-table is the ONLY thing that can admit a capture requirement, and it is
-empty/minimal for #438 — an honest fail-closed baseline. EXP-010 (#752) is
-the seam that extends the table alongside an honest
-``create_aptl_manifest().observation`` declaration.
+EXP-002 shipped an empty ``SUPPORTED_CAPTURE_CAPABILITIES`` table here; EXP-010
+evolves capture support into the code-owned
+:mod:`aptl.core.experiment.capture_registry` and turns this module into the
+thin admission entry point :func:`bind_capture_requirements`. The production
+:data:`~aptl.core.experiment.capture_registry.DEFAULT_COLLECTOR_REGISTRY` is
+EMPTY, so the honest fail-closed baseline is preserved: a capture requirement
+is admitted only when a trusted registration covers it, never because a
+collector function exists.
 
-Uses the installed ACES fixture corpus
-(``aces_contracts.corpus.corpus_family_root(FIXTURES)``) as the contract
-test source rather than a copied-in schema, per ADR-047's testing contract.
+Uses the installed ACES fixture corpus as the contract test source (ADR-047).
 """
 
 from __future__ import annotations
 
-import dataclasses
 import json
 
 import pytest
-from aces_backend_protocols.capabilities import BackendManifest, ObservationCapabilities
 from aces_contracts.contracts import ExperimentCaptureSpecModel
 from aces_contracts.corpus import FIXTURES, corpus_family_root
 
-from aptl.backends.aces_manifest import create_aptl_manifest
 from aptl.core.collectors import collect_traces
-from aptl.core.experiment import capture_mapping
-from aptl.core.experiment.capture_mapping import (
-    SUPPORTED_CAPTURE_CAPABILITIES,
-    CaptureCapability,
-    map_capture_requirements,
+from aptl.core.experiment.capture_mapping import bind_capture_requirements
+from aptl.core.experiment.capture_registry import (
+    CaptureLimits,
+    CaptureVisibility,
+    CollectorRegistration,
+    CollectorRegistry,
 )
 from aptl.core.experiment.errors import EXPERIMENT_ADMISSION_DOMAIN, AdmissionRejection
-from aptl.core.experiment.policy import default_admission_policy
+from aptl.core.experiment.policy import (
+    AdmissionPolicy,
+    CaptureLimitationAcceptance,
+    default_admission_policy,
+)
 
 CORPUS_ROOT = corpus_family_root(FIXTURES)
 
+_LIMITS = CaptureLimits(max_bytes=1_048_576, max_artifact_count=100, max_duration_s=300)
+
 
 def _read(*parts: str) -> bytes:
+    """Read a byte payload from the installed ACES fixture corpus."""
     path = CORPUS_ROOT
     for part in parts:
         path = path / part
@@ -48,344 +50,168 @@ def _read(*parts: str) -> bytes:
 
 
 def _load_reference_capture_spec() -> ExperimentCaptureSpecModel:
-    payload = json.loads(
-        _read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json")
-    )
+    """Load the realistic reference capture spec from the corpus."""
+    payload = json.loads(_read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json"))
     return ExperimentCaptureSpecModel.model_validate(payload)
 
 
-def _capture_spec_with_requirement(*, capture_kind: str, capture_scope: str) -> ExperimentCaptureSpecModel:
-    payload = json.loads(
-        _read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json")
-    )
-    requirement = next(iter(payload["capture_requirements"].values()))
-    requirement["capture_kind"] = capture_kind
-    requirement["capture_scope"] = capture_scope
-    payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
-    return ExperimentCaptureSpecModel.model_validate(payload)
-
-
-def _capture_spec_with_requirement_fields(
-    *,
-    capture_kind: str = "trace",
-    capture_scope: str = "network",
-    expected_media_types: list[str] | None = None,
-    integrity_requirements: list[str] | None = None,
-) -> ExperimentCaptureSpecModel:
-    """Like :func:`_capture_spec_with_requirement` but also lets a test
-    independently override ``expected_media_types``/``integrity_requirements``
-    -- needed to isolate the media-type-subset and integrity-subset
-    continue-conditions in ``_resolve_capture_owner`` from the
-    capture_kind/capture_scope ones.
-    """
-    payload = json.loads(
-        _read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json")
-    )
-    requirement = next(iter(payload["capture_requirements"].values()))
-    requirement["capture_kind"] = capture_kind
-    requirement["capture_scope"] = capture_scope
-    if expected_media_types is not None:
-        requirement["expected_media_types"] = expected_media_types
-    if integrity_requirements is not None:
-        requirement["integrity_requirements"] = integrity_requirements
-    payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
-    return ExperimentCaptureSpecModel.model_validate(payload)
-
-
-def _matching_capability(*, capture_owner: str = "aptl.core.collectors.collect_traces") -> CaptureCapability:
-    """The one ``CaptureCapability`` that exactly matches
-    ``_capture_spec_with_requirement_fields()``'s default requirement
-    (capture_kind="trace", capture_scope="network",
-    expected_media_types=["application/json"],
-    integrity_requirements=["sha256-digest"]) on every predicate --
-    the SUCCESS baseline every miss-test below deviates from by exactly
-    one field.
-    """
-    return CaptureCapability(
-        capture_kind="trace",
-        capture_scope="network",
-        media_types=frozenset({"application/json"}),
-        integrity_requirements=frozenset({"sha256-digest"}),
-        capture_owner=capture_owner,
-    )
-
-
-def _matching_observation(
-    *,
-    supported_capture_kinds: frozenset[str] = frozenset({"trace"}),
-    supported_media_types: frozenset[str] = frozenset({"application/json"}),
-) -> ObservationCapabilities:
-    return ObservationCapabilities(
-        name="test-observation",
-        supported_capture_kinds=supported_capture_kinds,
-        supported_channel_kinds=frozenset({"file-artifact"}),
-        supported_evidence_contracts=frozenset({"experiment-capture-spec-v1"}),
-        supported_media_types=supported_media_types,
-        supported_sealing_modes=frozenset({"digest"}),
-    )
-
-
-def _backend_manifest_with_observation(observation: ObservationCapabilities) -> BackendManifest:
-    # NOTE: dataclasses.replace(create_aptl_manifest(), observation=...)
-    # does NOT work here -- BackendManifest has a custom __init__ that
-    # resolves a pre-built `capabilities` object from its own `capabilities`
-    # kwarg when present (which dataclasses.replace always supplies, since
-    # it is itself a real dataclass field), silently discarding a sibling
-    # `observation=` kwarg. Explicit reconstruction (the pattern the
-    # existing "never fabricates support" test below already uses) is the
-    # only way to actually set `observation`.
-    manifest = create_aptl_manifest()
-    return BackendManifest(
-        name=manifest.name,
-        version=manifest.version,
-        supported_contract_versions=manifest.supported_contract_versions,
-        compatible_processors=manifest.compatible_processors,
-        realization_support=manifest.realization_support,
-        concept_bindings=manifest.concept_bindings,
-        provisioner=manifest.provisioner,
-        orchestrator=manifest.orchestrator,
-        evaluator=manifest.evaluator,
-        participant_runtime=manifest.participant_runtime,
-        observation=observation,
-    )
+def _covering_registration(**overrides: object) -> CollectorRegistration:
+    """Return a registration that covers the reference ``network-trace`` requirement."""
+    fields: dict[str, object] = {
+        "registration_id": "aptl.collector.network-trace",
+        "implementation_version": "1.0.0",
+        "contract_version": "experiment-capture-spec/v1",
+        "channel_kind": "evaluation-history",
+        "capture_kind": "trace",
+        "capture_scope": "network",
+        "window_kinds": frozenset({"run"}),
+        "media_types": frozenset({"application/json"}),
+        "required_artifact_roles": frozenset({"observation"}),
+        "supported_sensitivities": frozenset({"internal", "public"}),
+        "supports_redaction": True,
+        "integrity_modes": frozenset({"sha256-digest"}),
+        "sealing_modes": frozenset({"digest"}),
+        "supports_chain_of_custody": False,
+        "supports_retention": True,
+        "supports_loss_disclosure": True,
+        "visibility_class": CaptureVisibility.EVALUATOR_ONLY,
+        "limits": _LIMITS,
+    }
+    fields.update(overrides)
+    return CollectorRegistration(**fields)
 
 
 # ---------------------------------------------------------------------------
-# SUPPORTED_CAPTURE_CAPABILITIES — honest fail-closed baseline
+# Fail-closed baseline (empty production registry)
 # ---------------------------------------------------------------------------
 
 
-class TestSupportedCaptureCapabilitiesBaseline:
-    def test_the_table_is_empty_for_438(self):
-        assert tuple(SUPPORTED_CAPTURE_CAPABILITIES) == ()
-
-    def test_create_aptl_manifest_observation_is_still_none(self):
-        # If this ever flips true, SUPPORTED_CAPTURE_CAPABILITIES may gain
-        # entries (EXP-010) — until then the fail-closed baseline below is
-        # load-bearing and this sanity check documents the precondition.
-        assert create_aptl_manifest().observation is None
-
-    def test_capture_capability_is_a_frozen_dataclass_shape(self):
-        capability = CaptureCapability(
-            capture_kind="trace",
-            capture_scope="network",
-            media_types=frozenset({"application/json"}),
-            integrity_requirements=frozenset({"sha256-digest"}),
-            capture_owner="aptl.core.collectors.collect_traces",
-        )
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            capability.capture_kind = "log"
-
-
-# ---------------------------------------------------------------------------
-# map_capture_requirements — fail-closed on the realistic corpus spec
-# ---------------------------------------------------------------------------
-
-
-class TestMapCaptureRequirementsFailsClosed:
-    def test_the_realistic_corpus_capture_spec_is_rejected(self):
+class TestBindCaptureRequirementsFailsClosed:
+    def test_the_realistic_corpus_capture_spec_is_rejected_by_default(self):
         spec = _load_reference_capture_spec()
-        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            map_capture_requirements([spec], policy=policy)
+            bind_capture_requirements([spec], policy=default_admission_policy())
 
         assert excinfo.value.diagnostics
         assert all(d.domain == EXPERIMENT_ADMISSION_DOMAIN for d in excinfo.value.diagnostics)
 
     def test_the_rejection_names_the_unsupported_capture_kind_and_scope(self):
         spec = _load_reference_capture_spec()
-        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection) as excinfo:
-            map_capture_requirements([spec], policy=policy)
+            bind_capture_requirements([spec], policy=default_admission_policy())
 
         messages = " ".join(d.message + " " + d.address for d in excinfo.value.diagnostics)
         assert "trace" in messages
         assert "network" in messages
 
-    def test_an_unknown_capture_kind_also_fails_closed(self):
-        spec = _capture_spec_with_requirement(capture_kind="other", capture_scope="service")
-        policy = default_admission_policy()
-
-        with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], policy=policy)
-
     def test_a_collector_function_existing_does_not_cause_admission(self):
-        # collect_traces is a real, importable, callable collector for
-        # exactly the "trace" capture_kind the corpus spec requires. Its
-        # mere existence must never be what admission consults.
+        # collect_traces is a real, importable collector for exactly the
+        # "trace" capture_kind the corpus spec requires. Its mere existence
+        # must never be what admission consults.
         assert callable(collect_traces)
         spec = _load_reference_capture_spec()
         assert spec.capture_requirements["network-trace"].capture_kind == "trace"
-        policy = default_admission_policy()
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], policy=policy)
+            bind_capture_requirements([spec], policy=default_admission_policy())
 
-    def test_never_fabricates_support_by_injecting_a_backend_manifest_with_non_none_observation_but_wrong_terms(self):
-        # Even if a caller injects a backend manifest whose observation IS
-        # populated, an empty SUPPORTED_CAPTURE_CAPABILITIES table still
-        # fails closed -- the table gates admission, not observation
-        # presence alone.
-        from aces_backend_protocols.capabilities import BackendManifest, ObservationCapabilities
 
-        manifest = create_aptl_manifest()
-        with_observation = BackendManifest(
-            name=manifest.name,
-            version=manifest.version,
-            supported_contract_versions=manifest.supported_contract_versions,
-            compatible_processors=manifest.compatible_processors,
-            realization_support=manifest.realization_support,
-            concept_bindings=manifest.concept_bindings,
-            provisioner=manifest.provisioner,
-            orchestrator=manifest.orchestrator,
-            evaluator=manifest.evaluator,
-            participant_runtime=manifest.participant_runtime,
-            observation=ObservationCapabilities(
-                name="test-observation",
-                supported_capture_kinds=frozenset({"trace"}),
-                supported_channel_kinds=frozenset({"file-artifact"}),
-                supported_evidence_contracts=frozenset({"experiment-capture-spec-v1"}),
-                supported_media_types=frozenset({"application/json"}),
-                supported_sealing_modes=frozenset({"digest"}),
-            ),
-        )
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+
+class TestBindCaptureRequirementsEmptyInput:
+    def test_no_capture_specs_yields_an_empty_tuple_and_does_not_reject(self):
+        result = bind_capture_requirements([], policy=default_admission_policy())
+        assert result == ()
+
+
+# ---------------------------------------------------------------------------
+# Success path (injected covering registry)
+# ---------------------------------------------------------------------------
+
+
+class TestBindCaptureRequirementsSuccess:
+    def test_a_covered_requirement_binds_to_an_immutable_binding(self):
+        registry = CollectorRegistry((_covering_registration(),))
         spec = _load_reference_capture_spec()
-        policy = default_admission_policy()
+
+        bindings = bind_capture_requirements([spec], registry=registry, policy=default_admission_policy())
+
+        assert len(bindings) == 1
+        assert bindings[0].registration_id == "aptl.collector.network-trace"
+        assert bindings[0].requirement_id == "network-trace"
+
+    def test_binding_is_all_or_nothing_across_specs(self):
+        # A registry that covers "trace" but not a second "log" requirement:
+        # ANY unbound requirement rejects the whole admission.
+        registry = CollectorRegistry((_covering_registration(),))
+        covered = _load_reference_capture_spec()
+        payload = json.loads(_read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json"))
+        requirement = next(iter(payload["capture_requirements"].values()))
+        requirement["capture_kind"] = "log"
+        payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
+        uncovered = ExperimentCaptureSpecModel.model_validate(payload)
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=with_observation, policy=policy)
+            bind_capture_requirements([covered, uncovered], registry=registry, policy=default_admission_policy())
 
 
 # ---------------------------------------------------------------------------
-# map_capture_requirements — no capture specs at all
+# Degradation — accepted only via explicit policy, never inferred
 # ---------------------------------------------------------------------------
 
 
-class TestMapCaptureRequirementsEmptyInput:
-    def test_no_capture_specs_yields_an_empty_mapping_and_does_not_reject(self):
-        result = map_capture_requirements([], policy=default_admission_policy())
+class TestCaptureDegradationAcceptance:
+    def test_a_bound_requirement_carries_no_limitation_by_default(self):
+        registry = CollectorRegistry((_covering_registration(),))
+        spec = _load_reference_capture_spec()
 
-        assert result == {}
+        binding = bind_capture_requirements([spec], registry=registry, policy=default_admission_policy())[0]
 
+        assert binding.accepted_limitation is None
+        assert binding.comparability_disclosure_ref is None
 
-# ---------------------------------------------------------------------------
-# _resolve_capture_owner — the matching loop's own predicates (Finding 1)
-#
-# SUPPORTED_CAPTURE_CAPABILITIES is empty in production (see the module
-# docstring), so this loop body -- every `continue` and the eventual
-# `return capability.capture_owner` -- never runs against the real table.
-# Each test below monkeypatches in exactly ONE synthetic capability so the
-# loop body genuinely executes, and isolates exactly one predicate at a
-# time: the requirement deviates from a capability/observation pair that
-# would otherwise fully match on every other axis, so if that one guard
-# were ever deleted the requirement WOULD wrongly match and the test would
-# fail (no AdmissionRejection raised).
-# ---------------------------------------------------------------------------
-
-
-class TestResolveCaptureOwnerSuccessPath:
-    def test_a_requirement_matching_a_supported_capability_and_observation_is_admitted(self, monkeypatch):
-        capability = _matching_capability()
-        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
-        manifest = _backend_manifest_with_observation(_matching_observation())
-        spec = _capture_spec_with_requirement_fields()
-
-        result = map_capture_requirements([spec], backend_manifest=manifest, policy=default_admission_policy())
-
-        assert result == {f"{spec.capture_spec_id}.network-trace": "aptl.core.collectors.collect_traces"}
-
-
-class TestResolveCaptureOwnerEachContinueConditionFailsClosed:
-    """One requirement per miss -- every test below deviates from the
-    matching baseline (``_matching_capability()``/``_matching_observation()``
-    exactly matching ``_capture_spec_with_requirement_fields()``'s default
-    requirement) on exactly one predicate.
-    """
-
-    def test_capture_kind_mismatch(self, monkeypatch):
-        capability = _matching_capability()  # capture_kind="trace"
-        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
-        manifest = _backend_manifest_with_observation(_matching_observation())
-        spec = _capture_spec_with_requirement_fields(capture_kind="observation", capture_scope="network")
-        policy = default_admission_policy()
-
-        with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
-
-    def test_capture_scope_mismatch(self, monkeypatch):
-        capability = _matching_capability()  # capture_scope="network"
-        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
-        manifest = _backend_manifest_with_observation(_matching_observation())
-        spec = _capture_spec_with_requirement_fields(capture_kind="trace", capture_scope="service")
-        policy = default_admission_policy()
-
-        with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
-
-    def test_expected_media_types_not_a_subset_of_the_capability(self, monkeypatch):
-        capability = _matching_capability()  # media_types={"application/json"}
-        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
-        # The observation's own supported_media_types is deliberately made
-        # WIDER than the capability's (includes "application/xml" too) so
-        # this test isolates the capability-side subset guard specifically
-        # from the later, separate observation-side subset guard (which
-        # would otherwise also reject "application/xml" and mask a removal
-        # of the earlier check).
-        manifest = _backend_manifest_with_observation(
-            _matching_observation(supported_media_types=frozenset({"application/json", "application/xml"}))
+    def test_an_explicit_policy_acceptance_annotates_the_binding(self):
+        registry = CollectorRegistry((_covering_registration(),))
+        spec = _load_reference_capture_spec()
+        key = f"{spec.capture_spec_id}.network-trace"
+        policy = AdmissionPolicy(
+            accepted_capture_limitations={
+                key: CaptureLimitationAcceptance(
+                    limitation_code="partial-window",
+                    comparability_disclosure_ref="disclosure:partial-window/v1",
+                )
+            }
         )
-        spec = _capture_spec_with_requirement_fields(expected_media_types=["application/xml"])
-        policy = default_admission_policy()
 
-        with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
+        binding = bind_capture_requirements([spec], registry=registry, policy=policy)[0]
 
-    def test_integrity_requirements_not_a_subset_of_the_capability(self, monkeypatch):
-        capability = _matching_capability()  # integrity_requirements={"sha256-digest"}
-        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
-        manifest = _backend_manifest_with_observation(_matching_observation())
-        spec = _capture_spec_with_requirement_fields(integrity_requirements=["sha512-digest"])
-        policy = default_admission_policy()
+        assert binding.accepted_limitation == "partial-window"
+        assert binding.comparability_disclosure_ref == "disclosure:partial-window/v1"
 
-        with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
-
-    def test_capability_capture_kind_not_declared_by_the_observation(self, monkeypatch):
-        # Requirement fully matches the capability on every one of its own
-        # fields; the capability's declared capture_kind ("trace") is
-        # simply never named in the observation's own declaration.
-        capability = _matching_capability()
-        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
-        manifest = _backend_manifest_with_observation(
-            _matching_observation(supported_capture_kinds=frozenset({"log"}))
+    def test_an_acceptance_for_a_different_requirement_does_not_leak(self):
+        registry = CollectorRegistry((_covering_registration(),))
+        spec = _load_reference_capture_spec()
+        policy = AdmissionPolicy(
+            accepted_capture_limitations={
+                "some-other-spec.some-other-requirement": CaptureLimitationAcceptance(
+                    limitation_code="irrelevant",
+                    comparability_disclosure_ref="disclosure:irrelevant/v1",
+                )
+            }
         )
-        spec = _capture_spec_with_requirement_fields()
-        policy = default_admission_policy()
 
-        with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
+        binding = bind_capture_requirements([spec], registry=registry, policy=policy)[0]
 
-    def test_expected_media_types_not_a_subset_of_the_observation(self, monkeypatch):
-        # Requirement/capability fully match each other (and the
-        # capability's capture_kind IS declared by the observation); only
-        # the observation's own supported_media_types excludes what the
-        # requirement asks for.
-        capability = _matching_capability()
-        monkeypatch.setattr(capture_mapping, "SUPPORTED_CAPTURE_CAPABILITIES", (capability,))
-        manifest = _backend_manifest_with_observation(
-            _matching_observation(supported_media_types=frozenset({"text/plain"}))
-        )
-        spec = _capture_spec_with_requirement_fields()
-        policy = default_admission_policy()
-
-        with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], backend_manifest=manifest, policy=policy)
+        assert binding.accepted_limitation is None
 
 
 # ---------------------------------------------------------------------------
-# Fuzz
+# Fuzz — every ACES-legal kind/scope still fails closed against the empty default
 # ---------------------------------------------------------------------------
 
 from hypothesis import given, settings  # noqa: E402
@@ -396,17 +222,19 @@ _CAPTURE_SCOPES = ("task", "run", "apparatus", "participant", "backend", "proces
 
 
 @pytest.mark.fuzz
-class TestFuzzCaptureRequirementsAlwaysFailClosed:
+class TestFuzzCaptureRequirementsFailClosed:
     @given(
         capture_kind=st.sampled_from(_CAPTURE_KINDS),
         capture_scope=st.sampled_from(_CAPTURE_SCOPES),
     )
     @settings(max_examples=56, deadline=2000)
-    def test_every_aces_legal_capture_kind_and_scope_combination_fails_closed(
-        self, capture_kind, capture_scope
-    ):
-        spec = _capture_spec_with_requirement(capture_kind=capture_kind, capture_scope=capture_scope)
-        policy = default_admission_policy()
+    def test_every_legal_kind_scope_combination_fails_closed_by_default(self, capture_kind, capture_scope):
+        payload = json.loads(_read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json"))
+        requirement = next(iter(payload["capture_requirements"].values()))
+        requirement["capture_kind"] = capture_kind
+        requirement["capture_scope"] = capture_scope
+        payload["capture_requirements"] = {requirement["requirement_id"]: requirement}
+        spec = ExperimentCaptureSpecModel.model_validate(payload)
 
         with pytest.raises(AdmissionRejection):
-            map_capture_requirements([spec], policy=policy)
+            bind_capture_requirements([spec], policy=default_admission_policy())

--- a/tests/test_experiment_trial_plan.py
+++ b/tests/test_experiment_trial_plan.py
@@ -38,6 +38,11 @@ from aptl.core.experiment.policy import (
     default_admission_policy,
 )
 from aptl.core.experiment import trial_plan
+from aptl.core.experiment.capture_registry import (
+    CaptureBinding,
+    CaptureLimits,
+    CaptureVisibility,
+)
 from aptl.core.experiment.trial_plan import (
     PlannedTrial,
     TrialPlan,
@@ -47,6 +52,35 @@ from aptl.core.experiment.trial_plan import (
 
 CORPUS_ROOT = corpus_family_root(FIXTURES)
 SOURCE_SET_DIGEST = "sha256:" + "ab" * 32
+
+
+def _capture_binding(**overrides: object) -> CaptureBinding:
+    """Build a representative pinned :class:`CaptureBinding` for the pinning tests."""
+    fields: dict[str, object] = {
+        "capture_spec_id": "capture-spec-1",
+        "requirement_id": "network-trace",
+        "window_refs": ("run-window",),
+        "registration_id": "aptl.collector.network-trace",
+        "implementation_version": "1.0.0",
+        "contract_version": "experiment-capture-spec/v1",
+        "effective_config_digest": "sha256:" + "cd" * 32,
+        "channel_ref_id": "evaluation-history-channel",
+        "channel_ref_version": "1.0.0",
+        "channel_kind": "evaluation-history",
+        "capture_kind": "trace",
+        "capture_scope": "network",
+        "expected_media_types": ("application/json",),
+        "required_artifact_roles": ("observation",),
+        "sensitivity": "internal",
+        "redaction_required": False,
+        "integrity_requirements": ("sha256-digest",),
+        "retention_policy": "retain-review-window",
+        "loss_disclosure_required": True,
+        "visibility_class": CaptureVisibility.EVALUATOR_ONLY,
+        "limits": CaptureLimits(max_bytes=1024, max_artifact_count=10, max_duration_s=60),
+    }
+    fields.update(overrides)
+    return CaptureBinding(**fields)
 
 
 def _read_corpus_reference() -> dict:
@@ -877,3 +911,60 @@ class TestFuzzDictOrderingNeverChangesCanonicalBytes:
         plan_canonical = expand_trial_plan(spec_canonical, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
 
         assert plan_shuffled.canonical_bytes == plan_canonical.canonical_bytes
+
+
+# ---------------------------------------------------------------------------
+# Capture-binding pinning (EXP-010 / #752)
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureBindingPinning:
+    """The admitted capture bindings are pinned in the canonical plan bytes so
+    runtime executes exactly them, never re-matching a changed registry."""
+
+    def test_bindings_are_carried_on_the_plan(self):
+        spec = _flat_spec(target_run_count=2)
+        binding = _capture_binding()
+        plan = expand_trial_plan(
+            spec, source_set_digest=SOURCE_SET_DIGEST, capture_bindings=(binding,), policy=default_admission_policy()
+        )
+        assert plan.capture_bindings == (binding,)
+
+    def test_no_bindings_yields_an_empty_tuple(self):
+        spec = _flat_spec(target_run_count=2)
+        plan = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=default_admission_policy())
+        assert plan.capture_bindings == ()
+
+    def test_bindings_change_the_plan_digest(self):
+        spec = _flat_spec(target_run_count=2)
+        policy = default_admission_policy()
+        without = expand_trial_plan(spec, source_set_digest=SOURCE_SET_DIGEST, policy=policy)
+        with_binding = expand_trial_plan(
+            spec, source_set_digest=SOURCE_SET_DIGEST, capture_bindings=(_capture_binding(),), policy=policy
+        )
+        assert without.plan_digest != with_binding.plan_digest
+
+    def test_same_bindings_produce_byte_identical_plans(self):
+        spec = _flat_spec(target_run_count=2)
+        policy = default_admission_policy()
+        first = expand_trial_plan(
+            spec, source_set_digest=SOURCE_SET_DIGEST, capture_bindings=(_capture_binding(),), policy=policy
+        )
+        second = expand_trial_plan(
+            spec, source_set_digest=SOURCE_SET_DIGEST, capture_bindings=(_capture_binding(),), policy=policy
+        )
+        assert first.canonical_bytes == second.canonical_bytes
+
+    def test_a_changed_binding_field_changes_the_digest(self):
+        spec = _flat_spec(target_run_count=2)
+        policy = default_admission_policy()
+        base = expand_trial_plan(
+            spec, source_set_digest=SOURCE_SET_DIGEST, capture_bindings=(_capture_binding(),), policy=policy
+        )
+        changed = expand_trial_plan(
+            spec,
+            source_set_digest=SOURCE_SET_DIGEST,
+            capture_bindings=(_capture_binding(accepted_limitation="partial-window"),),
+            policy=policy,
+        )
+        assert base.plan_digest != changed.plan_digest

--- a/tests/test_manifest_observation.py
+++ b/tests/test_manifest_observation.py
@@ -1,0 +1,98 @@
+"""Tests for the backend manifest's observation capability (EXP-010 / #752).
+
+``create_aptl_manifest().observation`` is an aggregate projection of the
+code-owned collector registry, not a hand-maintained matrix. Two invariants
+matter:
+
+* HONEST DEFAULT — while the production registry is empty, the manifest must
+  declare no observation capability and must NOT carry the observation-only
+  evidence contracts (turning them on without a backed capability is the exact
+  dishonesty the registry prevents).
+* CONTRACT-COMPLETE WHEN ON — when a real registration turns the projection on,
+  ACES's ``observation_capability_contract_gaps`` invariant must be clean,
+  which requires the capture-spec/evidence-record/derived-measure/experiment-run
+  contracts in the manifest's ``supported_contract_versions``.
+"""
+
+from __future__ import annotations
+
+from aces_backend_protocols.capabilities import observation_capability_contract_gaps
+
+import aptl.backends.aces_manifest as aces_manifest
+from aptl.backends.aces_manifest import create_aptl_manifest
+from aptl.core.experiment.capture_registry import (
+    OBSERVATION_EVIDENCE_CONTRACTS,
+    CaptureLimits,
+    CaptureVisibility,
+    CollectorRegistration,
+    CollectorRegistry,
+)
+
+_LIMITS = CaptureLimits(max_bytes=1_048_576, max_artifact_count=100, max_duration_s=300)
+
+
+def _registration() -> CollectorRegistration:
+    """Return one governed-vocabulary registration for the populated-projection tests."""
+    return CollectorRegistration(
+        registration_id="aptl.collector.network-trace",
+        implementation_version="1.0.0",
+        contract_version="experiment-capture-spec/v1",
+        channel_kind="evaluation-history",
+        capture_kind="trace",
+        capture_scope="network",
+        window_kinds=frozenset({"run"}),
+        media_types=frozenset({"application/json"}),
+        required_artifact_roles=frozenset({"observation"}),
+        supported_sensitivities=frozenset({"internal", "public"}),
+        supports_redaction=True,
+        integrity_modes=frozenset({"sha256-digest"}),
+        sealing_modes=frozenset({"digest"}),
+        supports_chain_of_custody=False,
+        supports_retention=True,
+        supports_loss_disclosure=True,
+        visibility_class=CaptureVisibility.EVALUATOR_ONLY,
+        limits=_LIMITS,
+    )
+
+
+class TestHonestDefault:
+    def test_default_manifest_declares_no_observation(self):
+        assert create_aptl_manifest().observation is None
+
+    def test_default_manifest_omits_the_observation_only_contracts(self):
+        supported = create_aptl_manifest().supported_contract_versions
+        assert OBSERVATION_EVIDENCE_CONTRACTS.isdisjoint(supported)
+
+
+class TestPopulatedProjection:
+    def test_a_populated_registry_turns_observation_on(self, monkeypatch):
+        monkeypatch.setattr(
+            aces_manifest, "DEFAULT_COLLECTOR_REGISTRY", CollectorRegistry((_registration(),))
+        )
+        manifest = create_aptl_manifest()
+
+        assert manifest.observation is not None
+        assert manifest.observation.supported_capture_kinds == frozenset({"trace"})
+
+    def test_turning_observation_on_adds_the_required_contracts(self, monkeypatch):
+        monkeypatch.setattr(
+            aces_manifest, "DEFAULT_COLLECTOR_REGISTRY", CollectorRegistry((_registration(),))
+        )
+        manifest = create_aptl_manifest()
+
+        assert OBSERVATION_EVIDENCE_CONTRACTS <= manifest.supported_contract_versions
+
+    def test_the_populated_manifest_has_no_observation_contract_gaps(self, monkeypatch):
+        # The ACES invariant: a declared observation's required contracts must
+        # all be present in supported_contract_versions.
+        monkeypatch.setattr(
+            aces_manifest, "DEFAULT_COLLECTOR_REGISTRY", CollectorRegistry((_registration(),))
+        )
+        manifest = create_aptl_manifest()
+
+        assert observation_capability_contract_gaps(manifest) == ()
+
+    def test_the_default_manifest_also_has_no_observation_contract_gaps(self):
+        # With observation None the gap check is vacuously clean — the honest
+        # default must never trip the invariant either.
+        assert observation_capability_contract_gaps(create_aptl_manifest()) == ()


### PR DESCRIPTION
## Summary

EXP-010 PR 1 of 2 — the capture-admission foundation, extending the EXP-002 admission controller. A single versioned collector registry becomes the source of truth for capture support: admission deterministically matches every authored capture-requirement axis (contract version, capture kind/scope, window, media, artifact roles, sensitivity, integrity, redaction, retention, loss disclosure) and returns an immutable CaptureBinding with a non-executable registration ID. Bindings pin into the canonical trial-plan bytes before any range mutation, so runtime never re-matches a changed registry. The backend ObservationCapabilities manifest is an aggregate projection of the registry — honestly None until a capability is genuinely backed end-to-end. Capture is required by default; degradation is admitted only via an explicit, persisted policy limitation and comparability disclosure. The acquisition half (collector protocol, content-addressed evidence, ACES evidence records, terminal semantics, #447 correlation) is PR 2.

## Requirement UIDs

- `EXP-010`

## Related Issues

Closes #752

## ADR Impact

- ADR-047

## Changes

- New src/aptl/core/experiment/capture_registry.py: CollectorRegistry/CollectorRegistration/CaptureBinding, 11-axis deterministic match, non-executable registration-ID validation, and the aggregate ObservationCapabilities projection
- capture_mapping.py: evolve into the registry-backed bind_capture_requirements entry point returning immutable bindings sorted by stable identity
- trial_plan.py: pin capture bindings into the canonical projection (schema bumped to v2)
- aces_manifest.py: derive observation from the registry and add the four ACES-required evidence contracts only when the projection is on
- policy.py: CaptureLimitationAcceptance + accepted_capture_limitations for auditable, non-silent degradation
- admission.py: bind capture requirements against an injectable registry and pin the bindings into the plan
- Sort semantically unordered requirement axes and the bindings list so ACES document ordering never leaks into the plan digest (codex determinism finding)

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Lint / complexity / Vale gates pass
- [x] No coverage regression

Full non-integration suite: 2960 passed, 92 skipped. New: tests/test_capture_registry.py (ID validation, 11-axis one-miss-per-axis match, determinism, observation projection, order-canonical projection), tests/test_manifest_observation.py (honest-None default + populated-projection contract-gap invariant), rewritten tests/test_experiment_capture_mapping.py (registry-backed binding, fail-closed, degradation), and added coverage in tests/test_experiment_trial_plan.py (binding pinning) and tests/test_experiment_admission.py (end-to-end admitted-capture path + zero-mutation fail-closed). Fuzz determinism green.

## Ground Control Checks

- [x] `make policy` passes (Vale)
- [x] Quality gates pass (gc_assert_quality_gates)
- [x] Codex + test-quality reviews consumed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: src/aptl/core/experiment/capture_registry.py, src/aptl/core/experiment/capture_mapping.py, src/aptl/backends/aces_manifest.py, src/aptl/core/experiment/trial_plan.py, src/aptl/core/experiment/policy.py
- TESTS: tests/test_capture_registry.py, tests/test_manifest_observation.py, tests/test_experiment_capture_mapping.py

## Documentation

Updated: added the EXP-010 architecture preflight note and linked it from the architecture index.
