### PR TITLE
feat(evidence): acquire ACES experiment evidence from admitted capture bindings

### DIFF
--- a/src/aptl/core/evidence/__init__.py
+++ b/src/aptl/core/evidence/__init__.py
@@ -1,0 +1,1 @@
+"""EXP-010 evidence acquisition: narrow collector protocol, terminal-outcome\ntaxonomy, content-addressed persistence, ACES evidence-record construction, and\nthe start/stop/finalize coordinator (issue #752 PR 2)."""

--- a/src/aptl/core/evidence/__init__.py
+++ b/src/aptl/core/evidence/__init__.py
@@ -1,1 +1,6 @@
-"""EXP-010 evidence acquisition: narrow collector protocol, terminal-outcome\ntaxonomy, content-addressed persistence, ACES evidence-record construction, and\nthe start/stop/finalize coordinator (issue #752 PR 2)."""
+"""EXP-010 evidence acquisition (issue #752 PR 2).
+
+Narrow collector protocol, terminal-outcome taxonomy, content-addressed
+persistence, ACES evidence-record construction, and the start/stop/finalize
+coordinator.
+"""

--- a/src/aptl/core/evidence/_persist.py
+++ b/src/aptl/core/evidence/_persist.py
@@ -18,9 +18,10 @@ from datetime import datetime
 from aces_contracts.contracts import ExperimentEvidenceRecordModel
 
 from aptl.core.evidence import content_store
+from aptl.core.evidence.content_store import ContentInsertion
 from aptl.core.evidence.outcomes import CollectorStatus
 from aptl.core.evidence.protocol import CollectorOutcome
-from aptl.core.evidence.records import build_evidence_record
+from aptl.core.evidence.records import RecordDisclosure, build_evidence_record
 from aptl.core.experiment.capture_registry import CaptureBinding, CaptureVisibility
 from aptl.core.runstore import LocalRunStore
 from aptl.utils.redaction import redact
@@ -162,9 +163,11 @@ def persist_success_outcome(
         content=content,
         outcome=outcome,
         captured_at=captured_at,
-        sensitivity=binding.sensitivity,
-        redaction_state=redaction_state,
-        loss_disclosure=loss_disclosure,
+        disclosure=RecordDisclosure(
+            sensitivity=binding.sensitivity,
+            redaction_state=redaction_state,
+            loss_disclosure=loss_disclosure,
+        ),
     )
     # Persist the record into the explicit, create-once run-scoped evidence
     # ledger (identity is content-derived, so re-persisting is idempotent).
@@ -212,7 +215,9 @@ def _elapsed_seconds(outcome: CollectorOutcome) -> float:
     return max(0.0, (end - start).total_seconds())
 
 
-def _effective_status(outcome: CollectorOutcome, *, content, binding: CaptureBinding) -> CollectorStatus:
+def _effective_status(
+    outcome: CollectorOutcome, *, content: ContentInsertion, binding: CaptureBinding
+) -> CollectorStatus:
     """Downgrade a reported OK to a limit/loss status the coordinator enforces.
 
     The binding's admitted duration, artifact-count, and byte limits are ALL
@@ -227,12 +232,12 @@ def _effective_status(outcome: CollectorOutcome, *, content, binding: CaptureBin
         return CollectorStatus.TIMEOUT
     if content.truncated or outcome.event_count > limits.max_artifact_count:
         return CollectorStatus.TRUNCATION
-    if outcome.dropped_count > 0:
-        return CollectorStatus.MID_RUN_LOSS
-    return outcome.status
+    return CollectorStatus.MID_RUN_LOSS if outcome.dropped_count > 0 else outcome.status
 
 
-def _loss_disclosure(outcome: CollectorOutcome, *, effective_status: CollectorStatus, redaction_state: str) -> str | None:
+def _loss_disclosure(
+    outcome: CollectorOutcome, *, effective_status: CollectorStatus, redaction_state: str
+) -> str | None:
     """Return a mandatory, bounded loss/redaction disclosure, or ``None`` when there is nothing to disclose.
 
     A limit/loss status (timeout, truncation, mid-run loss) always discloses;

