### PR TITLE
fix(security): content-source deny-list + Linux capability allowlist

### DIFF
--- a/src/aptl/backends/aces_base_substrate.py
+++ b/src/aptl/backends/aces_base_substrate.py
@@ -26,6 +26,28 @@ from aptl.backends.aces_materializer import (
 )
 from aptl.core.deployment.realization import LOOPBACK_HOST_IP
 
+# ADR-047: a scenario declares runtime.linux_capabilities.add and APTL grants
+# it directly via `docker run --cap-add`, with no per-product code standing
+# between the SDL and the host-privilege flag. Without a bound on which
+# capabilities are grantable, any scenario could request CAP_SYS_ADMIN or
+# another host-impacting capability and APTL would honor it unquestioningly
+# (issue #816). Only capabilities APTL's own scenarios have a verified need
+# for are permitted; anything else fails admission rather than a silent
+# grant. Expanding this set is a deliberate decision, matching the
+# manifest-honesty rule elsewhere in the materializer: never claim more than
+# is proven necessary.
+_ALLOWED_EXTRA_CAPABILITIES = frozenset(
+    {
+        # aptl lab continuity-audit reverts blanket kali source-IP DROPs on a
+        # target's own INPUT chain (src/aptl/core/continuity.py).
+        "NET_ADMIN",
+    }
+)
+
+
+class UnauthorizedCapabilityError(ValueError):
+    """Raised when a scenario declares a Linux capability outside APTL's allowlist."""
+
 
 @dataclass(frozen=True)
 class InitRequirements:
@@ -177,6 +199,14 @@ def _init_requirements(runtime: RuntimeConfiguration | None) -> InitRequirements
         name.removeprefix("CAP_")
         for name in (runtime.linux_capabilities.add if runtime and runtime.linux_capabilities else ())
     )
+    unauthorized = sorted(set(extra) - _ALLOWED_EXTRA_CAPABILITIES)
+    if unauthorized:
+        raise UnauthorizedCapabilityError(
+            "runtime.linux_capabilities.add declared a capability APTL does "
+            f"not permit: {', '.join('CAP_' + cap for cap in unauthorized)}. "
+            "Allowed: "
+            f"{', '.join('CAP_' + cap for cap in sorted(_ALLOWED_EXTRA_CAPABILITIES))}."
+        )
     if not extra:
         return InitRequirements()
     base = InitRequirements()

--- a/src/aptl/backends/aces_content_realization.py
+++ b/src/aptl/backends/aces_content_realization.py
@@ -65,6 +65,62 @@ _CONTENT_REALIZABLE_SERVICES: dict[str, str] = {
 _RUNTIME_OBSERVED_PREFIX = "runtime-observed:"
 _SAFE_DEST_RELPATH = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
 
+# Pure secret material with no legitimate scenario-content use, regardless
+# of project-root containment (issue #816): a content placement naming one
+# of these as its source could copy a real operator credential into any
+# addressed node, including one a lab participant can reach (e.g. kali over
+# SSH). Checked before containment so nothing about the target node or the
+# author's self-reported `sensitive` flag can authorize it.
+_FORBIDDEN_SOURCE_PREFIXES = (
+    ".git/",
+    "config/soc_certs/",
+    "config/wazuh_indexer_ssl_certs/",
+)
+
+# keys/ and config/lab-ssh/ are the one exception: they hold both the
+# public/combined authorized_keys files legitimately distributed onto
+# target nodes and the SEC #417 pivot private keys intentionally placed
+# onto their designated node (src/aptl/core/ssh.py). A blanket deny would
+# break those already-shipped placements, so instead only the exact
+# filenames that module generates are allowed; anything else under these
+# directories is unexpected and rejected the same as a forbidden path.
+_KEY_MATERIAL_PREFIXES = ("keys/", "config/lab-ssh/")
+_ALLOWED_KEY_SOURCE_NAMES = frozenset(
+    {
+        "keys/aptl_lab_key.pub",
+        "keys/authorized_keys",
+        "keys/target_authorized_keys",
+        "keys/victim_authorized_keys",
+        "config/lab-ssh/kali_pivot_key",
+        "config/lab-ssh/kali_pivot_key.pub",
+        "config/lab-ssh/workstation_pivot_key",
+        "config/lab-ssh/workstation_pivot_key.pub",
+    }
+)
+
+
+def _forbidden_source_reason(source_name: str) -> str | None:
+    """Return a reason code if `source_name` must never be a content source.
+
+    Independent of, and checked before, the project-containment check: a
+    path can be entirely inside the project root and still be something a
+    scenario must never be able to select (issue #816).
+    """
+
+    normalized = source_name.lstrip("/")
+    if normalized == ".env" or normalized.startswith(".env."):
+        return "source-is-environment-file"
+    if normalized == ".git" or any(
+        normalized.startswith(prefix) for prefix in _FORBIDDEN_SOURCE_PREFIXES
+    ):
+        return "source-is-forbidden-path"
+    if (
+        any(normalized.startswith(prefix) for prefix in _KEY_MATERIAL_PREFIXES)
+        and normalized not in _ALLOWED_KEY_SOURCE_NAMES
+    ):
+        return "source-is-unlisted-key-material"
+    return None
+
 
 @dataclass(frozen=True)
 class _ContentPlacementInputs(object):
@@ -320,6 +376,9 @@ def _resolve_project_source(
 ) -> tuple[Path | None, list[Diagnostic]]:
     """Resolve a checked-in source path, failing closed on containment escape."""
 
+    forbidden_reason = _forbidden_source_reason(source_name)
+    if forbidden_reason is not None:
+        return None, [_reject(address, forbidden_reason)]
     try:
         resolved = _resolve_within_project(project_dir, Path(source_name))
     except PathContainmentError:
@@ -398,6 +457,15 @@ def _project_source_rejection(
                 "aptl.provisioner.content-not-realizable",
                 resource.address,
                 "runtime-observed content cannot be recreated from source.",
+            )
+        ]
+    forbidden_reason = _forbidden_source_reason(source_name)
+    if forbidden_reason is not None:
+        return [
+            diagnostic(
+                "aptl.provisioner.content-source-forbidden",
+                resource.address,
+                f"content source is not permitted (reason={forbidden_reason}).",
             )
         ]
     try:

--- a/src/aptl/backends/aces_content_realization.py
+++ b/src/aptl/backends/aces_content_realization.py
@@ -38,6 +38,7 @@ from typing import Any
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.planning import PlannedResource
 
+from aptl.backends.aces_content_source_policy import forbidden_source_reason
 from aptl.backends.aces_diagnostics import diagnostic
 from aptl.backends.aces_realization_values import (
     content_source_name as _content_source_name,
@@ -64,62 +65,6 @@ _CONTENT_REALIZABLE_SERVICES: dict[str, str] = {
 
 _RUNTIME_OBSERVED_PREFIX = "runtime-observed:"
 _SAFE_DEST_RELPATH = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
-
-# Pure secret material with no legitimate scenario-content use, regardless
-# of project-root containment (issue #816): a content placement naming one
-# of these as its source could copy a real operator credential into any
-# addressed node, including one a lab participant can reach (e.g. kali over
-# SSH). Checked before containment so nothing about the target node or the
-# author's self-reported `sensitive` flag can authorize it.
-_FORBIDDEN_SOURCE_PREFIXES = (
-    ".git/",
-    "config/soc_certs/",
-    "config/wazuh_indexer_ssl_certs/",
-)
-
-# keys/ and config/lab-ssh/ are the one exception: they hold both the
-# public/combined authorized_keys files legitimately distributed onto
-# target nodes and the SEC #417 pivot private keys intentionally placed
-# onto their designated node (src/aptl/core/ssh.py). A blanket deny would
-# break those already-shipped placements, so instead only the exact
-# filenames that module generates are allowed; anything else under these
-# directories is unexpected and rejected the same as a forbidden path.
-_KEY_MATERIAL_PREFIXES = ("keys/", "config/lab-ssh/")
-_ALLOWED_KEY_SOURCE_NAMES = frozenset(
-    {
-        "keys/aptl_lab_key.pub",
-        "keys/authorized_keys",
-        "keys/target_authorized_keys",
-        "keys/victim_authorized_keys",
-        "config/lab-ssh/kali_pivot_key",
-        "config/lab-ssh/kali_pivot_key.pub",
-        "config/lab-ssh/workstation_pivot_key",
-        "config/lab-ssh/workstation_pivot_key.pub",
-    }
-)
-
-
-def _forbidden_source_reason(source_name: str) -> str | None:
-    """Return a reason code if `source_name` must never be a content source.
-
-    Independent of, and checked before, the project-containment check: a
-    path can be entirely inside the project root and still be something a
-    scenario must never be able to select (issue #816).
-    """
-
-    normalized = source_name.lstrip("/")
-    if normalized == ".env" or normalized.startswith(".env."):
-        return "source-is-environment-file"
-    if normalized == ".git" or any(
-        normalized.startswith(prefix) for prefix in _FORBIDDEN_SOURCE_PREFIXES
-    ):
-        return "source-is-forbidden-path"
-    if (
-        any(normalized.startswith(prefix) for prefix in _KEY_MATERIAL_PREFIXES)
-        and normalized not in _ALLOWED_KEY_SOURCE_NAMES
-    ):
-        return "source-is-unlisted-key-material"
-    return None
 
 
 @dataclass(frozen=True)
@@ -376,7 +321,7 @@ def _resolve_project_source(
 ) -> tuple[Path | None, list[Diagnostic]]:
     """Resolve a checked-in source path, failing closed on containment escape."""
 
-    forbidden_reason = _forbidden_source_reason(source_name)
+    forbidden_reason = forbidden_source_reason(source_name)
     if forbidden_reason is not None:
         return None, [_reject(address, forbidden_reason)]
     try:
@@ -413,155 +358,3 @@ def _reject(address: str, reason_code: str) -> Diagnostic:
             f"realization policy (reason={reason_code})."
         ),
     )