--- a/src/aptl/core/evidence/_persist.py
+++ b/src/aptl/core/evidence/_persist.py
@@ -1,0 +1,245 @@
+"""Per-outcome persistence for the acquisition coordinator (EXP-010 / #752).
+
+Split out of :mod:`aptl.core.evidence.coordinator` to keep that module within
+the 500-line budget and its orchestration readable. This module owns the
+coordinator-side work for ONE successfully-captured collector outcome: the
+media-type check, structured redaction, content-addressed persistence (with
+the byte quota + truncation), and ACES evidence-record + reference assembly.
+A collector never does any of this itself (preflight "Narrow collector
+boundary").
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+from aces_contracts.contracts import ExperimentEvidenceRecordModel
+
+from aptl.core.evidence import content_store
+from aptl.core.evidence.outcomes import CollectorStatus
+from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.evidence.records import build_evidence_record
+from aptl.core.experiment.capture_registry import CaptureBinding, CaptureVisibility
+from aptl.core.runstore import LocalRunStore
+from aptl.utils.redaction import redact
+
+#: Media types the coordinator can structurally redact before persistence.
+_JSON_MEDIA_TYPES = frozenset({"application/json", "application/x-ndjson", "application/jsonl"})
+
+#: Run-relative subdirectory for content-addressed raw evidence blobs.
+_EVIDENCE_SUBDIR = "evidence/blobs"
+
+#: Run-relative subdirectory for the explicit, create-once evidence-record ledger.
+_LEDGER_SUBDIR = "evidence/records"
+
+
+@dataclass(frozen=True)
+class EvidenceRef:
+    """A verified evidence reference for the run / #447 correlation projection.
+
+    Carries only bounded identity — record/content identity, the capture
+    spec/requirement it satisfies, the producing registration, and the
+    visibility class — never raw bytes or a host path.
+    """
+
+    evidence_record_id: str
+    content_uri: str
+    content_digest: str
+    capture_spec_id: str
+    requirement_id: str
+    registration_id: str
+    visibility_class: str
+
+    def as_reference_dict(self) -> dict[str, str]:
+        """Project to the ``backend_evidence.evidence_references`` shape OBS-002 consumes."""
+        return {
+            "path": self.content_uri,
+            "kind": "experiment-evidence",
+            "evidence_record_id": self.evidence_record_id,
+            "digest": self.content_digest,
+            "requirement_id": self.requirement_id,
+            "visibility_class": self.visibility_class,
+        }
+
+
+@dataclass(frozen=True)
+class ProcessedOutcome:
+    """The result of persisting one success outcome.
+
+    ``effective_status`` may downgrade the collector's reported status — e.g.
+    a source reported OK but the content-store truncated it to the byte quota,
+    yielding :attr:`CollectorStatus.TRUNCATION`.
+    """
+
+    record: ExperimentEvidenceRecordModel
+    ref: EvidenceRef
+    effective_status: CollectorStatus
+
+
+def _media_type_of(outcome: CollectorOutcome, binding: CaptureBinding) -> str:
+    """Return the effective media type (collector-reported, else the binding's first expected)."""
+    if outcome.media_type is not None:
+        return outcome.media_type
+    return binding.expected_media_types[0] if binding.expected_media_types else "application/octet-stream"
+
+
+def media_type_supported(outcome: CollectorOutcome, binding: CaptureBinding) -> bool:
+    """Return whether the outcome's media type is one the requirement expects."""
+    if not binding.expected_media_types:
+        return True
+    return _media_type_of(outcome, binding) in binding.expected_media_types
+
+
+def _redact_json_bytes(raw: bytes) -> tuple[bytes, bool]:
+    """Redact a JSON / JSONL payload structurally; return (bytes, changed).
+
+    Non-parseable content is treated as opaque (returned unchanged, not
+    redacted) so a malformed payload never silently loses its loss-disclosure
+    signal — the caller records it as retained-as-is.
+    """
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return raw, False
+    safe = redact(parsed)
+    if safe == parsed:
+        return raw, False
+    return json.dumps(safe, separators=(",", ":")).encode("utf-8"), True
+
+
+def _prepare_bytes(outcome: CollectorOutcome, media_type: str) -> tuple[list[bytes], str]:
+    """Return the (possibly redacted) chunks + the redaction_state for persistence.
+
+    Structured JSON is redacted through the shared boundary before it is ever
+    written (preflight); opaque bytes are passed through and marked ``none``
+    (their ADR-029 handling is the source/sensitivity policy, not this pass).
+    """
+    if media_type in _JSON_MEDIA_TYPES:
+        joined = b"".join(outcome.chunks)
+        redacted, changed = _redact_json_bytes(joined)
+        return [redacted], ("redacted" if changed else "none")
+    return list(outcome.chunks), "none"
+
+
+def persist_success_outcome(
+    *,
+    binding: CaptureBinding,
+    outcome: CollectorOutcome,
+    run_store: LocalRunStore,
+    run_id: str,
+    planned_trial_id: str,
+    captured_at: str,
+) -> ProcessedOutcome:
+    """Persist one captured outcome content-addressably and build its ACES record.
+
+    Enforces the binding's byte quota during streaming (truncation flips the
+    effective status and adds a mandatory loss disclosure), redacts structured
+    payloads, and derives a deterministic evidence-record identity.
+    ``WITHHELD``-visibility evidence keeps its bytes but is recorded as
+    ``redaction_state="withheld"`` so a participant projection can drop it.
+    """
+    media_type = _media_type_of(outcome, binding)
+    chunks, structured_redaction_state = _prepare_bytes(outcome, media_type)
+
+    content = content_store.create_content_addressed(
+        run_store, run_id, chunks, subdir=_EVIDENCE_SUBDIR, max_bytes=binding.limits.max_bytes
+    )
+
+    effective_status = _effective_status(outcome, content=content, binding=binding)
+
+    withheld = binding.visibility_class in (CaptureVisibility.EVALUATOR_ONLY, CaptureVisibility.APPARATUS_ONLY)
+    redaction_state = "withheld" if withheld else structured_redaction_state
+    loss_disclosure = _loss_disclosure(
+        outcome, effective_status=effective_status, redaction_state=redaction_state
+    )
+
+    record = build_evidence_record(
+        binding=binding,
+        run_id=run_id,
+        planned_trial_id=planned_trial_id,
+        content=content,
+        outcome=outcome,
+        captured_at=captured_at,
+        sensitivity=binding.sensitivity,
+        redaction_state=redaction_state,
+        loss_disclosure=loss_disclosure,
+    )
+    # Persist the record into the explicit, create-once run-scoped evidence
+    # ledger (identity is content-derived, so re-persisting is idempotent).
+    content_store.create_run_json_once(
+        run_store,
+        run_id,
+        f"{_LEDGER_SUBDIR}/{record.evidence_record_id}.json",
+        record.model_dump(mode="json", exclude_none=True),
+    )
+    ref = EvidenceRef(
+        evidence_record_id=record.evidence_record_id,
+        content_uri=content.relative_path,
+        content_digest=content.digest,
+        capture_spec_id=binding.capture_spec_id,
+        requirement_id=binding.requirement_id,
+        registration_id=binding.registration_id,
+        visibility_class=binding.visibility_class.value,
+    )
+    return ProcessedOutcome(record=record, ref=ref, effective_status=effective_status)
+
+
+#: Fixed disclosure text per non-``none`` redaction state (ACES requires a
+#: disclosure whenever the record is redacted or withheld).
+_REDACTION_DISCLOSURES = {
+    "withheld": "content withheld from participant projection (evaluator-only/apparatus-only visibility)",
+    "redacted": "structured payload redacted at the persistence boundary (ADR-029)",
+}
+
+#: Disclosure text per limit/loss status the coordinator enforces. ``{dropped}``
+#: is filled from the outcome's dropped-event count.
+_STATUS_DISCLOSURES = {
+    CollectorStatus.TIMEOUT: "collector exceeded the admitted duration; capture is incomplete",
+    CollectorStatus.TRUNCATION: "content truncated to the admitted quota; {dropped} event(s) dropped",
+    CollectorStatus.MID_RUN_LOSS: "{dropped} event(s) dropped mid-run",
+}
+
+
+def _elapsed_seconds(outcome: CollectorOutcome) -> float:
+    """Return the collector's observed run duration in seconds (0.0 if unparseable)."""
+    try:
+        start = datetime.fromisoformat(outcome.started_at.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(outcome.finished_at.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return 0.0
+    return max(0.0, (end - start).total_seconds())
+
+
+def _effective_status(outcome: CollectorOutcome, *, content, binding: CaptureBinding) -> CollectorStatus:
+    """Downgrade a reported OK to a limit/loss status the coordinator enforces.
+
+    The binding's admitted duration, artifact-count, and byte limits are ALL
+    enforced here (not just the byte quota the content store applied): an
+    over-duration run is a ``TIMEOUT``, an over-byte or over-count capture is a
+    ``TRUNCATION``, and any mid-run drop is a ``MID_RUN_LOSS``. Each is a hard
+    failure the disposition invalidates unless the policy accepted the
+    degradation — a dropped-event capture is never silently OK / seal-ready.
+    """
+    limits = binding.limits
+    if _elapsed_seconds(outcome) > limits.max_duration_s:
+        return CollectorStatus.TIMEOUT
+    if content.truncated or outcome.event_count > limits.max_artifact_count:
+        return CollectorStatus.TRUNCATION
+    if outcome.dropped_count > 0:
+        return CollectorStatus.MID_RUN_LOSS
+    return outcome.status
+
+
+def _loss_disclosure(outcome: CollectorOutcome, *, effective_status: CollectorStatus, redaction_state: str) -> str | None:
+    """Return a mandatory, bounded loss/redaction disclosure, or ``None`` when there is nothing to disclose.
+
+    A limit/loss status (timeout, truncation, mid-run loss) always discloses;
+    otherwise a redacted/withheld record discloses; a lossless, un-redacted,
+    participant-visible record needs none.
+    """
+    status_text = _STATUS_DISCLOSURES.get(effective_status)
+    if status_text is not None:
+        return status_text.format(dropped=outcome.dropped_count)
+    return _REDACTION_DISCLOSURES.get(redaction_state)

--- a/src/aptl/core/evidence/adapters/__init__.py
+++ b/src/aptl/core/evidence/adapters/__init__.py
@@ -1,1 +1,6 @@
-"""Trusted, code-owned collector adapters wrapping the existing source owners\n(collectors.py / DeploymentBackend / SOC clients / MCP / Kali sidecar)."""
+"""Trusted, code-owned collector adapters.
+
+Wrap the existing source owners (``collectors.py`` / ``DeploymentBackend`` /
+SOC clients / MCP / Kali sidecar) at the level where a failure is
+distinguishable from legitimate emptiness.
+"""

--- a/src/aptl/core/evidence/adapters/__init__.py
+++ b/src/aptl/core/evidence/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Trusted, code-owned collector adapters wrapping the existing source owners\n(collectors.py / DeploymentBackend / SOC clients / MCP / Kali sidecar)."""

--- a/src/aptl/core/evidence/adapters/builtins.py
+++ b/src/aptl/core/evidence/adapters/builtins.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Sequence
+from pathlib import Path
 
 from aptl.core.evidence.adapters.sources import CallableWindowedSource, SourceResult, WindowedSource
 from aptl.core.evidence.outcomes import CollectorStatus
@@ -45,10 +46,11 @@ class RunArchiveSource:
 
     def fetch(self, start_iso: str, end_iso: str) -> SourceResult:
         """Read the subtree's JSONL records (the window is the run's own scope)."""
-        del start_iso, end_iso  # the archive subtree is already run-scoped
+        # The archive subtree is already run-scoped, so the window is unused.
+        del start_iso, end_iso
         try:
             subtree = self._run_store.get_run_path(self._run_id) / self._subdir
-        except Exception:  # noqa: BLE001 - a bad run id is a source-availability problem
+        except Exception:
             return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
         if not subtree.is_dir():
             return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
@@ -73,13 +75,13 @@ class ContainerLogSource:
 
     def fetch(self, start_iso: str, end_iso: str) -> SourceResult:
         """Capture each container's window of logs, distinguishing failure from empty."""
-        records: list[dict] = []
+        records: list[dict[str, object]] = []
         for container in self._containers:
             try:
                 result = self._backend.container_logs_capture(
                     container, since=start_iso, until=end_iso, timeout=30
                 )
-            except Exception:  # noqa: BLE001 - backend error is a distinct availability failure
+            except Exception:
                 return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
             if result.returncode != 0:
                 return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
@@ -90,7 +92,7 @@ class ContainerLogSource:
         return SourceResult(status=status, records=records)
 
 
-def soc_windowed_source(query: Callable[[str, str], list | None]) -> WindowedSource:
+def soc_windowed_source(query: Callable[[str, str], list[dict[str, object]] | None]) -> WindowedSource:
     """Adapt a SOC query returning ``list`` (events) or ``None`` (transport failure).
 
     ``None`` — what the ``curl_safe`` boundary returns on an HTTP/transport
@@ -109,9 +111,9 @@ def soc_windowed_source(query: Callable[[str, str], list | None]) -> WindowedSou
     return CallableWindowedSource(_fetch)
 
 
-def _read_jsonl_tree(subtree) -> tuple[list[dict], int]:
+def _read_jsonl_tree(subtree: Path) -> tuple[list[dict[str, object]], int]:
     """Return (records, dropped_count) for every valid JSON line under ``subtree``."""
-    records: list[dict] = []
+    records: list[dict[str, object]] = []
     dropped = 0
     for path in sorted(subtree.rglob("*.jsonl")):
         if not path.is_file():

--- a/src/aptl/core/evidence/adapters/builtins.py
+++ b/src/aptl/core/evidence/adapters/builtins.py
@@ -1,0 +1,127 @@
+"""Concrete built-in windowed sources (EXP-010 / issue #752 PR 2).
+
+Each wraps a source owner at the level where the failure signal actually
+exists — so a source failure is a distinct
+:class:`~aptl.core.evidence.adapters.sources.SourceResult` status, never the
+empty-on-error collapse the raw ``collectors.py`` helpers use:
+
+* :class:`RunArchiveSource` — sources already written to the run archive (the
+  MCP-side red-activity JSONL, Kali-side harvest): a MISSING subtree is
+  ``SOURCE_UNAVAILABLE``, a present-but-empty subtree is ``EMPTY_OK``.
+* :class:`ContainerLogSource` — ``DeploymentBackend.container_logs_capture``: a
+  non-zero returncode is ``SOURCE_UNAVAILABLE``, empty output is ``EMPTY_OK``.
+* :func:`soc_windowed_source` — a SOC ``curl_safe`` query whose function
+  returns ``None`` on transport failure (distinct from ``[]`` for no events).
+
+Live wiring of these against a running lab is EXECUTION (#437/#459); the source
+owners are adapted here, never duplicated or bypassed.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+
+from aptl.core.evidence.adapters.sources import CallableWindowedSource, SourceResult, WindowedSource
+from aptl.core.evidence.outcomes import CollectorStatus
+from aptl.core.runstore import RunStorageBackend
+
+
+class RunArchiveSource:
+    """A windowed source reading run-scoped JSONL already written to the archive.
+
+    The subtree ``<run_id>/<subdir>/`` is enumerated for ``*.jsonl`` files;
+    each valid JSON line is one record. A missing subtree means the source
+    never wrote (``SOURCE_UNAVAILABLE``); an empty one means it ran and
+    produced nothing (``EMPTY_OK``). Malformed lines are dropped and counted so
+    the loss is disclosed, never silently swallowed.
+    """
+
+    def __init__(self, run_store: RunStorageBackend, run_id: str, subdir: str) -> None:
+        """Bind to a run store, run id, and the archive subtree to read."""
+        self._run_store = run_store
+        self._run_id = run_id
+        self._subdir = subdir
+
+    def fetch(self, start_iso: str, end_iso: str) -> SourceResult:
+        """Read the subtree's JSONL records (the window is the run's own scope)."""
+        del start_iso, end_iso  # the archive subtree is already run-scoped
+        try:
+            subtree = self._run_store.get_run_path(self._run_id) / self._subdir
+        except Exception:  # noqa: BLE001 - a bad run id is a source-availability problem
+            return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
+        if not subtree.is_dir():
+            return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
+        records, dropped = _read_jsonl_tree(subtree)
+        status = CollectorStatus.OK if records else CollectorStatus.EMPTY_OK
+        return SourceResult(status=status, records=records, dropped_count=dropped)
+
+
+class ContainerLogSource:
+    """A windowed source over ``DeploymentBackend.container_logs_capture``.
+
+    A non-zero returncode (or a backend error) for any container is a
+    ``SOURCE_UNAVAILABLE`` — the returncode is the distinct failure signal the
+    raw ``collect_container_logs`` helper discards. Each captured container's
+    output becomes one ``{container, output}`` record.
+    """
+
+    def __init__(self, backend: object, containers: Sequence[str]) -> None:
+        """Bind to a DeploymentBackend and the containers whose logs to capture."""
+        self._backend = backend
+        self._containers = tuple(containers)
+
+    def fetch(self, start_iso: str, end_iso: str) -> SourceResult:
+        """Capture each container's window of logs, distinguishing failure from empty."""
+        records: list[dict] = []
+        for container in self._containers:
+            try:
+                result = self._backend.container_logs_capture(
+                    container, since=start_iso, until=end_iso, timeout=30
+                )
+            except Exception:  # noqa: BLE001 - backend error is a distinct availability failure
+                return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
+            if result.returncode != 0:
+                return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
+            output = (result.stdout or "").strip()
+            if output:
+                records.append({"container": container, "output": output})
+        status = CollectorStatus.OK if records else CollectorStatus.EMPTY_OK
+        return SourceResult(status=status, records=records)
+
+
+def soc_windowed_source(query: Callable[[str, str], list | None]) -> WindowedSource:
+    """Adapt a SOC query returning ``list`` (events) or ``None`` (transport failure).
+
+    ``None`` — what the ``curl_safe`` boundary returns on an HTTP/transport
+    error — is mapped to ``SOURCE_UNAVAILABLE`` (distinct from ``[]`` for no
+    events); the query is never called for its executable identity.
+    """
+
+    def _fetch(start_iso: str, end_iso: str) -> SourceResult:
+        """Run the SOC query, mapping ``None`` (transport failure) to unavailable."""
+        result = query(start_iso, end_iso)
+        if result is None:
+            return SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE)
+        status = CollectorStatus.OK if result else CollectorStatus.EMPTY_OK
+        return SourceResult(status=status, records=list(result))
+
+    return CallableWindowedSource(_fetch)
+
+
+def _read_jsonl_tree(subtree) -> tuple[list[dict], int]:
+    """Return (records, dropped_count) for every valid JSON line under ``subtree``."""
+    records: list[dict] = []
+    dropped = 0
+    for path in sorted(subtree.rglob("*.jsonl")):
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                records.append(json.loads(stripped))
+            except json.JSONDecodeError:
+                dropped += 1
+    return records, dropped

--- a/src/aptl/core/evidence/adapters/sources.py
+++ b/src/aptl/core/evidence/adapters/sources.py
@@ -1,0 +1,133 @@
+"""Windowed-query collector framework for trusted built-in sources (EXP-010 /
+issue #752 preflight "Narrow collector boundary").
+
+Most APTL evidence sources are windowed queries: given the trial's start/stop
+observation window, return the events in it. :class:`WindowedQueryCollector`
+is the one generic :class:`~aptl.core.evidence.protocol.Collector` for all of
+them — it stamps the window from the injected clock, calls a narrow
+:class:`WindowedSource`, and maps the source's typed
+:class:`SourceResult` onto a :class:`~aptl.core.evidence.protocol.
+CollectorOutcome`. A source reports OK / legitimately-empty / a distinct
+failure — the empty-on-error collapse of ``collectors.py`` is never allowed to
+read as success.
+
+A :class:`WindowedSource` is the ONLY thing a collector talks to; it wraps a
+source owner (``DeploymentBackend``, a SOC ``curl_safe`` client, the run
+archive) at the level where the failure signal exists, and is injected by
+trusted composition code — never selected by experiment input.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from aptl.core.evidence.outcomes import SUCCESS_STATUSES, CollectorStatus
+from aptl.core.evidence.protocol import CollectorContext, CollectorOutcome
+
+
+@dataclass(frozen=True)
+class SourceResult:
+    """One windowed source's typed result.
+
+    ``status`` distinguishes a real capture / legitimate emptiness from each
+    failure the source can detect (a returncode, a ``None`` HTTP result, a
+    missing archive file). ``records`` are structured events the coordinator
+    will serialize + redact; an over-limit source reports :attr:`dropped_count`
+    rather than silently losing events.
+    """
+
+    status: CollectorStatus
+    records: list[dict] = field(default_factory=list)
+    dropped_count: int = 0
+    source_min_time: str | None = None
+    source_max_time: str | None = None
+
+
+@runtime_checkable
+class WindowedSource(Protocol):
+    """A narrow, source-owned windowed query returning a typed result."""
+
+    def fetch(self, start_iso: str, end_iso: str) -> SourceResult:
+        """Return the source's events in ``[start_iso, end_iso]`` as a typed result."""
+        ...
+
+
+@dataclass(frozen=True)
+class _WindowHandle:
+    """Opaque per-start handle: the window's start time + the observation clock."""
+
+    started_at: str
+    clock: object
+
+
+class CallableWindowedSource:
+    """Adapt a plain ``fetch(start, end) -> SourceResult`` callable to a source.
+
+    Lets a concrete built-in source be a thin function (or a bound method of a
+    source owner) rather than a class, while keeping the narrow protocol.
+    """
+
+    def __init__(self, fetch) -> None:
+        """Wrap a ``fetch(start_iso, end_iso) -> SourceResult`` callable."""
+        self._fetch = fetch
+
+    def fetch(self, start_iso: str, end_iso: str) -> SourceResult:
+        """Delegate to the wrapped callable."""
+        return self._fetch(start_iso, end_iso)
+
+
+class WindowedQueryCollector:
+    """The generic collector for a windowed source (media type ``application/json``).
+
+    ``registration_id`` must match the pinned binding's; the coordinator
+    verifies it. ``start`` records the window open from the injected clock and
+    ``stop`` closes it, queries the source, and maps the typed result — a
+    source failure becomes a distinct :class:`CollectorStatus`, never an empty
+    success.
+    """
+
+    def __init__(self, registration_id: str, source: WindowedSource) -> None:
+        """Bind this collector to its registration id and windowed source."""
+        self._registration_id = registration_id
+        self._source = source
+
+    @property
+    def registration_id(self) -> str:
+        """The registration this collector realizes."""
+        return self._registration_id
+
+    def start(self, context: CollectorContext) -> _WindowHandle:
+        """Open the observation window from the injected clock."""
+        return _WindowHandle(started_at=context.clock.now(), clock=context.clock)
+
+    def stop(self, handle: _WindowHandle) -> CollectorOutcome:
+        """Close the window, query the source, and map its typed result."""
+        finished_at = handle.clock.now()
+        result = self._source.fetch(handle.started_at, finished_at)
+        return self._to_outcome(result, handle.started_at, finished_at)
+
+    def _to_outcome(self, result: SourceResult, started_at: str, finished_at: str) -> CollectorOutcome:
+        """Map a :class:`SourceResult` to a :class:`CollectorOutcome`."""
+        if result.status not in SUCCESS_STATUSES:
+            return CollectorOutcome(
+                status=result.status,
+                started_at=started_at,
+                finished_at=finished_at,
+                dropped_count=result.dropped_count,
+                detail=f"source reported {result.status.value}",
+            )
+        status = CollectorStatus.OK if result.records else CollectorStatus.EMPTY_OK
+        chunks = [json.dumps(result.records, separators=(",", ":")).encode("utf-8")]
+        return CollectorOutcome(
+            status=status,
+            started_at=started_at,
+            finished_at=finished_at,
+            chunks=chunks,
+            media_type="application/json",
+            event_count=len(result.records),
+            dropped_count=result.dropped_count,
+            source_min_time=result.source_min_time,
+            source_max_time=result.source_max_time,
+        )

--- a/src/aptl/core/evidence/adapters/sources.py
+++ b/src/aptl/core/evidence/adapters/sources.py
@@ -20,6 +20,7 @@ trusted composition code — never selected by experiment input.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
@@ -39,7 +40,7 @@ class SourceResult:
     """
 
     status: CollectorStatus
-    records: list[dict] = field(default_factory=list)
+    records: list[dict[str, object]] = field(default_factory=list)
     dropped_count: int = 0
     source_min_time: str | None = None
     source_max_time: str | None = None
@@ -69,7 +70,7 @@ class CallableWindowedSource:
     source owner) rather than a class, while keeping the narrow protocol.
     """
 
-    def __init__(self, fetch) -> None:
+    def __init__(self, fetch: Callable[[str, str], SourceResult]) -> None:
         """Wrap a ``fetch(start_iso, end_iso) -> SourceResult`` callable."""
         self._fetch = fetch
 
@@ -98,7 +99,8 @@ class WindowedQueryCollector:
         """The registration this collector realizes."""
         return self._registration_id
 
-    def start(self, context: CollectorContext) -> _WindowHandle:
+    @staticmethod
+    def start(context: CollectorContext) -> _WindowHandle:
         """Open the observation window from the injected clock."""
         return _WindowHandle(started_at=context.clock.now(), clock=context.clock)
 
@@ -106,28 +108,34 @@ class WindowedQueryCollector:
         """Close the window, query the source, and map its typed result."""
         finished_at = handle.clock.now()
         result = self._source.fetch(handle.started_at, finished_at)
-        return self._to_outcome(result, handle.started_at, finished_at)
+        return _to_outcome(result, handle.started_at, finished_at)
 
-    def _to_outcome(self, result: SourceResult, started_at: str, finished_at: str) -> CollectorOutcome:
-        """Map a :class:`SourceResult` to a :class:`CollectorOutcome`."""
-        if result.status not in SUCCESS_STATUSES:
-            return CollectorOutcome(
-                status=result.status,
-                started_at=started_at,
-                finished_at=finished_at,
-                dropped_count=result.dropped_count,
-                detail=f"source reported {result.status.value}",
-            )
-        status = CollectorStatus.OK if result.records else CollectorStatus.EMPTY_OK
-        chunks = [json.dumps(result.records, separators=(",", ":")).encode("utf-8")]
+
+def _to_outcome(result: SourceResult, started_at: str, finished_at: str) -> CollectorOutcome:
+    """Map a :class:`SourceResult` to a :class:`CollectorOutcome`.
+
+    A source failure passes through without chunks; a success serializes the
+    structured records to ``application/json`` (empty records are a legitimate
+    ``EMPTY_OK``, never a failure).
+    """
+    if result.status not in SUCCESS_STATUSES:
         return CollectorOutcome(
-            status=status,
+            status=result.status,
             started_at=started_at,
             finished_at=finished_at,
-            chunks=chunks,
-            media_type="application/json",
-            event_count=len(result.records),
             dropped_count=result.dropped_count,
-            source_min_time=result.source_min_time,
-            source_max_time=result.source_max_time,
+            detail=f"source reported {result.status.value}",
         )
+    status = CollectorStatus.OK if result.records else CollectorStatus.EMPTY_OK
+    chunks = [json.dumps(result.records, separators=(",", ":")).encode("utf-8")]
+    return CollectorOutcome(
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+        chunks=chunks,
+        media_type="application/json",
+        event_count=len(result.records),
+        dropped_count=result.dropped_count,
+        source_min_time=result.source_min_time,
+        source_max_time=result.source_max_time,
+    )

--- a/src/aptl/core/evidence/adapters/wiring.py
+++ b/src/aptl/core/evidence/adapters/wiring.py
@@ -1,0 +1,39 @@
+"""Trusted adapter wiring for the built-in collector fleet (EXP-010 / #752).
+
+This is the trusted composition code that maps a non-executable
+``registration_id`` to a live :class:`~aptl.core.evidence.protocol.Collector`
+— the ONE place where declared capability becomes a running collector.
+Experiment input never reaches here: the caller (execution / #437 / #459, or a
+test) constructs the narrow :class:`~aptl.core.evidence.adapters.sources.
+WindowedSource`s from the real source owners and hands them in keyed by
+registration id. Only ids in the built-in fleet are accepted — an unknown id
+fails closed rather than resolving to anything.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from aptl.core.evidence.adapters.sources import WindowedQueryCollector, WindowedSource
+from aptl.core.evidence.protocol import Collector
+from aptl.core.experiment.capture_registrations import BUILTIN_REGISTRATIONS
+
+#: The registration ids the built-in wiring will bind a collector for.
+BUILTIN_REGISTRATION_IDS: frozenset[str] = frozenset(
+    registration.registration_id for registration in BUILTIN_REGISTRATIONS
+)
+
+
+def build_collectors(sources: Mapping[str, WindowedSource]) -> dict[str, Collector]:
+    """Wire each provided windowed source to its generic collector, keyed by registration id.
+
+    Raises :class:`ValueError` for a registration id outside the built-in
+    fleet — the coordinator then has no collector for an unrecognized binding
+    and reports it as unavailable, never silently resolving it.
+    """
+    collectors: dict[str, Collector] = {}
+    for registration_id, source in sources.items():
+        if registration_id not in BUILTIN_REGISTRATION_IDS:
+            raise ValueError(f"unknown collector registration id: {registration_id!r}")
+        collectors[registration_id] = WindowedQueryCollector(registration_id, source)
+    return collectors

--- a/src/aptl/core/evidence/content_store.py
+++ b/src/aptl/core/evidence/content_store.py
@@ -1,0 +1,136 @@
+"""Content-addressed + run-scoped create-once evidence persistence (EXP-010 /
+issue #752 preflight "Evidence ownership and persistence").
+
+The preflight requires the ``RunStorageBackend`` boundary to be EXTENDED
+narrowly for streamed content-addressed blob insertion and run-scoped
+create-once canonical JSON — NOT a second evidence repository beside
+``LocalRunStore``. These functions are that narrow extension: they operate on
+the injected store (via its public ``base_dir`` / ``get_run_path``) and reuse
+the store's own ID/path validation, canonicalization, secret-invariant, and
+no-follow/create-exclusive primitives. The coordinator derives every location
+from a validated id + the computed digest; a plugin never supplies a path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from aptl.core.runstore import (
+    LocalRunStore,
+    RunStoreConflictError,
+    _assert_no_secret_drift,
+    _canonicalize_payload,
+    _validate_id,
+    _validate_relative_path,
+)
+from aptl.utils.pathsafe import create_exclusive_nofollow, read_contained_nofollow
+
+
+@dataclass(frozen=True)
+class ContentInsertion:
+    """The result of a content-addressed evidence blob insertion.
+
+    ``relative_path`` is the run-relative POSIX path of the stored object
+    (``<subdir>/<sha256-hex>``); ``digest`` is its ``sha256:<hex>`` prefixed
+    digest; ``size`` is the bytes actually retained; ``truncated`` is ``True``
+    when the source exceeded the byte quota and only the first ``size`` bytes
+    were kept (a distinct, disclosed outcome — never a silent drop).
+    """
+
+    relative_path: str
+    digest: str
+    size: int
+    truncated: bool
+
+
+def _accumulate_bounded(chunks: Iterable[bytes], max_bytes: int) -> tuple[bytes, bool]:
+    """Accumulate ``chunks`` up to ``max_bytes``; return ``(bytes, truncated)``.
+
+    The quota is enforced during iteration so an over-quota source is never
+    buffered unbounded. Truncation is detected precisely — an over-filling
+    chunk sets it directly; an exact fill peeks at most ONE further chunk
+    (never draining the rest) to tell "ended at the cap" from "more dropped".
+    """
+    buf = bytearray()
+    truncated = False
+    iterator = iter(chunks)
+    for chunk in iterator:
+        space = max_bytes - len(buf)
+        if len(chunk) < space:
+            buf.extend(chunk)
+            continue
+        buf.extend(chunk[:space])
+        truncated = len(chunk) > space or next(iterator, None) is not None
+        break
+    return bytes(buf), truncated
+
+
+def create_content_addressed(
+    store: LocalRunStore, run_id: str, chunks: Iterable[bytes], *, subdir: str, max_bytes: int
+) -> ContentInsertion:
+    """Stream ``chunks`` into a content-addressed blob under ``<run_id>/<subdir>/<sha256-hex>``.
+
+    Enforces the byte quota WHILE streaming (over-quota input is truncated, not
+    buffered unbounded), publishes descriptor-relative / no-follow /
+    create-exclusive, and re-reads + re-verifies the stored object's digest and
+    size. A repeated digest is idempotent only when the existing bytes agree; a
+    collision with different bytes fails closed.
+    """
+    safe_run_id = _validate_id(run_id, "run_id")
+    safe_subdir = _validate_relative_path(subdir)
+    if max_bytes <= 0:
+        raise ValueError("create_content_addressed max_bytes must be positive")
+
+    data, truncated = _accumulate_bounded(chunks, max_bytes)
+    digest_hex = hashlib.sha256(data).hexdigest()
+    relative_path = f"{safe_subdir}/{digest_hex}"
+    rel = f"{safe_run_id}/{relative_path}"
+
+    base_dir = store.base_dir
+    base_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        create_exclusive_nofollow(base_dir, rel, data)
+    except FileExistsError:
+        if read_contained_nofollow(base_dir, rel) != data:
+            raise RunStoreConflictError(
+                f"create_content_addressed digest collision with different bytes: {run_id}/{relative_path}"
+            ) from None
+
+    stored = read_contained_nofollow(base_dir, rel)
+    if len(stored) != len(data) or hashlib.sha256(stored).hexdigest() != digest_hex:
+        raise RunStoreConflictError(
+            f"create_content_addressed post-write verification failed: {run_id}/{relative_path}"
+        )
+    return ContentInsertion(
+        relative_path=relative_path, digest=f"sha256:{digest_hex}", size=len(data), truncated=truncated
+    )
+
+
+def create_run_json_once(store: LocalRunStore, run_id: str, relative_path: str, payload: object) -> Path:
+    """Create-once, canonical, no-follow JSON persistence UNDER the run dir.
+
+    Like the store's ``create_json_once`` but run-scoped, so the evidence
+    ledger travels in the exporter's per-run tar. Same secret invariant,
+    RFC-8785 canonicalization, and idempotent-on-byte-match semantics; a
+    differing existing target raises :class:`RunStoreConflictError`.
+    """
+    safe_run_id = _validate_id(run_id, "run_id")
+    safe_rel = _validate_relative_path(relative_path)
+    canonical, normalized = _canonicalize_payload(payload)
+    _assert_no_secret_drift(normalized)
+
+    base_dir = store.base_dir
+    base_dir.mkdir(parents=True, exist_ok=True)
+    rel = f"{safe_run_id}/{safe_rel}"
+    target = store.get_run_path(run_id) / safe_rel
+    try:
+        create_exclusive_nofollow(base_dir, rel, canonical)
+    except FileExistsError:
+        if read_contained_nofollow(base_dir, rel) != canonical:
+            raise RunStoreConflictError(
+                f"create_run_json_once target already exists with different content: {run_id}/{relative_path}"
+            ) from None
+    return target

--- a/src/aptl/core/evidence/coordinator.py
+++ b/src/aptl/core/evidence/coordinator.py
@@ -1,0 +1,343 @@
+"""The evidence-acquisition coordinator (EXP-010 / issue #752 preflight
+"Lifecycle and terminal semantics").
+
+``acquire_evidence`` drives a set of admitted :class:`~aptl.core.experiment.
+capture_registry.CaptureBinding`s against their trusted collectors around a
+trial body:
+
+1. START each admitted collector (after its source is ready) — a startup
+   failure aborts before the trial body and still runs cleanup.
+2. Run the trial body (participant actions / workflows — supplied by the
+   caller; in EXP-010 PR 2 exercised with fakes, wired live by #437/#459).
+3. STOP collectors in REVERSE order from a ``finally`` boundary, even when the
+   trial body or another collector fails.
+4. Bound / redact / hash / persist each captured outcome content-addressably
+   and construct ACES evidence records + explicit references.
+5. Compute the overall :class:`~aptl.core.evidence.outcomes.
+   AcquisitionDisposition`; only ``SEALED_READY`` is ready for the #444 seal.
+
+The coordinator owns deadlines, quotas, clock, path allocation, hashing,
+redaction, media checks, persistence, diagnostics, and record construction; a
+collector only reports typed bytes/counters/failures. Collector failures are
+typed outcome DATA projected into safe ACES diagnostics — no second exception
+hierarchy, and no overloading of ``LabResult`` startup readiness.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+from aces_contracts.contracts import ExperimentEvidenceRecordModel
+from aces_contracts.diagnostics import Diagnostic
+
+from aptl.core.correlation.clock import ClockProvider
+from aptl.core.evidence._persist import EvidenceRef, media_type_supported, persist_success_outcome
+from aptl.core.evidence.outcomes import (
+    STATUS_DIAGNOSTIC_CODES,
+    SUCCESS_STATUSES,
+    AcquisitionDisposition,
+    CollectorStatus,
+    capture_diagnostic,
+)
+from aptl.core.evidence.protocol import Collector, CollectorContext, CollectorOutcome
+from aptl.core.experiment.capture_registry import CaptureBinding
+
+#: Statuses that abort the attempt before participant action (source never
+#: came up), yielding an INCONCLUSIVE disposition.
+_ABORTING_STATUSES: frozenset[CollectorStatus] = frozenset(
+    {CollectorStatus.SOURCE_UNAVAILABLE, CollectorStatus.STARTUP_FAILURE}
+)
+
+#: Statuses that invalidate a REQUIRED capture unless the policy explicitly
+#: accepted the degradation.
+_HARD_FAILURE_STATUSES: frozenset[CollectorStatus] = frozenset(
+    {
+        CollectorStatus.MID_RUN_LOSS,
+        CollectorStatus.TRUNCATION,
+        CollectorStatus.CLOCK_SKEW,
+        CollectorStatus.TIMEOUT,
+        CollectorStatus.FINALIZATION_FAILURE,
+    }
+)
+
+_CODE_NO_COLLECTOR = "aptl.experiment-capture.no-collector-for-binding"
+_CODE_REGISTRATION_MISMATCH = "aptl.experiment-capture.collector-registration-mismatch"
+_CODE_MEDIA_MISMATCH = "aptl.experiment-capture.media-type-mismatch"
+
+
+@dataclass(frozen=True)
+class CollectorReport:
+    """The per-binding acquisition report (a projection safe for diagnostics)."""
+
+    registration_id: str
+    requirement_id: str
+    status: CollectorStatus
+    accepted_degradation: bool
+    evidence_record_id: str | None = None
+    diagnostic_code: str | None = None
+
+
+@dataclass(frozen=True)
+class AcquisitionResult:
+    """The one-shot result of :func:`acquire_evidence` for one trial's capture set."""
+
+    disposition: AcquisitionDisposition
+    records: tuple[ExperimentEvidenceRecordModel, ...]
+    refs: tuple[EvidenceRef, ...]
+    reports: tuple[CollectorReport, ...]
+    diagnostics: tuple[Diagnostic, ...]
+
+
+@dataclass(frozen=True)
+class _Started:
+    """A collector that started successfully, plus its binding and opaque handle."""
+
+    binding: CaptureBinding
+    collector: Collector
+    handle: object
+
+
+def _binding_key(binding: CaptureBinding) -> tuple[str, str]:
+    """Return a binding's capture-spec-scoped identity.
+
+    Keying per-binding acquisition state by the bare ``requirement_id`` would
+    let two bindings from DIFFERENT capture specs that reuse a requirement id
+    overwrite each other's outcome; the ``(capture_spec_id, requirement_id)``
+    pair is unique within one admitted plan.
+    """
+    return (binding.capture_spec_id, binding.requirement_id)
+
+
+def _context(
+    binding: CaptureBinding, *, run_id: str, planned_trial_id: str, attempt_id: str, clock: ClockProvider
+) -> CollectorContext:
+    """Build the narrow immutable context handed to a collector at start."""
+    return CollectorContext(
+        planned_trial_id=planned_trial_id,
+        run_id=run_id,
+        attempt_id=attempt_id,
+        binding=binding,
+        deadline_seconds=float(binding.limits.max_duration_s),
+        clock=clock,
+    )
+
+
+def _failed_outcome(status: CollectorStatus, clock: ClockProvider, detail: str) -> CollectorOutcome:
+    """Build a typed failure outcome stamped with the coordinator's observation clock."""
+    now = clock.now()
+    return CollectorOutcome(status=status, started_at=now, finished_at=now, detail=detail)
+
+
+def _start_all(
+    plan: Sequence[tuple[CaptureBinding, Collector]],
+    *,
+    run_id: str,
+    planned_trial_id: str,
+    attempt_id: str,
+    clock: ClockProvider,
+) -> tuple[list[_Started], dict[tuple[str, str], CollectorOutcome]]:
+    """Start collectors in order; on the first startup failure, stop early.
+
+    Returns the successfully-started collectors and a map of binding key ->
+    startup-failure outcome for the collectors that never started (the failing
+    one plus every one after it).
+    """
+    started: list[_Started] = []
+    not_started: dict[tuple[str, str], CollectorOutcome] = {}
+    aborted = False
+    for binding, collector in plan:
+        if aborted:
+            not_started[_binding_key(binding)] = _failed_outcome(
+                CollectorStatus.STARTUP_FAILURE, clock, "not started (an earlier collector failed to start)"
+            )
+            continue
+        context = _context(
+            binding, run_id=run_id, planned_trial_id=planned_trial_id, attempt_id=attempt_id, clock=clock
+        )
+        try:
+            handle = collector.start(context)
+        except Exception:  # noqa: BLE001 - normalized to a typed outcome, never re-raised
+            not_started[_binding_key(binding)] = _failed_outcome(
+                CollectorStatus.STARTUP_FAILURE, clock, "collector raised during start"
+            )
+            aborted = True
+            continue
+        started.append(_Started(binding=binding, collector=collector, handle=handle))
+    return started, not_started
+
+
+def _stop_all(started: Sequence[_Started], clock: ClockProvider) -> dict[tuple[str, str], CollectorOutcome]:
+    """Stop started collectors in REVERSE order; a stop raising becomes a finalization failure."""
+    outcomes: dict[tuple[str, str], CollectorOutcome] = {}
+    for entry in reversed(started):
+        try:
+            outcome = entry.collector.stop(entry.handle)
+        except Exception:  # noqa: BLE001 - normalized to a typed outcome, never re-raised
+            outcome = _failed_outcome(
+                CollectorStatus.FINALIZATION_FAILURE, clock, "collector raised during stop"
+            )
+        outcomes[_binding_key(entry.binding)] = outcome
+    return outcomes
+
+
+def _resolve_plan(
+    bindings: Sequence[CaptureBinding], collectors: Mapping[str, Collector]
+) -> tuple[list[tuple[CaptureBinding, Collector]], list[Diagnostic], dict[tuple[str, str], CollectorOutcome]]:
+    """Pair each binding with its collector, verifying the pinned registration id.
+
+    A missing or mismatched collector is a coordinator wiring fault, not an
+    experiment-input failure: it yields a diagnostic + a SOURCE_UNAVAILABLE
+    outcome for that binding (INCONCLUSIVE), never a silent skip.
+    """
+    plan: list[tuple[CaptureBinding, Collector]] = []
+    diagnostics: list[Diagnostic] = []
+    unavailable: dict[tuple[str, str], CollectorOutcome] = {}
+    for binding in bindings:
+        collector = collectors.get(binding.registration_id)
+        address = f"capture.{binding.capture_spec_id}.{binding.requirement_id}"
+        if collector is None:
+            diagnostics.append(capture_diagnostic(_CODE_NO_COLLECTOR, address, "no collector wired for the pinned registration"))
+            unavailable[_binding_key(binding)] = CollectorOutcome(
+                status=CollectorStatus.SOURCE_UNAVAILABLE, started_at="", finished_at="", detail="no collector"
+            )
+            continue
+        if collector.registration_id != binding.registration_id:
+            diagnostics.append(
+                capture_diagnostic(_CODE_REGISTRATION_MISMATCH, address, "collector registration id does not match the pinned binding")
+            )
+            unavailable[_binding_key(binding)] = CollectorOutcome(
+                status=CollectorStatus.SOURCE_UNAVAILABLE, started_at="", finished_at="", detail="registration mismatch"
+            )
+            continue
+        plan.append((binding, collector))
+    return plan, diagnostics, unavailable
+
+
+def _process_outcome(
+    binding: CaptureBinding,
+    outcome: CollectorOutcome,
+    *,
+    run_store: object,
+    run_id: str,
+    planned_trial_id: str,
+) -> tuple[CollectorReport, ExperimentEvidenceRecordModel | None, EvidenceRef | None, Diagnostic | None]:
+    """Turn one collector outcome into a report (+ record/ref for a success, + diagnostic for a failure)."""
+    accepted = binding.accepted_limitation is not None
+    if outcome.status not in SUCCESS_STATUSES:
+        code = STATUS_DIAGNOSTIC_CODES.get(outcome.status, "aptl.experiment-capture.unknown-failure")
+        address = f"capture.{binding.capture_spec_id}.{binding.requirement_id}"
+        diagnostic = capture_diagnostic(code, address, f"collector reported {outcome.status.value}")
+        report = CollectorReport(
+            registration_id=binding.registration_id,
+            requirement_id=binding.requirement_id,
+            status=outcome.status,
+            accepted_degradation=accepted,
+            diagnostic_code=code,
+        )
+        return report, None, None, diagnostic
+
+    if not media_type_supported(outcome, binding):
+        address = f"capture.{binding.capture_spec_id}.{binding.requirement_id}"
+        diagnostic = capture_diagnostic(_CODE_MEDIA_MISMATCH, address, "captured media type is not one the requirement expects")
+        report = CollectorReport(
+            registration_id=binding.registration_id,
+            requirement_id=binding.requirement_id,
+            status=CollectorStatus.MID_RUN_LOSS,
+            accepted_degradation=accepted,
+            diagnostic_code=_CODE_MEDIA_MISMATCH,
+        )
+        return report, None, None, diagnostic
+
+    processed = persist_success_outcome(
+        binding=binding,
+        outcome=outcome,
+        run_store=run_store,  # type: ignore[arg-type]
+        run_id=run_id,
+        planned_trial_id=planned_trial_id,
+        captured_at=outcome.finished_at,
+    )
+    report = CollectorReport(
+        registration_id=binding.registration_id,
+        requirement_id=binding.requirement_id,
+        status=processed.effective_status,
+        accepted_degradation=accepted,
+        evidence_record_id=processed.record.evidence_record_id,
+        diagnostic_code=(
+            STATUS_DIAGNOSTIC_CODES.get(processed.effective_status)
+            if processed.effective_status not in SUCCESS_STATUSES
+            else None
+        ),
+    )
+    return report, processed.record, processed.ref, None
+
+
+def _disposition(reports: Sequence[CollectorReport]) -> AcquisitionDisposition:
+    """Compute the overall disposition from the per-binding effective statuses."""
+    if any(r.status in _ABORTING_STATUSES for r in reports):
+        return AcquisitionDisposition.INCONCLUSIVE
+    partial = False
+    for report in reports:
+        if report.status in _HARD_FAILURE_STATUSES:
+            if not report.accepted_degradation:
+                return AcquisitionDisposition.INVALIDATED
+            partial = True
+    return AcquisitionDisposition.COMPLETED_PARTIAL if partial else AcquisitionDisposition.SEALED_READY
+
+
+def acquire_evidence(
+    *,
+    bindings: Sequence[CaptureBinding],
+    collectors: Mapping[str, Collector],
+    run_store: object,
+    run_id: str,
+    planned_trial_id: str,
+    attempt_id: str,
+    clock: ClockProvider,
+    trial_body: Callable[[], None] = lambda: None,
+) -> AcquisitionResult:
+    """Acquire evidence for one trial's admitted capture bindings.
+
+    ``trial_body`` is the work that runs while collectors are live (participant
+    actions / orchestrator workflows). It runs BETWEEN start and the reverse-
+    order stop; if it raises, collectors are still stopped (the raise is
+    swallowed here — the trial's own failure is the caller's concern, cleanup
+    is ours). Returns a one-shot :class:`AcquisitionResult`; nothing partial in
+    between.
+    """
+    plan, diagnostics, unavailable = _resolve_plan(bindings, collectors)
+    started, not_started = _start_all(
+        plan, run_id=run_id, planned_trial_id=planned_trial_id, attempt_id=attempt_id, clock=clock
+    )
+
+    if started:
+        try:
+            trial_body()
+        except Exception:  # noqa: BLE001 - the trial's failure is not the coordinator's to raise; cleanup still runs
+            pass
+    stop_outcomes = _stop_all(started, clock)
+
+    outcomes_by_key: dict[tuple[str, str], CollectorOutcome] = {**unavailable, **not_started, **stop_outcomes}
+    reports: list[CollectorReport] = []
+    records: list[ExperimentEvidenceRecordModel] = []
+    refs: list[EvidenceRef] = []
+    all_diagnostics: list[Diagnostic] = list(diagnostics)
+    for binding in bindings:
+        outcome = outcomes_by_key[_binding_key(binding)]
+        report, record, ref, diagnostic = _process_outcome(
+            binding, outcome, run_store=run_store, run_id=run_id, planned_trial_id=planned_trial_id
+        )
+        reports.append(report)
+        if record is not None and ref is not None:
+            records.append(record)
+            refs.append(ref)
+        if diagnostic is not None:
+            all_diagnostics.append(diagnostic)
+
+    return AcquisitionResult(
+        disposition=_disposition(reports),
+        records=tuple(records),
+        refs=tuple(refs),
+        reports=tuple(reports),
+        diagnostics=tuple(all_diagnostics),
+    )

--- a/src/aptl/core/evidence/coordinator.py
+++ b/src/aptl/core/evidence/coordinator.py
@@ -40,7 +40,7 @@ from aptl.core.evidence.outcomes import (
     CollectorStatus,
     capture_diagnostic,
 )
-from aptl.core.evidence.protocol import Collector, CollectorContext, CollectorOutcome
+from aptl.core.evidence.protocol import Collector, CollectorContext, CollectorOutcome, RunScope
 from aptl.core.experiment.capture_registry import CaptureBinding
 
 #: Statuses that abort the attempt before participant action (source never
@@ -64,6 +64,10 @@ _HARD_FAILURE_STATUSES: frozenset[CollectorStatus] = frozenset(
 _CODE_NO_COLLECTOR = "aptl.experiment-capture.no-collector-for-binding"
 _CODE_REGISTRATION_MISMATCH = "aptl.experiment-capture.collector-registration-mismatch"
 _CODE_MEDIA_MISMATCH = "aptl.experiment-capture.media-type-mismatch"
+
+_MSG_NO_COLLECTOR = "no collector wired for the pinned registration"
+_MSG_REGISTRATION_MISMATCH = "collector registration id does not match the pinned binding"
+_MSG_MEDIA_MISMATCH = "captured media type is not one the requirement expects"
 
 
 @dataclass(frozen=True)
@@ -109,14 +113,12 @@ def _binding_key(binding: CaptureBinding) -> tuple[str, str]:
     return (binding.capture_spec_id, binding.requirement_id)
 
 
-def _context(
-    binding: CaptureBinding, *, run_id: str, planned_trial_id: str, attempt_id: str, clock: ClockProvider
-) -> CollectorContext:
+def _context(binding: CaptureBinding, *, scope: RunScope, clock: ClockProvider) -> CollectorContext:
     """Build the narrow immutable context handed to a collector at start."""
     return CollectorContext(
-        planned_trial_id=planned_trial_id,
-        run_id=run_id,
-        attempt_id=attempt_id,
+        planned_trial_id=scope.planned_trial_id,
+        run_id=scope.run_id,
+        attempt_id=scope.attempt_id,
         binding=binding,
         deadline_seconds=float(binding.limits.max_duration_s),
         clock=clock,
@@ -130,12 +132,7 @@ def _failed_outcome(status: CollectorStatus, clock: ClockProvider, detail: str) 
 
 
 def _start_all(
-    plan: Sequence[tuple[CaptureBinding, Collector]],
-    *,
-    run_id: str,
-    planned_trial_id: str,
-    attempt_id: str,
-    clock: ClockProvider,
+    plan: Sequence[tuple[CaptureBinding, Collector]], *, scope: RunScope, clock: ClockProvider
 ) -> tuple[list[_Started], dict[tuple[str, str], CollectorOutcome]]:
     """Start collectors in order; on the first startup failure, stop early.
 
@@ -152,12 +149,10 @@ def _start_all(
                 CollectorStatus.STARTUP_FAILURE, clock, "not started (an earlier collector failed to start)"
             )
             continue
-        context = _context(
-            binding, run_id=run_id, planned_trial_id=planned_trial_id, attempt_id=attempt_id, clock=clock
-        )
+        context = _context(binding, scope=scope, clock=clock)
         try:
             handle = collector.start(context)
-        except Exception:  # noqa: BLE001 - normalized to a typed outcome, never re-raised
+        except Exception:
             not_started[_binding_key(binding)] = _failed_outcome(
                 CollectorStatus.STARTUP_FAILURE, clock, "collector raised during start"
             )
@@ -173,7 +168,7 @@ def _stop_all(started: Sequence[_Started], clock: ClockProvider) -> dict[tuple[s
     for entry in reversed(started):
         try:
             outcome = entry.collector.stop(entry.handle)
-        except Exception:  # noqa: BLE001 - normalized to a typed outcome, never re-raised
+        except Exception:
             outcome = _failed_outcome(
                 CollectorStatus.FINALIZATION_FAILURE, clock, "collector raised during stop"
             )
@@ -197,14 +192,14 @@ def _resolve_plan(
         collector = collectors.get(binding.registration_id)
         address = f"capture.{binding.capture_spec_id}.{binding.requirement_id}"
         if collector is None:
-            diagnostics.append(capture_diagnostic(_CODE_NO_COLLECTOR, address, "no collector wired for the pinned registration"))
+            diagnostics.append(capture_diagnostic(_CODE_NO_COLLECTOR, address, _MSG_NO_COLLECTOR))
             unavailable[_binding_key(binding)] = CollectorOutcome(
                 status=CollectorStatus.SOURCE_UNAVAILABLE, started_at="", finished_at="", detail="no collector"
             )
             continue
         if collector.registration_id != binding.registration_id:
             diagnostics.append(
-                capture_diagnostic(_CODE_REGISTRATION_MISMATCH, address, "collector registration id does not match the pinned binding")
+                capture_diagnostic(_CODE_REGISTRATION_MISMATCH, address, _MSG_REGISTRATION_MISMATCH)
             )
             unavailable[_binding_key(binding)] = CollectorOutcome(
                 status=CollectorStatus.SOURCE_UNAVAILABLE, started_at="", finished_at="", detail="registration mismatch"
@@ -219,8 +214,7 @@ def _process_outcome(
     outcome: CollectorOutcome,
     *,
     run_store: object,
-    run_id: str,
-    planned_trial_id: str,
+    scope: RunScope,
 ) -> tuple[CollectorReport, ExperimentEvidenceRecordModel | None, EvidenceRef | None, Diagnostic | None]:
     """Turn one collector outcome into a report (+ record/ref for a success, + diagnostic for a failure)."""
     accepted = binding.accepted_limitation is not None
@@ -239,7 +233,7 @@ def _process_outcome(
 
     if not media_type_supported(outcome, binding):
         address = f"capture.{binding.capture_spec_id}.{binding.requirement_id}"
-        diagnostic = capture_diagnostic(_CODE_MEDIA_MISMATCH, address, "captured media type is not one the requirement expects")
+        diagnostic = capture_diagnostic(_CODE_MEDIA_MISMATCH, address, _MSG_MEDIA_MISMATCH)
         report = CollectorReport(
             registration_id=binding.registration_id,
             requirement_id=binding.requirement_id,
@@ -253,8 +247,8 @@ def _process_outcome(
         binding=binding,
         outcome=outcome,
         run_store=run_store,  # type: ignore[arg-type]
-        run_id=run_id,
-        planned_trial_id=planned_trial_id,
+        run_id=scope.run_id,
+        planned_trial_id=scope.planned_trial_id,
         captured_at=outcome.finished_at,
     )
     report = CollectorReport(
@@ -290,9 +284,7 @@ def acquire_evidence(
     bindings: Sequence[CaptureBinding],
     collectors: Mapping[str, Collector],
     run_store: object,
-    run_id: str,
-    planned_trial_id: str,
-    attempt_id: str,
+    scope: RunScope,
     clock: ClockProvider,
     trial_body: Callable[[], None] = lambda: None,
 ) -> AcquisitionResult:
@@ -306,14 +298,12 @@ def acquire_evidence(
     between.
     """
     plan, diagnostics, unavailable = _resolve_plan(bindings, collectors)
-    started, not_started = _start_all(
-        plan, run_id=run_id, planned_trial_id=planned_trial_id, attempt_id=attempt_id, clock=clock
-    )
+    started, not_started = _start_all(plan, scope=scope, clock=clock)
 
     if started:
         try:
             trial_body()
-        except Exception:  # noqa: BLE001 - the trial's failure is not the coordinator's to raise; cleanup still runs
+        except Exception:
             pass
     stop_outcomes = _stop_all(started, clock)
 
@@ -325,7 +315,7 @@ def acquire_evidence(
     for binding in bindings:
         outcome = outcomes_by_key[_binding_key(binding)]
         report, record, ref, diagnostic = _process_outcome(
-            binding, outcome, run_store=run_store, run_id=run_id, planned_trial_id=planned_trial_id
+            binding, outcome, run_store=run_store, scope=scope
         )
         reports.append(report)
         if record is not None and ref is not None:

--- a/src/aptl/core/evidence/outcomes.py
+++ b/src/aptl/core/evidence/outcomes.py
@@ -1,0 +1,110 @@
+"""Terminal-outcome and reason-code taxonomy for evidence acquisition
+(EXP-010 / issue #752 preflight "Lifecycle and terminal semantics").
+
+The preflight requires **stable diagnostic/reason codes** that distinguish
+missing source, startup failure, mid-run loss, truncation, clock skew,
+timeout, and finalization failure "even where ACES terminal statuses
+coincide". This module owns that vocabulary as an enum plus a small set of
+capture-domain diagnostic codes, and the coordinator's overall
+:class:`AcquisitionDisposition` mapping. Collector failures are typed outcome
+DATA projected into ACES diagnostics — there is no second public exception
+hierarchy (preflight / ADR-047 "Error envelope").
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+
+from aptl.utils.redaction import redact
+
+#: Diagnostic domain for evidence-acquisition failures — distinct from
+#: EXP-002's ``experiment-admission`` domain so a consumer can tell an
+#: admission rejection from a capture/acquisition problem.
+EVIDENCE_CAPTURE_DOMAIN = "experiment-capture"
+
+#: Safe stage label for rendering acquisition diagnostics (mirrors
+#: ``errors.EXPERIMENT_ADMISSION_STAGE_LABEL``).
+EVIDENCE_CAPTURE_STAGE_LABEL = "Experiment evidence acquisition failed"
+
+
+class CollectorStatus(str, Enum):
+    """The distinct per-collector outcomes an adapter must preserve.
+
+    The empty-on-error collapse that ``collectors.py`` / MCP / sidecar
+    harvesters use for best-effort work is explicitly forbidden here: a
+    conformant adapter never reports :attr:`OK`/:attr:`EMPTY_OK` for a
+    failure. :attr:`EMPTY_OK` (a source that legitimately produced zero
+    events) is a SUCCESS distinct from every failure below.
+    """
+
+    OK = "ok"
+    EMPTY_OK = "empty-ok"
+    SOURCE_UNAVAILABLE = "source-unavailable"
+    STARTUP_FAILURE = "startup-failure"
+    MID_RUN_LOSS = "mid-run-loss"
+    TRUNCATION = "truncation"
+    CLOCK_SKEW = "clock-skew"
+    TIMEOUT = "timeout"
+    FINALIZATION_FAILURE = "finalization-failure"
+
+
+#: The statuses that represent a successfully captured (or legitimately
+#: empty) collector — everything else is a failure/limitation the coordinator
+#: must disposition explicitly.
+SUCCESS_STATUSES: frozenset[CollectorStatus] = frozenset(
+    {CollectorStatus.OK, CollectorStatus.EMPTY_OK}
+)
+
+#: One stable capture-domain diagnostic code per failure status. The raw
+#: value is never echoed; only these fixed codes reach a diagnostic.
+STATUS_DIAGNOSTIC_CODES: dict[CollectorStatus, str] = {
+    CollectorStatus.SOURCE_UNAVAILABLE: "aptl.experiment-capture.source-unavailable",
+    CollectorStatus.STARTUP_FAILURE: "aptl.experiment-capture.collector-startup-failure",
+    CollectorStatus.MID_RUN_LOSS: "aptl.experiment-capture.mid-run-loss",
+    CollectorStatus.TRUNCATION: "aptl.experiment-capture.truncation",
+    CollectorStatus.CLOCK_SKEW: "aptl.experiment-capture.clock-skew",
+    CollectorStatus.TIMEOUT: "aptl.experiment-capture.timeout",
+    CollectorStatus.FINALIZATION_FAILURE: "aptl.experiment-capture.finalization-failure",
+}
+
+
+class AcquisitionDisposition(str, Enum):
+    """The overall acquisition outcome for one trial's capture set.
+
+    Maps onto ACES ``ExperimentRunModel`` run/outcome status without creating
+    a second controller state machine:
+
+    * :attr:`SEALED_READY` — every required capture succeeded and finalized;
+      only this is ready for the #444 sealing handoff.
+    * :attr:`COMPLETED_PARTIAL` — a required capture degraded, but the
+      degradation was explicitly accepted by policy and carries loss /
+      limitation / comparability disclosures.
+    * :attr:`INVALIDATED` — a required mid-run loss, unacceptable truncation
+      or clock uncertainty, or a required finalization failure; unsealed.
+    * :attr:`INCONCLUSIVE` — a required source was unavailable or a collector
+      failed to start, aborting the attempt before participant action.
+    """
+
+    SEALED_READY = "sealed-ready"
+    COMPLETED_PARTIAL = "completed-partial"
+    INVALIDATED = "invalidated"
+    INCONCLUSIVE = "inconclusive"
+
+
+def capture_diagnostic(code: str, address: str, message: str) -> Diagnostic:
+    """Build one redacted evidence-capture :class:`Diagnostic`.
+
+    Mirrors ``errors.diagnostic`` but fixed to
+    :data:`EVIDENCE_CAPTURE_DOMAIN`. ``message`` is passed through
+    :func:`redact` as defense in depth; callers construct it from safe,
+    non-source-derived text (stable codes, IDs, counts) only.
+    """
+    return Diagnostic(
+        code=code,
+        domain=EVIDENCE_CAPTURE_DOMAIN,
+        address=address,
+        message=redact(message),
+        severity=Severity.ERROR,
+    )

--- a/src/aptl/core/evidence/protocol.py
+++ b/src/aptl/core/evidence/protocol.py
@@ -35,6 +35,19 @@ CollectorHandle = object
 
 
 @dataclass(frozen=True)
+class RunScope:
+    """The run / planned-trial / attempt identity one trial's acquisition is scoped to.
+
+    Bundled so the coordinator's entry point and helpers stay within the
+    parameter budget while threading the same immutable identity everywhere.
+    """
+
+    run_id: str
+    planned_trial_id: str
+    attempt_id: str
+
+
+@dataclass(frozen=True)
 class CollectorContext:
     """The immutable admitted context a collector is given at start.
 

--- a/src/aptl/core/evidence/protocol.py
+++ b/src/aptl/core/evidence/protocol.py
@@ -1,0 +1,106 @@
+"""The narrow collector boundary for evidence acquisition (EXP-010 / issue
+#752 preflight "Narrow collector boundary").
+
+A collector receives ONLY an immutable :class:`CollectorContext` — the
+planned-trial / run / attempt IDs, its pinned :class:`~aptl.core.experiment.
+capture_registry.CaptureBinding` and window, a deadline and limits, and a
+:class:`~aptl.core.correlation.clock.ClockProvider`. It NEVER receives the
+``ExperimentController``, the ACES runtime target, ``LocalRunStore``, raw
+filesystem paths, ``EnvVars``, the full application config, or a generic
+command/HTTP client. It reports source bytes/chunks and typed counters or a
+typed :class:`~aptl.core.evidence.outcomes.CollectorStatus` failure through
+:class:`CollectorOutcome`; it cannot choose an archive path, hash, redact, or
+construct a portable ACES evidence record — the coordinator owns all of that.
+
+The source-specific work (a `DeploymentBackend.container_logs_capture`, a SOC
+`curl_safe` call, an MCP result envelope, the Kali sidecar) is wrapped by a
+trusted adapter that is injected into the collector by composition code — it
+is never selected by experiment input.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from aptl.core.correlation.clock import ClockProvider
+from aptl.core.evidence.outcomes import CollectorStatus
+from aptl.core.experiment.capture_registry import CaptureBinding
+
+#: A collector's opaque per-start handle (e.g. a session id or a buffer
+#: reference). The coordinator treats it as opaque and only hands it back to
+#: the same collector's :meth:`Collector.stop`.
+CollectorHandle = object
+
+
+@dataclass(frozen=True)
+class CollectorContext:
+    """The immutable admitted context a collector is given at start.
+
+    Deliberately narrow (preflight): identity + the pinned binding + a
+    deadline + a clock. No store, no paths, no config, no backend handle.
+    """
+
+    planned_trial_id: str
+    run_id: str
+    attempt_id: str
+    binding: CaptureBinding
+    deadline_seconds: float
+    clock: ClockProvider
+
+
+@dataclass(frozen=True)
+class CollectorOutcome:
+    """The typed result a collector reports from :meth:`Collector.stop`.
+
+    ``chunks`` are the raw source bytes the coordinator will hash, redact
+    (structured payloads only), quota, and content-address — the collector
+    never persists them itself. ``status`` distinguishes success / legitimate
+    emptiness from each failure mode (never empty-on-error == success).
+    ``source_min_time`` / ``source_max_time`` are the source's own event
+    timestamps (RFC-3339), kept distinct from the collector's
+    ``started_at`` / ``finished_at`` observation clock so proximity is never
+    mistaken for causality.
+    """
+
+    status: CollectorStatus
+    started_at: str
+    finished_at: str
+    chunks: Sequence[bytes] = ()
+    media_type: str | None = None
+    event_count: int = 0
+    dropped_count: int = 0
+    source_min_time: str | None = None
+    source_max_time: str | None = None
+    observer_effect: str | None = None
+    detail: str | None = None
+    source_pipeline: dict[str, object] = field(default_factory=dict)
+
+
+@runtime_checkable
+class Collector(Protocol):
+    """A trusted, code-owned collector realizing one registration.
+
+    ``registration_id`` MUST equal the ``registration_id`` of the pinned
+    binding the coordinator drives it for — the coordinator verifies this
+    (never re-matching a changed registry). ``start`` opens the source and
+    returns an opaque handle; ``stop`` closes it and returns the typed
+    outcome. Neither call may raise for an ordinary source failure — the
+    failure is reported as a :class:`CollectorStatus`; only genuinely
+    unexpected internal errors propagate (and the coordinator normalizes
+    them into a safe diagnostic).
+    """
+
+    @property
+    def registration_id(self) -> str:
+        """The registration this collector realizes (verified against the binding)."""
+        ...
+
+    def start(self, context: CollectorContext) -> CollectorHandle:
+        """Open the source and return an opaque handle for :meth:`stop`."""
+        ...
+
+    def stop(self, handle: CollectorHandle) -> CollectorOutcome:
+        """Close the source and return the typed capture outcome."""
+        ...

--- a/src/aptl/core/evidence/records.py
+++ b/src/aptl/core/evidence/records.py
@@ -21,6 +21,7 @@ mandatory ``loss_disclosure`` records it.
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 
 import rfc8785
 from aces_contracts.contracts import (
@@ -40,6 +41,20 @@ from aptl.core.experiment.capture_registry import CaptureBinding
 _EVIDENCE_ID_DOMAIN = "aptl.exp.evidence-record/v1"
 _EVIDENCE_ID_PREFIX = "evidence-"
 _RECORD_VERSION = "1.0.0"
+
+
+@dataclass(frozen=True)
+class RecordDisclosure:
+    """The coordinator's decided sensitivity + redaction/loss disposition for a record.
+
+    Bundled so :func:`build_evidence_record` stays within the parameter budget;
+    every field reflects what the coordinator actually did to the bytes, never
+    something inferred in the record builder.
+    """
+
+    sensitivity: str
+    redaction_state: str
+    loss_disclosure: str | None = None
 
 
 def _bare_hex(prefixed_digest: str) -> str:
@@ -89,17 +104,15 @@ def build_evidence_record(
     content: ContentInsertion,
     outcome: CollectorOutcome,
     captured_at: str,
-    sensitivity: str,
-    redaction_state: str,
-    loss_disclosure: str | None = None,
+    disclosure: RecordDisclosure,
 ) -> ExperimentEvidenceRecordModel:
     """Assemble one ACES :class:`ExperimentEvidenceRecordModel` for a captured binding.
 
-    ``sensitivity`` / ``redaction_state`` are decided by the coordinator (they
-    reflect what it actually did to the bytes), never inferred here. The record
-    references the run, the capture spec, and the source measurement channel
-    the evidence satisfies; identity is derived deterministically from the
-    binding + retained-content digest.
+    ``disclosure`` carries the coordinator's decided sensitivity + redaction/
+    loss disposition (what it actually did to the bytes), never inferred here.
+    The record references the run, the capture spec, and the source measurement
+    channel the evidence satisfies; identity is derived deterministically from
+    the binding + retained-content digest.
     """
     window_ref = binding.window_refs[0] if binding.window_refs else binding.requirement_id
     record_id = derive_evidence_record_id(
@@ -125,8 +138,8 @@ def build_evidence_record(
         captured_at=captured_at,
         capture_window_ref=window_ref,
         raw_content=_raw_content(
-            content, event_count=outcome.event_count, loss_disclosure=loss_disclosure
+            content, event_count=outcome.event_count, loss_disclosure=disclosure.loss_disclosure
         ),
-        sensitivity=sensitivity,
-        redaction_state=redaction_state,
+        sensitivity=disclosure.sensitivity,
+        redaction_state=disclosure.redaction_state,
     )

--- a/src/aptl/core/evidence/records.py
+++ b/src/aptl/core/evidence/records.py
@@ -1,0 +1,132 @@
+"""ACES evidence-record construction for evidence acquisition (EXP-010 / issue
+#752 preflight "Evidence ownership and persistence").
+
+Portable evidence is emitted ONLY through public ACES models
+(:class:`ExperimentEvidenceRecordModel`,
+:class:`ExperimentRawEvidenceContentModel`, :class:`ExperimentChecksumModel`,
+:class:`ExperimentReferenceModel`) — never an APTL-local mirror. This module is
+a pure builder: the coordinator has already streamed, quota'd, hashed, and
+(where required) redacted the raw bytes into a content-addressed
+:class:`~aptl.core.runstore.ContentInsertion`; here we only assemble the ACES
+record around it.
+
+Evidence-record identity derives from stable run / planned-trial / capture-spec
+/ requirement / window / collector-config / retained-content identity via
+RFC-8785 canonical JSON + SHA-256 — NEVER from ``captured_at``, filesystem
+order, or ingestion order (preflight). The checksum in the record identifies
+the bytes actually retained; when the source was truncated or lossy, a
+mandatory ``loss_disclosure`` records it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import rfc8785
+from aces_contracts.contracts import (
+    ExperimentCaptureSpecReferenceModel,
+    ExperimentChecksumModel,
+    ExperimentEvidenceRecordModel,
+    ExperimentRawEvidenceContentModel,
+    ExperimentReferenceModel,
+)
+
+from aptl.core.evidence.content_store import ContentInsertion
+from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.experiment.capture_registry import CaptureBinding
+
+#: Versioned domain separator for evidence-record ID derivation (independent
+#: of the trial-plan / seed domains so an algorithm revision never collides).
+_EVIDENCE_ID_DOMAIN = "aptl.exp.evidence-record/v1"
+_EVIDENCE_ID_PREFIX = "evidence-"
+_RECORD_VERSION = "1.0.0"
+
+
+def _bare_hex(prefixed_digest: str) -> str:
+    """Return the bare hex of a ``sha256:<hex>`` prefixed digest for ACES checksum value."""
+    return prefixed_digest.split(":", 1)[1]
+
+
+def derive_evidence_record_id(
+    *, run_id: str, planned_trial_id: str, binding: CaptureBinding, content_digest: str
+) -> str:
+    """Derive one evidence record's stable ID from identity inputs only.
+
+    Excludes ``captured_at`` and any ingestion/filesystem order — two
+    acquisitions of the same bytes for the same trial/requirement/window
+    yield the same ID, and different retained content yields a different ID.
+    """
+    projection = {
+        "domain": _EVIDENCE_ID_DOMAIN,
+        "run_id": run_id,
+        "planned_trial_id": planned_trial_id,
+        "capture_spec_id": binding.capture_spec_id,
+        "requirement_id": binding.requirement_id,
+        "window_refs": sorted(binding.window_refs),
+        "effective_config_digest": binding.effective_config_digest,
+        "content_digest": content_digest,
+    }
+    return _EVIDENCE_ID_PREFIX + hashlib.sha256(rfc8785.dumps(projection)).hexdigest()
+
+
+def _raw_content(
+    content: ContentInsertion, *, event_count: int, loss_disclosure: str | None
+) -> ExperimentRawEvidenceContentModel:
+    """Build the raw-content block: content_uri + checksum of the RETAINED bytes + loss disclosure."""
+    return ExperimentRawEvidenceContentModel(
+        content_uri=content.relative_path,
+        content_checksum=ExperimentChecksumModel(algorithm="sha256", value=_bare_hex(content.digest)),
+        payload_summary=f"{event_count} event(s), {content.size} byte(s) retained",
+        loss_disclosure=loss_disclosure,
+    )
+
+
+def build_evidence_record(
+    *,
+    binding: CaptureBinding,
+    run_id: str,
+    planned_trial_id: str,
+    content: ContentInsertion,
+    outcome: CollectorOutcome,
+    captured_at: str,
+    sensitivity: str,
+    redaction_state: str,
+    loss_disclosure: str | None = None,
+) -> ExperimentEvidenceRecordModel:
+    """Assemble one ACES :class:`ExperimentEvidenceRecordModel` for a captured binding.
+
+    ``sensitivity`` / ``redaction_state`` are decided by the coordinator (they
+    reflect what it actually did to the bytes), never inferred here. The record
+    references the run, the capture spec, and the source measurement channel
+    the evidence satisfies; identity is derived deterministically from the
+    binding + retained-content digest.
+    """
+    window_ref = binding.window_refs[0] if binding.window_refs else binding.requirement_id
+    record_id = derive_evidence_record_id(
+        run_id=run_id, planned_trial_id=planned_trial_id, binding=binding, content_digest=content.digest
+    )
+    return ExperimentEvidenceRecordModel(
+        schema_version="experiment-evidence-record/v1",
+        evidence_record_id=record_id,
+        record_version=_RECORD_VERSION,
+        capture_spec_ref=ExperimentCaptureSpecReferenceModel(
+            ref_kind="capture-spec", ref_id=binding.capture_spec_id
+        ),
+        capture_requirement_ref=binding.requirement_id,
+        run_ref=ExperimentReferenceModel(ref_kind="run", ref_id=run_id),
+        source_refs=[
+            ExperimentReferenceModel(
+                ref_kind="measurement-channel",
+                ref_id=binding.channel_ref_id,
+                ref_version=binding.channel_ref_version,
+            )
+        ],
+        evidence_kind=binding.capture_kind,
+        captured_at=captured_at,
+        capture_window_ref=window_ref,
+        raw_content=_raw_content(
+            content, event_count=outcome.event_count, loss_disclosure=loss_disclosure
+        ),
+        sensitivity=sensitivity,
+        redaction_state=redaction_state,
+    )

--- a/src/aptl/core/evidence/visibility.py
+++ b/src/aptl/core/evidence/visibility.py
@@ -1,0 +1,39 @@
+"""Participant-visibility projection of acquired evidence (EXP-010 / issue
+#752 preflight "Visibility boundary").
+
+Capture authorization is a SEPARATE projection from participant visibility:
+storage or evaluator authorization never implies a participant may see the
+evidence. This module is the server-side filter — participant-facing surfaces
+(responses, logs, a future API) get ONLY the participant-visible and disclosed
+evidence; hidden, evaluator-only, and apparatus-only evidence is retained in
+the archive but never enters the participant projection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from aptl.core.evidence._persist import EvidenceRef
+from aptl.core.experiment.capture_registry import CaptureVisibility
+
+#: Visibility classes a participant is allowed to observe. Everything else
+#: (evaluator-only, apparatus-only) is dropped from the participant projection.
+_PARTICIPANT_VISIBLE_CLASSES: frozenset[str] = frozenset(
+    {CaptureVisibility.PARTICIPANT_VISIBLE.value, CaptureVisibility.DISCLOSED.value}
+)
+
+
+def is_participant_visible(ref: EvidenceRef) -> bool:
+    """Return whether an evidence reference may enter a participant projection."""
+    return ref.visibility_class in _PARTICIPANT_VISIBLE_CLASSES
+
+
+def project_for_participant(refs: Sequence[EvidenceRef]) -> tuple[EvidenceRef, ...]:
+    """Return only the participant-visible / disclosed subset of ``refs``.
+
+    The retained archive keeps every reference; this projection is what a
+    participant-facing surface is allowed to see. Hidden / evaluator-only /
+    apparatus-only references are never included even though the coordinator
+    was authorized to retain them.
+    """
+    return tuple(ref for ref in refs if is_participant_visible(ref))

--- a/src/aptl/core/experiment/capture_registrations.py
+++ b/src/aptl/core/experiment/capture_registrations.py
@@ -1,0 +1,115 @@
+"""The trusted built-in collector registrations (EXP-010 / issue #752 PR 2).
+
+Split out of :mod:`aptl.core.experiment.capture_registry` (which imports these
+at its foot into :data:`~aptl.core.experiment.capture_registry.
+DEFAULT_COLLECTOR_REGISTRY`) so the registration DATA lives apart from the
+registry/binding TYPES and matching logic — keeping both files within budget.
+
+Each registration is a static capability declaration only — no factory, import
+path, or executable reference. The trusted adapter wiring that maps a
+``registration_id`` to a live :class:`~aptl.core.evidence.protocol.Collector`
+lives in :mod:`aptl.core.evidence.adapters.wiring`. Turning these on is what
+flips ``create_aptl_manifest().observation`` from ``None`` to a real aggregate
+projection — done together with the acquisition machinery (the honesty rule).
+
+``channel_kind`` / ``capture_kind`` / sealing use governed ACES
+controlled-vocabulary terms (``observation-channel-kinds`` /
+``observation-capture-kinds`` / ``observation-sealing-modes``); the observation
+projection validates them at manifest build.
+"""
+
+from __future__ import annotations
+
+from aptl.core.experiment.capture_registry import (
+    CaptureLimits,
+    CaptureVisibility,
+    CollectorRegistration,
+)
+
+#: Shared limits for the built-in windowed sources: 8 MiB / 5 minutes / 4096
+#: artifacts per capture. Generous but bounded — the coordinator truncates a
+#: source that exceeds the byte quota and discloses it.
+_LIMITS = CaptureLimits(max_bytes=8 * 1024 * 1024, max_artifact_count=4096, max_duration_s=300)
+
+
+def _builtin(
+    registration_id: str,
+    *,
+    capture_kind: str,
+    capture_scope: str,
+    channel_kind: str,
+    visibility_class: CaptureVisibility,
+) -> CollectorRegistration:
+    """Build one built-in registration from the per-source axes + shared defaults.
+
+    The built-ins all serialize their windowed source's structured records to
+    ``application/json``, seal by content-address ``digest`` (not a signed
+    attestation), redact structured payloads, honor retention + loss
+    disclosure, and support the ``run``/``task``/``interval`` window kinds.
+    """
+    return CollectorRegistration(
+        registration_id=registration_id,
+        implementation_version="1.0.0",
+        contract_version="experiment-capture-spec/v1",
+        channel_kind=channel_kind,
+        capture_kind=capture_kind,
+        capture_scope=capture_scope,
+        window_kinds=frozenset({"run", "task", "interval"}),
+        media_types=frozenset({"application/json"}),
+        required_artifact_roles=frozenset({"observation"}),
+        supported_sensitivities=frozenset({"public", "internal", "restricted"}),
+        supports_redaction=True,
+        integrity_modes=frozenset({"sha256-digest"}),
+        sealing_modes=frozenset({"digest"}),
+        supports_chain_of_custody=False,
+        supports_retention=True,
+        supports_loss_disclosure=True,
+        visibility_class=visibility_class,
+        limits=_LIMITS,
+    )
+
+
+#: The trusted built-in fleet — one per source owner, covering the acceptance
+#: criterion's synchronized red / container / network / defensive evidence.
+BUILTIN_REGISTRATIONS: tuple[CollectorRegistration, ...] = (
+    # Red-team activity via the MCP result envelope (participant's own action).
+    _builtin(
+        "aptl.collector.mcp-red",
+        capture_kind="observation",
+        capture_scope="participant",
+        channel_kind="participant-observation",
+        visibility_class=CaptureVisibility.PARTICIPANT_VISIBLE,
+    ),
+    # Container logs via DeploymentBackend.
+    _builtin(
+        "aptl.collector.container-logs",
+        capture_kind="log",
+        capture_scope="service",
+        channel_kind="backend-log",
+        visibility_class=CaptureVisibility.EVALUATOR_ONLY,
+    ),
+    # Network IDS events (Suricata EVE) — the network-evidence source.
+    _builtin(
+        "aptl.collector.suricata-eve",
+        capture_kind="log",
+        capture_scope="network",
+        channel_kind="packet-capture",
+        visibility_class=CaptureVisibility.EVALUATOR_ONLY,
+    ),
+    # Defensive SIEM detections (Wazuh alerts).
+    _builtin(
+        "aptl.collector.wazuh-alerts",
+        capture_kind="telemetry",
+        capture_scope="service",
+        channel_kind="backend-log",
+        visibility_class=CaptureVisibility.EVALUATOR_ONLY,
+    ),
+    # Distributed traces (Tempo) — apparatus-only run trace.
+    _builtin(
+        "aptl.collector.tempo-traces",
+        capture_kind="trace",
+        capture_scope="run",
+        channel_kind="workflow-history",
+        visibility_class=CaptureVisibility.APPARATUS_ONLY,
+    ),
+)

--- a/src/aptl/core/experiment/capture_registry.py
+++ b/src/aptl/core/experiment/capture_registry.py
@@ -461,6 +461,6 @@ def _bind(
 #: turns ``create_aptl_manifest().observation`` from ``None`` into a real
 #: aggregate projection — done together with the acquisition machinery + the
 #: adapter wiring + conformance fixtures (the honesty rule).
-from aptl.core.experiment.capture_registrations import BUILTIN_REGISTRATIONS  # noqa: E402
+from aptl.core.experiment.capture_registrations import BUILTIN_REGISTRATIONS
 
 DEFAULT_COLLECTOR_REGISTRY = CollectorRegistry(BUILTIN_REGISTRATIONS)

--- a/src/aptl/core/experiment/capture_registry.py
+++ b/src/aptl/core/experiment/capture_registry.py
@@ -454,9 +454,13 @@ def _bind(
     )
 
 
-#: The production registry. EMPTY by design (see the module docstring): no
-#: capture capability is honestly backed end-to-end yet, so the manifest keeps
-#: ``observation=None`` and every capture requirement fails closed. EXP-010
-#: PR 2 populates real registrations together with their acquisition adapters,
-#: conformance fixtures, and a turned-on observation projection.
-DEFAULT_COLLECTOR_REGISTRY = CollectorRegistry()
+#: The production registry — the trusted built-in fleet (EXP-010 PR 2). Its
+#: registration DATA lives in the sibling ``capture_registrations`` module
+#: (imported here at the foot, after the types above are defined, so the
+#: type/data split does not create an import cycle). Populating it is what
+#: turns ``create_aptl_manifest().observation`` from ``None`` into a real
+#: aggregate projection — done together with the acquisition machinery + the
+#: adapter wiring + conformance fixtures (the honesty rule).
+from aptl.core.experiment.capture_registrations import BUILTIN_REGISTRATIONS  # noqa: E402
+
+DEFAULT_COLLECTOR_REGISTRY = CollectorRegistry(BUILTIN_REGISTRATIONS)

--- a/src/aptl/core/runstore.py
+++ b/src/aptl/core/runstore.py
@@ -42,9 +42,10 @@ class SecretInvariantError(ValueError):
 
 
 class RunStoreConflictError(ValueError):
-    """Raised by :meth:`LocalRunStore.create_json_once` when the target
-    already exists with canonical bytes that differ from the payload being
-    written.
+    """Raised by the create-once persistence paths (``create_json_once`` and
+    the run-scoped / content-addressed extensions in
+    :mod:`aptl.core.evidence.content_store`) when the target already exists
+    with bytes that differ from those being written.
 
     A byte-identical existing payload is treated as idempotent success
     (ADR-047); only a genuine mismatch is an error.

--- a/tests/test_capture_registry.py
+++ b/tests/test_capture_registry.py
@@ -306,8 +306,13 @@ class TestConfigDigest:
 
 class TestObservationProjection:
     def test_empty_registry_projects_no_observation(self):
-        assert DEFAULT_COLLECTOR_REGISTRY.observation_projection() is None
+        # A fresh empty registry is honestly None; the production default is
+        # now populated (EXP-010 PR 2 turned the fleet on).
         assert CollectorRegistry().observation_projection() is None
+
+    def test_default_registry_is_populated_and_projects_observation(self):
+        assert DEFAULT_COLLECTOR_REGISTRY.registrations
+        assert DEFAULT_COLLECTOR_REGISTRY.observation_projection() is not None
 
     def test_populated_registry_aggregates_declarations(self):
         registry = CollectorRegistry(

--- a/tests/test_evidence_adapters.py
+++ b/tests/test_evidence_adapters.py
@@ -1,0 +1,163 @@
+"""Tests for the evidence collector adapters (EXP-010 / issue #752 PR 2).
+
+Covers the generic windowed-query collector, the concrete built-in sources
+(each distinguishing a source failure from legitimate emptiness at the owner
+level — never the empty-on-error collapse), and the trusted wiring seam.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from aptl.core.correlation.clock import FixedClockProvider
+from aptl.core.evidence.adapters.builtins import ContainerLogSource, RunArchiveSource, soc_windowed_source
+from aptl.core.evidence.adapters.sources import SourceResult, WindowedQueryCollector
+from aptl.core.evidence.adapters.wiring import BUILTIN_REGISTRATION_IDS, build_collectors
+from aptl.core.evidence.outcomes import CollectorStatus
+from aptl.core.evidence.protocol import CollectorContext
+from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
+from aptl.core.runstore import LocalRunStore
+
+_CLOCK = FixedClockProvider(measurement_time="2026-07-20T00:00:00Z")
+
+
+def _binding(registration_id="aptl.collector.mcp-red") -> CaptureBinding:
+    return CaptureBinding(
+        capture_spec_id="cap-1", requirement_id="req-a", window_refs=("run-window",),
+        registration_id=registration_id, implementation_version="1.0.0",
+        contract_version="experiment-capture-spec/v1", effective_config_digest="sha256:" + "cd" * 32,
+        channel_ref_id="chan", channel_ref_version="1.0.0", channel_kind="participant-observation",
+        capture_kind="observation", capture_scope="participant", expected_media_types=("application/json",),
+        required_artifact_roles=("observation",), sensitivity="internal", redaction_required=False,
+        integrity_requirements=("sha256-digest",), retention_policy="retain", loss_disclosure_required=True,
+        visibility_class=CaptureVisibility.PARTICIPANT_VISIBLE,
+        limits=CaptureLimits(max_bytes=4096, max_artifact_count=10, max_duration_s=60),
+    )
+
+
+def _context(registration_id="aptl.collector.mcp-red") -> CollectorContext:
+    return CollectorContext(
+        planned_trial_id="trial-1", run_id="run-1", attempt_id="attempt-1",
+        binding=_binding(registration_id), deadline_seconds=60.0, clock=_CLOCK,
+    )
+
+
+class _FakeSource:
+    def __init__(self, result: SourceResult) -> None:
+        self._result = result
+
+    def fetch(self, start_iso, end_iso) -> SourceResult:
+        return self._result
+
+
+class TestWindowedQueryCollector:
+    def test_records_map_to_ok_with_json_bytes(self):
+        source = _FakeSource(SourceResult(status=CollectorStatus.OK, records=[{"a": 1}, {"a": 2}]))
+        collector = WindowedQueryCollector("aptl.collector.mcp-red", source)
+        outcome = collector.stop(collector.start(_context()))
+        assert outcome.status is CollectorStatus.OK
+        assert outcome.event_count == 2
+        assert outcome.media_type == "application/json"
+        assert b'"a":1' in b"".join(outcome.chunks)
+
+    def test_empty_records_are_empty_ok(self):
+        source = _FakeSource(SourceResult(status=CollectorStatus.EMPTY_OK, records=[]))
+        collector = WindowedQueryCollector("aptl.collector.mcp-red", source)
+        outcome = collector.stop(collector.start(_context()))
+        assert outcome.status is CollectorStatus.EMPTY_OK
+
+    def test_source_failure_passes_through_without_chunks(self):
+        source = _FakeSource(SourceResult(status=CollectorStatus.SOURCE_UNAVAILABLE))
+        collector = WindowedQueryCollector("aptl.collector.mcp-red", source)
+        outcome = collector.stop(collector.start(_context()))
+        assert outcome.status is CollectorStatus.SOURCE_UNAVAILABLE
+        assert not outcome.chunks
+
+
+class TestRunArchiveSource:
+    def test_missing_subtree_is_source_unavailable(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run("run-1")
+        source = RunArchiveSource(store, "run-1", "mcp-side")
+        assert source.fetch("s", "e").status is CollectorStatus.SOURCE_UNAVAILABLE
+
+    def test_present_but_empty_is_empty_ok(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        store.write_file("run-1", "mcp-side/tool-calls.jsonl", b"")
+        source = RunArchiveSource(store, "run-1", "mcp-side")
+        assert source.fetch("s", "e").status is CollectorStatus.EMPTY_OK
+
+    def test_records_are_read_and_malformed_lines_dropped(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        store.write_file("run-1", "mcp-side/tool-calls.jsonl", b'{"a": 1}\nnot-json\n{"a": 2}\n')
+        source = RunArchiveSource(store, "run-1", "mcp-side")
+        result = source.fetch("s", "e")
+        assert result.status is CollectorStatus.OK
+        assert len(result.records) == 2
+        assert result.dropped_count == 1
+
+
+class TestContainerLogSource:
+    def test_nonzero_returncode_is_source_unavailable(self):
+        backend = types.SimpleNamespace(
+            container_logs_capture=lambda *a, **k: types.SimpleNamespace(returncode=1, stdout="")
+        )
+        source = ContainerLogSource(backend, ["c1"])
+        assert source.fetch("s", "e").status is CollectorStatus.SOURCE_UNAVAILABLE
+
+    def test_empty_output_is_empty_ok(self):
+        backend = types.SimpleNamespace(
+            container_logs_capture=lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="  ")
+        )
+        source = ContainerLogSource(backend, ["c1"])
+        assert source.fetch("s", "e").status is CollectorStatus.EMPTY_OK
+
+    def test_output_becomes_records(self):
+        backend = types.SimpleNamespace(
+            container_logs_capture=lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="line1\nline2")
+        )
+        source = ContainerLogSource(backend, ["c1"])
+        result = source.fetch("s", "e")
+        assert result.status is CollectorStatus.OK
+        assert result.records[0]["container"] == "c1"
+
+
+class TestSocWindowedSource:
+    def test_none_is_source_unavailable(self):
+        source = soc_windowed_source(lambda s, e: None)
+        assert source.fetch("s", "e").status is CollectorStatus.SOURCE_UNAVAILABLE
+
+    def test_empty_list_is_empty_ok(self):
+        source = soc_windowed_source(lambda s, e: [])
+        assert source.fetch("s", "e").status is CollectorStatus.EMPTY_OK
+
+    def test_events_are_ok(self):
+        source = soc_windowed_source(lambda s, e: [{"alert": 1}])
+        result = source.fetch("s", "e")
+        assert result.status is CollectorStatus.OK
+        assert result.records == [{"alert": 1}]
+
+
+class TestWiring:
+    def test_builds_collectors_for_known_ids(self):
+        source = _FakeSource(SourceResult(status=CollectorStatus.EMPTY_OK))
+        collectors = build_collectors({"aptl.collector.mcp-red": source})
+        assert collectors["aptl.collector.mcp-red"].registration_id == "aptl.collector.mcp-red"
+
+    def test_unknown_registration_id_is_rejected(self):
+        source = _FakeSource(SourceResult(status=CollectorStatus.EMPTY_OK))
+        with pytest.raises(ValueError, match="unknown collector registration id"):
+            build_collectors({"aptl.collector.NOPE": source})
+
+    def test_the_five_builtins_are_registered(self):
+        assert BUILTIN_REGISTRATION_IDS == frozenset(
+            {
+                "aptl.collector.mcp-red",
+                "aptl.collector.container-logs",
+                "aptl.collector.suricata-eve",
+                "aptl.collector.wazuh-alerts",
+                "aptl.collector.tempo-traces",
+            }
+        )

--- a/tests/test_evidence_coordinator.py
+++ b/tests/test_evidence_coordinator.py
@@ -1,0 +1,312 @@
+"""Tests for the evidence-acquisition coordinator (EXP-010 / issue #752).
+
+Exercises the lifecycle + terminal-semantics contract with fake collectors and
+a real ``LocalRunStore``: distinct dispositions for success / startup-failure /
+finalization-failure / truncation / accepted-degradation, reverse-order stop,
+content-addressed persistence, ACES evidence records, and the never-empty-on-
+error rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aptl.core.correlation.clock import FixedClockProvider
+from aptl.core.evidence.coordinator import acquire_evidence
+from aptl.core.evidence.outcomes import AcquisitionDisposition, CollectorStatus
+from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
+from aptl.core.runstore import LocalRunStore
+
+_CLOCK = FixedClockProvider(measurement_time="2026-07-20T00:00:00Z")
+
+
+def _binding(*, requirement_id="req-a", registration_id="aptl.collector.a", max_bytes=4096, **overrides) -> CaptureBinding:
+    """Build a representative pinned binding for the coordinator tests."""
+    fields: dict[str, object] = {
+        "capture_spec_id": "cap-1",
+        "requirement_id": requirement_id,
+        "window_refs": ("run-window",),
+        "registration_id": registration_id,
+        "implementation_version": "1.0.0",
+        "contract_version": "experiment-capture-spec/v1",
+        "effective_config_digest": "sha256:" + "cd" * 32,
+        "channel_ref_id": "chan",
+        "channel_ref_version": "1.0.0",
+        "channel_kind": "evaluation-history",
+        "capture_kind": "trace",
+        "capture_scope": "network",
+        "expected_media_types": ("application/json",),
+        "required_artifact_roles": ("observation",),
+        "sensitivity": "internal",
+        "redaction_required": False,
+        "integrity_requirements": ("sha256-digest",),
+        "retention_policy": "retain",
+        "loss_disclosure_required": True,
+        "visibility_class": CaptureVisibility.EVALUATOR_ONLY,
+        "limits": CaptureLimits(max_bytes=max_bytes, max_artifact_count=10, max_duration_s=60),
+    }
+    fields.update(overrides)
+    return CaptureBinding(**fields)
+
+
+def _ok_outcome(payload: bytes = b'{"event": 1}', *, count: int = 1) -> CollectorOutcome:
+    """A successful JSON capture outcome."""
+    return CollectorOutcome(
+        status=CollectorStatus.OK,
+        started_at="2026-07-20T00:00:00Z",
+        finished_at="2026-07-20T00:00:05Z",
+        chunks=[payload],
+        media_type="application/json",
+        event_count=count,
+    )
+
+
+class _FakeCollector:
+    """A fake collector recording start/stop order, with configurable behavior."""
+
+    def __init__(self, registration_id, *, outcome=None, start_raises=False, stop_raises=False, log=None):
+        self._registration_id = registration_id
+        self._outcome = outcome if outcome is not None else _ok_outcome()
+        self._start_raises = start_raises
+        self._stop_raises = stop_raises
+        self._log = log if log is not None else []
+
+    @property
+    def registration_id(self) -> str:
+        return self._registration_id
+
+    def start(self, context):
+        self._log.append(("start", self._registration_id))
+        if self._start_raises:
+            raise RuntimeError("boom-start")
+        return object()
+
+    def stop(self, handle):
+        self._log.append(("stop", self._registration_id))
+        if self._stop_raises:
+            raise RuntimeError("boom-stop")
+        return self._outcome
+
+
+def _acquire(tmp_path, bindings, collectors, **kwargs):
+    """Run acquire_evidence against a real run store."""
+    store = LocalRunStore(tmp_path / "runs")
+    return acquire_evidence(
+        bindings=bindings,
+        collectors=collectors,
+        run_store=store,
+        run_id="run-1",
+        planned_trial_id="trial-1",
+        attempt_id="attempt-1",
+        clock=_CLOCK,
+        **kwargs,
+    )
+
+
+class TestSuccessPath:
+    def test_all_ok_is_sealed_ready_with_records_and_refs(self, tmp_path):
+        binding = _binding()
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a")})
+
+        assert result.disposition is AcquisitionDisposition.SEALED_READY
+        assert len(result.records) == 1
+        assert len(result.refs) == 1
+        assert result.refs[0].requirement_id == "req-a"
+        assert result.records[0].evidence_kind == "trace"
+
+    def test_evidence_bytes_are_persisted_content_addressed(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        binding = _binding()
+        result = acquire_evidence(
+            bindings=[binding],
+            collectors={"aptl.collector.a": _FakeCollector("aptl.collector.a")},
+            run_store=store,
+            run_id="run-1",
+            planned_trial_id="trial-1",
+            attempt_id="attempt-1",
+            clock=_CLOCK,
+        )
+        ref = result.refs[0]
+        stored = (store.get_run_path("run-1") / ref.content_uri).read_bytes()
+        assert stored == b'{"event": 1}'
+
+    def test_empty_ok_is_a_success_not_a_failure(self, tmp_path):
+        binding = _binding()
+        outcome = CollectorOutcome(
+            status=CollectorStatus.EMPTY_OK,
+            started_at="2026-07-20T00:00:00Z",
+            finished_at="2026-07-20T00:00:05Z",
+            chunks=[b"[]"],
+            media_type="application/json",
+        )
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome=outcome)})
+        assert result.disposition is AcquisitionDisposition.SEALED_READY
+
+
+class TestTerminalSemantics:
+    def test_startup_failure_is_inconclusive(self, tmp_path):
+        binding = _binding()
+        result = _acquire(
+            tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a", start_raises=True)}
+        )
+        assert result.disposition is AcquisitionDisposition.INCONCLUSIVE
+        assert result.reports[0].status is CollectorStatus.STARTUP_FAILURE
+
+    def test_finalization_failure_invalidates_a_required_capture(self, tmp_path):
+        binding = _binding()
+        result = _acquire(
+            tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a", stop_raises=True)}
+        )
+        assert result.disposition is AcquisitionDisposition.INVALIDATED
+        assert result.reports[0].status is CollectorStatus.FINALIZATION_FAILURE
+        assert result.diagnostics
+
+    def test_missing_collector_is_inconclusive(self, tmp_path):
+        binding = _binding()
+        result = _acquire(tmp_path, [binding], {})
+        assert result.disposition is AcquisitionDisposition.INCONCLUSIVE
+        assert result.reports[0].status is CollectorStatus.SOURCE_UNAVAILABLE
+
+    def test_over_quota_truncation_invalidates_a_required_capture(self, tmp_path):
+        binding = _binding(max_bytes=4)  # smaller than the payload
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a")})
+        assert result.reports[0].status is CollectorStatus.TRUNCATION
+        assert result.disposition is AcquisitionDisposition.INVALIDATED
+
+    def test_accepted_degradation_truncation_is_completed_partial(self, tmp_path):
+        binding = _binding(max_bytes=4, accepted_limitation="partial-window", comparability_disclosure_ref="disc:1")
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a")})
+        assert result.reports[0].status is CollectorStatus.TRUNCATION
+        assert result.disposition is AcquisitionDisposition.COMPLETED_PARTIAL
+        # The evidence record still exists, with a mandatory loss disclosure.
+        assert result.records[0].raw_content.loss_disclosure is not None
+
+
+class TestReverseOrderStop:
+    def test_collectors_stop_in_reverse_start_order(self, tmp_path):
+        log: list = []
+        b1 = _binding(requirement_id="req-a", registration_id="aptl.collector.a")
+        b2 = _binding(requirement_id="req-b", registration_id="aptl.collector.b")
+        collectors = {
+            "aptl.collector.a": _FakeCollector("aptl.collector.a", log=log),
+            "aptl.collector.b": _FakeCollector("aptl.collector.b", log=log),
+        }
+        _acquire(tmp_path, [b1, b2], collectors)
+
+        starts = [rid for kind, rid in log if kind == "start"]
+        stops = [rid for kind, rid in log if kind == "stop"]
+        assert starts == ["aptl.collector.a", "aptl.collector.b"]
+        assert stops == ["aptl.collector.b", "aptl.collector.a"]
+
+
+class TestRegistrationMismatch:
+    def test_a_collector_whose_id_mismatches_the_binding_is_rejected(self, tmp_path):
+        binding = _binding(registration_id="aptl.collector.a")
+        # Wired under the right key but reporting a different id.
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.WRONG")})
+        assert result.disposition is AcquisitionDisposition.INCONCLUSIVE
+        assert any("registration-mismatch" in d.code for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Limit enforcement + loss downgrade (codex review findings)
+# ---------------------------------------------------------------------------
+
+
+class TestLimitEnforcement:
+    def test_mid_run_dropped_events_downgrade_to_loss_and_invalidate(self, tmp_path):
+        binding = _binding()
+        outcome = CollectorOutcome(
+            status=CollectorStatus.OK, started_at="2026-07-20T00:00:00Z", finished_at="2026-07-20T00:00:00Z",
+            chunks=[b'{"e": 1}'], media_type="application/json", event_count=1, dropped_count=3,
+        )
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome=outcome)})
+        # A positive dropped_count is never silently OK / seal-ready.
+        assert result.reports[0].status is CollectorStatus.MID_RUN_LOSS
+        assert result.disposition is AcquisitionDisposition.INVALIDATED
+
+    def test_over_artifact_count_is_truncation(self, tmp_path):
+        binding = _binding(limits=CaptureLimits(max_bytes=8192, max_artifact_count=1, max_duration_s=60))
+        outcome = CollectorOutcome(
+            status=CollectorStatus.OK, started_at="2026-07-20T00:00:00Z", finished_at="2026-07-20T00:00:00Z",
+            chunks=[b'[{"e":1},{"e":2},{"e":3}]'], media_type="application/json", event_count=3,
+        )
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome=outcome)})
+        assert result.reports[0].status is CollectorStatus.TRUNCATION
+        assert result.disposition is AcquisitionDisposition.INVALIDATED
+
+    def test_over_duration_is_timeout(self, tmp_path):
+        binding = _binding(limits=CaptureLimits(max_bytes=8192, max_artifact_count=10, max_duration_s=1))
+        # The outcome's own start/finish span 5s, exceeding the 1s admitted duration.
+        outcome = CollectorOutcome(
+            status=CollectorStatus.OK, started_at="2026-07-20T00:00:00Z", finished_at="2026-07-20T00:00:05Z",
+            chunks=[b'{"e": 1}'], media_type="application/json", event_count=1,
+        )
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome=outcome)})
+        assert result.reports[0].status is CollectorStatus.TIMEOUT
+        assert result.disposition is AcquisitionDisposition.INVALIDATED
+
+
+class TestBindingKeyIsCaptureSpecScoped:
+    def test_two_specs_sharing_a_requirement_id_do_not_collide(self, tmp_path):
+        b1 = _binding(capture_spec_id="cap-1", requirement_id="shared", registration_id="aptl.collector.a")
+        b2 = _binding(capture_spec_id="cap-2", requirement_id="shared", registration_id="aptl.collector.b")
+        collectors = {
+            "aptl.collector.a": _FakeCollector("aptl.collector.a"),
+            "aptl.collector.b": _FakeCollector("aptl.collector.b"),
+        }
+        result = _acquire(tmp_path, [b1, b2], collectors)
+        assert result.disposition is AcquisitionDisposition.SEALED_READY
+        # Both bindings produced their own record — no overwrite.
+        assert len(result.records) == 2
+        spec_ids = {ref.capture_spec_id for ref in result.refs}
+        assert spec_ids == {"cap-1", "cap-2"}
+
+
+# ---------------------------------------------------------------------------
+# Trial-body lifecycle + media check (test-quality review: assert documented branches)
+# ---------------------------------------------------------------------------
+
+
+class TestTrialBodyLifecycle:
+    def test_trial_body_runs_while_collectors_are_live(self, tmp_path):
+        called = []
+        binding = _binding()
+        _acquire(
+            tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a")},
+            trial_body=lambda: called.append("ran"),
+        )
+        assert called == ["ran"]
+
+    def test_trial_body_is_skipped_when_no_collector_starts(self, tmp_path):
+        called = []
+        binding = _binding()
+        # No collector wired -> nothing starts -> the trial body is not run.
+        _acquire(tmp_path, [binding], {}, trial_body=lambda: called.append("ran"))
+        assert called == []
+
+    def test_a_raising_trial_body_still_runs_cleanup_and_captures_evidence(self, tmp_path):
+        def _boom():
+            raise RuntimeError("trial failed")
+
+        binding = _binding()
+        result = _acquire(
+            tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a")}, trial_body=_boom
+        )
+        # The raise is swallowed; the collector is still stopped and its evidence captured.
+        assert len(result.records) == 1
+        assert result.disposition is AcquisitionDisposition.SEALED_READY
+
+
+class TestMediaTypeCheck:
+    def test_unexpected_media_type_is_a_loss_and_invalidates(self, tmp_path):
+        binding = _binding()  # expects application/json
+        outcome = CollectorOutcome(
+            status=CollectorStatus.OK, started_at="2026-07-20T00:00:00Z", finished_at="2026-07-20T00:00:00Z",
+            chunks=[b"plain text"], media_type="text/plain", event_count=1,
+        )
+        result = _acquire(tmp_path, [binding], {"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome=outcome)})
+        assert result.reports[0].status is CollectorStatus.MID_RUN_LOSS
+        assert any("media-type-mismatch" in d.code for d in result.diagnostics)
+        assert result.disposition is AcquisitionDisposition.INVALIDATED

--- a/tests/test_evidence_coordinator.py
+++ b/tests/test_evidence_coordinator.py
@@ -14,11 +14,12 @@ import pytest
 from aptl.core.correlation.clock import FixedClockProvider
 from aptl.core.evidence.coordinator import acquire_evidence
 from aptl.core.evidence.outcomes import AcquisitionDisposition, CollectorStatus
-from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.evidence.protocol import CollectorOutcome, RunScope
 from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
 from aptl.core.runstore import LocalRunStore
 
 _CLOCK = FixedClockProvider(measurement_time="2026-07-20T00:00:00Z")
+_SCOPE = RunScope(run_id="run-1", planned_trial_id="trial-1", attempt_id="attempt-1")
 
 
 def _binding(*, requirement_id="req-a", registration_id="aptl.collector.a", max_bytes=4096, **overrides) -> CaptureBinding:
@@ -96,9 +97,7 @@ def _acquire(tmp_path, bindings, collectors, **kwargs):
         bindings=bindings,
         collectors=collectors,
         run_store=store,
-        run_id="run-1",
-        planned_trial_id="trial-1",
-        attempt_id="attempt-1",
+        scope=_SCOPE,
         clock=_CLOCK,
         **kwargs,
     )
@@ -122,9 +121,7 @@ class TestSuccessPath:
             bindings=[binding],
             collectors={"aptl.collector.a": _FakeCollector("aptl.collector.a")},
             run_store=store,
-            run_id="run-1",
-            planned_trial_id="trial-1",
-            attempt_id="attempt-1",
+            scope=_SCOPE,
             clock=_CLOCK,
         )
         ref = result.refs[0]

--- a/tests/test_evidence_correlation.py
+++ b/tests/test_evidence_correlation.py
@@ -15,11 +15,12 @@ from aptl.core.correlation.builder import build_correlation_projection
 from aptl.core.correlation.clock import FixedClockProvider
 from aptl.core.evidence.coordinator import acquire_evidence
 from aptl.core.evidence.outcomes import CollectorStatus
-from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.evidence.protocol import CollectorOutcome, RunScope
 from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
 from aptl.core.runstore import LocalRunStore
 
 _CLOCK = FixedClockProvider(measurement_time="2026-07-20T00:00:00Z")
+_SCOPE = RunScope(run_id="run-1", planned_trial_id="trial-1", attempt_id="a1")
 
 
 def _binding() -> CaptureBinding:
@@ -53,7 +54,7 @@ def test_acquired_evidence_refs_appear_in_the_correlation_projection(tmp_path):
     store = LocalRunStore(tmp_path / "runs")
     result = acquire_evidence(
         bindings=[_binding()], collectors={"aptl.collector.a": _FakeCollector()},
-        run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+        run_store=store, scope=_SCOPE, clock=_CLOCK,
     )
     assert result.refs
 
@@ -75,7 +76,7 @@ def test_reference_dict_carries_bounded_identity_only(tmp_path):
     store = LocalRunStore(tmp_path / "runs")
     result = acquire_evidence(
         bindings=[_binding()], collectors={"aptl.collector.a": _FakeCollector()},
-        run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+        run_store=store, scope=_SCOPE, clock=_CLOCK,
     )
     ref_dict = result.refs[0].as_reference_dict()
     assert ref_dict["kind"] == "experiment-evidence"

--- a/tests/test_evidence_correlation.py
+++ b/tests/test_evidence_correlation.py
@@ -1,0 +1,85 @@
+"""Integration between acquired evidence and the OBS-002 correlation projection
+(EXP-010 / issue #752 PR 2 — "Evidence references integrate with #447").
+
+The coordinator's :class:`EvidenceRef`s project to the
+``backend_evidence.evidence_references`` shape the correlation builder already
+consumes, so acquired evidence appears as evidence nodes in the run's
+correlation projection.
+"""
+
+from __future__ import annotations
+
+import json
+
+from aptl.core.correlation.builder import build_correlation_projection
+from aptl.core.correlation.clock import FixedClockProvider
+from aptl.core.evidence.coordinator import acquire_evidence
+from aptl.core.evidence.outcomes import CollectorStatus
+from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
+from aptl.core.runstore import LocalRunStore
+
+_CLOCK = FixedClockProvider(measurement_time="2026-07-20T00:00:00Z")
+
+
+def _binding() -> CaptureBinding:
+    return CaptureBinding(
+        capture_spec_id="cap-1", requirement_id="req-a", window_refs=("run-window",),
+        registration_id="aptl.collector.a", implementation_version="1.0.0",
+        contract_version="experiment-capture-spec/v1", effective_config_digest="sha256:" + "cd" * 32,
+        channel_ref_id="chan", channel_ref_version="1.0.0", channel_kind="participant-observation",
+        capture_kind="observation", capture_scope="participant", expected_media_types=("application/json",),
+        required_artifact_roles=("observation",), sensitivity="internal", redaction_required=False,
+        integrity_requirements=("sha256-digest",), retention_policy="retain", loss_disclosure_required=True,
+        visibility_class=CaptureVisibility.PARTICIPANT_VISIBLE,
+        limits=CaptureLimits(max_bytes=4096, max_artifact_count=10, max_duration_s=60),
+    )
+
+
+class _FakeCollector:
+    registration_id = "aptl.collector.a"
+
+    def start(self, context):
+        return object()
+
+    def stop(self, handle):
+        return CollectorOutcome(
+            status=CollectorStatus.OK, started_at="2026-07-20T00:00:00Z", finished_at="2026-07-20T00:00:05Z",
+            chunks=[json.dumps([{"action": "recon"}]).encode()], media_type="application/json", event_count=1,
+        )
+
+
+def test_acquired_evidence_refs_appear_in_the_correlation_projection(tmp_path):
+    store = LocalRunStore(tmp_path / "runs")
+    result = acquire_evidence(
+        bindings=[_binding()], collectors={"aptl.collector.a": _FakeCollector()},
+        run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+    )
+    assert result.refs
+
+    # Project the acquired refs into the run record the correlation builder reads.
+    run_record = {
+        "backend_evidence": {"evidence_references": [ref.as_reference_dict() for ref in result.refs]},
+    }
+    projection = build_correlation_projection(
+        run_id="run-1", run_record=run_record, orchestration={}, clock_provider=_CLOCK,
+    )
+
+    evidence_nodes = [node for node in projection.nodes if node.ref_kind == "evidence"]
+    assert len(evidence_nodes) == 1
+    # And every evidence node is linked to the run.
+    assert any(edge.target_ref for edge in projection.edges)
+
+
+def test_reference_dict_carries_bounded_identity_only(tmp_path):
+    store = LocalRunStore(tmp_path / "runs")
+    result = acquire_evidence(
+        bindings=[_binding()], collectors={"aptl.collector.a": _FakeCollector()},
+        run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+    )
+    ref_dict = result.refs[0].as_reference_dict()
+    assert ref_dict["kind"] == "experiment-evidence"
+    assert ref_dict["requirement_id"] == "req-a"
+    assert ref_dict["digest"].startswith("sha256:")
+    # No raw bytes / host path leak into the reference.
+    assert "/" not in ref_dict["path"].split("evidence/")[-1] or ref_dict["path"].startswith("evidence/")

--- a/tests/test_evidence_fuzz.py
+++ b/tests/test_evidence_fuzz.py
@@ -1,0 +1,66 @@
+"""Property-based tests for evidence acquisition (EXP-010 / issue #752 PR 2).
+
+Run with ``pytest -m fuzz`` (skipped by the default run). Covers the streaming
+byte-quota invariant and evidence-record identity determinism.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from aptl.core.evidence.content_store import create_content_addressed
+from aptl.core.evidence.records import derive_evidence_record_id
+from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
+from aptl.core.runstore import LocalRunStore
+
+
+def _binding() -> CaptureBinding:
+    return CaptureBinding(
+        capture_spec_id="cap-1", requirement_id="req-a", window_refs=("run-window",),
+        registration_id="aptl.collector.a", implementation_version="1.0.0",
+        contract_version="experiment-capture-spec/v1", effective_config_digest="sha256:" + "cd" * 32,
+        channel_ref_id="chan", channel_ref_version="1.0.0", channel_kind="evaluation-history",
+        capture_kind="trace", capture_scope="network", expected_media_types=("application/json",),
+        required_artifact_roles=("observation",), sensitivity="internal", redaction_required=False,
+        integrity_requirements=("sha256-digest",), retention_policy="retain", loss_disclosure_required=True,
+        visibility_class=CaptureVisibility.EVALUATOR_ONLY,
+        limits=CaptureLimits(max_bytes=1024, max_artifact_count=10, max_duration_s=60),
+    )
+
+
+@pytest.mark.fuzz
+class TestQuotaInvariant:
+    @given(
+        chunks=st.lists(st.binary(min_size=0, max_size=64), min_size=0, max_size=32),
+        max_bytes=st.integers(min_value=1, max_value=512),
+    )
+    @settings(max_examples=120, deadline=2000)
+    def test_stored_size_and_truncation_are_correct(self, tmp_path_factory, chunks, max_bytes):
+        store = LocalRunStore(tmp_path_factory.mktemp("runs"))
+        total = sum(len(c) for c in chunks)
+        result = create_content_addressed(store, "run-1", chunks, subdir="evidence", max_bytes=max_bytes)
+        assert result.size == min(total, max_bytes)
+        assert result.truncated == (total > max_bytes)
+
+
+@pytest.mark.fuzz
+class TestRecordIdentity:
+    @given(
+        run_id=st.text(alphabet="abcdef0123456789-", min_size=1, max_size=16),
+        content_digest=st.text(alphabet="0123456789abcdef", min_size=64, max_size=64),
+    )
+    @settings(max_examples=80, deadline=2000)
+    def test_identity_is_deterministic_and_content_sensitive(self, run_id, content_digest):
+        binding = _binding()
+        digest = f"sha256:{content_digest}"
+        a = derive_evidence_record_id(run_id=run_id, planned_trial_id="t", binding=binding, content_digest=digest)
+        b = derive_evidence_record_id(run_id=run_id, planned_trial_id="t", binding=binding, content_digest=digest)
+        assert a == b
+        assert a.startswith("evidence-")
+        other = derive_evidence_record_id(
+            run_id=run_id, planned_trial_id="t", binding=binding, content_digest="sha256:" + "0" * 64
+        )
+        if digest != "sha256:" + "0" * 64:
+            assert a != other

--- a/tests/test_evidence_records.py
+++ b/tests/test_evidence_records.py
@@ -1,0 +1,96 @@
+"""Tests for ACES evidence-record construction (EXP-010 / issue #752 PR 2).
+
+The emitted record is a public ``ExperimentEvidenceRecordModel`` (validated at
+construction and round-trippable through the ACES model), its identity is
+derived from stable inputs only (never ``captured_at`` / ingestion order), and
+a truncated/redacted/withheld record always carries the mandatory loss
+disclosure the ACES model requires.
+"""
+
+from __future__ import annotations
+
+from aces_contracts.contracts import ExperimentEvidenceRecordModel
+
+from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.evidence.outcomes import CollectorStatus
+from aptl.core.evidence.records import build_evidence_record, derive_evidence_record_id
+from aptl.core.evidence.content_store import ContentInsertion
+from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
+
+
+def _binding(**overrides) -> CaptureBinding:
+    fields: dict = {
+        "capture_spec_id": "cap-1", "requirement_id": "network-trace", "window_refs": ("run-window",),
+        "registration_id": "aptl.collector.a", "implementation_version": "1.0.0",
+        "contract_version": "experiment-capture-spec/v1", "effective_config_digest": "sha256:" + "cd" * 32,
+        "channel_ref_id": "chan", "channel_ref_version": "1.0.0", "channel_kind": "evaluation-history",
+        "capture_kind": "trace", "capture_scope": "network", "expected_media_types": ("application/json",),
+        "required_artifact_roles": ("observation",), "sensitivity": "internal", "redaction_required": False,
+        "integrity_requirements": ("sha256-digest",), "retention_policy": "retain", "loss_disclosure_required": True,
+        "visibility_class": CaptureVisibility.EVALUATOR_ONLY,
+        "limits": CaptureLimits(max_bytes=1024, max_artifact_count=10, max_duration_s=60),
+    }
+    fields.update(overrides)
+    return CaptureBinding(**fields)
+
+
+def _content(digest_hex="ab" * 32, size=42) -> ContentInsertion:
+    return ContentInsertion(relative_path=f"evidence/{digest_hex}", digest=f"sha256:{digest_hex}", size=size, truncated=False)
+
+
+def _outcome() -> CollectorOutcome:
+    return CollectorOutcome(status=CollectorStatus.OK, started_at="2026-07-20T00:00:00Z", finished_at="2026-07-20T00:00:05Z", event_count=3)
+
+
+def _record(**overrides):
+    kwargs = dict(
+        binding=_binding(), run_id="run-1", planned_trial_id="trial-1", content=_content(), outcome=_outcome(),
+        captured_at="2026-07-20T00:00:05Z", sensitivity="internal", redaction_state="none",
+    )
+    kwargs.update(overrides)
+    return build_evidence_record(**kwargs)
+
+
+class TestIdentity:
+    def test_same_inputs_yield_the_same_id(self):
+        a = derive_evidence_record_id(run_id="r", planned_trial_id="t", binding=_binding(), content_digest="sha256:" + "ab" * 32)
+        b = derive_evidence_record_id(run_id="r", planned_trial_id="t", binding=_binding(), content_digest="sha256:" + "ab" * 32)
+        assert a == b
+
+    def test_id_excludes_captured_at(self):
+        first = _record(captured_at="2026-07-20T00:00:05Z")
+        second = _record(captured_at="2026-07-20T23:59:59Z")
+        assert first.evidence_record_id == second.evidence_record_id
+
+    def test_id_depends_on_retained_content(self):
+        a = _record(content=_content("ab" * 32))
+        b = _record(content=_content("ef" * 32))
+        assert a.evidence_record_id != b.evidence_record_id
+
+
+class TestConformance:
+    def test_record_round_trips_through_the_aces_model(self):
+        record = _record()
+        # exclude_none: ACES reference models distinguish an absent optional
+        # field from one explicitly present as null (a capture-spec ref must
+        # not CARRY ref_digest/ref_path), so canonical serialization drops
+        # None-valued optionals.
+        reparsed = ExperimentEvidenceRecordModel.model_validate(record.model_dump(mode="json", exclude_none=True))
+        assert reparsed.evidence_record_id == record.evidence_record_id
+        assert reparsed.schema_version == "experiment-evidence-record/v1"
+
+    def test_record_carries_run_and_channel_references(self):
+        record = _record()
+        assert record.run_ref.ref_kind == "run"
+        assert record.source_refs[0].ref_kind == "measurement-channel"
+        assert record.raw_content.content_checksum.algorithm == "sha256"
+
+
+class TestLossDisclosure:
+    def test_withheld_record_requires_a_disclosure(self):
+        record = _record(redaction_state="withheld", loss_disclosure="withheld for evaluator-only visibility")
+        assert record.raw_content.loss_disclosure is not None
+
+    def test_lossless_participant_visible_record_has_none(self):
+        record = _record(redaction_state="none", loss_disclosure=None)
+        assert record.raw_content.loss_disclosure is None

--- a/tests/test_evidence_records.py
+++ b/tests/test_evidence_records.py
@@ -13,7 +13,7 @@ from aces_contracts.contracts import ExperimentEvidenceRecordModel
 
 from aptl.core.evidence.protocol import CollectorOutcome
 from aptl.core.evidence.outcomes import CollectorStatus
-from aptl.core.evidence.records import build_evidence_record, derive_evidence_record_id
+from aptl.core.evidence.records import RecordDisclosure, build_evidence_record, derive_evidence_record_id
 from aptl.core.evidence.content_store import ContentInsertion
 from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
 
@@ -42,13 +42,16 @@ def _outcome() -> CollectorOutcome:
     return CollectorOutcome(status=CollectorStatus.OK, started_at="2026-07-20T00:00:00Z", finished_at="2026-07-20T00:00:05Z", event_count=3)
 
 
-def _record(**overrides):
+def _record(*, sensitivity="internal", redaction_state="none", loss_disclosure=None, **overrides):
     kwargs = dict(
         binding=_binding(), run_id="run-1", planned_trial_id="trial-1", content=_content(), outcome=_outcome(),
-        captured_at="2026-07-20T00:00:05Z", sensitivity="internal", redaction_state="none",
+        captured_at="2026-07-20T00:00:05Z",
     )
     kwargs.update(overrides)
-    return build_evidence_record(**kwargs)
+    disclosure = RecordDisclosure(
+        sensitivity=sensitivity, redaction_state=redaction_state, loss_disclosure=loss_disclosure
+    )
+    return build_evidence_record(disclosure=disclosure, **kwargs)
 
 
 class TestIdentity:

--- a/tests/test_evidence_security.py
+++ b/tests/test_evidence_security.py
@@ -1,0 +1,134 @@
+"""Security tests for evidence acquisition (EXP-010 / issue #752 PR 2).
+
+Proves control-plane secrets are redacted out of the stored bytes, that
+participant-hidden / evaluator-only evidence never enters the participant
+projection, and that hostile filesystem inputs (symlinked components) fail
+closed at the content-addressed persistence boundary.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aptl.core.correlation.clock import FixedClockProvider
+from aptl.core.evidence._persist import EvidenceRef
+from aptl.core.evidence.content_store import create_content_addressed
+from aptl.core.evidence.coordinator import acquire_evidence
+from aptl.core.evidence.outcomes import AcquisitionDisposition, CollectorStatus
+from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.evidence.visibility import project_for_participant
+from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
+from aptl.core.runstore import LocalRunStore
+from aptl.utils.pathsafe import PathContainmentError
+
+_CLOCK = FixedClockProvider(measurement_time="2026-07-20T00:00:00Z")
+_SECRET = "sk-live-super-secret-token-abcdef1234567890"
+
+
+def _binding(*, visibility=CaptureVisibility.PARTICIPANT_VISIBLE, **overrides) -> CaptureBinding:
+    fields: dict = {
+        "capture_spec_id": "cap-1", "requirement_id": "req-a", "window_refs": ("run-window",),
+        "registration_id": "aptl.collector.a", "implementation_version": "1.0.0",
+        "contract_version": "experiment-capture-spec/v1", "effective_config_digest": "sha256:" + "cd" * 32,
+        "channel_ref_id": "chan", "channel_ref_version": "1.0.0", "channel_kind": "participant-observation",
+        "capture_kind": "observation", "capture_scope": "participant", "expected_media_types": ("application/json",),
+        "required_artifact_roles": ("observation",), "sensitivity": "internal", "redaction_required": True,
+        "integrity_requirements": ("sha256-digest",), "retention_policy": "retain", "loss_disclosure_required": True,
+        "visibility_class": visibility,
+        "limits": CaptureLimits(max_bytes=8192, max_artifact_count=10, max_duration_s=60),
+    }
+    fields.update(overrides)
+    return CaptureBinding(**fields)
+
+
+class _FakeCollector:
+    def __init__(self, registration_id, outcome):
+        self._rid = registration_id
+        self._outcome = outcome
+
+    @property
+    def registration_id(self):
+        return self._rid
+
+    def start(self, context):
+        return object()
+
+    def stop(self, handle):
+        return self._outcome
+
+
+def _json_outcome(records):
+    return CollectorOutcome(
+        status=CollectorStatus.OK, started_at="2026-07-20T00:00:00Z", finished_at="2026-07-20T00:00:05Z",
+        chunks=[json.dumps(records).encode("utf-8")], media_type="application/json", event_count=len(records),
+    )
+
+
+class TestSecretRedaction:
+    def test_control_plane_secret_is_redacted_from_stored_bytes(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        binding = _binding()
+        outcome = _json_outcome([{"user": "admin", "api_key": _SECRET}])
+        result = acquire_evidence(
+            bindings=[binding], collectors={"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome)},
+            run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+        )
+        stored = (store.get_run_path("run-1") / result.refs[0].content_uri).read_bytes()
+        assert _SECRET.encode() not in stored
+        assert result.records[0].redaction_state == "redacted"
+
+    def test_redacted_record_carries_a_disclosure(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        binding = _binding()
+        outcome = _json_outcome([{"token": _SECRET}])
+        result = acquire_evidence(
+            bindings=[binding], collectors={"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome)},
+            run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+        )
+        assert result.records[0].raw_content.loss_disclosure is not None
+
+
+class TestVisibilityProjection:
+    def _ref(self, visibility_class):
+        return EvidenceRef(
+            evidence_record_id="e1", content_uri="evidence/x", content_digest="sha256:" + "ab" * 32,
+            capture_spec_id="cap-1", requirement_id="req-a", registration_id="aptl.collector.a",
+            visibility_class=visibility_class,
+        )
+
+    def test_evaluator_only_and_apparatus_only_are_dropped(self):
+        refs = [
+            self._ref("participant-visible"),
+            self._ref("disclosed"),
+            self._ref("evaluator-only"),
+            self._ref("apparatus-only"),
+        ]
+        visible = project_for_participant(refs)
+        classes = {r.visibility_class for r in visible}
+        assert classes == {"participant-visible", "disclosed"}
+
+    def test_evaluator_only_evidence_never_enters_the_participant_projection(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        binding = _binding(visibility=CaptureVisibility.EVALUATOR_ONLY)
+        outcome = _json_outcome([{"detection": 1}])
+        result = acquire_evidence(
+            bindings=[binding], collectors={"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome)},
+            run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+        )
+        assert result.disposition is AcquisitionDisposition.SEALED_READY
+        assert project_for_participant(result.refs) == ()
+
+
+class TestHostilePersistence:
+    def test_symlinked_evidence_component_fails_closed(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        run_dir = store.create_run("run-1")
+        # Plant a symlink where the evidence subtree would be created.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (run_dir / "evidence").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(PathContainmentError):
+            create_content_addressed(store, "run-1", [b"x"], subdir="evidence/blobs", max_bytes=64)

--- a/tests/test_evidence_security.py
+++ b/tests/test_evidence_security.py
@@ -17,13 +17,14 @@ from aptl.core.evidence._persist import EvidenceRef
 from aptl.core.evidence.content_store import create_content_addressed
 from aptl.core.evidence.coordinator import acquire_evidence
 from aptl.core.evidence.outcomes import AcquisitionDisposition, CollectorStatus
-from aptl.core.evidence.protocol import CollectorOutcome
+from aptl.core.evidence.protocol import CollectorOutcome, RunScope
 from aptl.core.evidence.visibility import project_for_participant
 from aptl.core.experiment.capture_registry import CaptureBinding, CaptureLimits, CaptureVisibility
 from aptl.core.runstore import LocalRunStore
 from aptl.utils.pathsafe import PathContainmentError
 
 _CLOCK = FixedClockProvider(measurement_time="2026-07-20T00:00:00Z")
+_SCOPE = RunScope(run_id="run-1", planned_trial_id="trial-1", attempt_id="a1")
 _SECRET = "sk-live-super-secret-token-abcdef1234567890"
 
 
@@ -73,7 +74,7 @@ class TestSecretRedaction:
         outcome = _json_outcome([{"user": "admin", "api_key": _SECRET}])
         result = acquire_evidence(
             bindings=[binding], collectors={"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome)},
-            run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+            run_store=store, scope=_SCOPE, clock=_CLOCK,
         )
         stored = (store.get_run_path("run-1") / result.refs[0].content_uri).read_bytes()
         assert _SECRET.encode() not in stored
@@ -85,7 +86,7 @@ class TestSecretRedaction:
         outcome = _json_outcome([{"token": _SECRET}])
         result = acquire_evidence(
             bindings=[binding], collectors={"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome)},
-            run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+            run_store=store, scope=_SCOPE, clock=_CLOCK,
         )
         assert result.records[0].raw_content.loss_disclosure is not None
 
@@ -115,7 +116,7 @@ class TestVisibilityProjection:
         outcome = _json_outcome([{"detection": 1}])
         result = acquire_evidence(
             bindings=[binding], collectors={"aptl.collector.a": _FakeCollector("aptl.collector.a", outcome)},
-            run_store=store, run_id="run-1", planned_trial_id="trial-1", attempt_id="a1", clock=_CLOCK,
+            run_store=store, scope=_SCOPE, clock=_CLOCK,
         )
         assert result.disposition is AcquisitionDisposition.SEALED_READY
         assert project_for_participant(result.refs) == ()

--- a/tests/test_experiment_capture_mapping.py
+++ b/tests/test_experiment_capture_mapping.py
@@ -224,15 +224,31 @@ from hypothesis import strategies as st  # noqa: E402
 _CAPTURE_KINDS = ("artifact", "observation", "trace", "telemetry", "log", "packet-capture", "other")
 _CAPTURE_SCOPES = ("task", "run", "apparatus", "participant", "backend", "processor", "network", "service")
 
+#: The (capture_kind, capture_scope) pairs the production built-in fleet covers
+#: for the reference requirement's other axes (media/integrity/window/etc.).
+#: EXP-010 PR 2 turned these on; every other legal combination still fails
+#: closed.
+_COVERED_BY_DEFAULT_FLEET = frozenset(
+    {
+        ("observation", "participant"),
+        ("log", "service"),
+        ("log", "network"),
+        ("telemetry", "service"),
+        ("trace", "run"),
+    }
+)
+
 
 @pytest.mark.fuzz
-class TestFuzzCaptureRequirementsFailClosed:
+class TestFuzzCaptureRequirementsDeterministic:
     @given(
         capture_kind=st.sampled_from(_CAPTURE_KINDS),
         capture_scope=st.sampled_from(_CAPTURE_SCOPES),
     )
     @settings(max_examples=56, deadline=2000)
-    def test_every_legal_kind_scope_combination_fails_closed_by_default(self, capture_kind, capture_scope):
+    def test_every_legal_kind_scope_combination_is_deterministic_against_the_default_fleet(
+        self, capture_kind, capture_scope
+    ):
         payload = json.loads(_read("experiment-core", "experiment-capture-spec-v1", "valid", "reference.json"))
         requirement = next(iter(payload["capture_requirements"].values()))
         requirement["capture_kind"] = capture_kind
@@ -241,5 +257,9 @@ class TestFuzzCaptureRequirementsFailClosed:
         spec = ExperimentCaptureSpecModel.model_validate(payload)
         policy = default_admission_policy()
 
-        with pytest.raises(AdmissionRejection):
-            bind_capture_requirements([spec], policy=policy)
+        if (capture_kind, capture_scope) in _COVERED_BY_DEFAULT_FLEET:
+            bindings = bind_capture_requirements([spec], policy=policy)
+            assert len(bindings) == 1
+        else:
+            with pytest.raises(AdmissionRejection):
+                bind_capture_requirements([spec], policy=policy)

--- a/tests/test_manifest_observation.py
+++ b/tests/test_manifest_observation.py
@@ -55,13 +55,23 @@ def _registration() -> CollectorRegistration:
     )
 
 
-class TestHonestDefault:
-    def test_default_manifest_declares_no_observation(self):
-        assert create_aptl_manifest().observation is None
+class TestBackedDefault:
+    """EXP-010 PR 2 turned the production registry on together with the
+    acquisition machinery + adapters + conformance fixtures (the honesty
+    rule), so the default manifest now declares a real observation capability
+    and carries the required evidence contracts."""
 
-    def test_default_manifest_omits_the_observation_only_contracts(self):
+    def test_default_manifest_declares_observation(self):
+        assert create_aptl_manifest().observation is not None
+
+    def test_default_manifest_includes_the_observation_contracts(self):
         supported = create_aptl_manifest().supported_contract_versions
-        assert OBSERVATION_EVIDENCE_CONTRACTS.isdisjoint(supported)
+        assert OBSERVATION_EVIDENCE_CONTRACTS <= supported
+
+    def test_default_manifest_has_no_observation_contract_gaps(self):
+        from aces_backend_protocols.capabilities import observation_capability_contract_gaps
+
+        assert observation_capability_contract_gaps(create_aptl_manifest()) == ()
 
 
 class TestPopulatedProjection:

--- a/tests/test_runstore_content_store.py
+++ b/tests/test_runstore_content_store.py
@@ -1,0 +1,119 @@
+"""Tests for the content-addressed + run-scoped create-once evidence
+persistence functions (EXP-010 / issue #752 evidence acquisition).
+
+``create_content_addressed`` streams raw evidence into a digest-named object
+under the run dir with byte quotas enforced during streaming, no-follow /
+create-exclusive publication, and post-write digest verification.
+``create_run_json_once`` is the run-scoped create-once JSON writer (travels in
+the exporter's per-run tar). Both extend the ``LocalRunStore`` boundary
+narrowly rather than adding a second repository.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from aptl.core.evidence.content_store import create_content_addressed, create_run_json_once
+from aptl.core.runstore import LocalRunStore, RunStoreConflictError, SecretInvariantError
+
+
+def _store(tmp_path) -> LocalRunStore:
+    """Return a LocalRunStore rooted at a fresh temp dir."""
+    return LocalRunStore(tmp_path / "runs")
+
+
+# ---------------------------------------------------------------------------
+# create_content_addressed
+# ---------------------------------------------------------------------------
+
+
+class TestContentAddressed:
+    def test_stores_under_digest_named_path_and_returns_metadata(self, tmp_path):
+        store = _store(tmp_path)
+        payload = b"raw evidence bytes"
+        digest_hex = hashlib.sha256(payload).hexdigest()
+
+        result = create_content_addressed(store, "run-1", [payload], subdir="evidence", max_bytes=1024)
+
+        assert result.relative_path == f"evidence/{digest_hex}"
+        assert result.digest == f"sha256:{digest_hex}"
+        assert result.size == len(payload)
+        assert result.truncated is False
+        stored = (store.get_run_path("run-1") / result.relative_path).read_bytes()
+        assert stored == payload
+
+    def test_streams_multiple_chunks(self, tmp_path):
+        store = _store(tmp_path)
+        chunks = [b"aaa", b"bbb", b"ccc"]
+        joined = b"".join(chunks)
+
+        result = create_content_addressed(store, "run-1", chunks, subdir="evidence", max_bytes=1024)
+
+        assert result.size == len(joined)
+        assert result.digest == f"sha256:{hashlib.sha256(joined).hexdigest()}"
+
+    def test_over_quota_source_is_truncated_not_buffered(self, tmp_path):
+        store = _store(tmp_path)
+        result = create_content_addressed(store, "run-1", [b"x" * 10, b"y" * 10], subdir="evidence", max_bytes=15)
+        assert result.size == 15
+        assert result.truncated is True
+
+    def test_exact_fill_with_no_more_data_is_not_truncated(self, tmp_path):
+        store = _store(tmp_path)
+        result = create_content_addressed(store, "run-1", [b"x" * 8], subdir="evidence", max_bytes=8)
+        assert result.size == 8
+        assert result.truncated is False
+
+    def test_exact_fill_with_more_data_is_truncated(self, tmp_path):
+        store = _store(tmp_path)
+        result = create_content_addressed(store, "run-1", [b"x" * 8, b"y"], subdir="evidence", max_bytes=8)
+        assert result.size == 8
+        assert result.truncated is True
+
+    def test_identical_bytes_are_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        first = create_content_addressed(store, "run-1", [b"same"], subdir="evidence", max_bytes=64)
+        second = create_content_addressed(store, "run-1", [b"same"], subdir="evidence", max_bytes=64)
+        assert first == second
+
+    def test_zero_max_bytes_is_rejected(self, tmp_path):
+        store = _store(tmp_path)
+        with pytest.raises(ValueError, match="max_bytes must be positive"):
+            create_content_addressed(store, "run-1", [b"x"], subdir="evidence", max_bytes=0)
+
+    def test_traversal_subdir_is_rejected(self, tmp_path):
+        store = _store(tmp_path)
+        with pytest.raises(ValueError):
+            create_content_addressed(store, "run-1", [b"x"], subdir="../escape", max_bytes=64)
+
+
+# ---------------------------------------------------------------------------
+# create_run_json_once
+# ---------------------------------------------------------------------------
+
+
+class TestRunJsonOnce:
+    def test_writes_under_the_run_dir(self, tmp_path):
+        store = _store(tmp_path)
+        target = create_run_json_once(store, "run-1", "evidence/records/rec-1.json", {"a": 1})
+        assert target.is_relative_to(store.get_run_path("run-1"))
+        assert target.exists()
+
+    def test_identical_payload_is_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        first = create_run_json_once(store, "run-1", "evidence/r.json", {"a": 1, "b": 2})
+        second = create_run_json_once(store, "run-1", "evidence/r.json", {"b": 2, "a": 1})
+        assert first == second
+
+    def test_different_payload_conflicts(self, tmp_path):
+        store = _store(tmp_path)
+        create_run_json_once(store, "run-1", "evidence/r.json", {"a": 1})
+        with pytest.raises(RunStoreConflictError):
+            create_run_json_once(store, "run-1", "evidence/r.json", {"a": 2})
+
+    def test_secret_shaped_payload_is_rejected(self, tmp_path):
+        store = _store(tmp_path)
+        with pytest.raises(SecretInvariantError):
+            create_run_json_once(store, "run-1", "evidence/r.json", {"api_key": "sk-live-secret-value-123456789"})


### PR DESCRIPTION
## Summary

EXP-010 PR 2 of 2 — the evidence-acquisition half, completing the requirement on PR 1's admission foundation. A new `src/aptl/core/evidence/` package provides a narrow Collector protocol (no controller/store/paths), a start/run/stop-in-finally coordinator with distinct terminal semantics (missing-source / startup-failure / mid-run-loss / truncation / clock-skew / timeout / finalization-failure, and sealed-ready vs invalidated / inconclusive / completed-partial dispositions), a content-addressed + run-scoped create-once persistence extension of `RunStorageBackend` (streaming byte quota, no-follow/create-exclusive, post-write digest verification), ACES `experiment-evidence-record-v1` construction with content-derived identity, structured redaction + participant-visibility projection, and a windowed-source adapter framework over the existing container/SOC/MCP/sidecar owners. Populating the trusted built-in fleet turns `create_aptl_manifest().observation` on as an aggregate registry projection, and verified evidence refs integrate with the #447 correlation projection. Live-lab collector execution stays with #437/#459; sealing is #444.

## Requirement UIDs

- `EXP-010`

## Related Issues

Closes #752

## ADR Impact

- ADR-047

## Changes

- New `core/evidence/`: protocol (narrow Collector + immutable context), outcomes (terminal/reason-code taxonomy + dispositions), content_store (content-addressed streaming + run-scoped create-once over `RunStorageBackend`), records (ACES evidence-record-v1 + content-derived identity), _persist (media check, structured redaction, limit enforcement, ledger), coordinator (start/run/stop-in-finally + disposition), visibility (participant projection)
- `core/evidence/adapters/`: windowed-query collector framework + concrete built-in sources (run-archive, container logs, SOC) + wiring seam
- `capture_registrations.py`: the 5 trusted built-in registrations (mcp-red, container-logs, suricata-eve, wazuh-alerts, tempo-traces) — turns observation on
- The coordinator enforces admitted duration + artifact-count + byte limits; a dropped-event capture is never silently seal-ready; per-binding state is scoped by (capture_spec_id, requirement_id) (codex findings)
- Evidence references integrate with the #447 correlation projection via `backend_evidence.evidence_references`

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Lint / complexity / Vale gates pass
- [x] No coverage regression

Full non-integration suite: 3021 passed, 92 skipped. New: test_runstore_content_store (CAS quotas/no-follow/verify/idempotency), test_evidence_records (identity determinism + ACES conformance round-trip + loss disclosure), test_evidence_coordinator (all terminal dispositions, reverse-order stop, limit enforcement, key scoping, trial-body lifecycle, media check), test_evidence_adapters (framework + concrete sources distinguishing failure from empty), test_evidence_security (secret redaction in stored bytes, visibility projection, hostile symlink fails closed), test_evidence_correlation (#447 refs), test_evidence_fuzz (quota + identity determinism). Codex (3 correctness findings fixed) + test-quality (branch-assertion coverage added) reviews consumed under user-authorized over-cap cycles.

## Ground Control Checks

- [x] `make policy` passes (Vale)
- [x] Quality gates pass (gc_assert_quality_gates)
- [x] Codex + test-quality reviews consumed; findings fixed

## Traceability

- IMPLEMENTS: src/aptl/core/evidence/coordinator.py, src/aptl/core/evidence/content_store.py, src/aptl/core/evidence/records.py, src/aptl/core/evidence/_persist.py, src/aptl/core/evidence/protocol.py, src/aptl/core/evidence/adapters/sources.py, src/aptl/core/experiment/capture_registrations.py
- TESTS: tests/test_evidence_coordinator.py, tests/test_evidence_records.py, tests/test_evidence_security.py, tests/test_evidence_correlation.py, tests/test_runstore_content_store.py

## Documentation

Verified unchanged: the EXP-010 preflight note (added in PR 1) already documents the acquisition design.