-
-
-_ImageFreeResult = tuple[DeploymentContentRealization | None, list[Diagnostic]]
-
-
-def _inline_text_image_free_placement(
-    resource: PlannedResource,
-    target_address: str,
-    *,
-    dest: str,
-    name: str,
-    text: str | None,
-    spec: Mapping[str, Any],
-) -> _ImageFreeResult | None:
-    """Lower an inline-text placement, or None if this spec is not one."""
-
-    if text is None or not dest:
-        return None
-    return (
-        DeploymentContentRealization(
-            address=resource.address,
-            target_address=target_address,
-            content_name=name,
-            volume_suffix="",
-            dest_relpath=dest.lstrip("/"),
-            source_kind="inline-text",
-            inline_text=text,
-            sensitive=spec.get("sensitive") is True,
-        ),
-        [],
-    )
-
-
-def _project_source_rejection(
-    resource: PlannedResource, source_name: str
-) -> list[Diagnostic] | None:
-    """Return fail-closed diagnostics if a project source can't be realized, else None."""
-
-    if source_name.startswith(_RUNTIME_OBSERVED_PREFIX):
-        return [
-            diagnostic(
-                "aptl.provisioner.content-not-realizable",
-                resource.address,
-                "runtime-observed content cannot be recreated from source.",
-            )
-        ]
-    forbidden_reason = _forbidden_source_reason(source_name)
-    if forbidden_reason is not None:
-        return [
-            diagnostic(
-                "aptl.provisioner.content-source-forbidden",
-                resource.address,
-                f"content source is not permitted (reason={forbidden_reason}).",
-            )
-        ]
-    try:
-        _resolve_within_project(Path(""), source_name)
-    except PathContainmentError:
-        return [
-            diagnostic(
-                "aptl.provisioner.content-source-escapes-project",
-                resource.address,
-                "content source path escapes the project root.",
-            )
-        ]
-    return None
-
-
-def _project_source_image_free_placement(
-    resource: PlannedResource,
-    target_address: str,
-    *,
-    dest: str,
-    name: str,
-    source_name: str,
-    content_type: str,
-    spec: Mapping[str, Any],
-) -> _ImageFreeResult | None:
-    """Lower a project-contained source placement, or None if this spec is not one."""
-
-    if not source_name or not dest:
-        return None
-    diagnostics = _project_source_rejection(resource, source_name)
-    if diagnostics is not None:
-        return None, diagnostics
-    kind = "project-directory" if content_type == "directory" else "project-file"
-    return (
-        DeploymentContentRealization(
-            address=resource.address,
-            target_address=target_address,
-            content_name=name,
-            volume_suffix="",
-            dest_relpath=dest.lstrip("/"),
-            source_kind=kind,
-            source_relpath=source_name,
-            sensitive=spec.get("sensitive") is True,
-        ),
-        [],
-    )
-
-
-def resolve_image_free_content_placement(
-    resource: PlannedResource,
-    payload: Mapping[str, Any],
-    target_address: str,
-) -> _ImageFreeResult:
-    """Resolve content for an image-free node (ADR-048).
-
-    The generic materializer places declared config directly into the node's
-    container, so there is no compose service / named-volume requirement.
-    ``path``/``destination`` is the authored, literal absolute destination
-    (never volume-relative). Inline text and project-contained file/directory
-    sources both lower to a ``DeploymentContentRealization``; dataset content
-    and runtime-observed sources are not realizable and fail closed rather
-    than being silently dropped.
-    """
-
-    spec = _placement_spec(payload)
-    if spec is None:
-        return None, [
-            diagnostic(
-                "aptl.provisioner.invalid-content-spec",
-                resource.address,
-                "content placement has no spec.",
-            )
-        ]
-    dest = _optional_string(spec, "path") or _optional_string(spec, "destination")
-    name = _optional_string(payload, "content_name") or _optional_string(payload, "name") or ""
-
-    result = _inline_text_image_free_placement(
-        resource, target_address, dest=dest, name=name, text=_content_text(spec), spec=spec
-    )
-    if result is None:
-        result = _project_source_image_free_placement(
-            resource,
-            target_address,
-            dest=dest,
-            name=name,
-            source_name=_content_source_name(spec),
-            content_type=_optional_string(spec, "type") or "",
-            spec=spec,
-        )
-    if result is None:
-        result = None, [
-            diagnostic(
-                "aptl.provisioner.image-free-content-unsupported",
-                resource.address,
-                "image-free content placement supports an inline-text file or a "
-                "project-contained file/directory source with a destination path.",
-            )
-        ]
-    return result

--- a/src/aptl/backends/aces_content_source_policy.py
+++ b/src/aptl/backends/aces_content_source_policy.py
@@ -1,0 +1,74 @@
+"""Content-placement source policy: what a scenario may name as `source:` (#816).
+
+Split out of ``aces_content_realization.py`` (module-length budget). A
+retroactive Codex security review of merged PR #812 found that content-
+placement source resolution only checked project-root containment, never
+*which* file was selected — a scenario could name ``.env`` (real operator
+credentials) as its source, target a participant-accessible node like kali,
+and the file would be copied in. The author-set ``sensitive`` flag on the
+content spec is self-reported metadata; it never gated this.
+
+``forbidden_source_reason`` is checked before, and independent of, the
+project-containment check both content-realization entry points already
+run: a path can be entirely inside the project root and still be something
+a scenario must never be able to select.
+"""
+
+from __future__ import annotations
+
+# Pure secret material with no legitimate scenario-content use, regardless
+# of project-root containment: a content placement naming one of these as
+# its source could copy a real operator credential into any addressed
+# node, including one a lab participant can reach (e.g. kali over SSH).
+_FORBIDDEN_SOURCE_PREFIXES = (
+    ".git/",
+    "config/soc_certs/",
+    "config/wazuh_indexer_ssl_certs/",
+)
+
+# keys/ and config/lab-ssh/ are the one exception: they hold both the
+# public/combined authorized_keys files legitimately distributed onto
+# target nodes and the SEC #417 pivot private keys intentionally placed
+# onto their designated node (src/aptl/core/ssh.py). A blanket deny would
+# break those already-shipped placements, so instead only the exact
+# filenames that module generates are allowed; anything else under these
+# directories is unexpected and rejected the same as a forbidden path.
+_KEY_MATERIAL_PREFIXES = ("keys/", "config/lab-ssh/")
+_ALLOWED_KEY_SOURCE_NAMES = frozenset(
+    {
+        "keys/aptl_lab_key.pub",
+        "keys/authorized_keys",
+        "keys/target_authorized_keys",
+        "keys/victim_authorized_keys",
+        "config/lab-ssh/kali_pivot_key",
+        "config/lab-ssh/kali_pivot_key.pub",
+        "config/lab-ssh/workstation_pivot_key",
+        "config/lab-ssh/workstation_pivot_key.pub",
+    }
+)
+
+
+def forbidden_source_reason(source_name: str) -> str | None:
+    """Return a reason code if `source_name` must never be a content source."""
+
+    normalized = source_name.lstrip("/")
+    checks = (
+        (
+            normalized == ".env" or normalized.startswith(".env."),
+            "source-is-environment-file",
+        ),
+        (
+            normalized == ".git"
+            or any(normalized.startswith(prefix) for prefix in _FORBIDDEN_SOURCE_PREFIXES),
+            "source-is-forbidden-path",
+        ),
+        (
+            any(normalized.startswith(prefix) for prefix in _KEY_MATERIAL_PREFIXES)
+            and normalized not in _ALLOWED_KEY_SOURCE_NAMES,
+            "source-is-unlisted-key-material",
+        ),
+    )
+    for is_match, reason in checks:
+        if is_match:
+            return reason
+    return None

--- a/src/aptl/backends/aces_image_free_content_realization.py
+++ b/src/aptl/backends/aces_image_free_content_realization.py
@@ -1,0 +1,178 @@
+"""Resolve ACES content-placement payloads for image-free nodes (ADR-048).
+
+Split out of ``aces_content_realization.py`` (module-length budget). The
+generic materializer places declared config directly into a node's own
+container filesystem, never a Compose-managed named volume, so this path
+carries no ``volume_suffix``/``target_service`` and the authored
+``path``/``destination`` is a literal absolute destination.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import PlannedResource
+
+from aptl.backends.aces_content_source_policy import forbidden_source_reason
+from aptl.backends.aces_diagnostics import diagnostic
+from aptl.backends.aces_realization_values import (
+    content_source_name as _content_source_name,
+    content_text as _content_text,
+    optional_string as _optional_string,
+    placement_spec as _placement_spec,
+)
+from aptl.core.credentials import PathContainmentError, _resolve_within_project
+from aptl.core.deployment.realization import DeploymentContentRealization
+
+_RUNTIME_OBSERVED_PREFIX = "runtime-observed:"
+
+_ImageFreeResult = tuple[DeploymentContentRealization | None, list[Diagnostic]]
+
+
+def _inline_text_image_free_placement(
+    resource: PlannedResource,
+    target_address: str,
+    *,
+    dest: str,
+    name: str,
+    text: str | None,
+    spec: Mapping[str, Any],
+) -> _ImageFreeResult | None:
+    """Lower an inline-text placement, or None if this spec is not one."""
+
+    if text is None or not dest:
+        return None
+    return (
+        DeploymentContentRealization(
+            address=resource.address,
+            target_address=target_address,
+            content_name=name,
+            volume_suffix="",
+            dest_relpath=dest.lstrip("/"),
+            source_kind="inline-text",
+            inline_text=text,
+            sensitive=spec.get("sensitive") is True,
+        ),
+        [],
+    )
+
+
+def _project_source_rejection(
+    resource: PlannedResource, source_name: str
+) -> list[Diagnostic] | None:
+    """Return fail-closed diagnostics if a project source can't be realized, else None."""
+
+    rejection: tuple[str, str] | None = None
+    if source_name.startswith(_RUNTIME_OBSERVED_PREFIX):
+        rejection = (
+            "aptl.provisioner.content-not-realizable",
+            "runtime-observed content cannot be recreated from source.",
+        )
+    else:
+        forbidden_reason = forbidden_source_reason(source_name)
+        if forbidden_reason is not None:
+            rejection = (
+                "aptl.provisioner.content-source-forbidden",
+                f"content source is not permitted (reason={forbidden_reason}).",
+            )
+        else:
+            try:
+                _resolve_within_project(Path(""), source_name)
+            except PathContainmentError:
+                rejection = (
+                    "aptl.provisioner.content-source-escapes-project",
+                    "content source path escapes the project root.",
+                )
+    if rejection is None:
+        return None
+    code, message = rejection
+    return [diagnostic(code, resource.address, message)]
+
+
+def _project_source_image_free_placement(
+    resource: PlannedResource,
+    target_address: str,
+    *,
+    dest: str,
+    name: str,
+    source_name: str,
+    content_type: str,
+    spec: Mapping[str, Any],
+) -> _ImageFreeResult | None:
+    """Lower a project-contained source placement, or None if this spec is not one."""
+
+    if not source_name or not dest:
+        return None
+    diagnostics = _project_source_rejection(resource, source_name)
+    if diagnostics is not None:
+        return None, diagnostics
+    kind = "project-directory" if content_type == "directory" else "project-file"
+    return (
+        DeploymentContentRealization(
+            address=resource.address,
+            target_address=target_address,
+            content_name=name,
+            volume_suffix="",
+            dest_relpath=dest.lstrip("/"),
+            source_kind=kind,
+            source_relpath=source_name,
+            sensitive=spec.get("sensitive") is True,
+        ),
+        [],
+    )
+
+
+def resolve_image_free_content_placement(
+    resource: PlannedResource,
+    payload: Mapping[str, Any],
+    target_address: str,
+) -> _ImageFreeResult:
+    """Resolve content for an image-free node (ADR-048).
+
+    The generic materializer places declared config directly into the node's
+    container, so there is no compose service / named-volume requirement.
+    ``path``/``destination`` is the authored, literal absolute destination
+    (never volume-relative). Inline text and project-contained file/directory
+    sources both lower to a ``DeploymentContentRealization``; dataset content
+    and runtime-observed sources are not realizable and fail closed rather
+    than being silently dropped.
+    """
+
+    spec = _placement_spec(payload)
+    if spec is None:
+        return None, [
+            diagnostic(
+                "aptl.provisioner.invalid-content-spec",
+                resource.address,
+                "content placement has no spec.",
+            )
+        ]
+    dest = _optional_string(spec, "path") or _optional_string(spec, "destination")
+    name = _optional_string(payload, "content_name") or _optional_string(payload, "name") or ""
+
+    result = _inline_text_image_free_placement(
+        resource, target_address, dest=dest, name=name, text=_content_text(spec), spec=spec
+    )
+    if result is None:
+        result = _project_source_image_free_placement(
+            resource,
+            target_address,
+            dest=dest,
+            name=name,
+            source_name=_content_source_name(spec),
+            content_type=_optional_string(spec, "type") or "",
+            spec=spec,
+        )
+    if result is None:
+        result = None, [
+            diagnostic(
+                "aptl.provisioner.image-free-content-unsupported",
+                resource.address,
+                "image-free content placement supports an inline-text file or a "
+                "project-contained file/directory source with a destination path.",
+            )
+        ]
+    return result

--- a/src/aptl/backends/aces_placement_realization.py
+++ b/src/aptl/backends/aces_placement_realization.py
@@ -18,11 +18,11 @@ from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.planning import PlannedResource
 
 from aptl.backends.aces_account_realization import resolve_account_placement
-from aptl.backends.aces_content_realization import (
-    resolve_content_placement,
+from aptl.backends.aces_content_realization import resolve_content_placement
+from aptl.backends.aces_diagnostics import diagnostic
+from aptl.backends.aces_image_free_content_realization import (
     resolve_image_free_content_placement,
 )
-from aptl.backends.aces_diagnostics import diagnostic
 from aptl.backends.aces_profiles import normalize_identifier
 from aptl.backends.aces_realization_model import (
     NodeRealization,

--- a/tests/test_aces_base_substrate.py
+++ b/tests/test_aces_base_substrate.py
@@ -4,7 +4,8 @@ A node runs on a generic base-OS container chosen solely from its declared
 `os`/`os_version` (never a per-node or appliance image). A node that declares
 service units needs an init-capable substrate so `systemctl` works; a node that
 declares none does not. This module encodes that scenario-independent decision;
-the concrete init mechanism is backend/host integration validated in AWS.
+the concrete init mechanism is backend/host integration validated against real
+local Docker.
 """
 
 from __future__ import annotations
@@ -17,7 +18,11 @@ from aces_sdl.runtime_configuration import (
     ServiceManagerUnit,
 )
 
-from aptl.backends.aces_base_substrate import base_container_spec, plan_node
+from aptl.backends.aces_base_substrate import (
+    UnauthorizedCapabilityError,
+    base_container_spec,
+    plan_node,
+)
 from aptl.backends.aces_materializer import (
     BaseSubstrateOp,
     StartServiceUnitOp,
@@ -86,13 +91,25 @@ class TestBaseContainerSpec:
             service_manager_units=[
                 ServiceManagerUnit(unit_id="svc", unit_name="svc.service", active_state="active")
             ],
-            linux_capabilities=RuntimeCapabilityPolicy(add=["CAP_AUDIT_CONTROL"]),
+            linux_capabilities=RuntimeCapabilityPolicy(add=["CAP_NET_ADMIN"]),
         )
         spec = base_container_spec("n.node", os="linux", os_version="", runtime=runtime)
         assert spec.init is not None
-        assert "AUDIT_CONTROL" in spec.init.capabilities
+        assert "NET_ADMIN" in spec.init.capabilities
         # The fixed systemd requirements are still present alongside the addition.
         assert "SYS_ADMIN" in spec.init.capabilities
+
+    def test_declared_capability_outside_the_allowlist_is_rejected(self):
+        # issue #816: a scenario declaring a host-impacting capability APTL
+        # has no verified need for must fail admission, not be granted.
+        runtime = RuntimeConfiguration(
+            service_manager_units=[
+                ServiceManagerUnit(unit_id="svc", unit_name="svc.service", active_state="active")
+            ],
+            linux_capabilities=RuntimeCapabilityPolicy(add=["CAP_SYS_ADMIN"]),
+        )
+        with pytest.raises(UnauthorizedCapabilityError, match="CAP_SYS_ADMIN"):
+            base_container_spec("n.node", os="linux", os_version="", runtime=runtime)
 
     def test_no_declared_capabilities_keeps_the_fixed_default_set(self):
         spec = base_container_spec(

--- a/tests/test_content_realization_source_policy.py
+++ b/tests/test_content_realization_source_policy.py
@@ -1,0 +1,237 @@
+"""Content-source policy tests: forbidden paths + key-material allowlist (#816).
+
+A retroactive Codex security review of PR #812 found that content-placement
+source resolution only checked project-root containment, not *which*
+in-repo file was selected — a scenario could name `.env` (real operator
+credentials) as its source, targeting a participant-accessible node like
+kali, and the file would be copied in. These tests pin the fix: universal
+secret paths are always rejected regardless of project-root containment,
+and the one legitimate exception (keys/ + config/lab-ssh/, which hold both
+distributable public keys and the SEC #417 pivot private keys) is
+restricted to the exact filenames src/aptl/core/ssh.py generates.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aces_contracts.planning import PlannedResource, RuntimeDomain
+
+from aptl.backends.aces_content_realization import (
+    _forbidden_source_reason,
+    resolve_content_placement,
+    resolve_image_free_content_placement,
+)
+
+# --------------------------------------------------------------------------- #
+# _forbidden_source_reason — pure policy function
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "source_name",
+    [
+        ".env",
+        ".env.local",
+        ".env.development.local",
+        ".env.production.local",
+        "config/soc_certs/ca.key",
+        "config/wazuh_indexer_ssl_certs/indexer.pem",
+        ".git/config",
+        ".git",
+        "keys/some_new_secret",
+        "config/lab-ssh/other_key",
+    ],
+)
+def test_forbidden_or_unlisted_sources_are_rejected(source_name):
+    assert _forbidden_source_reason(source_name) is not None
+
+
+@pytest.mark.parametrize(
+    "source_name",
+    [
+        "keys/aptl_lab_key.pub",
+        "keys/authorized_keys",
+        "keys/target_authorized_keys",
+        "keys/victim_authorized_keys",
+        "config/lab-ssh/kali_pivot_key",
+        "config/lab-ssh/kali_pivot_key.pub",
+        "config/lab-ssh/workstation_pivot_key",
+        "config/lab-ssh/workstation_pivot_key.pub",
+        "src",
+        "pyproject.toml",
+        "README.md",
+        "hatch_build.py",
+        "containers/db/init/01-schema.sql",
+        "containers/kali/scripts/aptl-wrap-shell.sh",
+    ],
+)
+def test_legitimate_sources_are_not_forbidden(source_name):
+    assert _forbidden_source_reason(source_name) is None
+
+
+def test_leading_slash_does_not_bypass_the_check():
+    assert _forbidden_source_reason("/.env") is not None
+    assert _forbidden_source_reason("/config/soc_certs/ca.key") is not None
+
+
+# --------------------------------------------------------------------------- #
+# resolve_content_placement — legacy (Compose-managed) entry point
+# --------------------------------------------------------------------------- #
+
+
+def _resource(address: str = "provision.content-placement.attack") -> PlannedResource:
+    return PlannedResource(
+        address=address,
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="content-placement",
+        payload={},
+    )
+
+
+def _file_payload(source_name: str, *, dest: str = "public/leak.txt") -> dict:
+    return {
+        "name": "attack",
+        "content_name": "attack",
+        "target_node": "fileshare",
+        "target_address": "provision.node.fileshare",
+        "spec": {
+            "type": "file",
+            "description": "",
+            "target": "fileshare",
+            "path": dest,
+            "destination": "",
+            "text": None,
+            "source": {"name": source_name, "version": "*", "build": None},
+            "format": "",
+            "items": [],
+            "sensitive": False,
+            "tags": [],
+        },
+    }
+
+
+def test_legacy_path_rejects_dotenv_as_a_content_source(tmp_path):
+    (tmp_path / ".env").write_text("MISP_API_KEY=real-secret-value\n")
+    payload = _file_payload(".env")
+
+    content, diagnostics = resolve_content_placement(
+        resource=_resource(),
+        payload=payload,
+        target_address="provision.node.fileshare",
+        target_service="fileshare",
+        project_dir=tmp_path,
+    )
+
+    assert content is None
+    assert len(diagnostics) == 1
+    assert diagnostics[0].is_error
+
+
+def test_legacy_path_still_realizes_an_allowed_key_source(tmp_path):
+    keys_dir = tmp_path / "keys"
+    keys_dir.mkdir()
+    (keys_dir / "victim_authorized_keys").write_text("ssh-ed25519 AAAA...\n")
+    payload = _file_payload("keys/victim_authorized_keys")
+
+    content, diagnostics = resolve_content_placement(
+        resource=_resource(),
+        payload=payload,
+        target_address="provision.node.fileshare",
+        target_service="fileshare",
+        project_dir=tmp_path,
+    )
+
+    assert diagnostics == []
+    assert content is not None
+    assert content.source_relpath == "keys/victim_authorized_keys"
+
+
+def test_legacy_path_rejects_an_unlisted_file_under_keys(tmp_path):
+    keys_dir = tmp_path / "keys"
+    keys_dir.mkdir()
+    (keys_dir / "some_new_secret").write_text("shh\n")
+    payload = _file_payload("keys/some_new_secret")
+
+    content, diagnostics = resolve_content_placement(
+        resource=_resource(),
+        payload=payload,
+        target_address="provision.node.fileshare",
+        target_service="fileshare",
+        project_dir=tmp_path,
+    )
+
+    assert content is None
+    assert len(diagnostics) == 1
+    assert diagnostics[0].is_error
+
+
+# --------------------------------------------------------------------------- #
+# resolve_image_free_content_placement — ADR-048 generic-materializer entry point
+# --------------------------------------------------------------------------- #
+
+
+def _image_free_payload(source_name: str, *, dest: str = "/home/kali/leak.txt") -> dict:
+    return {
+        "name": "attack",
+        "content_name": "attack",
+        "spec": {
+            "type": "file",
+            "description": "",
+            "target": "kali",
+            "path": dest,
+            "destination": "",
+            "text": None,
+            "source": {"name": source_name, "version": "*", "build": None},
+            "format": "",
+            "items": [],
+            "sensitive": False,
+            "tags": [],
+        },
+    }
+
+
+def test_image_free_path_rejects_dotenv_targeting_kali():
+    payload = _image_free_payload(".env")
+
+    content, diagnostics = resolve_image_free_content_placement(
+        resource=_resource(),
+        payload=payload,
+        target_address="provision.node.kali",
+    )
+
+    assert content is None
+    assert len(diagnostics) == 1
+    assert diagnostics[0].code == "aptl.provisioner.content-source-forbidden"
+    assert diagnostics[0].is_error
+
+
+def test_image_free_path_still_realizes_the_kali_pivot_key():
+    payload = _image_free_payload(
+        "config/lab-ssh/kali_pivot_key", dest="/home/kali/.ssh/kali_pivot_key"
+    )
+
+    content, diagnostics = resolve_image_free_content_placement(
+        resource=_resource(),
+        payload=payload,
+        target_address="provision.node.kali",
+    )
+
+    assert diagnostics == []
+    assert content is not None
+    assert content.source_relpath == "config/lab-ssh/kali_pivot_key"
+
+
+def test_image_free_path_rejects_an_unlisted_file_under_config_lab_ssh():
+    payload = _image_free_payload(
+        "config/lab-ssh/other_key", dest="/home/kali/.ssh/other_key"
+    )
+
+    content, diagnostics = resolve_image_free_content_placement(
+        resource=_resource(),
+        payload=payload,
+        target_address="provision.node.kali",
+    )
+
+    assert content is None
+    assert len(diagnostics) == 1
+    assert diagnostics[0].code == "aptl.provisioner.content-source-forbidden"

--- a/tests/test_content_realization_source_policy.py
+++ b/tests/test_content_realization_source_policy.py
@@ -16,14 +16,14 @@ from __future__ import annotations
 import pytest
 from aces_contracts.planning import PlannedResource, RuntimeDomain
 
-from aptl.backends.aces_content_realization import (
-    _forbidden_source_reason,
-    resolve_content_placement,
+from aptl.backends.aces_content_realization import resolve_content_placement
+from aptl.backends.aces_content_source_policy import forbidden_source_reason
+from aptl.backends.aces_image_free_content_realization import (
     resolve_image_free_content_placement,
 )
 
 # --------------------------------------------------------------------------- #
-# _forbidden_source_reason — pure policy function
+# forbidden_source_reason — pure policy function
 # --------------------------------------------------------------------------- #
 
 
@@ -43,7 +43,7 @@ from aptl.backends.aces_content_realization import (
     ],
 )
 def test_forbidden_or_unlisted_sources_are_rejected(source_name):
-    assert _forbidden_source_reason(source_name) is not None
+    assert forbidden_source_reason(source_name) is not None
 
 
 @pytest.mark.parametrize(
@@ -66,12 +66,12 @@ def test_forbidden_or_unlisted_sources_are_rejected(source_name):
     ],
 )
 def test_legitimate_sources_are_not_forbidden(source_name):
-    assert _forbidden_source_reason(source_name) is None
+    assert forbidden_source_reason(source_name) is None
 
 
 def test_leading_slash_does_not_bypass_the_check():
-    assert _forbidden_source_reason("/.env") is not None
-    assert _forbidden_source_reason("/config/soc_certs/ca.key") is not None
+    assert forbidden_source_reason("/.env") is not None
+    assert forbidden_source_reason("/config/soc_certs/ca.key") is not None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Fixes issue #816: two real security gaps in the generic materializer's admission path, found by a retroactive Codex security review of merged PR #812.

## Finding 1 — content-source deny-list (credential exfiltration)

`_project_source_rejection()`/`_resolve_project_source()` only checked that a declared content `source:` path stayed within the project root — never *which* file was selected. `.env` (real MISP/Shuffle/TheHive/Cortex/indexer credentials) lives inside the project root, so a content placement naming it as `source:`, targeting a participant-accessible node like kali (reachable over SSH), would pass the existing check and get copied in. The author-set `sensitive` flag is self-reported metadata — it never gated this.

Fixed by rejecting known-secret paths before the containment check runs at all, independent of any author-supplied flag: `.env` and its dotenv variants, `config/soc_certs/`, `config/wazuh_indexer_ssl_certs/`, `.git/`.

`keys/` and `config/lab-ssh/` are the one exception — both hold legitimate, already-shipped content (public/combined `authorized_keys` files, and the SEC #417 pivot private keys intentionally placed onto their designated node). A blanket deny would regress real functionality, so instead they're restricted to the exact filenames `src/aptl/core/ssh.py` generates; anything else under them is rejected the same as a forbidden path.

## Finding 2 — Linux capability allowlist

`_init_requirements()` took `runtime.linux_capabilities.add` straight from the SDL and `_init_run_flags()` passed each one directly to `docker run --cap-add`, with no bound on which capabilities a scenario could request. Any node could declare `CAP_SYS_ADMIN` or another host-impacting capability and APTL would grant it unquestioningly.

Fixed with a fixed allowlist — currently just `NET_ADMIN`, the one capability APTL's own scenarios have a verified need for (`aptl lab continuity-audit` reverting blanket kali source-IP DROPs). Anything outside it fails admission with a diagnostic instead of a silent grant.

## Verification

- `uv run pytest -n auto -k "not integration"` — 3117 passed
- `uv run ruff check` — clean
- New tests in `tests/test_content_realization_source_policy.py` covering both the deny-list and the allowlist, using the exact attack shape described above (`.env` → kali)
- New test in `tests/test_aces_base_substrate.py` covering the capability allowlist rejection
- Real local `aptl lab start`: clean boot, zero diagnostics; confirmed webapp/fileshare/dns still get `CAP_NET_ADMIN`, and the workstation/kali pivot keys still place correctly

## Test plan

- [x] Full unit suite green
- [x] Real local lab boot, zero diagnostics
- [x] Direct verification: `docker inspect aptl-webapp` shows `CAP_NET_ADMIN`; workstation/kali pivot key files present in their containers