### PR TITLE
feat: define bounded participant lab profile

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,6 +156,7 @@ The victim and kali containers publish no host ports; use
 
 ## Preflights
 
+- [Issue #820 Resource-Bounded Participant Profile](issue-820-resource-bounded-participant-profile-preflight.md)
 - [DEP-008 Self-Contained Lab Assets](dep-008-self-contained-lab-assets-preflight.md)
 - [RNG-001 Ephemeral Environments](rng-001-ephemeral-environments-preflight.md)
 - [DEP-003 Ephemeral Lifecycle Policy](dep-003-ephemeral-lifecycle-preflight.md)

--- a/docs/architecture/issue-820-resource-bounded-participant-profile-preflight.md
+++ b/docs/architecture/issue-820-resource-bounded-participant-profile-preflight.md
@@ -1,0 +1,150 @@
+# Issue #820: Resource-Bounded Participant Profile
+
+This note records the implementation boundary for APTL's reusable bounded
+participant lab profile. ADR-049 owns the disposable appliance around the lab;
+this issue owns the inner APTL workload that the appliance will carry.
+
+## Dependency direction
+
+Issues #820, #821, and #822 are peers:
+
+- #820 defines and qualifies the bounded APTL lab profile.
+- #821 supplies the in-appliance workbench profiles and their exact MCP and
+  bookmark inventories.
+- #822 enforces appliance zones, egress, and physical-host exposure.
+- #823 consumes all three outputs to assemble and qualify the disposable
+  appliance artifact.
+
+The participant profile therefore does not reference an appliance payload,
+require #823 output, or duplicate #822 listener policy. Its qualification
+report is an input to #823's broader appliance qualification.
+
+## Profile authority
+
+`participant-profiles/guided-purple-v1/profile.json` is the versioned binding.
+It references immutable inputs by contained path and SHA-256 digest:
+
+- the required, optional, and facilitator-only narrative;
+- the existing `techvault-attacker-target` ACES scenario;
+- the non-secret `AptlConfig`;
+- the readiness suite;
+- the staged profile asset lock;
+- the #821 workbench profile sequence; and
+- minimum hardware plus resource and lifecycle ceilings.
+
+The profile is not another topology. APTL continues to derive services and
+networks from the scenario catalog, ACES planning and dependency closure,
+`AptlConfig`, and the Compose profile index. Both missing and unexpected
+steady-state services fail qualification.
+
+Unknown manifest fields, unsafe paths, digest drift, scenario/catalog drift,
+unrecognised workbench profiles, and required narrative operations without
+readiness checks fail closed.
+
+## Frozen guided narrative
+
+Version 1 requires one attack → detect → investigate → purple loop:
+
+1. open the staged guide and Kali desktop projections;
+2. prove the real Kali backend with `id`;
+3. generate bounded failed SSH logins against the declared victim;
+4. find the resulting Wazuh rule 5710 event through the indexer MCP;
+5. retrieve it through the Wazuh MCP;
+6. inspect it through the `soc-wazuh` browser projection; and
+7. correlate those results in one run record.
+
+SMB, web SQL injection, Suricata, MISP, TheHive, Cortex, Shuffle, and the
+enterprise range remain full-research material. No event-specific scenario,
+Compose profile, image, MCP server, or source fork is introduced.
+
+## Workbench and capability surface
+
+The delivery sequence is `red` followed by `guided-blue`. These are #821
+workbench profiles, not copied allow-lists:
+
+- `red` contributes `aptl-red`, `aptl-guide`, and `kali-desktop`;
+- `guided-blue` contributes `aptl-indexer`, `aptl-wazuh`, `aptl-guide`, and
+  `soc-wazuh`.
+
+The participant-profile loader derives the union of MCP server IDs and browser
+bookmarks from those workbench definitions. Qualification requires the exact
+workbench sequence and exact derived MCP/browser surfaces.
+
+Each allowed MCP must initialize, return the exact tool inventory defined by
+its workbench `ServerProfile`, and complete its bounded semantic backend
+operation. A successful process start, TCP connect, or `tools/list` call alone
+does not pass. Disabled full-blue servers and bookmarks must be absent.
+
+#822 owns network listener and egress enforcement. #823 owns the appliance
+participant route and proves the combined artifact. This profile supplies the
+capability expectations they consume.
+
+## Staged assets
+
+`asset-lock.json` is the content-addressed closure for version 1. It locks the
+profile inputs, Compose model, released MCP artifacts/dependency locks, and
+the exact OCI identities required by the derived service set. Profile loading
+verifies every project-contained entry and validates every OCI digest
+relationship before qualification.
+
+Profile startup is staged-only. The qualification report fails if startup or
+the guided workflow records a download, image pull, image build, or package
+resolution. Developer starts may retain their normal conveniences, but they
+are not qualification evidence.
+
+The asset lock is intentionally separate from ADR-049's signed appliance
+payload manifest. #823 embeds this locked closure and binds it into the signed
+outer artifact.
+
+## Readiness and qualification
+
+`readiness.json` is the machine-readable required-check set. The report must
+contain that exact set (no missing or extra check IDs), and all checks must pass.
+It also records:
+
+- exact expected and actual services and networks;
+- actual workbench profiles, MCP servers, and browser bookmarks;
+- minimum-hardware identity;
+- denied-egress and post-stage resolution counters;
+- peak CPU and memory;
+- staged profile-asset, unique compressed-image, unique expanded-image, and
+  peak runtime-disk sizes;
+- cold start, warm start, and clean inner reset durations; and
+- canonical run-record and snapshot references.
+
+Those are inner workload measurements. Guest OS, kiosk lifecycle, physical
+host listeners, and disposable-seat replacement are outer appliance concerns
+measured by #823.
+
+`aptl lab qualify-profile --report <path> --public-key <path> --run-id <id>`
+reloads the bound profile, verifies the qualification pipeline's Ed25519
+attestation plus the content-addressed run record and range snapshot,
+re-derives the runtime surface from that authenticated snapshot, evaluates the
+strict report, and persists the redacted result through the configured run
+store. It exits nonzero for invalid, unauthenticated, or nonconforming
+evidence. The protected pipeline supplies the trusted key independently of the
+report producer.
+
+## Acceptance mapping
+
+- Clean minimum-hardware boot: exact hardware plus cold-start evidence.
+- Measured memory, disk, start, warm start, and reset: typed measurements
+  evaluated against the versioned ceilings.
+- Real MCP smoke: the red backend proof and attack run before the indexer and
+  Wazuh alert checks, with exact `tools/list` validation.
+- Disabled service absence: exact derived service matrix and exact
+  workbench/MCP/browser surfaces.
+- No post-stage downloads: asset-lock identity, denied egress, and zero
+  pull/build/download/package-resolution counters.
+- Complete guided workflow: every narrative operation maps to a required
+  readiness check.
+- Bounded versus full research: the participant reference and workshop
+  material name the excluded research systems explicitly.
+
+## Non-goals
+
+This issue does not implement the disposable appliance, host kiosk, seat
+replacement, outer signed payload, network zones, physical-host publication,
+or a general role system. It does not change ACES scenario meaning, add a
+second start path, or turn the full blue workbench into a workshop-specific
+profile.

--- a/docs/components/participant-workbench.md
+++ b/docs/components/participant-workbench.md
@@ -8,11 +8,12 @@ for the appliance's network enforcement.
 
 ## Profiles
 
-The workbench accepts only two closed profiles:
+The workbench accepts only three closed profiles:
 
 | Profile | MCP servers | Browser references |
 | --- | --- | --- |
 | `red` | `aptl-red` | APTL guide and Kali desktop |
+| `guided-blue` | `aptl-indexer`, `aptl-wazuh` | APTL guide and Wazuh |
 | `blue` | `aptl-indexer`, `aptl-wazuh`, `aptl-network`, `aptl-threatintel`, `aptl-casemgmt`, `aptl-soar` | APTL guide, Wazuh, TheHive, MISP, and Shuffle |
 
 A profile is a launch compartment, not a UI visibility toggle. A purple
@@ -25,11 +26,11 @@ The runtime verifies the exact `tools/list` inventory immediately after each
 profile launch. The red profile is limited to `kali_info`, `kali_run_command`,
 `kali_interactive_session`, `kali_background_session`, `kali_session_command`,
 `kali_list_sessions`, `kali_close_session`, `kali_get_session_output`, and
-`kali_close_all_sessions`. The blue profile's allowed tool set is the union of
-the published indexer, Wazuh, network, threat-intelligence, case-management,
-and SOAR server inventories encoded in `aptl.workbench.profiles`; an added,
-removed, or cross-profile tool fails the launch rather than being hidden from
-the user interface.
+`kali_close_all_sessions`. The guided-blue variation admits only the published
+indexer and Wazuh inventories for the bounded profile in issue #820. The full
+blue profile adds network, threat-intelligence, case-management, and SOAR. An
+added, removed, or cross-profile tool fails the launch rather than being
+hidden from the user interface.
 
 ## Launch contract
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ run from source instead, use a virtualenv editable install
 - [Smoke Test Plan](testing/smoke-test-plan.md): Historical full-stack plan for the pre-SDL scenario engine
 
 ### Reference
+- [Guided Purple Participant Profile](reference/participant-profile.md): Versioned bounded workshop surface, readiness contract, and qualification ceilings
 - [TechVault Scenario Overview](reference/techvault-scenario-overview.md): What the default range contains—topology, targets, SOC stack, planted vulnerabilities, and curated variants
 - [TechVault Company Profile](reference/techvault-company-profile.md)
 - [TechVault OSINT Readiness](reference/techvault-osint-readiness.md)

--- a/docs/reference/participant-profile.md
+++ b/docs/reference/participant-profile.md
@@ -1,0 +1,119 @@
+# Guided Purple Participant Profile
+
+`guided-purple` version 1 is APTL's bounded workshop and classroom profile. It
+freezes one attack-detect-investigate-purple narrative without creating an
+event-specific scenario, Compose profile, or source fork.
+
+The versioned binding is
+`participant-profiles/guided-purple-v1/profile.json`. It references, by path
+and SHA-256 digest, the narrative, existing `techvault-attacker-target`
+scenario, non-secret `aptl.json`, readiness suite, and staged asset lock.
+
+Unknown fields, unsafe paths, digest drift, scenario catalog drift, and a
+required narrative operation without a readiness check all fail closed.
+
+## Required guided loop
+
+The participant path is deliberately small:
+
+1. open the staged participant guide;
+2. use the red workbench to prove the real Kali backend and desktop;
+3. generate bounded failed SSH authentication attempts against the victim;
+4. switch to the guided-blue workbench;
+5. find the resulting Wazuh rule 5710 alert through the indexer MCP;
+6. investigate the same event through the Wazuh MCP and `soc-wazuh` browser
+   projection; and
+7. bind the attack, detection, and investigation to one run record.
+
+SMB enumeration, web SQL injection, MISP, TheHive, Cortex, Shuffle, Suricata,
+and the wider enterprise are optional research or facilitator material. They
+are not part of version 1 qualification.
+
+## Derived runtime and participant surfaces
+
+APTL derives the service and network surface from the catalog entry, ACES
+planning and dependency closure, the strict profile config, and the Compose
+profile index. The current derivation selects `kali`, `victim`, `wazuh`, and
+`otel`, producing ten steady-state services:
+
+- Kali, its capture sidecar, and its loopback SSH proxy;
+- the monitored victim;
+- Wazuh manager, indexer, and dashboard; and
+- OpenTelemetry Collector, Tempo, and Grafana.
+
+Both missing and unexpected services fail qualification.
+
+The participant profile composes the workbench contracts introduced by #821:
+
+| Phase | Workbench | MCP servers | Browser bookmarks |
+| --- | --- | --- | --- |
+| Attack | `red` | `aptl-red` | `aptl-guide`, `kali-desktop` |
+| Detect and investigate | `guided-blue` | `aptl-indexer`, `aptl-wazuh` | `aptl-guide`, `soc-wazuh` |
+
+The profile derives these surfaces from the workbench registry rather than
+copying them. The full `blue` workbench remains unchanged for research use.
+Case management, network IDS, SOAR, threat intelligence, and their bookmarks
+must be absent from a guided-purple participant session.
+
+Each enabled MCP qualification starts the real server, checks its exact
+workbench tool inventory, invokes a bounded backend operation, and validates
+the semantic result. Process health or tool discovery alone is insufficient.
+
+## Staged asset contract
+
+`participant-profiles/guided-purple-v1/asset-lock.json` locks the profile
+documents, scenario, Compose model, released MCP builds and dependency locks,
+and every required OCI image identity. Qualification fails if any contained
+asset digest drifts.
+
+After staging, the profile must complete without downloads, image pulls, image
+builds, or package resolution. The profile asset lock is an input to #823's
+signed appliance payload; it is not that outer payload manifest.
+
+## Budget and report contract
+
+The declared minimum fixture is x86-64 with 8 vCPUs, 16 GiB of memory, and
+100 GiB of disk. Version 1 ceilings are:
+
+| Dimension | Ceiling |
+| --- | ---: |
+| Peak profile CPU | 90% |
+| Peak profile memory | 12 GiB |
+| Staged profile assets | 50 GiB |
+| Unique compressed OCI content | 15 GiB |
+| Unique expanded OCI content | 35 GiB |
+| Peak runtime disk | 30 GiB |
+| Cold start | 900 seconds |
+| Warm start | 300 seconds |
+| Clean inner reset | 600 seconds |
+
+These values are conformance limits, not claimed measurements.
+
+The machine-readable report binds the profile and asset-lock digests to the
+hardware fixture, derived and actual runtime matrices, exact workbench/MCP/
+browser surfaces, readiness results, denied-egress counters, measurements,
+run record, and snapshot.
+
+`aptl lab qualify-profile --report <path> --public-key <path> --run-id <id>`
+verifies the report's Ed25519 attestation against the qualification pipeline's
+trusted public key, verifies the content digests and correlation of its run
+record and range snapshot, re-derives the expected surface, evaluates every
+conformance layer, and persists the redacted result. It exits nonzero for
+invalid, unauthenticated, or nonconforming evidence. The protected
+qualification pipeline controls the trusted key; a key selected by the report
+producer is not a trust anchor.
+
+## Relation to the appliance work
+
+#820, #821, and #822 are peer inputs to #823. This profile owns the bounded
+inner workload and clean lab reset. #822 owns zone/egress enforcement. #823
+owns the signed outer appliance, kiosk lifecycle, physical-host exposure, and
+disposable seat reset, and consumes this profile's lock and qualification
+report.
+
+## Full research stack
+
+`techvault-operational` remains the full developer and research scenario. It
+adds the enterprise, Suricata, MISP, TheHive, Cortex, Shuffle, and other
+systems and needs more than 20 GiB of Docker memory. Its readiness or resource
+results are not evidence for `guided-purple`.

--- a/docs/reference/techvault-scenario-overview.md
+++ b/docs/reference/techvault-scenario-overview.md
@@ -121,3 +121,10 @@ than the scenario name:
 Select a variant with `aptl lab start --scenario <catalog id>`. See
 [Curated ACES Variants](../sdl/techvault-curated-variants.md) for the full
 authoring and proof detail.
+
+The versioned [Guided Purple Participant Profile](participant-profile.md)
+binds `techvault-attacker-target` to one supported workshop narrative, strict
+config, participant surface, readiness suite, and qualification budget. The
+curated scenario remains general ACES content; it is not renamed or forked for
+an event. The full `techvault-operational` stack remains the broader developer
+and research path.

--- a/docs/workshop/playbook.md
+++ b/docs/workshop/playbook.md
@@ -1,11 +1,11 @@
 # Workshop Playbook
 
-A facilitator guide for an introductory, hands-on cyber workshop built on APTL
-and the full TechVault range. The audience is undergraduate and graduate
-computer-science students with little or no prior security background. Students
-run their own lab and drive it with their own AI agent over MCP. The guided
-portion (sections 1 to 10) runs about 60 minutes, followed by open play
-(section 11).
+A facilitator guide for an introductory, hands-on cyber workshop built on
+APTL's `guided-purple` participant profile. The audience is undergraduate and
+graduate computer-science students with little or no prior security
+background. Students run the bounded TechVault attack-detect-investigate loop
+and drive it with their own AI agent over MCP. The guided portion (sections 1
+to 10) runs about 60 minutes, followed by bounded open play (section 11).
 
 The times below are estimates for a beginner cohort, not measurements from a
 live group. The companion [Lab Walkthrough](walkthrough.md) gives the exact
@@ -13,16 +13,19 @@ commands and agent prompts for every hands-on step.
 
 ## Before you start
 
-Students, beforehand: complete the per-OS prerequisites in the
-[Lab Walkthrough](walkthrough.md), boot the lab with `aptl lab start`, confirm
-health with `aptl lab status`, and wire the agent to the lab's MCP servers.
-Facilitator: bring your own lab up and open the dashboards on the projector.
+For an appliance release produced by issue #823, staging and qualification
+happen before delivery. Students use only its participant surface. For a
+developer preview, complete the prerequisites in the
+[Lab Walkthrough](walkthrough.md), start the `techvault-attacker-target`
+scenario with the profile config, confirm health, and register exactly the
+three profile MCP servers. Facilitators can use management access for support,
+but management commands are not part of participant acceptance.
 
 If students cannot run Docker locally, use the
 [Emergency Workshop Rollout Runbook](emergency-rollout.md) to prepare a
-short-lived hosted fleet. Treat that path as a contingency: prove every host
-with the same walkthrough before students use it, and tear down cloud resources
-immediately after the event.
+short-lived legacy developer-host fleet. That is an unqualified contingency,
+not the sealed participant appliance or hosted-seat contract. Tear down its
+cloud resources immediately after the event.
 
 ## 1. Intro (about 5 min)
 
@@ -30,8 +33,9 @@ Set the frame and the hook.
 
 - Introduce yourself and the plan: a whirlwind tour of security by doing it.
 - The hook: in the next hour you attack a company, then catch yourself doing it.
-- Safety: this is an isolated range on your own machine. Nothing leaves it, and
-  you can break it and reset with `aptl lab stop -v`.
+- Safety: this is an isolated range. `aptl lab stop -v` performs the clean
+  inner reset measured by this profile; an appliance release may additionally
+  offer disposable-seat replacement.
 - The agenda in one line: range, agents, attacks, defense, do both, purple.
 
 ## 2. Cyber ranges (about 5 min)
@@ -44,7 +48,7 @@ Explain what a range is, why they exist, and what you learn from one.
   range gives real repetitions at no risk.
 - What you learn: which attacks are noisy versus quiet, whether detections
   work, and how analysts (and now agents) actually operate.
-- Show `aptl lab status` and name the parts: an enterprise, a SOC, and an
+- Show `aptl lab status` and name the parts: a monitored victim, Wazuh, and an
   attacker box.
 
 ## 3. Agents in cyber (about 5 min)
@@ -65,45 +69,40 @@ Attacks are a sequence, and defenders try to catch each step.
 - Walk the chain plainly: reconnaissance, then gaining access, then acting on
   the objective such as stealing data or moving laterally.
 - Each step leaves traces that the defensive side can detect.
-- Preview: students run reconnaissance and an access step against TechVault,
+- Preview: students generate failed authentication attempts against TechVault,
   then go find the traces.
 
 ## 5. Offensive tools (about 5 min)
 
 Meet the attacker's toolbox on the Kali box before using it.
 
-- Kali is the red-team host, loaded with real tools: `nmap` for reconnaissance,
-  `smbclient` for file shares, `curl` and web tooling for web attacks, and
-  `msfconsole` for exploitation.
+- Kali is the red-team host. The required profile uses its standard shell and
+  SSH tooling to generate a bounded, noisy authentication attack.
 - The agent reaches these through the `kali_run_command` MCP tool, which runs
   real commands on Kali and returns the output.
-- Kali sits on the TechVault networks, so it can reach the internal and DMZ
-  hosts.
+- Kali reaches the monitored victim through the TechVault internal network.
 
 ## 6. Attack, hands-on (about 12 min)
 
-Students drive their agent through reconnaissance and one attack. Let students
-phrase the prompts their own way. The examples below are starting points, and
-all are verified to work.
+Students first prove the real Kali backend, then generate one bounded attack.
+Let students phrase the prompts their own way.
 
-Reconnaissance prompt:
+Backend prompt:
 
-> Use the Kali tools to scan the TechVault internal network and list the hosts
-> and open services you find.
+> Use the Kali tool to run `id`.
 
-Expect the domain controller (ports 445 and 53), the database (port 5432), the
-file server (port 445), the victim host (port 22), and the web application.
+Expect `uid=1000(kali)`.
 
-Then pick an attack, any or all of these:
+Attack prompt:
 
-- File share: connect to the file server `files.techvault.local` anonymously
-  and list its shares.
-- Web application: probe the TechVault web application for SQL injection.
-- Victim: attempt an SSH brute-force against the victim host, which is
-  deliberately noisy.
+> From Kali, make several failed SSH login attempts with made-up usernames
+> against the monitored victim.
 
-Narrate as students go. Ask which kill-chain step each action maps to, and
-which actions are loud.
+The failed authentication attempts are deliberately noisy and produce Wazuh
+rule 5710 alerts.
+
+Narrate as students go. Ask which kill-chain step the action maps to and why it
+is loud.
 
 Facilitator watch-fors: if an agent refuses, remind it that this is an
 authorized lab and rephrase the request as a security exercise. If an agent
@@ -123,16 +122,16 @@ The defender's job, and where it happens.
 
 Meet the TechVault SOC and what each tool does.
 
-- Wazuh is the SIEM and host-based detection layer. Agents on hosts feed
-  alerts.
-- Suricata is network intrusion detection and watches traffic.
-- MISP is threat intelligence and tracks known-bad indicators.
-- TheHive and Cortex provide case management and automated analysis of
-  observables.
-- Shuffle is the SOAR layer and automates response.
-- The agent reaches these through MCP tools as well, such as `indexer_query`
-  for Wazuh alerts. The dashboards give the human view, and Wazuh serves its
-  dashboard on `https://localhost:443`.
+- Wazuh is the SIEM and host-based detection layer. Its agent on the victim
+  feeds alerts to the manager and indexer.
+- The agent reaches the same alert through the `indexer_query` and
+  `wazuh_query_alerts` MCP tools.
+- The Wazuh dashboard supplies the required human view. The supported
+  participant appliance projects that capability through its participant
+  route rather than exposing the operator control plane.
+- OpenTelemetry, Tempo, and Grafana are required supporting services and are
+  included in the resource budget, but they are not additional participant
+  investigation tools.
 
 ## 9. Investigate, hands-on (about 12 min)
 
@@ -144,16 +143,15 @@ Find-it prompt:
 > Query the SOC (Wazuh) for alerts caused by our activity against TechVault in
 > the last few minutes. What fired, and from where?
 
-Expect an SSH-brute alert sourced from the Kali IP address and a SQL-injection
-alert.
+Expect an SSH authentication alert sourced from Kali.
 
 Explain-it prompt:
 
 > Pull the details of the top alert and explain in plain English what it
 > detected.
 
-Human view: open the Wazuh dashboard and find the same events. As a stretch
-goal, check MISP for known-bad indicators and open a case in TheHive.
+Human view: open the participant Wazuh dashboard projection and find the same
+rule 5710 event.
 
 Debrief: you attacked, the SOC saw it, and your agent investigated. That is the
 loop.
@@ -169,10 +167,15 @@ Name what the students just did, and why it matters.
 
 ## 11. Play (open)
 
-Let students loose on the full lab.
+Let students explore within the bounded profile.
 
-- Try a different attack and check whether the SOC catches it.
-- Try to do something the SOC misses, then discuss why coverage has gaps.
+- Vary the SSH usernames or timing and compare the alerts.
+- Try a different action against the victim and check whether Wazuh sees it.
 - Ask your agent to summarize every alert it caused, ranked by severity.
 - Two-person purple: one student drives red, one drives blue, and they race the
   loop.
+
+SMB enumeration, web SQL injection, MISP, TheHive, Cortex, Shuffle, and
+Suricata exercises belong to the full `techvault-operational` research stack.
+They are optional follow-on material, not a fallback required to complete this
+profile.

--- a/docs/workshop/walkthrough.md
+++ b/docs/workshop/walkthrough.md
@@ -1,24 +1,29 @@
 # Lab Walkthrough
 
-The runnable companion to the [Workshop Playbook](playbook.md). Every command
-appears in order, with the result observed on a fresh box (a PyPI `aptl-labs`
-install running the full TechVault range). Bracketed numbers point back to the
-matching playbook section.
+The runnable companion to the [Workshop Playbook](playbook.md). It describes
+the `guided-purple` version 1 participant path. Bracketed numbers point back
+to the matching playbook section.
+
+The shell commands below are a developer and facilitator preview of the inner
+APTL profile. Issue #823 embeds this same profile in the signed participant
+appliance; these commands are not outer-appliance qualification evidence.
 
 Two ways drive the attack and investigate steps:
 
-- Path A, the agent, is the point of the workshop. A student's AI agent calls
-  the MCP tools. The minimum workshop path uses `kali_run_command` and
-  `indexer_query`; the full SOC path also uses Wazuh, network IDS, MISP,
-  TheHive, and Shuffle MCP tools. Each step gives a prompt.
-- Path B, direct, is a facilitator fallback. It shows the raw `docker exec` or
-  `curl` that the agent runs underneath. Use it if an agent gets stuck.
+- Path A, the participant agent, is the workshop path. It calls
+  `kali_run_command`, `indexer_query`, and `wazuh_query_alerts`.
+- Path B is a developer/facilitator diagnostic. It uses management-owned
+  Docker access and does not satisfy participant workflow qualification.
 
 ## 0. Prerequisites, once, at home
 
-You need Docker running, Python 3.11 or newer, `pipx`, Node.js 18 or newer for
-the MCP servers, and an AI agent of your choice such as Cursor or Claude Code.
-The full TechVault workshop stack needs more than 20GB of Docker memory.
+The released appliance owns its guest Docker engine, APTL runtime, MCP builds,
+and staged dependencies. It requires the hardware fixture named in the
+[participant profile](../reference/participant-profile.md): x86-64, 8 vCPUs,
+16 GiB of memory, and 100 GiB of disk.
+
+For the developer preview only, you need Docker, Python 3.11 or newer, `pipx`,
+Node.js 18 or newer for the MCP servers, and an MCP-capable agent.
 
 On native Linux Docker Engine only, raise the memory-map limit that OpenSearch
 needs:
@@ -53,22 +58,18 @@ aptl --version
 aptl lab init workshop && cd workshop
 ```
 
-Select the full TechVault profile by writing `aptl.json` in the `workshop`
-directory:
-
-```json
-{"deployment":{"provider":"docker-compose"},
- "containers":{"wazuh":true,"victim":true,"kali":true,"reverse":false,
-   "enterprise":true,"soc":true,"mail":false,"fileshare":true,"dns":true},
- "run_storage":{"backend":"local","local_path":"./runs"}}
-```
-
-Then start the lab and wait for the "Lab is ready." message. The first boot
-takes roughly 10 to 15 minutes while images build and the SOC images pull.
+For a source-tree preview, copy the profile config into the initialized
+project and select its referenced catalog scenario:
 
 ```bash
-aptl lab start --yes
+cp participant-profiles/guided-purple-v1/aptl.json aptl.json
+aptl lab start --scenario techvault-attacker-target --yes
 ```
+
+A developer start may build or pull missing assets. The participant appliance
+instead starts from its digest-locked staged payload with egress denied; a
+download, image pull, image build, or package resolution is a qualification
+failure.
 
 ## 2. Verify the range is up [2]
 
@@ -77,49 +78,41 @@ aptl lab status
 docker exec aptl-wazuh-manager /var/ossec/bin/agent_control -l | grep -c Active
 ```
 
-Expect "Lab is running" with about 30 healthy containers. Active Wazuh agent
-counts can vary by platform and startup timing; 7 to 9 active agents is normal
-for a fresh workshop run. Name the parts out loud: `aptl-kali` is the attacker,
-the victim and enterprise hosts are targets, and the `aptl-wazuh-*`, Suricata,
-MISP, TheHive, Cortex, and Shuffle containers form the SOC.
+Expect "Lab is running" with the derived ten-service steady-state surface:
+Kali, Kali capture, the Kali SSH proxy, victim, the three Wazuh services, and
+the three OpenTelemetry services. Missing or additional steady-state services
+fail profile qualification.
 
 ## 3. Wire your agent [3]
 
-In the `workshop` directory, create `.mcp.json` (copy it from
-`.mcp.json.example`). The minimum set for the workshop is the red tool, which
-drives Kali, and the indexer tool, which queries the SOC. The red MCP reaches
-Kali through the loopback-only SSH proxy on `localhost:2023`, so the same
-configuration works on Linux Docker, Docker Desktop, Colima, and WSL2 without
-host routing to Compose bridge IPs:
+The participant management layer creates owner-only MCP client state after
+the backing services and real semantic smoke operations pass. Start in the
+`red` workbench, which contains only `aptl-red`. For a developer preview, use:
 
 ```jsonc
 { "mcpServers": {
-  "kali-ssh": { "command": "node", "args": ["./mcp/mcp-red/build/index.js"],
-    "env": { "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318" } },
-  "indexer": { "command": "node", "args": ["./mcp/mcp-indexer/build/index.js"],
-    "env": { "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
-             "INDEXER_USERNAME": "admin",
-             "INDEXER_PASSWORD": "<from grep '^INDEXER_PASSWORD=' .env>" } } } }
+  "aptl-red": { "command": "node", "args": ["./mcp/mcp-red/build/index.js"],
+    "env": { "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318" } } } }
 ```
 
-Point the agent at this directory and confirm it lists `kali_run_command` and
-`indexer_query`.
+Point the agent at that config and confirm the exact red tool inventory. After
+the SSH attack, close that agent and all MCP processes, remove its generated
+configuration, and switch to the `guided-blue` workbench:
 
-For the full SOC workshop, register the additional API MCP servers only when
-their backing services are enabled and healthy:
+```jsonc
+{ "mcpServers": {
+  "aptl-indexer": { "command": "node",
+    "args": ["./mcp/mcp-indexer/build/index.js"],
+    "env": { "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318" } },
+  "aptl-wazuh": { "command": "node",
+    "args": ["./mcp/mcp-wazuh/build/index.js"],
+    "env": { "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318" } } } }
+```
 
-| MCP server | Entrypoint | Smoke-test tool |
-| ---------- | ---------- | --------------- |
-| `wazuh` | `./mcp/mcp-wazuh/build/index.js` | `wazuh_query_alerts` |
-| `network` | `./mcp/mcp-network/build/index.js` | `network_query_ids_alerts` |
-| `threatintel` | `./mcp/mcp-threatintel/build/index.js` | `threatintel_search_iocs` |
-| `cases` | `./mcp/mcp-casemgmt/build/index.js` | `cases_list_cases` |
-| `soar` | `./mcp/mcp-soar/build/index.js` | `soar_list_workflows` |
-
-The SOC MCPs read service credentials from `.env`. Provision or renew service
-API keys before registering them, especially TheHive. Do not register
-`reverse` unless the reverse-engineering container is enabled in `aptl.json`
-and visible in `aptl lab status`.
+Confirm the exact indexer and Wazuh tool inventories. Network IDS, threat
+intelligence, case management, SOAR, and reverse-engineering MCPs must be
+absent. Never keep red and guided-blue MCPs in one process environment or
+client config.
 
 ## 4. Confirm the agent can reach Kali [3, 5]
 
@@ -127,10 +120,7 @@ Path A (agent):
 
 > Run `id` and `hostname` on the Kali box and show me its IP addresses.
 
-Expect `uid=1000(kali)`, the host `kali-redteam`, and three addresses:
-`172.20.1.30` on the DMZ, `172.20.2.35` on the internal network, and
-`172.20.4.30` on the red-team network. Kali is multi-homed, which is why it can
-reach everything.
+Expect `uid=1000(kali)` and the host `kali-redteam`.
 
 Path B (direct):
 
@@ -138,49 +128,18 @@ Path B (direct):
 docker exec aptl-kali bash -lc 'id; hostname; hostname -I'
 ```
 
-## 5. See the attacker's toolbox [5]
+## 5. See the required attack tool [5]
+
+The required path uses the standard SSH client. A facilitator can verify the
+developer preview with:
 
 ```bash
-for t in nmap smbclient curl msfconsole hydra; do docker exec aptl-kali which $t; done
+docker exec aptl-kali which ssh
 ```
-
-All of the tools resolve. No agent step is needed here, since this only shows
-what Kali carries.
 
 ## 6. Attack, hands-on [6]
 
-### Reconnaissance
-
-Path A (agent):
-
-> Use the Kali tools to scan the TechVault internal (172.20.2.0/24) and DMZ
-> (172.20.1.0/24) networks and list the hosts and open services.
-
-Expect the domain controller `172.20.2.10` (ports 53 and 445), the database
-`172.20.2.11` (port 5432), the file server `172.20.2.12` (port 445), the victim
-`172.20.2.20` (port 22), and the web application (port 8080).
-
-Path B (direct):
-
-```bash
-docker exec aptl-kali nmap -Pn -T4 --open -p22,53,80,445,3389,5432,8080 172.20.2.0/24 172.20.1.0/24
-```
-
-### Enumerate the file server over anonymous SMB
-
-Path A (agent):
-
-> Connect to `files.techvault.local` anonymously and list its shares.
-
-Expect the shares Public, Engineering, Finance, HR, Shared, and IPC$.
-
-Path B (direct):
-
-```bash
-docker exec aptl-kali smbclient -N -L //files.techvault.local
-```
-
-### Noisy attack one: SSH brute-force, which triggers rule 5710
+### Bounded SSH authentication attack
 
 Path A (agent):
 
@@ -194,21 +153,8 @@ docker exec aptl-kali bash -lc 'for u in admin root oracle test hacker1 hacker2 
   ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=5 $u@172.20.2.20 true 2>/dev/null; done; echo done'
 ```
 
-### Noisy attack two: web SQL injection, which triggers rule 302011
-
-Path A (agent):
-
-> Probe the TechVault web application (`172.20.1.20:8080`) for SQL injection.
-
-Path B (direct):
-
-```bash
-docker exec aptl-kali bash -lc 'curl -s -o /dev/null -w "%{http_code}\n" \
-  "http://172.20.1.20:8080/?id=1%27+OR+%271%27=%271"'
-```
-
-Narrate as students go. Ask which kill-chain step each maps to and which is
-loud. Steps three and four are deliberately loud.
+Narrate as students go. Ask which kill-chain step the action maps to and why it
+is deliberately loud.
 
 ## 7. The blue side [7]
 
@@ -216,22 +162,12 @@ No commands here. Explain the loop: monitor, detect, investigate, respond,
 inside the SOC. Everything in section 6 left evidence, which the students find
 next.
 
-## 8. Meet the SOC dashboards [8]
+## 8. Meet the SOC dashboard [8]
 
-The dashboards bind to loopback, so open them on the lab host or over an SSH
-tunnel:
-
-| Tool     | URL                       | Expected code |
-| -------- | ------------------------- | ------------- |
-| Wazuh    | `https://localhost:443`   | 302 to login  |
-| Grafana  | `http://localhost:3100`   | 302           |
-| TheHive  | `https://localhost:9000`  | 200           |
-| MISP     | `https://localhost:8443`  | 302           |
-| Cortex   | `http://localhost:9001`   | 303           |
-| Shuffle  | `http://localhost:3001`   | 200           |
-
-The Wazuh login is `admin` with the `INDEXER_PASSWORD` value from `.env`.
-TheHive serves HTTPS with a self-signed certificate.
+The required human capability is the Wazuh dashboard. The supported appliance
+projects it through the participant gateway. `https://localhost:443` is only
+the developer-host diagnostic endpoint; it is not the appliance participant
+route.
 
 ## 9. Investigate, hands-on [9]
 
@@ -243,12 +179,9 @@ and run it again.
 Path A (agent):
 
 > Query the SOC (Wazuh) for alerts from our activity in the last few minutes,
-> specifically rule IDs 5710 and 302011. What fired, and from which source IP?
+> specifically rule ID 5710. What fired, and from which source IP?
 
-Expect rule 5710 (sshd non-existent user) about 6 times and rule 302011 (SQL
-injection special characters in URL) about a dozen times (roughly three alerts
-per probe). The source addresses are Kali's `172.20.2.35` for the SSH path and
-`172.20.1.30` for the web path.
+Expect rule 5710 (`sshd`: non-existent user) from Kali's internal address.
 
 Path B (direct):
 
@@ -256,7 +189,7 @@ Path B (direct):
 IP=$(grep -m1 '^INDEXER_PASSWORD=' .env | cut -d= -f2-)
 docker exec aptl-wazuh-indexer curl -sk -u "admin:$IP" \
   "https://localhost:9200/wazuh-alerts-*/_search" -H 'Content-Type: application/json' \
-  -d '{"size":20,"query":{"query_string":{"query":"rule.id:5710 OR rule.id:302011"}}}' \
+  -d '{"size":20,"query":{"query_string":{"query":"rule.id:5710"}}}' \
   | python3 -c 'import sys,json;d=json.load(sys.stdin);print("alerts:",d["hits"]["total"]["value"]);[print(" ",x["_source"]["rule"]["id"],x["_source"]["rule"]["description"]) for x in d["hits"]["hits"][:6]]'
 ```
 
@@ -272,13 +205,6 @@ Path A (agent):
 Open the Wazuh dashboard, go to Security events, and search `rule.id:5710`. The
 same events appear in the human view.
 
-### Stretch
-
-Path A (agent):
-
-> Check MISP for known-bad indicators, and open a case in TheHive for this
-> incident.
-
 Debrief: you attacked, the SOC saw it, and your agent investigated. That is the
 loop.
 
@@ -289,21 +215,26 @@ agentic purple.
 
 ## 11. Play [11]
 
-- Ask your agent for a different attack, then check whether the SOC catches it.
-- Try to do something the SOC misses, then discuss why coverage has gaps.
+- Vary the SSH usernames or timing and compare the resulting alerts.
+- Try another action against the victim and discuss whether Wazuh detects it.
 - Ask your agent to summarize every alert it caused, ranked by severity.
 - Two-person purple: one student drives red, one drives blue, and they race the
   loop.
 
-## Teardown
+The full `techvault-operational` research stack is a separate follow-on. Its
+enterprise, web, MISP, TheHive, Cortex, Shuffle, and Suricata exercises are not
+required participant-profile operations.
+
+## Developer-preview clean reset
 
 ```bash
 aptl lab stop -v
 ```
 
-## Facilitator notes
+This is the clean inner reset measured by the participant profile. Disposable
+appliance replacement is a separate #823 lifecycle measurement.
 
-Each of these held true on the last fresh-box run:
+## Developer-preview troubleshooting
 
 - If an agent refuses an attack, remind it that this is an authorized isolated
   lab and rephrase the request as a security exercise, or use the path B
@@ -311,13 +242,6 @@ Each of these held true on the last fresh-box run:
 - If an agent cannot see the tools, check that `.mcp.json` is in the working
   directory and that the indexer password is filled in.
 - If no alert appears yet, wait for the roughly 15-second ingestion lag and run
-  the query again. Rule 5710 (SSH) and rule 302011 (SQL injection) are the
-  reliable pair, so lead with them.
-- If the active Wazuh agent count is below 9 on Docker Desktop, Colima, or WSL2,
-  continue with the attack and alert checks. The required proof is that the
-  5710 and 302011 alerts appear from the Kali source addresses.
-- The attacker address shows as `172.20.2.35` or `172.20.1.30`, not a single
-  value, because Kali is multi-homed across the internal and DMZ paths. That is
-  a good teaching moment.
-- The dashboards bind to loopback, so reach them from the host rather than a
-  remote laptop.
+  the rule 5710 query again.
+- The developer dashboard binds to loopback. The supported appliance uses the
+  separate participant projection defined by its release.

--- a/mcp/mcp-indexer/build/index.js
+++ b/mcp/mcp-indexer/build/index.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/**
+ * APTL Indexer MCP Server
+ * Minimal server: raw ES DSL queries + detection rule writing
+ */
+import { startServer } from 'aptl-mcp-common';
+startServer(import.meta.url).catch((error) => {
+    console.error('[MCP] Fatal error:', error);
+    process.exit(1);
+});

--- a/mcp/mcp-red/build/index.js
+++ b/mcp/mcp-red/build/index.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * APTL Kali Red Team MCP Server.
+ *
+ * Wires the shared MCP server's `postToolHook` (ADR-027, amended by
+ * ADR-033 / OBS-003) so that AI-agent-executed Kali commands emit
+ * OCSF-shaped activity events to the per-run experimental record.
+ * The default composite sink writes to stderr (local dev visibility)
+ * and to `<state>/runs/<trace_id>/mcp-side/ocsf.jsonl` — NOT to the
+ * blue defensive stack's SIEM (non-contamination principle). Logging
+ * is best-effort — classifier/extractor/sink errors never break
+ * command execution.
+ */
+import { startServer } from 'aptl-mcp-common';
+import { captureToolCall } from './capture.js';
+import { topLevelSegments } from './classifier.js';
+import { isEffectiveRawCall, isOutcomeKnown } from './effective-mode.js';
+import { defaultRedTeamSinks, deriveCommandOutcome, logRedTeamCommandAsync, } from './logger.js';
+const AGENT_NAME = 'aptl-kali-red';
+const COMMAND_TOOL_SUFFIXES = ['_run_command', '_session_command'];
+function isCommandTool(toolName) {
+    return COMMAND_TOOL_SUFFIXES.some((suffix) => toolName.endsWith(suffix));
+}
+/**
+ * Resolve the session id for capture/OCSF correlation. Prefer the
+ * explicit `args.session_id` (persistent session handlers); fall
+ * back to the synthetic `exec-...` id the one-shot run_command path
+ * generates in `SSHConnectionManager.executeCommand` and surfaces
+ * back in `result.output.sessionId` (codex pre-push cycle 3
+ * finding-5). Without this fallback, run_command's tool-call JSONL
+ * + OCSF records ship without a session id, leaving no join key to
+ * the per-run mcp-side PTY tee or kali-side captures.
+ */
+function extractSessionId(info) {
+    const fromArgs = info.args.session_id;
+    if (typeof fromArgs === 'string' && fromArgs.length > 0)
+        return fromArgs;
+    // run_command returns { target, command, username, success, output }.
+    // `output` is the underlying CommandResult, which now carries
+    // `sessionId` per OBS-003 / cycle 1 finding-3.
+    const result = info.result;
+    return result?.output?.sessionId;
+}
+function captureContextFor(info, outcome, outcomeKnown) {
+    const sessionId = extractSessionId(info);
+    const base = {
+        toolName: info.toolName,
+        agentName: AGENT_NAME,
+        sessionId,
+        args: info.args,
+        durationMs: info.durationMs,
+    };
+    if (info.error)
+        base.error = info.error;
+    else if (info.result !== undefined)
+        base.result = info.result;
+    if (outcomeKnown) {
+        if (typeof outcome.exit_code === 'number')
+            base.exitCode = outcome.exit_code;
+        if (outcome.signal)
+            base.signal = outcome.signal;
+        base.success = outcome.success === true;
+    }
+    return base;
+}
+function ocsfContextForSegment(toolName, sessionId, durationMs, outcome, outcomeAppliesHere) {
+    const ctx = {
+        tool_name: toolName,
+        agent_name: AGENT_NAME,
+        session_id: sessionId,
+        duration_ms: durationMs,
+    };
+    if (outcomeAppliesHere) {
+        ctx.success = outcome.success === true;
+        if (typeof outcome.exit_code === 'number')
+            ctx.exit_code = outcome.exit_code;
+        if (outcome.signal)
+            ctx.signal = outcome.signal;
+    }
+    else {
+        ctx.outcome_unknown = true;
+    }
+    return ctx;
+}
+function ocsfTasksForCommand(toolName, command, sessionId, durationMs, outcome, outcomeKnown, sink) {
+    const segments = topLevelSegments(command);
+    const lastIdx = segments.length - 1;
+    return segments.map((segment, segIdx) => {
+        const outcomeAppliesHere = segIdx === lastIdx && outcomeKnown;
+        return logRedTeamCommandAsync(segment, ocsfContextForSegment(toolName, sessionId, durationMs, outcome, outcomeAppliesHere), sink);
+    });
+}
+// Build the composite OCSF sink once per process — it reads
+// `APTL_STATE_DIR` lazily on each invocation through `ocsfFilePath`,
+// so trace-context changes between tool calls are picked up. The
+// closure itself is cheap to retain.
+const ocsfSink = defaultRedTeamSinks();
+async function postToolHook(info) {
+    const { toolName, args, durationMs } = info;
+    const sessionId = extractSessionId(info);
+    // #282: read effective raw mode from the result envelope (which captures
+    // the inherited-raw case), not from args.raw alone. The helper falls
+    // back to args.raw for compatibility with older common builds.
+    const isRawSessionCommand = isEffectiveRawCall(info);
+    const outcome = deriveCommandOutcome(info.result, info.error);
+    // Raw-mode Unknown ONLY suppresses the transport exit_code: 0 artifact.
+    // Handler-level KNOWN failures (errors, success:false envelopes) stay
+    // known so OCSF emits Failure, not Unknown. Codex review cycle 2 / D-001.
+    const outcomeKnown = isOutcomeKnown(info.error !== undefined, outcome.success, isRawSessionCommand);
+    const captureTask = captureToolCall(captureContextFor(info, outcome, outcomeKnown));
+    const ocsfTasks = [];
+    if (isCommandTool(toolName)) {
+        const command = args.command;
+        if (typeof command === 'string' && command) {
+            ocsfTasks.push(...ocsfTasksForCommand(toolName, command, sessionId, durationMs, outcome, outcomeKnown, ocsfSink));
+        }
+    }
+    // Run both sinks independently — a slow capture must not delay or
+    // starve the OCSF emission and vice versa.
+    await Promise.allSettled([captureTask, ...ocsfTasks]);
+}
+try {
+    await startServer(import.meta.url, { postToolHook });
+}
+catch (error) {
+    console.error('[MCP] Fatal error:', error);
+    process.exit(1);
+}

--- a/mcp/mcp-wazuh/build/index.js
+++ b/mcp/mcp-wazuh/build/index.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+/**
+ * APTL Wazuh SIEM MCP Server
+ */
+import { startServer } from 'aptl-mcp-common';
+startServer(import.meta.url).catch((error) => {
+    console.error('[MCP] Fatal error:', error);
+    process.exit(1);
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
     - Property-Based Parser Tests: testing/property-based-parser-tests.md
   - Reference:
     - Red Team Taxonomy: red-team-taxonomy.md
+    - Guided Purple Participant Profile: reference/participant-profile.md
     - TechVault Scenario Overview: reference/techvault-scenario-overview.md
     - TechVault Company Profile: reference/techvault-company-profile.md
     - TechVault OSINT Readiness: reference/techvault-osint-readiness.md

--- a/participant-profiles/guided-purple-v1/aptl.json
+++ b/participant-profiles/guided-purple-v1/aptl.json
@@ -1,0 +1,20 @@
+{
+  "deployment": {
+    "provider": "docker-compose"
+  },
+  "containers": {
+    "wazuh": true,
+    "victim": true,
+    "kali": true,
+    "reverse": false,
+    "enterprise": false,
+    "soc": false,
+    "mail": false,
+    "fileshare": false,
+    "dns": false
+  },
+  "run_storage": {
+    "backend": "local",
+    "local_path": "./runs"
+  }
+}

--- a/participant-profiles/guided-purple-v1/asset-lock.json
+++ b/participant-profiles/guided-purple-v1/asset-lock.json
@@ -1,0 +1,173 @@
+{
+  "schema_version": "aptl.participant-asset-lock/v1",
+  "profile_id": "guided-purple",
+  "profile_version": 1,
+  "assets": [
+    {
+      "asset_id": "narrative",
+      "kind": "project-file",
+      "source": "participant-profiles/guided-purple-v1/narrative.json",
+      "sha256": "a1d971348cbf22f97c3f7957ccb1387bef6de7a5f5bd9c031863a7f6959ef8af"
+    },
+    {
+      "asset_id": "readiness",
+      "kind": "project-file",
+      "source": "participant-profiles/guided-purple-v1/readiness.json",
+      "sha256": "a8e991a7c180225488778c8ce7491ec125be078002120eb15a73ba40dd98d57d"
+    },
+    {
+      "asset_id": "aptl-config",
+      "kind": "project-file",
+      "source": "participant-profiles/guided-purple-v1/aptl.json",
+      "sha256": "be9e7f8bf0485085ae1903bf47c4566d101367bf2d0b7abc42e1479ac0b2bf4c"
+    },
+    {
+      "asset_id": "aces-scenario",
+      "kind": "project-file",
+      "source": "scenarios/techvault-attacker-target.sdl.yaml",
+      "sha256": "a85b11d98aab9b5b4cd209bade57b5869556882dab5b5f3f41e5f44292372a78"
+    },
+    {
+      "asset_id": "scenario-catalog",
+      "kind": "project-file",
+      "source": "scenarios/catalog.json",
+      "sha256": "a3239a0600f6310c7d718ed51582446b25712260aa049d74326396ea504cb082"
+    },
+    {
+      "asset_id": "workbench-registry",
+      "kind": "project-file",
+      "source": "src/aptl/workbench/profiles.py",
+      "sha256": "41bb57a742b11edd73bceb443df7f0cae88a77f9d3a4f971235d8a687631d67a"
+    },
+    {
+      "asset_id": "compose-model",
+      "kind": "project-file",
+      "source": "docker-compose.yml",
+      "sha256": "8dc9b4c418b732ea8d98eaf70f9bb2604e5af5721a7a6c5ad058c3dfe227fa60"
+    },
+    {
+      "asset_id": "mcp-red-build",
+      "kind": "mcp-artifact",
+      "source": "mcp/mcp-red/build/index.js",
+      "sha256": "8e2b2072d2787b6c28d73ec31a54d5da29ce6c0601ee9cbf9ba51de3c93de6e9"
+    },
+    {
+      "asset_id": "mcp-red-dependencies",
+      "kind": "project-file",
+      "source": "mcp/mcp-red/package-lock.json",
+      "sha256": "ce95c1e458935f8176ce6fe640b3b05db63166a1e5154ae26ae5dab1099369fb"
+    },
+    {
+      "asset_id": "mcp-red-config",
+      "kind": "project-file",
+      "source": "mcp/mcp-red/docker-lab-config.json",
+      "sha256": "811c25b67e09832ddebdeb9dee13ee64ee46c54534fe5a96af606806eeef8efa"
+    },
+    {
+      "asset_id": "mcp-indexer-build",
+      "kind": "mcp-artifact",
+      "source": "mcp/mcp-indexer/build/index.js",
+      "sha256": "11014137cc5f31553cf9a7e104c0e230dbe849b16fcbb52c6c15c15f03820ccb"
+    },
+    {
+      "asset_id": "mcp-indexer-dependencies",
+      "kind": "project-file",
+      "source": "mcp/mcp-indexer/package-lock.json",
+      "sha256": "da5cb48180685bc4619e36900e4b3664e390b307ad799f2a3842c109eaedc3e0"
+    },
+    {
+      "asset_id": "mcp-indexer-config",
+      "kind": "project-file",
+      "source": "mcp/mcp-indexer/docker-lab-config.json",
+      "sha256": "5eecf4e5931b77b674eb0ff89d7980d31b99307260c546b20a57abb66de62e91"
+    },
+    {
+      "asset_id": "mcp-wazuh-build",
+      "kind": "mcp-artifact",
+      "source": "mcp/mcp-wazuh/build/index.js",
+      "sha256": "a6413637f5733754ad315d7013ef4d9beeb7d2568e1460002865a75a0be823c8"
+    },
+    {
+      "asset_id": "mcp-wazuh-dependencies",
+      "kind": "project-file",
+      "source": "mcp/mcp-wazuh/package-lock.json",
+      "sha256": "57ceab20ebb66d7279bf033cc848fa7936ecf0d6f6a2748085da115ecdb0ed69"
+    },
+    {
+      "asset_id": "mcp-wazuh-config",
+      "kind": "project-file",
+      "source": "mcp/mcp-wazuh/docker-lab-config.json",
+      "sha256": "7d6929f3758b7debe1a3d6a9ae546597bd7628f73fc45ac0f244cb8ef89b5616"
+    },
+    {
+      "asset_id": "image-kali",
+      "kind": "oci-image",
+      "source": "local://aptl-kali@sha256:871d2dbe51b579620c86de9f8fdd78002a073eae8b0471e0f5d11c83843d89f0",
+      "sha256": "871d2dbe51b579620c86de9f8fdd78002a073eae8b0471e0f5d11c83843d89f0",
+      "services": ["kali"]
+    },
+    {
+      "asset_id": "image-kali-capture",
+      "kind": "oci-image",
+      "source": "local://aptl-kali-capture@sha256:821ec7c26c62d4d501e04ae6031d1acaafb532df900ac4ab8ae890f06d965751",
+      "sha256": "821ec7c26c62d4d501e04ae6031d1acaafb532df900ac4ab8ae890f06d965751",
+      "services": ["kali-capture"]
+    },
+    {
+      "asset_id": "image-kali-ssh-proxy",
+      "kind": "oci-image",
+      "source": "local://aptl-kali-ssh-proxy@sha256:a2592cd742c4399c954e651784b455325f96f32cd4e0025453f64b8f9fa07016",
+      "sha256": "a2592cd742c4399c954e651784b455325f96f32cd4e0025453f64b8f9fa07016",
+      "services": ["kali-ssh-proxy"]
+    },
+    {
+      "asset_id": "image-victim",
+      "kind": "oci-image",
+      "source": "local://aptl-victim@sha256:7ad2cbc7e0f708513032e923ecad32f53a04db99c899394078d900fe9c353549",
+      "sha256": "7ad2cbc7e0f708513032e923ecad32f53a04db99c899394078d900fe9c353549",
+      "services": ["victim"]
+    },
+    {
+      "asset_id": "image-wazuh-manager",
+      "kind": "oci-image",
+      "source": "wazuh/wazuh-manager@sha256:dea2fa1e6d5062147b6a85b241f5f501c5f1ba4b817d12bda06f7870a89ad561",
+      "sha256": "dea2fa1e6d5062147b6a85b241f5f501c5f1ba4b817d12bda06f7870a89ad561",
+      "services": ["wazuh.manager"]
+    },
+    {
+      "asset_id": "image-wazuh-indexer",
+      "kind": "oci-image",
+      "source": "wazuh/wazuh-indexer@sha256:3691b3b27658695aad0c6879b412a001caf233ebbc1a5ba15647053aa03a2299",
+      "sha256": "3691b3b27658695aad0c6879b412a001caf233ebbc1a5ba15647053aa03a2299",
+      "services": ["wazuh.indexer"]
+    },
+    {
+      "asset_id": "image-wazuh-dashboard",
+      "kind": "oci-image",
+      "source": "wazuh/wazuh-dashboard@sha256:8f5b50fde67a0b1c4d2321aa26b12bbc5cef21269cf4f6225746f0b946458bd7",
+      "sha256": "8f5b50fde67a0b1c4d2321aa26b12bbc5cef21269cf4f6225746f0b946458bd7",
+      "services": ["wazuh.dashboard"]
+    },
+    {
+      "asset_id": "image-otel-collector",
+      "kind": "oci-image",
+      "source": "otel/opentelemetry-collector-contrib@sha256:e39311df1f3d941923c00da79ac7ba6269124a870ee87e3c3ad24d60f8aee4d2",
+      "sha256": "e39311df1f3d941923c00da79ac7ba6269124a870ee87e3c3ad24d60f8aee4d2",
+      "services": ["aptl-otel-collector"]
+    },
+    {
+      "asset_id": "image-tempo",
+      "kind": "oci-image",
+      "source": "grafana/tempo@sha256:4b0277a9b572a4b1fa43b01468e58911ec214dd69d033f2cd476596d14de9fe3",
+      "sha256": "4b0277a9b572a4b1fa43b01468e58911ec214dd69d033f2cd476596d14de9fe3",
+      "services": ["aptl-tempo"]
+    },
+    {
+      "asset_id": "image-grafana",
+      "kind": "oci-image",
+      "source": "grafana/grafana@sha256:62d2b9d20a19714ebfe48d1bb405086081bc602aa053e28cf6d73c7537640dfb",
+      "sha256": "62d2b9d20a19714ebfe48d1bb405086081bc602aa053e28cf6d73c7537640dfb",
+      "services": ["aptl-grafana-otel"]
+    }
+  ]
+}

--- a/participant-profiles/guided-purple-v1/narrative.json
+++ b/participant-profiles/guided-purple-v1/narrative.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "aptl.participant-narrative/v1",
+  "narrative_id": "guided-purple",
+  "version": 1,
+  "operations": [
+    {
+      "operation_id": "open-participant-guide",
+      "classification": "required",
+      "capability_id": "browser.aptl-guide",
+      "channel": "browser",
+      "expected_result": "The participant guide opens from its staged workbench bookmark."
+    },
+    {
+      "operation_id": "confirm-kali",
+      "classification": "required",
+      "capability_id": "red.kali-command",
+      "channel": "mcp",
+      "expected_result": "The Kali backend returns uid=1000(kali)."
+    },
+    {
+      "operation_id": "inspect-kali-desktop",
+      "classification": "required",
+      "capability_id": "browser.kali-desktop",
+      "channel": "browser",
+      "expected_result": "The Kali desktop projection is reachable from the red workbench."
+    },
+    {
+      "operation_id": "ssh-authentication-attack",
+      "classification": "required",
+      "capability_id": "red.ssh-authentication-attack",
+      "channel": "mcp",
+      "expected_result": "Kali generates bounded failed SSH authentication attempts against the declared victim."
+    },
+    {
+      "operation_id": "detect-ssh-alert",
+      "classification": "required",
+      "capability_id": "blue.indexer-investigation",
+      "channel": "mcp",
+      "expected_result": "The indexer returns a recent Wazuh SSH authentication alert produced by the guided attack."
+    },
+    {
+      "operation_id": "investigate-ssh-alert",
+      "classification": "required",
+      "capability_id": "blue.wazuh-investigation",
+      "channel": "mcp",
+      "expected_result": "The Wazuh API returns the matching alert details for investigation."
+    },
+    {
+      "operation_id": "inspect-human-view",
+      "classification": "required",
+      "capability_id": "browser.soc-wazuh",
+      "channel": "browser",
+      "expected_result": "The participant Wazuh dashboard projection is reachable and presents the matching security event."
+    },
+    {
+      "operation_id": "summarize-purple-loop",
+      "classification": "required",
+      "capability_id": "workflow.purple-summary",
+      "channel": "workflow",
+      "expected_result": "The run evidence binds the attack, detection, and investigation results to one guided participant run."
+    },
+    {
+      "operation_id": "enumerate-smb",
+      "classification": "optional",
+      "capability_id": "research.smb-enumeration",
+      "channel": "mcp",
+      "expected_result": "Available only in a broader TechVault research profile."
+    },
+    {
+      "operation_id": "probe-web-sqli",
+      "classification": "optional",
+      "capability_id": "research.web-sqli",
+      "channel": "mcp",
+      "expected_result": "Available only in a broader TechVault research profile."
+    },
+    {
+      "operation_id": "operate-full-soc",
+      "classification": "facilitator-only",
+      "capability_id": "research.full-soc",
+      "channel": "browser",
+      "expected_result": "MISP, TheHive, Cortex, Shuffle, and Suricata remain full-stack facilitator material."
+    }
+  ]
+}

--- a/participant-profiles/guided-purple-v1/profile.json
+++ b/participant-profiles/guided-purple-v1/profile.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "aptl.participant-profile/v1",
+  "profile_id": "guided-purple",
+  "version": 1,
+  "narrative": {
+    "path": "participant-profiles/guided-purple-v1/narrative.json",
+    "sha256": "a1d971348cbf22f97c3f7957ccb1387bef6de7a5f5bd9c031863a7f6959ef8af"
+  },
+  "scenario": {
+    "catalog_id": "techvault-attacker-target",
+    "path": "scenarios/techvault-attacker-target.sdl.yaml",
+    "sha256": "a85b11d98aab9b5b4cd209bade57b5869556882dab5b5f3f41e5f44292372a78"
+  },
+  "config": {
+    "path": "participant-profiles/guided-purple-v1/aptl.json",
+    "sha256": "be9e7f8bf0485085ae1903bf47c4566d101367bf2d0b7abc42e1479ac0b2bf4c"
+  },
+  "readiness": {
+    "path": "participant-profiles/guided-purple-v1/readiness.json",
+    "sha256": "a8e991a7c180225488778c8ce7491ec125be078002120eb15a73ba40dd98d57d"
+  },
+  "capabilities": {
+    "workbench_profiles": [
+      "red",
+      "guided-blue"
+    ]
+  },
+  "release_evidence": {
+    "asset_lock_schema": "aptl.participant-asset-lock/v1",
+    "qualification_report_schema": "aptl.participant-qualification/v1",
+    "asset_lock_ref": "participant-profiles/guided-purple-v1/asset-lock.json",
+    "asset_lock_sha256": "a6f0da270da1665cd7ed352ec7f72f3abcd60a0de34df7c66c732dfd9164aebc",
+    "qualification_report_ref": "release/qualification/guided-purple-v1.json"
+  },
+  "budgets": {
+    "minimum_hardware": {
+      "architecture": "x86_64",
+      "vcpus": 8,
+      "memory_bytes": 17179869184,
+      "disk_bytes": 107374182400
+    },
+    "maximums": {
+      "peak_cpu_percent": 90.0,
+      "peak_memory_bytes": 12884901888,
+      "staged_profile_assets_bytes": 53687091200,
+      "unique_image_compressed_bytes": 16106127360,
+      "unique_image_expanded_bytes": 37580963840,
+      "peak_runtime_disk_bytes": 32212254720,
+      "cold_start_seconds": 900.0,
+      "warm_start_seconds": 300.0,
+      "clean_reset_seconds": 600.0
+    }
+  }
+}

--- a/participant-profiles/guided-purple-v1/readiness.json
+++ b/participant-profiles/guided-purple-v1/readiness.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "aptl.participant-readiness/v1",
+  "suite_id": "guided-purple",
+  "version": 1,
+  "checks": [
+    {
+      "check_id": "runtime.exact-surface",
+      "capability_id": "runtime.exact-surface",
+      "kind": "runtime-surface",
+      "subject_id": "techvault-attacker-target",
+      "operation_id": "compare-expected-matrix",
+      "timeout_seconds": 30
+    },
+    {
+      "check_id": "browser.aptl-guide",
+      "capability_id": "browser.aptl-guide",
+      "kind": "browser-operation",
+      "subject_id": "aptl-guide",
+      "operation_id": "open-staged-guide",
+      "timeout_seconds": 30
+    },
+    {
+      "check_id": "mcp.red.kali-command",
+      "capability_id": "red.kali-command",
+      "kind": "mcp-tool",
+      "subject_id": "aptl-red",
+      "operation_id": "kali-id",
+      "timeout_seconds": 60
+    },
+    {
+      "check_id": "browser.kali-desktop",
+      "capability_id": "browser.kali-desktop",
+      "kind": "browser-operation",
+      "subject_id": "kali-desktop",
+      "operation_id": "open-red-desktop",
+      "timeout_seconds": 60
+    },
+    {
+      "check_id": "mcp.red.ssh-authentication-attack",
+      "capability_id": "red.ssh-authentication-attack",
+      "kind": "mcp-tool",
+      "subject_id": "aptl-red",
+      "operation_id": "bounded-failed-ssh-logins",
+      "timeout_seconds": 90
+    },
+    {
+      "check_id": "mcp.blue.indexer-investigation",
+      "capability_id": "blue.indexer-investigation",
+      "kind": "mcp-tool",
+      "subject_id": "aptl-indexer",
+      "operation_id": "recent-ssh-alert",
+      "timeout_seconds": 60
+    },
+    {
+      "check_id": "mcp.blue.wazuh-investigation",
+      "capability_id": "blue.wazuh-investigation",
+      "kind": "mcp-tool",
+      "subject_id": "aptl-wazuh",
+      "operation_id": "matching-alert-details",
+      "timeout_seconds": 60
+    },
+    {
+      "check_id": "browser.soc-wazuh",
+      "capability_id": "browser.soc-wazuh",
+      "kind": "browser-operation",
+      "subject_id": "soc-wazuh",
+      "operation_id": "matching-security-event",
+      "timeout_seconds": 60
+    },
+    {
+      "check_id": "workflow.purple-summary",
+      "capability_id": "workflow.purple-summary",
+      "kind": "evidence",
+      "subject_id": "guided-purple",
+      "operation_id": "correlated-run-evidence",
+      "timeout_seconds": 30
+    },
+    {
+      "check_id": "offline.staged-only",
+      "capability_id": "offline.staged-only",
+      "kind": "offline-assets",
+      "subject_id": "guided-purple-assets",
+      "operation_id": "deny-egress-and-audit-downloads",
+      "timeout_seconds": 900
+    },
+    {
+      "check_id": "resources.within-budget",
+      "capability_id": "resources.within-budget",
+      "kind": "resource-budget",
+      "subject_id": "guided-purple-runtime",
+      "operation_id": "measure-guided-workflow",
+      "timeout_seconds": 1800
+    }
+  ]
+}

--- a/src/aptl/_asset_manifest.py
+++ b/src/aptl/_asset_manifest.py
@@ -42,6 +42,7 @@ ASSET_ROOTS: tuple[str, ...] = (
     "hatch_build.py",
     "src",
     "scenarios",
+    "participant-profiles",
     "config",
     "containers",
     "web",

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -7,6 +7,7 @@ from typing import Optional
 import typer
 
 from aptl.cli import lab_init, lifecycle
+from aptl.cli.participant_profile import qualify_profile
 from aptl.cli.continuity import continuity_audit
 from aptl.cli.lab_render import (
     emit_lab_access_summary,
@@ -43,6 +44,7 @@ lab_init.register(app)
 # this module stays focused; register them under `lab` (no UX change:
 # `aptl lab enforce` / `monitor` / `policy show`).
 lifecycle.register(app)
+app.command("qualify-profile")(qualify_profile)
 
 
 # Shared destructive-data warning. Both `stop --volumes` and

--- a/src/aptl/cli/participant_profile.py
+++ b/src/aptl/cli/participant_profile.py
@@ -1,0 +1,97 @@
+"""CLI boundary for participant-profile qualification evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+from aptl.cli._common import resolve_run_store
+from aptl.core.runstore import _validate_id
+from aptl.validation.participant_profile import (
+    ParticipantProfileError,
+    load_participant_profile,
+)
+from aptl.validation.participant_qualification import (
+    ParticipantQualificationError,
+    evaluate_participant_qualification,
+    load_participant_qualification_report,
+    persist_participant_qualification,
+)
+
+DEFAULT_PARTICIPANT_PROFILE = Path("participant-profiles/guided-purple-v1/profile.json")
+
+
+def qualify_profile(
+    project_dir: Path = typer.Option(
+        Path("."),
+        "--project-dir",
+        "-d",
+        help="Path to the materialized APTL project directory.",
+    ),
+    profile: Path = typer.Option(
+        DEFAULT_PARTICIPANT_PROFILE,
+        "--profile",
+        help="Project-contained participant profile manifest.",
+    ),
+    report: Path = typer.Option(
+        ...,
+        "--report",
+        help="Project-contained machine-readable profile qualification report.",
+    ),
+    public_key: Path = typer.Option(
+        ...,
+        "--public-key",
+        help=(
+            "Project-contained Ed25519 public key trusted by the qualification "
+            "pipeline."
+        ),
+    ),
+    run_id: str = typer.Option(
+        ...,
+        "--run-id",
+        help="Run archive id that will own the evaluated report.",
+    ),
+) -> None:
+    """Validate and persist a bounded participant-profile report."""
+
+    project_root = project_dir.resolve()
+    try:
+        safe_run_id = _validate_id(run_id, "run_id")
+        resolved = load_participant_profile(project_root, profile)
+        evidence = load_participant_qualification_report(
+            project_root,
+            report,
+            public_key,
+        )
+    except (
+        OSError,
+        ParticipantProfileError,
+        ParticipantQualificationError,
+        ValueError,
+    ) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    evaluation = evaluate_participant_qualification(resolved, evidence)
+    store = resolve_run_store(project_root, resolved.config)
+    store.create_run(safe_run_id)
+    persist_participant_qualification(
+        store,
+        safe_run_id,
+        evidence,
+        evaluation,
+    )
+    typer.echo(
+        json.dumps(
+            {
+                "profile_id": resolved.manifest.profile_id,
+                "profile_version": resolved.manifest.version,
+                **evaluation.to_dict(),
+            },
+            separators=(",", ":"),
+        )
+    )
+    if not evaluation.passed:
+        raise typer.Exit(code=1)

--- a/src/aptl/cli/participant_profile.py
+++ b/src/aptl/cli/participant_profile.py
@@ -9,12 +9,8 @@ import typer
 
 from aptl.cli._common import resolve_run_store
 from aptl.core.runstore import _validate_id
-from aptl.validation.participant_profile import (
-    ParticipantProfileError,
-    load_participant_profile,
-)
+from aptl.validation.participant_profile import load_participant_profile
 from aptl.validation.participant_qualification import (
-    ParticipantQualificationError,
     evaluate_participant_qualification,
     load_participant_qualification_report,
     persist_participant_qualification,
@@ -65,12 +61,7 @@ def qualify_profile(
             report,
             public_key,
         )
-    except (
-        OSError,
-        ParticipantProfileError,
-        ParticipantQualificationError,
-        ValueError,
-    ) as exc:
+    except (OSError, ValueError) as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
 

--- a/src/aptl/validation/mcp_protocol.py
+++ b/src/aptl/validation/mcp_protocol.py
@@ -8,8 +8,9 @@ import selectors
 import subprocess
 import time
 from collections.abc import Callable, Collection, Mapping, Sequence
+from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import TextIO
 
 
 class McpProtocolError(RuntimeError):
@@ -17,30 +18,108 @@ class McpProtocolError(RuntimeError):
 
 
 def _read_response(
-    stdout: Any,
+    stdout: TextIO,
     *,
     deadline: float,
-) -> dict[str, Any] | None:
+) -> dict[str, object] | None:
+    """Read and decode one response before the shared exchange deadline."""
+
     remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        return None
-    selector = selectors.DefaultSelector()
-    try:
-        selector.register(stdout, selectors.EVENT_READ)
-        if not selector.select(timeout=remaining):
-            return None
-    finally:
-        selector.close()
-    line = stdout.readline()
-    if not line:
-        return None
-    try:
-        response = json.loads(line)
-    except json.JSONDecodeError as exc:
-        raise McpProtocolError("MCP server returned an invalid response") from exc
-    if not isinstance(response, dict):
-        raise McpProtocolError("MCP server returned an invalid response")
+    response: dict[str, object] | None = None
+    if remaining > 0:
+        selector = selectors.DefaultSelector()
+        try:
+            selector.register(stdout, selectors.EVENT_READ)
+            readable = bool(selector.select(timeout=remaining))
+        finally:
+            selector.close()
+        if readable:
+            line = stdout.readline()
+            if line:
+                try:
+                    decoded = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise McpProtocolError(
+                        "MCP server returned an invalid response"
+                    ) from exc
+                if not isinstance(decoded, dict):
+                    raise McpProtocolError("MCP server returned an invalid response")
+                response = decoded
     return response
+
+
+def _start_server(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str] | None,
+) -> subprocess.Popen[str]:
+    """Start one released MCP server with no child-output evidence channel."""
+
+    try:
+        return subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=dict(os.environ if env is None else env),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, ValueError) as exc:
+        raise McpProtocolError("MCP server could not start") from exc
+
+
+def _exchange_messages(
+    process: subprocess.Popen[str],
+    messages: Sequence[Mapping[str, object]],
+    deadline: float,
+    response_validator: (
+        Callable[[Mapping[str, object], Mapping[str, object]], None] | None
+    ),
+) -> tuple[list[dict[str, object]], bool]:
+    """Write the requests and collect their bounded responses."""
+
+    if process.stdin is None or process.stdout is None:
+        raise McpProtocolError("MCP server pipes are unavailable")
+    responses: list[dict[str, object]] = []
+    complete = True
+    for message in messages:
+        if time.monotonic() >= deadline:
+            complete = False
+            break
+        try:
+            process.stdin.write(json.dumps(dict(message), separators=(",", ":")) + "\n")
+            process.stdin.flush()
+        except (OSError, TypeError, ValueError):
+            complete = False
+            break
+        if "id" not in message:
+            continue
+        response = _read_response(process.stdout, deadline=deadline)
+        if response is None:
+            complete = False
+            break
+        if response_validator is not None:
+            response_validator(message, response)
+        responses.append(response)
+    return responses, complete
+
+
+def _stop_server(process: subprocess.Popen[str], deadline: float) -> None:
+    """Close stdin and terminate a server that outlives the exchange."""
+
+    if process.stdin is not None:
+        try:
+            process.stdin.close()
+        except OSError:
+            pass
+    remaining = max(0.0, deadline - time.monotonic())
+    try:
+        process.wait(timeout=min(1.0, remaining))
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
 
 
 def exchange_jsonrpc(
@@ -51,9 +130,9 @@ def exchange_jsonrpc(
     env: Mapping[str, str] | None = None,
     timeout_seconds: float = 30,
     response_validator: (
-        Callable[[Mapping[str, object], Mapping[str, Any]], None] | None
+        Callable[[Mapping[str, object], Mapping[str, object]], None] | None
     ) = None,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, object]]:
     """Exchange bounded line-delimited JSON-RPC messages with one MCP server.
 
     ``argv`` comes from a validated released MCP registration, never from the
@@ -67,63 +146,55 @@ def exchange_jsonrpc(
         raise McpProtocolError("MCP command is empty")
     if timeout_seconds <= 0:
         raise McpProtocolError("MCP timeout must be positive")
-    child_env = dict(os.environ if env is None else env)
-    try:
-        process = subprocess.Popen(
-            command,
-            cwd=cwd,
-            env=child_env,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-    except (OSError, ValueError) as exc:
-        raise McpProtocolError("MCP server could not start") from exc
-
-    assert process.stdin is not None
-    assert process.stdout is not None
+    process = _start_server(command, cwd=cwd, env=env)
     deadline = time.monotonic() + timeout_seconds
-    responses: list[dict[str, Any]] = []
-    complete = True
     try:
-        for message in messages:
-            if time.monotonic() >= deadline:
-                complete = False
-                break
-            try:
-                process.stdin.write(
-                    json.dumps(dict(message), separators=(",", ":")) + "\n"
-                )
-                process.stdin.flush()
-            except (BrokenPipeError, OSError, TypeError, ValueError):
-                complete = False
-                break
-            if "id" not in message:
-                continue
-            response = _read_response(process.stdout, deadline=deadline)
-            if response is None:
-                complete = False
-                break
-            if response_validator is not None:
-                response_validator(message, response)
-            responses.append(response)
+        responses, complete = _exchange_messages(
+            process,
+            messages,
+            deadline,
+            response_validator,
+        )
     finally:
-        try:
-            process.stdin.close()
-        except OSError:
-            pass
-        remaining = max(0.0, deadline - time.monotonic())
-        try:
-            process.wait(timeout=min(1.0, remaining))
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait()
+        _stop_server(process, deadline)
 
     expected_responses = sum("id" in message for message in messages)
     if not complete or len(responses) != expected_responses:
         raise McpProtocolError("MCP server did not return a complete response")
     return responses
+
+
+def _listed_tool_names(response: Mapping[str, object]) -> set[str]:
+    """Extract the exact string tool names from a successful list response."""
+
+    listed_result = response.get("result")
+    tools = listed_result.get("tools") if isinstance(listed_result, dict) else None
+    if not isinstance(tools, list):
+        return set()
+    return {
+        item.get("name")
+        for item in tools
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+
+
+def _validate_inventory(
+    expected_tool_names: Collection[str] | None,
+    requested_tool_name: str,
+    request: Mapping[str, object],
+    response: Mapping[str, object],
+) -> None:
+    """Fail closed when the released server exposes an unexpected inventory."""
+
+    if request.get("id") != 2:
+        return
+    if "error" in response:
+        raise McpProtocolError("MCP tool list failed")
+    listed_names = _listed_tool_names(response)
+    if expected_tool_names is not None and listed_names != set(expected_tool_names):
+        raise McpProtocolError("MCP tool inventory does not match the profile")
+    if requested_tool_name not in listed_names:
+        raise McpProtocolError("MCP tool is not registered")
 
 
 def call_mcp_tool(
@@ -135,34 +206,8 @@ def call_mcp_tool(
     env: Mapping[str, str] | None = None,
     timeout_seconds: float = 60,
     expected_tool_names: Collection[str] | None = None,
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """Initialize a real MCP server and return one ``tools/call`` result."""
-
-    def validate_inventory(
-        request: Mapping[str, object],
-        response: Mapping[str, Any],
-    ) -> None:
-        if request.get("id") != 2:
-            return
-        if "error" in response:
-            raise McpProtocolError("MCP tool list failed")
-        listed_result = response.get("result")
-        tools = listed_result.get("tools") if isinstance(listed_result, dict) else None
-        listed_names = (
-            {
-                item.get("name")
-                for item in tools
-                if isinstance(item, dict) and isinstance(item.get("name"), str)
-            }
-            if isinstance(tools, list)
-            else set()
-        )
-        if expected_tool_names is not None and listed_names != set(
-            expected_tool_names
-        ):
-            raise McpProtocolError("MCP tool inventory does not match the profile")
-        if tool_name not in listed_names:
-            raise McpProtocolError("MCP tool is not registered")
 
     responses = exchange_jsonrpc(
         argv,
@@ -203,7 +248,11 @@ def call_mcp_tool(
         cwd=cwd,
         env=env,
         timeout_seconds=timeout_seconds,
-        response_validator=validate_inventory,
+        response_validator=partial(
+            _validate_inventory,
+            expected_tool_names,
+            tool_name,
+        ),
     )
 
     response = next(

--- a/src/aptl/validation/mcp_protocol.py
+++ b/src/aptl/validation/mcp_protocol.py
@@ -1,0 +1,218 @@
+"""Bounded MCP stdio protocol exchange for live semantic qualification."""
+
+from __future__ import annotations
+
+import json
+import os
+import selectors
+import subprocess
+import time
+from collections.abc import Callable, Collection, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+class McpProtocolError(RuntimeError):
+    """A bounded MCP protocol exchange failed without exposing child output."""
+
+
+def _read_response(
+    stdout: Any,
+    *,
+    deadline: float,
+) -> dict[str, Any] | None:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return None
+    selector = selectors.DefaultSelector()
+    try:
+        selector.register(stdout, selectors.EVENT_READ)
+        if not selector.select(timeout=remaining):
+            return None
+    finally:
+        selector.close()
+    line = stdout.readline()
+    if not line:
+        return None
+    try:
+        response = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise McpProtocolError("MCP server returned an invalid response") from exc
+    if not isinstance(response, dict):
+        raise McpProtocolError("MCP server returned an invalid response")
+    return response
+
+
+def exchange_jsonrpc(
+    argv: Sequence[str],
+    messages: Sequence[Mapping[str, object]],
+    *,
+    cwd: Path,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: float = 30,
+    response_validator: (
+        Callable[[Mapping[str, object], Mapping[str, Any]], None] | None
+    ) = None,
+) -> list[dict[str, Any]]:
+    """Exchange bounded line-delimited JSON-RPC messages with one MCP server.
+
+    ``argv`` comes from a validated released MCP registration, never from the
+    participant-profile manifest. Child stderr is discarded at this boundary:
+    MCP errors may contain credentials or backend response bodies and are not a
+    qualification evidence surface.
+    """
+
+    command = list(argv)
+    if not command:
+        raise McpProtocolError("MCP command is empty")
+    if timeout_seconds <= 0:
+        raise McpProtocolError("MCP timeout must be positive")
+    child_env = dict(os.environ if env is None else env)
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=child_env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, ValueError) as exc:
+        raise McpProtocolError("MCP server could not start") from exc
+
+    assert process.stdin is not None
+    assert process.stdout is not None
+    deadline = time.monotonic() + timeout_seconds
+    responses: list[dict[str, Any]] = []
+    complete = True
+    try:
+        for message in messages:
+            if time.monotonic() >= deadline:
+                complete = False
+                break
+            try:
+                process.stdin.write(
+                    json.dumps(dict(message), separators=(",", ":")) + "\n"
+                )
+                process.stdin.flush()
+            except (BrokenPipeError, OSError, TypeError, ValueError):
+                complete = False
+                break
+            if "id" not in message:
+                continue
+            response = _read_response(process.stdout, deadline=deadline)
+            if response is None:
+                complete = False
+                break
+            if response_validator is not None:
+                response_validator(message, response)
+            responses.append(response)
+    finally:
+        try:
+            process.stdin.close()
+        except OSError:
+            pass
+        remaining = max(0.0, deadline - time.monotonic())
+        try:
+            process.wait(timeout=min(1.0, remaining))
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+    expected_responses = sum("id" in message for message in messages)
+    if not complete or len(responses) != expected_responses:
+        raise McpProtocolError("MCP server did not return a complete response")
+    return responses
+
+
+def call_mcp_tool(
+    argv: Sequence[str],
+    tool_name: str,
+    arguments: Mapping[str, object],
+    *,
+    cwd: Path,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: float = 60,
+    expected_tool_names: Collection[str] | None = None,
+) -> dict[str, Any]:
+    """Initialize a real MCP server and return one ``tools/call`` result."""
+
+    def validate_inventory(
+        request: Mapping[str, object],
+        response: Mapping[str, Any],
+    ) -> None:
+        if request.get("id") != 2:
+            return
+        if "error" in response:
+            raise McpProtocolError("MCP tool list failed")
+        listed_result = response.get("result")
+        tools = listed_result.get("tools") if isinstance(listed_result, dict) else None
+        listed_names = (
+            {
+                item.get("name")
+                for item in tools
+                if isinstance(item, dict) and isinstance(item.get("name"), str)
+            }
+            if isinstance(tools, list)
+            else set()
+        )
+        if expected_tool_names is not None and listed_names != set(
+            expected_tool_names
+        ):
+            raise McpProtocolError("MCP tool inventory does not match the profile")
+        if tool_name not in listed_names:
+            raise McpProtocolError("MCP tool is not registered")
+
+    responses = exchange_jsonrpc(
+        argv,
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "aptl-participant-qualification",
+                        "version": "1.0.0",
+                    },
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": tool_name,
+                    "arguments": dict(arguments),
+                },
+            },
+        ),
+        cwd=cwd,
+        env=env,
+        timeout_seconds=timeout_seconds,
+        response_validator=validate_inventory,
+    )
+
+    response = next(
+        (item for item in responses if item.get("id") == 3),
+        None,
+    )
+    if response is None or "error" in response:
+        raise McpProtocolError("MCP tool call failed")
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise McpProtocolError("MCP tool call returned an invalid result")
+    return result

--- a/src/aptl/validation/participant_mcp_smoke.py
+++ b/src/aptl/validation/participant_mcp_smoke.py
@@ -27,6 +27,8 @@ class McpRegistration:
 
 @dataclass(frozen=True)
 class _SmokeOperation:
+    """One readiness check bound to one released MCP tool call."""
+
     check_id: str
     server_id: str
     tool_name: str
@@ -60,7 +62,7 @@ _OPERATIONS = (
             "command": (
                 "for u in aptl-a aptl-b aptl-c aptl-d aptl-e aptl-f; do "
                 "ssh -o BatchMode=yes -o StrictHostKeyChecking=no "
-                "-o ConnectTimeout=5 \"$u\"@172.20.2.20 true 2>/dev/null "
+                '-o ConnectTimeout=5 "$u"@172.20.2.20 true 2>/dev/null '
                 "|| true; done; echo done"
             )
         },
@@ -84,6 +86,8 @@ _OPERATIONS = (
 
 
 def _text_content(result: Mapping[str, object]) -> list[str]:
+    """Return only text blocks from an MCP tool result."""
+
     content = result.get("content")
     if not isinstance(content, Sequence) or isinstance(content, str | bytes):
         return []
@@ -98,49 +102,64 @@ def _text_content(result: Mapping[str, object]) -> list[str]:
 
 
 def _has_alert_hit(value: object) -> bool:
+    """Return whether a nested indexer response contains at least one hit."""
+
+    found = False
     if isinstance(value, Mapping):
         hits = value.get("hits")
         if isinstance(hits, Mapping):
             rows = hits.get("hits")
             if isinstance(rows, list) and rows:
-                return True
-        return any(_has_alert_hit(item) for item in value.values())
-    if isinstance(value, list):
-        return any(_has_alert_hit(item) for item in value)
-    return False
+                found = True
+        if not found:
+            found = any(_has_alert_hit(item) for item in value.values())
+    elif isinstance(value, list):
+        found = any(_has_alert_hit(item) for item in value)
+    return found
+
+
+def _decoded_text_payloads(texts: Sequence[str]) -> list[object]:
+    """Decode the JSON text blocks emitted by the released MCP servers."""
+
+    payloads: list[object] = []
+    for text in texts:
+        try:
+            payloads.append(json.loads(text))
+        except json.JSONDecodeError:
+            continue
+    return payloads
+
+
+def _attack_completed(payload: object) -> bool:
+    """Validate the bounded failed-authentication attack completion marker."""
+
+    if not isinstance(payload, Mapping) or payload.get("success") is not True:
+        return False
+    output = payload.get("output")
+    stdout = output.get("stdout") if isinstance(output, Mapping) else None
+    return isinstance(stdout, str) and stdout.rstrip().endswith("done")
 
 
 def _semantic_passed(kind: str, result: Mapping[str, object]) -> bool:
-    if result.get("isError") is True:
-        return False
-    texts = _text_content(result)
-    if kind == "kali-user":
-        return any("uid=1000(kali)" in text for text in texts)
-    if kind == "attack-complete":
-        for text in texts:
-            try:
-                payload = json.loads(text)
-            except json.JSONDecodeError:
-                continue
-            output = payload.get("output") if isinstance(payload, Mapping) else None
-            stdout = output.get("stdout") if isinstance(output, Mapping) else None
-            if payload.get("success") is True and isinstance(stdout, str):
-                if stdout.rstrip().endswith("done"):
-                    return True
-        return False
-    if kind == "alert-hit":
-        for text in texts:
-            try:
-                payload = json.loads(text)
-            except json.JSONDecodeError:
-                continue
-            if _has_alert_hit(payload):
-                return True
-        return False
-    return False
+    """Validate semantic evidence without accepting result text as a verdict."""
+
+    passed = False
+    if result.get("isError") is not True:
+        texts = _text_content(result)
+        if kind == "kali-user":
+            passed = any("uid=1000(kali)" in text for text in texts)
+        else:
+            payloads = _decoded_text_payloads(texts)
+            if kind == "attack-complete":
+                passed = any(_attack_completed(payload) for payload in payloads)
+            elif kind == "alert-hit":
+                passed = any(_has_alert_hit(payload) for payload in payloads)
+    return passed
 
 
 def _validate_profile_binding(profile: ResolvedParticipantProfile) -> None:
+    """Require the smoke registry to equal the admitted MCP readiness surface."""
+
     allowed = set(profile.mcp_server_ids)
     operation_servers = {operation.server_id for operation in _OPERATIONS}
     if operation_servers != allowed:

--- a/src/aptl/validation/participant_mcp_smoke.py
+++ b/src/aptl/validation/participant_mcp_smoke.py
@@ -1,0 +1,211 @@
+"""Real semantic MCP smoke operations for the bounded participant profile."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from aptl.validation.mcp_protocol import McpProtocolError, call_mcp_tool
+from aptl.validation.participant_profile import ResolvedParticipantProfile
+from aptl.validation.participant_qualification import QualificationCheckEvidence
+
+
+class ParticipantMcpSmokeError(ValueError):
+    """The admitted profile cannot run its exact MCP smoke surface."""
+
+
+@dataclass(frozen=True)
+class McpRegistration:
+    """One management-owned released MCP process registration."""
+
+    argv: tuple[str, ...]
+    cwd: Path
+    env: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class _SmokeOperation:
+    check_id: str
+    server_id: str
+    tool_name: str
+    arguments: Mapping[str, object]
+    semantic_kind: str
+
+
+_RECENT_SSH_ALERT_QUERY = {
+    "size": 1,
+    "query": {
+        "bool": {
+            "must": [{"match": {"rule.id": "5710"}}],
+            "filter": [{"range": {"@timestamp": {"gte": "now-15m"}}}],
+        }
+    },
+}
+
+_OPERATIONS = (
+    _SmokeOperation(
+        check_id="mcp.red.kali-command",
+        server_id="aptl-red",
+        tool_name="kali_run_command",
+        arguments={"command": "id"},
+        semantic_kind="kali-user",
+    ),
+    _SmokeOperation(
+        check_id="mcp.red.ssh-authentication-attack",
+        server_id="aptl-red",
+        tool_name="kali_run_command",
+        arguments={
+            "command": (
+                "for u in aptl-a aptl-b aptl-c aptl-d aptl-e aptl-f; do "
+                "ssh -o BatchMode=yes -o StrictHostKeyChecking=no "
+                "-o ConnectTimeout=5 \"$u\"@172.20.2.20 true 2>/dev/null "
+                "|| true; done; echo done"
+            )
+        },
+        semantic_kind="attack-complete",
+    ),
+    _SmokeOperation(
+        check_id="mcp.blue.indexer-investigation",
+        server_id="aptl-indexer",
+        tool_name="indexer_query",
+        arguments={"body": _RECENT_SSH_ALERT_QUERY},
+        semantic_kind="alert-hit",
+    ),
+    _SmokeOperation(
+        check_id="mcp.blue.wazuh-investigation",
+        server_id="aptl-wazuh",
+        tool_name="wazuh_query_alerts",
+        arguments={"body": _RECENT_SSH_ALERT_QUERY},
+        semantic_kind="alert-hit",
+    ),
+)
+
+
+def _text_content(result: Mapping[str, object]) -> list[str]:
+    content = result.get("content")
+    if not isinstance(content, Sequence) or isinstance(content, str | bytes):
+        return []
+    texts: list[str] = []
+    for item in content:
+        if not isinstance(item, Mapping) or item.get("type") != "text":
+            continue
+        value = item.get("text")
+        if isinstance(value, str):
+            texts.append(value)
+    return texts
+
+
+def _has_alert_hit(value: object) -> bool:
+    if isinstance(value, Mapping):
+        hits = value.get("hits")
+        if isinstance(hits, Mapping):
+            rows = hits.get("hits")
+            if isinstance(rows, list) and rows:
+                return True
+        return any(_has_alert_hit(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_has_alert_hit(item) for item in value)
+    return False
+
+
+def _semantic_passed(kind: str, result: Mapping[str, object]) -> bool:
+    if result.get("isError") is True:
+        return False
+    texts = _text_content(result)
+    if kind == "kali-user":
+        return any("uid=1000(kali)" in text for text in texts)
+    if kind == "attack-complete":
+        for text in texts:
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            output = payload.get("output") if isinstance(payload, Mapping) else None
+            stdout = output.get("stdout") if isinstance(output, Mapping) else None
+            if payload.get("success") is True and isinstance(stdout, str):
+                if stdout.rstrip().endswith("done"):
+                    return True
+        return False
+    if kind == "alert-hit":
+        for text in texts:
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if _has_alert_hit(payload):
+                return True
+        return False
+    return False
+
+
+def _validate_profile_binding(profile: ResolvedParticipantProfile) -> None:
+    allowed = set(profile.mcp_server_ids)
+    operation_servers = {operation.server_id for operation in _OPERATIONS}
+    if operation_servers != allowed:
+        raise ParticipantMcpSmokeError(
+            "profile MCP operation registry does not match the allowed surface"
+        )
+    readiness = {
+        (check.check_id, check.subject_id)
+        for check in profile.readiness.checks
+        if check.kind == "mcp-tool"
+    }
+    expected = {(operation.check_id, operation.server_id) for operation in _OPERATIONS}
+    if readiness != expected:
+        raise ParticipantMcpSmokeError(
+            "profile MCP readiness suite does not match the operation registry"
+        )
+
+
+def run_participant_mcp_smoke(
+    profile: ResolvedParticipantProfile,
+    registrations: Mapping[str, McpRegistration],
+) -> tuple[QualificationCheckEvidence, ...]:
+    """Invoke every allowed MCP's bounded real backend operation exactly once."""
+
+    _validate_profile_binding(profile)
+    allowed = set(profile.mcp_server_ids)
+    if set(registrations) != allowed:
+        raise ParticipantMcpSmokeError(
+            "MCP registration surface does not match the participant profile"
+        )
+    timeouts = {
+        check.check_id: check.timeout_seconds
+        for check in profile.readiness.checks
+        if check.kind == "mcp-tool"
+    }
+    evidence: list[QualificationCheckEvidence] = []
+    expected_tools = {
+        server.server_id: server.tool_names
+        for workbench in profile.workbench_profiles
+        for server in workbench.servers
+    }
+    for operation in _OPERATIONS:
+        registration = registrations[operation.server_id]
+        try:
+            result = call_mcp_tool(
+                registration.argv,
+                operation.tool_name,
+                operation.arguments,
+                cwd=registration.cwd,
+                env=registration.env,
+                timeout_seconds=timeouts[operation.check_id],
+                expected_tool_names=expected_tools[operation.server_id],
+            )
+            passed = _semantic_passed(operation.semantic_kind, result)
+        except McpProtocolError:
+            passed = False
+        evidence.append(
+            QualificationCheckEvidence(
+                check_id=operation.check_id,
+                status="passed" if passed else "failed",
+                summary=(
+                    "semantic backend operation passed"
+                    if passed
+                    else "semantic backend operation failed"
+                ),
+            )
+        )
+    return tuple(evidence)

--- a/src/aptl/validation/participant_profile.py
+++ b/src/aptl/validation/participant_profile.py
@@ -10,12 +10,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import BaseModel, ValidationError
 
 from aptl.core.config import AptlConfig, load_config
 from aptl.core.scenario_catalog import load_scenario_catalog
@@ -24,292 +21,28 @@ from aptl.validation.curated_live_proof import (
     ExpectedMatrix,
     expected_reduced_matrix,
 )
+from aptl.validation.participant_profile_models import (
+    ArtifactReference,
+    ParticipantAssetLock,
+    ParticipantNarrative,
+    ParticipantProfileManifest,
+    ParticipantReadinessSuite,
+    ResolvedParticipantProfile,
+)
 from aptl.workbench.profiles import (
-    ProfileId,
     WorkbenchConfigurationError,
     WorkbenchProfile,
     profile_for,
 )
-
-_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
-_IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9.-]*$")
 
 
 class ParticipantProfileError(ValueError):
     """A participant profile cannot be validated or safely resolved."""
 
 
-class _StrictModel(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-
-_ModelT = TypeVar("_ModelT", bound=BaseModel)
-
-
-class ArtifactReference(_StrictModel):
-    """One project-contained immutable profile input."""
-
-    path: str
-    sha256: str
-
-    @field_validator("path")
-    @classmethod
-    def validate_path(cls, value: str) -> str:
-        if not value or Path(value).is_absolute():
-            raise ValueError("artifact path must be project-relative")
-        return value
-
-    @field_validator("sha256")
-    @classmethod
-    def validate_digest(cls, value: str) -> str:
-        if not _SHA256_RE.fullmatch(value):
-            raise ValueError("sha256 must be lowercase hexadecimal")
-        return value
-
-
-class ScenarioReference(ArtifactReference):
-    """Catalog identity plus the exact SDL bytes admitted for the profile."""
-
-    catalog_id: str
-
-    @field_validator("catalog_id")
-    @classmethod
-    def validate_catalog_id(cls, value: str) -> str:
-        if not _IDENTIFIER_RE.fullmatch(value):
-            raise ValueError("invalid scenario catalog id")
-        return value
-
-
-class ParticipantCapabilities(_StrictModel):
-    """Workbench compartments admitted in sequence by the guided workflow."""
-
-    workbench_profiles: tuple[ProfileId, ...]
-
-    @field_validator("workbench_profiles")
-    @classmethod
-    def validate_unique_identifiers(
-        cls, values: tuple[ProfileId, ...]
-    ) -> tuple[ProfileId, ...]:
-        if not values or len(set(values)) != len(values):
-            raise ValueError("capability ids must be non-empty and unique")
-        return values
-
-
-class MinimumHardware(_StrictModel):
-    architecture: Literal["x86_64", "aarch64"]
-    vcpus: int = Field(ge=1)
-    memory_bytes: int = Field(gt=0)
-    disk_bytes: int = Field(gt=0)
-
-
-class ProfileMaximums(_StrictModel):
-    peak_cpu_percent: float = Field(gt=0, le=100)
-    peak_memory_bytes: int = Field(gt=0)
-    staged_profile_assets_bytes: int = Field(gt=0)
-    unique_image_compressed_bytes: int = Field(gt=0)
-    unique_image_expanded_bytes: int = Field(gt=0)
-    peak_runtime_disk_bytes: int = Field(gt=0)
-    cold_start_seconds: float = Field(gt=0)
-    warm_start_seconds: float = Field(gt=0)
-    clean_reset_seconds: float = Field(gt=0)
-
-
-class ProfileBudgets(_StrictModel):
-    minimum_hardware: MinimumHardware
-    maximums: ProfileMaximums
-
-
-class ReleaseEvidenceContract(_StrictModel):
-    """Profile evidence that the appliance release in issue 823 consumes."""
-
-    asset_lock_schema: Literal["aptl.participant-asset-lock/v1"]
-    qualification_report_schema: Literal["aptl.participant-qualification/v1"]
-    asset_lock_ref: str
-    asset_lock_sha256: str
-    qualification_report_ref: str
-
-    @field_validator("asset_lock_ref", "qualification_report_ref")
-    @classmethod
-    def validate_release_ref(cls, value: str) -> str:
-        path = Path(value)
-        if not value or path.is_absolute() or "." in path.parts or ".." in path.parts:
-            raise ValueError("release evidence ref must be a safe relative path")
-        return value
-
-    @field_validator("asset_lock_sha256")
-    @classmethod
-    def validate_asset_lock_digest(cls, value: str) -> str:
-        if not _SHA256_RE.fullmatch(value):
-            raise ValueError("asset lock sha256 must be lowercase hexadecimal")
-        return value
-
-
-class AssetLockEntry(_StrictModel):
-    """One staged input identity required by the participant profile."""
-
-    asset_id: str
-    kind: Literal["project-file", "mcp-artifact", "oci-image"]
-    source: str = Field(min_length=1)
-    sha256: str
-    services: tuple[str, ...] = ()
-
-    @field_validator("asset_id")
-    @classmethod
-    def validate_asset_id(cls, value: str) -> str:
-        if not _IDENTIFIER_RE.fullmatch(value):
-            raise ValueError("invalid asset id")
-        return value
-
-    @field_validator("sha256")
-    @classmethod
-    def validate_sha256(cls, value: str) -> str:
-        if not _SHA256_RE.fullmatch(value):
-            raise ValueError("asset sha256 must be lowercase hexadecimal")
-        return value
-
-    @field_validator("services")
-    @classmethod
-    def validate_unique_services(cls, values: tuple[str, ...]) -> tuple[str, ...]:
-        if len(values) != len(set(values)):
-            raise ValueError("asset service ids must be unique")
-        return values
-
-
-class ParticipantAssetLock(_StrictModel):
-    """Content-addressed closure staged before participant delivery."""
-
-    schema_version: Literal["aptl.participant-asset-lock/v1"]
-    profile_id: str
-    profile_version: int = Field(ge=1)
-    assets: tuple[AssetLockEntry, ...]
-
-    @field_validator("assets")
-    @classmethod
-    def validate_unique_assets(
-        cls, assets: tuple[AssetLockEntry, ...]
-    ) -> tuple[AssetLockEntry, ...]:
-        ids = [asset.asset_id for asset in assets]
-        if not ids or len(ids) != len(set(ids)):
-            raise ValueError("asset lock ids must be non-empty and unique")
-        return assets
-
-
-class ParticipantProfileManifest(_StrictModel):
-    """The immutable release-level profile binding."""
-
-    schema_version: Literal["aptl.participant-profile/v1"]
-    profile_id: str
-    version: int = Field(ge=1)
-    narrative: ArtifactReference
-    scenario: ScenarioReference
-    config: ArtifactReference
-    readiness: ArtifactReference
-    capabilities: ParticipantCapabilities
-    release_evidence: ReleaseEvidenceContract
-    budgets: ProfileBudgets
-
-    @field_validator("profile_id")
-    @classmethod
-    def validate_profile_id(cls, value: str) -> str:
-        if not _IDENTIFIER_RE.fullmatch(value):
-            raise ValueError("invalid profile id")
-        return value
-
-
-class NarrativeOperation(_StrictModel):
-    operation_id: str
-    classification: Literal["required", "optional", "facilitator-only"]
-    capability_id: str
-    channel: Literal["mcp", "browser", "workflow"]
-    expected_result: str = Field(min_length=1)
-
-
-class ParticipantNarrative(_StrictModel):
-    schema_version: Literal["aptl.participant-narrative/v1"]
-    narrative_id: str
-    version: int = Field(ge=1)
-    operations: tuple[NarrativeOperation, ...]
-
-    @field_validator("operations")
-    @classmethod
-    def validate_unique_operations(
-        cls, operations: tuple[NarrativeOperation, ...]
-    ) -> tuple[NarrativeOperation, ...]:
-        operation_ids = [operation.operation_id for operation in operations]
-        if not operation_ids or len(operation_ids) != len(set(operation_ids)):
-            raise ValueError("narrative operation ids must be non-empty and unique")
-        return operations
-
-
-class ReadinessCheck(_StrictModel):
-    check_id: str
-    capability_id: str
-    kind: Literal[
-        "runtime-surface",
-        "mcp-tool",
-        "browser-operation",
-        "evidence",
-        "offline-assets",
-        "resource-budget",
-    ]
-    subject_id: str
-    operation_id: str
-    timeout_seconds: int = Field(gt=0, le=3600)
-
-
-class ParticipantReadinessSuite(_StrictModel):
-    schema_version: Literal["aptl.participant-readiness/v1"]
-    suite_id: str
-    version: int = Field(ge=1)
-    checks: tuple[ReadinessCheck, ...]
-
-    @field_validator("checks")
-    @classmethod
-    def validate_unique_checks(
-        cls, checks: tuple[ReadinessCheck, ...]
-    ) -> tuple[ReadinessCheck, ...]:
-        check_ids = [check.check_id for check in checks]
-        if not check_ids or len(check_ids) != len(set(check_ids)):
-            raise ValueError("readiness check ids must be non-empty and unique")
-        return checks
-
-
-@dataclass(frozen=True)
-class ResolvedParticipantProfile:
-    """Validated profile plus its canonical resolved runtime inputs."""
-
-    manifest: ParticipantProfileManifest
-    manifest_sha256: str
-    config: AptlConfig
-    scenario_path: Path
-    narrative: ParticipantNarrative
-    readiness: ParticipantReadinessSuite
-    asset_lock: ParticipantAssetLock
-    workbench_profiles: tuple[WorkbenchProfile, ...]
-    expected_matrix: ExpectedMatrix
-
-    @property
-    def mcp_server_ids(self) -> tuple[str, ...]:
-        return tuple(
-            dict.fromkeys(
-                server_id
-                for workbench in self.workbench_profiles
-                for server_id in workbench.server_ids
-            )
-        )
-
-    @property
-    def browser_refs(self) -> tuple[str, ...]:
-        return tuple(
-            dict.fromkeys(
-                bookmark
-                for workbench in self.workbench_profiles
-                for bookmark in workbench.bookmark_refs
-            )
-        )
-
-
 def _relative_path(project_root: Path, path: Path) -> Path:
+    """Return a contained project-relative path or reject the candidate."""
+
     try:
         return path.relative_to(project_root)
     except ValueError as exc:
@@ -320,6 +53,8 @@ def _read_reference(
     project_root: Path,
     reference: ArtifactReference,
 ) -> bytes:
+    """Read one contained no-follow reference and verify its exact digest."""
+
     try:
         payload = read_contained_nofollow(project_root, reference.path)
     except PathContainmentError as exc:
@@ -332,11 +67,13 @@ def _read_reference(
 
 
 def _load_model(
-    model_type: type[_ModelT],
+    model_type: type[BaseModel],
     payload: bytes,
     *,
     label: str,
-) -> _ModelT:
+) -> BaseModel:
+    """Decode strict JSON into the requested participant profile model."""
+
     try:
         value = json.loads(payload)
         return model_type.model_validate(value)
@@ -348,6 +85,8 @@ def _validate_profile_links(
     project_root: Path,
     manifest: ParticipantProfileManifest,
 ) -> tuple[AptlConfig, Path, ParticipantNarrative, ParticipantReadinessSuite]:
+    """Resolve and cross-bind all immutable profile input references."""
+
     narrative = _load_model(
         ParticipantNarrative,
         _read_reference(project_root, manifest.narrative),
@@ -358,6 +97,8 @@ def _validate_profile_links(
         _read_reference(project_root, manifest.readiness),
         label="readiness suite",
     )
+    assert isinstance(narrative, ParticipantNarrative)
+    assert isinstance(readiness, ParticipantReadinessSuite)
     _read_reference(project_root, manifest.config)
     scenario_bytes = _read_reference(project_root, manifest.scenario)
 
@@ -395,6 +136,8 @@ def _validate_narrative_readiness(
     narrative: ParticipantNarrative,
     readiness: ParticipantReadinessSuite,
 ) -> None:
+    """Require each mandatory narrative capability to have a readiness check."""
+
     required = {
         operation.capability_id
         for operation in narrative.operations
@@ -411,6 +154,8 @@ def _load_asset_lock(
     project_root: Path,
     manifest: ParticipantProfileManifest,
 ) -> ParticipantAssetLock:
+    """Load and byte-verify the staged asset closure."""
+
     reference = ArtifactReference(
         path=manifest.release_evidence.asset_lock_ref,
         sha256=manifest.release_evidence.asset_lock_sha256,
@@ -420,18 +165,14 @@ def _load_asset_lock(
         _read_reference(project_root, reference),
         label="asset lock",
     )
+    assert isinstance(lock, ParticipantAssetLock)
     if (
         lock.profile_id != manifest.profile_id
         or lock.profile_version != manifest.version
     ):
         raise ParticipantProfileError("participant asset lock identity mismatch")
     for asset in lock.assets:
-        if asset.kind == "project-file":
-            _read_reference(
-                project_root,
-                ArtifactReference(path=asset.source, sha256=asset.sha256),
-            )
-        elif asset.kind == "mcp-artifact":
+        if asset.kind in {"project-file", "mcp-artifact"}:
             _read_reference(
                 project_root,
                 ArtifactReference(path=asset.source, sha256=asset.sha256),
@@ -447,6 +188,8 @@ def _validate_asset_lock_coverage(
     workbench_profiles: tuple[WorkbenchProfile, ...],
     expected_matrix: ExpectedMatrix,
 ) -> None:
+    """Require the asset lock to cover every derived release input exactly."""
+
     locked_files = {
         asset.source: asset.sha256
         for asset in lock.assets
@@ -479,9 +222,8 @@ def _validate_asset_lock_coverage(
         if asset.kind == "oci-image"
         for service in asset.services
     ]
-    if (
-        len(image_services) != len(set(image_services))
-        or set(image_services) != set(expected_matrix.expected_services)
+    if len(image_services) != len(set(image_services)) or set(image_services) != set(
+        expected_matrix.expected_services
     ):
         raise ParticipantProfileError(
             "participant asset lock does not match the derived service surface"
@@ -496,6 +238,8 @@ def _validate_workbench_readiness(
     readiness: ParticipantReadinessSuite,
     workbench_profiles: tuple[WorkbenchProfile, ...],
 ) -> None:
+    """Require browser readiness checks to equal the workbench bookmarks."""
+
     expected_browser = {
         bookmark
         for workbench in workbench_profiles
@@ -543,7 +287,9 @@ def load_participant_profile(
             for profile_id in manifest.capabilities.workbench_profiles
         )
     except WorkbenchConfigurationError as exc:
-        raise ParticipantProfileError("participant workbench profile is invalid") from exc
+        raise ParticipantProfileError(
+            "participant workbench profile is invalid"
+        ) from exc
     _validate_workbench_readiness(readiness, workbench_profiles)
     asset_lock = _load_asset_lock(project_root, manifest)
     try:

--- a/src/aptl/validation/participant_profile.py
+++ b/src/aptl/validation/participant_profile.py
@@ -1,0 +1,575 @@
+"""Strict versioned participant-profile binding and resolution (APP-2).
+
+The profile is release/conformance data.  It references the canonical ACES
+scenario, first-party config, narrative, and readiness suite by contained path
+and digest, then derives the expected runtime surface through the same ACES and
+Compose authorities used by the public start path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from aptl.core.config import AptlConfig, load_config
+from aptl.core.scenario_catalog import load_scenario_catalog
+from aptl.utils.pathsafe import PathContainmentError, read_contained_nofollow
+from aptl.validation.curated_live_proof import (
+    ExpectedMatrix,
+    expected_reduced_matrix,
+)
+from aptl.workbench.profiles import (
+    ProfileId,
+    WorkbenchConfigurationError,
+    WorkbenchProfile,
+    profile_for,
+)
+
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9.-]*$")
+
+
+class ParticipantProfileError(ValueError):
+    """A participant profile cannot be validated or safely resolved."""
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
+
+
+class ArtifactReference(_StrictModel):
+    """One project-contained immutable profile input."""
+
+    path: str
+    sha256: str
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        if not value or Path(value).is_absolute():
+            raise ValueError("artifact path must be project-relative")
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_digest(cls, value: str) -> str:
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("sha256 must be lowercase hexadecimal")
+        return value
+
+
+class ScenarioReference(ArtifactReference):
+    """Catalog identity plus the exact SDL bytes admitted for the profile."""
+
+    catalog_id: str
+
+    @field_validator("catalog_id")
+    @classmethod
+    def validate_catalog_id(cls, value: str) -> str:
+        if not _IDENTIFIER_RE.fullmatch(value):
+            raise ValueError("invalid scenario catalog id")
+        return value
+
+
+class ParticipantCapabilities(_StrictModel):
+    """Workbench compartments admitted in sequence by the guided workflow."""
+
+    workbench_profiles: tuple[ProfileId, ...]
+
+    @field_validator("workbench_profiles")
+    @classmethod
+    def validate_unique_identifiers(
+        cls, values: tuple[ProfileId, ...]
+    ) -> tuple[ProfileId, ...]:
+        if not values or len(set(values)) != len(values):
+            raise ValueError("capability ids must be non-empty and unique")
+        return values
+
+
+class MinimumHardware(_StrictModel):
+    architecture: Literal["x86_64", "aarch64"]
+    vcpus: int = Field(ge=1)
+    memory_bytes: int = Field(gt=0)
+    disk_bytes: int = Field(gt=0)
+
+
+class ProfileMaximums(_StrictModel):
+    peak_cpu_percent: float = Field(gt=0, le=100)
+    peak_memory_bytes: int = Field(gt=0)
+    staged_profile_assets_bytes: int = Field(gt=0)
+    unique_image_compressed_bytes: int = Field(gt=0)
+    unique_image_expanded_bytes: int = Field(gt=0)
+    peak_runtime_disk_bytes: int = Field(gt=0)
+    cold_start_seconds: float = Field(gt=0)
+    warm_start_seconds: float = Field(gt=0)
+    clean_reset_seconds: float = Field(gt=0)
+
+
+class ProfileBudgets(_StrictModel):
+    minimum_hardware: MinimumHardware
+    maximums: ProfileMaximums
+
+
+class ReleaseEvidenceContract(_StrictModel):
+    """Profile evidence that the appliance release in issue 823 consumes."""
+
+    asset_lock_schema: Literal["aptl.participant-asset-lock/v1"]
+    qualification_report_schema: Literal["aptl.participant-qualification/v1"]
+    asset_lock_ref: str
+    asset_lock_sha256: str
+    qualification_report_ref: str
+
+    @field_validator("asset_lock_ref", "qualification_report_ref")
+    @classmethod
+    def validate_release_ref(cls, value: str) -> str:
+        path = Path(value)
+        if not value or path.is_absolute() or "." in path.parts or ".." in path.parts:
+            raise ValueError("release evidence ref must be a safe relative path")
+        return value
+
+    @field_validator("asset_lock_sha256")
+    @classmethod
+    def validate_asset_lock_digest(cls, value: str) -> str:
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("asset lock sha256 must be lowercase hexadecimal")
+        return value
+
+
+class AssetLockEntry(_StrictModel):
+    """One staged input identity required by the participant profile."""
+
+    asset_id: str
+    kind: Literal["project-file", "mcp-artifact", "oci-image"]
+    source: str = Field(min_length=1)
+    sha256: str
+    services: tuple[str, ...] = ()
+
+    @field_validator("asset_id")
+    @classmethod
+    def validate_asset_id(cls, value: str) -> str:
+        if not _IDENTIFIER_RE.fullmatch(value):
+            raise ValueError("invalid asset id")
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_sha256(cls, value: str) -> str:
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("asset sha256 must be lowercase hexadecimal")
+        return value
+
+    @field_validator("services")
+    @classmethod
+    def validate_unique_services(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        if len(values) != len(set(values)):
+            raise ValueError("asset service ids must be unique")
+        return values
+
+
+class ParticipantAssetLock(_StrictModel):
+    """Content-addressed closure staged before participant delivery."""
+
+    schema_version: Literal["aptl.participant-asset-lock/v1"]
+    profile_id: str
+    profile_version: int = Field(ge=1)
+    assets: tuple[AssetLockEntry, ...]
+
+    @field_validator("assets")
+    @classmethod
+    def validate_unique_assets(
+        cls, assets: tuple[AssetLockEntry, ...]
+    ) -> tuple[AssetLockEntry, ...]:
+        ids = [asset.asset_id for asset in assets]
+        if not ids or len(ids) != len(set(ids)):
+            raise ValueError("asset lock ids must be non-empty and unique")
+        return assets
+
+
+class ParticipantProfileManifest(_StrictModel):
+    """The immutable release-level profile binding."""
+
+    schema_version: Literal["aptl.participant-profile/v1"]
+    profile_id: str
+    version: int = Field(ge=1)
+    narrative: ArtifactReference
+    scenario: ScenarioReference
+    config: ArtifactReference
+    readiness: ArtifactReference
+    capabilities: ParticipantCapabilities
+    release_evidence: ReleaseEvidenceContract
+    budgets: ProfileBudgets
+
+    @field_validator("profile_id")
+    @classmethod
+    def validate_profile_id(cls, value: str) -> str:
+        if not _IDENTIFIER_RE.fullmatch(value):
+            raise ValueError("invalid profile id")
+        return value
+
+
+class NarrativeOperation(_StrictModel):
+    operation_id: str
+    classification: Literal["required", "optional", "facilitator-only"]
+    capability_id: str
+    channel: Literal["mcp", "browser", "workflow"]
+    expected_result: str = Field(min_length=1)
+
+
+class ParticipantNarrative(_StrictModel):
+    schema_version: Literal["aptl.participant-narrative/v1"]
+    narrative_id: str
+    version: int = Field(ge=1)
+    operations: tuple[NarrativeOperation, ...]
+
+    @field_validator("operations")
+    @classmethod
+    def validate_unique_operations(
+        cls, operations: tuple[NarrativeOperation, ...]
+    ) -> tuple[NarrativeOperation, ...]:
+        operation_ids = [operation.operation_id for operation in operations]
+        if not operation_ids or len(operation_ids) != len(set(operation_ids)):
+            raise ValueError("narrative operation ids must be non-empty and unique")
+        return operations
+
+
+class ReadinessCheck(_StrictModel):
+    check_id: str
+    capability_id: str
+    kind: Literal[
+        "runtime-surface",
+        "mcp-tool",
+        "browser-operation",
+        "evidence",
+        "offline-assets",
+        "resource-budget",
+    ]
+    subject_id: str
+    operation_id: str
+    timeout_seconds: int = Field(gt=0, le=3600)
+
+
+class ParticipantReadinessSuite(_StrictModel):
+    schema_version: Literal["aptl.participant-readiness/v1"]
+    suite_id: str
+    version: int = Field(ge=1)
+    checks: tuple[ReadinessCheck, ...]
+
+    @field_validator("checks")
+    @classmethod
+    def validate_unique_checks(
+        cls, checks: tuple[ReadinessCheck, ...]
+    ) -> tuple[ReadinessCheck, ...]:
+        check_ids = [check.check_id for check in checks]
+        if not check_ids or len(check_ids) != len(set(check_ids)):
+            raise ValueError("readiness check ids must be non-empty and unique")
+        return checks
+
+
+@dataclass(frozen=True)
+class ResolvedParticipantProfile:
+    """Validated profile plus its canonical resolved runtime inputs."""
+
+    manifest: ParticipantProfileManifest
+    manifest_sha256: str
+    config: AptlConfig
+    scenario_path: Path
+    narrative: ParticipantNarrative
+    readiness: ParticipantReadinessSuite
+    asset_lock: ParticipantAssetLock
+    workbench_profiles: tuple[WorkbenchProfile, ...]
+    expected_matrix: ExpectedMatrix
+
+    @property
+    def mcp_server_ids(self) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                server_id
+                for workbench in self.workbench_profiles
+                for server_id in workbench.server_ids
+            )
+        )
+
+    @property
+    def browser_refs(self) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                bookmark
+                for workbench in self.workbench_profiles
+                for bookmark in workbench.bookmark_refs
+            )
+        )
+
+
+def _relative_path(project_root: Path, path: Path) -> Path:
+    try:
+        return path.relative_to(project_root)
+    except ValueError as exc:
+        raise ParticipantProfileError("unsafe participant profile path") from exc
+
+
+def _read_reference(
+    project_root: Path,
+    reference: ArtifactReference,
+) -> bytes:
+    try:
+        payload = read_contained_nofollow(project_root, reference.path)
+    except PathContainmentError as exc:
+        raise ParticipantProfileError("unsafe profile reference") from exc
+    if hashlib.sha256(payload).hexdigest() != reference.sha256:
+        raise ParticipantProfileError(
+            f"profile reference digest mismatch: {reference.path}"
+        )
+    return payload
+
+
+def _load_model(
+    model_type: type[_ModelT],
+    payload: bytes,
+    *,
+    label: str,
+) -> _ModelT:
+    try:
+        value = json.loads(payload)
+        return model_type.model_validate(value)
+    except (json.JSONDecodeError, ValidationError, TypeError) as exc:
+        raise ParticipantProfileError(f"invalid participant {label}") from exc
+
+
+def _validate_profile_links(
+    project_root: Path,
+    manifest: ParticipantProfileManifest,
+) -> tuple[AptlConfig, Path, ParticipantNarrative, ParticipantReadinessSuite]:
+    narrative = _load_model(
+        ParticipantNarrative,
+        _read_reference(project_root, manifest.narrative),
+        label="narrative",
+    )
+    readiness = _load_model(
+        ParticipantReadinessSuite,
+        _read_reference(project_root, manifest.readiness),
+        label="readiness suite",
+    )
+    _read_reference(project_root, manifest.config)
+    scenario_bytes = _read_reference(project_root, manifest.scenario)
+
+    config_path = project_root / manifest.config.path
+    try:
+        config = load_config(config_path)
+        catalog = load_scenario_catalog(project_root)
+    except ValueError as exc:
+        raise ParticipantProfileError("invalid participant profile reference") from exc
+
+    entry = catalog.get(manifest.scenario.catalog_id)
+    if entry is None or entry.path != manifest.scenario.path:
+        raise ParticipantProfileError("participant scenario catalog reference mismatch")
+    scenario_path = project_root / manifest.scenario.path
+    # Keep the exact no-follow bytes alive through the catalog check above.  The
+    # planner reopens the canonical contained path through the ACES authority.
+    if not scenario_bytes:
+        raise ParticipantProfileError("participant scenario is empty")
+    if (
+        narrative.narrative_id != manifest.profile_id
+        or narrative.version != manifest.version
+        or readiness.suite_id != manifest.profile_id
+        or readiness.version != manifest.version
+    ):
+        raise ParticipantProfileError("participant profile input identity mismatch")
+    return (
+        config,
+        scenario_path,
+        narrative,
+        readiness,
+    )
+
+
+def _validate_narrative_readiness(
+    narrative: ParticipantNarrative,
+    readiness: ParticipantReadinessSuite,
+) -> None:
+    required = {
+        operation.capability_id
+        for operation in narrative.operations
+        if operation.classification == "required"
+    }
+    checked = {check.capability_id for check in readiness.checks}
+    if not required <= checked:
+        raise ParticipantProfileError(
+            "required narrative operation lacks a readiness check"
+        )
+
+
+def _load_asset_lock(
+    project_root: Path,
+    manifest: ParticipantProfileManifest,
+) -> ParticipantAssetLock:
+    reference = ArtifactReference(
+        path=manifest.release_evidence.asset_lock_ref,
+        sha256=manifest.release_evidence.asset_lock_sha256,
+    )
+    lock = _load_model(
+        ParticipantAssetLock,
+        _read_reference(project_root, reference),
+        label="asset lock",
+    )
+    if (
+        lock.profile_id != manifest.profile_id
+        or lock.profile_version != manifest.version
+    ):
+        raise ParticipantProfileError("participant asset lock identity mismatch")
+    for asset in lock.assets:
+        if asset.kind == "project-file":
+            _read_reference(
+                project_root,
+                ArtifactReference(path=asset.source, sha256=asset.sha256),
+            )
+        elif asset.kind == "mcp-artifact":
+            _read_reference(
+                project_root,
+                ArtifactReference(path=asset.source, sha256=asset.sha256),
+            )
+        elif not asset.source.endswith(f"@sha256:{asset.sha256}"):
+            raise ParticipantProfileError("participant OCI asset identity mismatch")
+    return lock
+
+
+def _validate_asset_lock_coverage(
+    manifest: ParticipantProfileManifest,
+    lock: ParticipantAssetLock,
+    workbench_profiles: tuple[WorkbenchProfile, ...],
+    expected_matrix: ExpectedMatrix,
+) -> None:
+    locked_files = {
+        asset.source: asset.sha256
+        for asset in lock.assets
+        if asset.kind == "project-file"
+    }
+    required_references = (
+        manifest.narrative,
+        manifest.scenario,
+        manifest.config,
+        manifest.readiness,
+    )
+    if any(
+        locked_files.get(reference.path) != reference.sha256
+        for reference in required_references
+    ):
+        raise ParticipantProfileError("participant asset lock misses a profile input")
+    workbench_artifacts = {
+        server.artifact_ref
+        for workbench in workbench_profiles
+        for server in workbench.servers
+    }
+    locked_mcp_artifacts = {
+        asset.source for asset in lock.assets if asset.kind == "mcp-artifact"
+    }
+    if not workbench_artifacts <= locked_mcp_artifacts:
+        raise ParticipantProfileError("participant asset lock misses an MCP artifact")
+    image_services = [
+        service
+        for asset in lock.assets
+        if asset.kind == "oci-image"
+        for service in asset.services
+    ]
+    if (
+        len(image_services) != len(set(image_services))
+        or set(image_services) != set(expected_matrix.expected_services)
+    ):
+        raise ParticipantProfileError(
+            "participant asset lock does not match the derived service surface"
+        )
+    if any(
+        bool(asset.services) != (asset.kind == "oci-image") for asset in lock.assets
+    ):
+        raise ParticipantProfileError("participant asset service binding is invalid")
+
+
+def _validate_workbench_readiness(
+    readiness: ParticipantReadinessSuite,
+    workbench_profiles: tuple[WorkbenchProfile, ...],
+) -> None:
+    expected_browser = {
+        bookmark
+        for workbench in workbench_profiles
+        for bookmark in workbench.bookmark_refs
+    }
+    checked_browser = {
+        check.subject_id
+        for check in readiness.checks
+        if check.kind == "browser-operation"
+    }
+    if checked_browser != expected_browser:
+        raise ParticipantProfileError(
+            "participant browser readiness does not match the workbench surface"
+        )
+
+
+def load_participant_profile(
+    project_dir: Path,
+    manifest_path: Path,
+) -> ResolvedParticipantProfile:
+    """Load and resolve one strict project-contained participant profile."""
+
+    project_root = project_dir.resolve()
+    manifest_candidate = (
+        manifest_path if manifest_path.is_absolute() else project_root / manifest_path
+    )
+    relative_manifest = _relative_path(project_root, manifest_candidate)
+    try:
+        manifest_bytes = read_contained_nofollow(project_root, relative_manifest)
+    except PathContainmentError as exc:
+        raise ParticipantProfileError("unsafe participant profile path") from exc
+    manifest = _load_model(
+        ParticipantProfileManifest,
+        manifest_bytes,
+        label="profile",
+    )
+    assert isinstance(manifest, ParticipantProfileManifest)
+    config, scenario_path, narrative, readiness = _validate_profile_links(
+        project_root, manifest
+    )
+    _validate_narrative_readiness(narrative, readiness)
+    try:
+        workbench_profiles = tuple(
+            profile_for(profile_id)
+            for profile_id in manifest.capabilities.workbench_profiles
+        )
+    except WorkbenchConfigurationError as exc:
+        raise ParticipantProfileError("participant workbench profile is invalid") from exc
+    _validate_workbench_readiness(readiness, workbench_profiles)
+    asset_lock = _load_asset_lock(project_root, manifest)
+    try:
+        expected_matrix = expected_reduced_matrix(
+            project_root,
+            config,
+            scenario_path,
+        )
+    except (OSError, TypeError, ValueError) as exc:
+        raise ParticipantProfileError(
+            "participant profile runtime surface is invalid"
+        ) from exc
+    _validate_asset_lock_coverage(
+        manifest,
+        asset_lock,
+        workbench_profiles,
+        expected_matrix,
+    )
+    return ResolvedParticipantProfile(
+        manifest=manifest,
+        manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+        config=config,
+        scenario_path=scenario_path,
+        narrative=narrative,
+        readiness=readiness,
+        asset_lock=asset_lock,
+        workbench_profiles=workbench_profiles,
+        expected_matrix=expected_matrix,
+    )

--- a/src/aptl/validation/participant_profile_models.py
+++ b/src/aptl/validation/participant_profile_models.py
@@ -1,0 +1,330 @@
+"""Strict data models for the versioned participant profile contract."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from aptl.core.config import AptlConfig
+from aptl.validation.curated_live_proof import ExpectedMatrix
+from aptl.workbench.profiles import ProfileId, WorkbenchProfile
+
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9.-]*$")
+
+
+class _StrictModel(BaseModel):
+    """Immutable profile model that rejects undeclared input fields."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ArtifactReference(_StrictModel):
+    """One project-contained immutable profile input."""
+
+    path: str
+    sha256: str
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        """Require a non-empty project-relative artifact path."""
+
+        if not value or Path(value).is_absolute():
+            raise ValueError("artifact path must be project-relative")
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_digest(cls, value: str) -> str:
+        """Require a lowercase SHA-256 content digest."""
+
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("sha256 must be lowercase hexadecimal")
+        return value
+
+
+class ScenarioReference(ArtifactReference):
+    """Catalog identity plus the exact SDL bytes admitted for the profile."""
+
+    catalog_id: str
+
+    @field_validator("catalog_id")
+    @classmethod
+    def validate_catalog_id(cls, value: str) -> str:
+        """Require the canonical lowercase catalog identifier shape."""
+
+        if not _IDENTIFIER_RE.fullmatch(value):
+            raise ValueError("invalid scenario catalog id")
+        return value
+
+
+class ParticipantCapabilities(_StrictModel):
+    """Workbench compartments admitted in sequence by the guided workflow."""
+
+    workbench_profiles: tuple[ProfileId, ...]
+
+    @field_validator("workbench_profiles")
+    @classmethod
+    def validate_unique_identifiers(
+        cls, values: tuple[ProfileId, ...]
+    ) -> tuple[ProfileId, ...]:
+        """Require a non-empty sequence without repeated compartments."""
+
+        if not values or len(set(values)) != len(values):
+            raise ValueError("capability ids must be non-empty and unique")
+        return values
+
+
+class MinimumHardware(_StrictModel):
+    """Minimum supported participant qualification fixture."""
+
+    architecture: Literal["x86_64", "aarch64"]
+    vcpus: int = Field(ge=1)
+    memory_bytes: int = Field(gt=0)
+    disk_bytes: int = Field(gt=0)
+
+
+class ProfileMaximums(_StrictModel):
+    """Resource and lifecycle ceilings for a conforming profile run."""
+
+    peak_cpu_percent: float = Field(gt=0, le=100)
+    peak_memory_bytes: int = Field(gt=0)
+    staged_profile_assets_bytes: int = Field(gt=0)
+    unique_image_compressed_bytes: int = Field(gt=0)
+    unique_image_expanded_bytes: int = Field(gt=0)
+    peak_runtime_disk_bytes: int = Field(gt=0)
+    cold_start_seconds: float = Field(gt=0)
+    warm_start_seconds: float = Field(gt=0)
+    clean_reset_seconds: float = Field(gt=0)
+
+
+class ProfileBudgets(_StrictModel):
+    """Minimum fixture and maximum measured values for the release."""
+
+    minimum_hardware: MinimumHardware
+    maximums: ProfileMaximums
+
+
+class ReleaseEvidenceContract(_StrictModel):
+    """Profile evidence that the appliance release in issue 823 consumes."""
+
+    asset_lock_schema: Literal["aptl.participant-asset-lock/v1"]
+    qualification_report_schema: Literal["aptl.participant-qualification/v1"]
+    asset_lock_ref: str
+    asset_lock_sha256: str
+    qualification_report_ref: str
+
+    @field_validator("asset_lock_ref", "qualification_report_ref")
+    @classmethod
+    def validate_release_ref(cls, value: str) -> str:
+        """Keep release evidence references inside the project."""
+
+        path = Path(value)
+        if not value or path.is_absolute() or "." in path.parts or ".." in path.parts:
+            raise ValueError("release evidence ref must be a safe relative path")
+        return value
+
+    @field_validator("asset_lock_sha256")
+    @classmethod
+    def validate_asset_lock_digest(cls, value: str) -> str:
+        """Require the exact lowercase asset-lock digest."""
+
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("asset lock sha256 must be lowercase hexadecimal")
+        return value
+
+
+class AssetLockEntry(_StrictModel):
+    """One staged input identity required by the participant profile."""
+
+    asset_id: str
+    kind: Literal["project-file", "mcp-artifact", "oci-image"]
+    source: str = Field(min_length=1)
+    sha256: str
+    services: tuple[str, ...] = ()
+
+    @field_validator("asset_id")
+    @classmethod
+    def validate_asset_id(cls, value: str) -> str:
+        """Require a stable lowercase asset identifier."""
+
+        if not _IDENTIFIER_RE.fullmatch(value):
+            raise ValueError("invalid asset id")
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_sha256(cls, value: str) -> str:
+        """Require a lowercase SHA-256 asset digest."""
+
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("asset sha256 must be lowercase hexadecimal")
+        return value
+
+    @field_validator("services")
+    @classmethod
+    def validate_unique_services(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        """Reject duplicate Compose service bindings."""
+
+        if len(values) != len(set(values)):
+            raise ValueError("asset service ids must be unique")
+        return values
+
+
+class ParticipantAssetLock(_StrictModel):
+    """Content-addressed closure staged before participant delivery."""
+
+    schema_version: Literal["aptl.participant-asset-lock/v1"]
+    profile_id: str
+    profile_version: int = Field(ge=1)
+    assets: tuple[AssetLockEntry, ...]
+
+    @field_validator("assets")
+    @classmethod
+    def validate_unique_assets(
+        cls, assets: tuple[AssetLockEntry, ...]
+    ) -> tuple[AssetLockEntry, ...]:
+        """Require a non-empty asset closure with unique identifiers."""
+
+        ids = [asset.asset_id for asset in assets]
+        if not ids or len(ids) != len(set(ids)):
+            raise ValueError("asset lock ids must be non-empty and unique")
+        return assets
+
+
+class ParticipantProfileManifest(_StrictModel):
+    """The immutable release-level profile binding."""
+
+    schema_version: Literal["aptl.participant-profile/v1"]
+    profile_id: str
+    version: int = Field(ge=1)
+    narrative: ArtifactReference
+    scenario: ScenarioReference
+    config: ArtifactReference
+    readiness: ArtifactReference
+    capabilities: ParticipantCapabilities
+    release_evidence: ReleaseEvidenceContract
+    budgets: ProfileBudgets
+
+    @field_validator("profile_id")
+    @classmethod
+    def validate_profile_id(cls, value: str) -> str:
+        """Require a stable lowercase profile identifier."""
+
+        if not _IDENTIFIER_RE.fullmatch(value):
+            raise ValueError("invalid profile id")
+        return value
+
+
+class NarrativeOperation(_StrictModel):
+    """One participant, optional, or facilitator workflow operation."""
+
+    operation_id: str
+    classification: Literal["required", "optional", "facilitator-only"]
+    capability_id: str
+    channel: Literal["mcp", "browser", "workflow"]
+    expected_result: str = Field(min_length=1)
+
+
+class ParticipantNarrative(_StrictModel):
+    """Versioned sequence of admitted guided-workflow operations."""
+
+    schema_version: Literal["aptl.participant-narrative/v1"]
+    narrative_id: str
+    version: int = Field(ge=1)
+    operations: tuple[NarrativeOperation, ...]
+
+    @field_validator("operations")
+    @classmethod
+    def validate_unique_operations(
+        cls, operations: tuple[NarrativeOperation, ...]
+    ) -> tuple[NarrativeOperation, ...]:
+        """Require a non-empty narrative without repeated operation ids."""
+
+        operation_ids = [operation.operation_id for operation in operations]
+        if not operation_ids or len(operation_ids) != len(set(operation_ids)):
+            raise ValueError("narrative operation ids must be non-empty and unique")
+        return operations
+
+
+class ReadinessCheck(_StrictModel):
+    """One bounded semantic readiness operation for an admitted capability."""
+
+    check_id: str
+    capability_id: str
+    kind: Literal[
+        "runtime-surface",
+        "mcp-tool",
+        "browser-operation",
+        "evidence",
+        "offline-assets",
+        "resource-budget",
+    ]
+    subject_id: str
+    operation_id: str
+    timeout_seconds: int = Field(gt=0, le=3600)
+
+
+class ParticipantReadinessSuite(_StrictModel):
+    """Versioned exact semantic checks for the guided workflow."""
+
+    schema_version: Literal["aptl.participant-readiness/v1"]
+    suite_id: str
+    version: int = Field(ge=1)
+    checks: tuple[ReadinessCheck, ...]
+
+    @field_validator("checks")
+    @classmethod
+    def validate_unique_checks(
+        cls, checks: tuple[ReadinessCheck, ...]
+    ) -> tuple[ReadinessCheck, ...]:
+        """Require a non-empty readiness suite without repeated ids."""
+
+        check_ids = [check.check_id for check in checks]
+        if not check_ids or len(check_ids) != len(set(check_ids)):
+            raise ValueError("readiness check ids must be non-empty and unique")
+        return checks
+
+
+@dataclass(frozen=True)
+class ResolvedParticipantProfile:
+    """Validated profile plus its canonical resolved runtime inputs."""
+
+    manifest: ParticipantProfileManifest
+    manifest_sha256: str
+    config: AptlConfig
+    scenario_path: Path
+    narrative: ParticipantNarrative
+    readiness: ParticipantReadinessSuite
+    asset_lock: ParticipantAssetLock
+    workbench_profiles: tuple[WorkbenchProfile, ...]
+    expected_matrix: ExpectedMatrix
+
+    @property
+    def mcp_server_ids(self) -> tuple[str, ...]:
+        """Return the ordered unique MCP surface of all compartments."""
+
+        return tuple(
+            dict.fromkeys(
+                server_id
+                for workbench in self.workbench_profiles
+                for server_id in workbench.server_ids
+            )
+        )
+
+    @property
+    def browser_refs(self) -> tuple[str, ...]:
+        """Return the ordered unique browser surface of all compartments."""
+
+        return tuple(
+            dict.fromkeys(
+                bookmark
+                for workbench in self.workbench_profiles
+                for bookmark in workbench.bookmark_refs
+            )
+        )

--- a/src/aptl/validation/participant_qualification.py
+++ b/src/aptl/validation/participant_qualification.py
@@ -1,0 +1,568 @@
+"""Participant-profile qualification report and conformance evaluation (APP-2)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from aptl.core.runstore import RunStorageBackend
+from aptl.utils.pathsafe import PathContainmentError, read_contained_nofollow
+from aptl.validation.curated_live_proof import compare_to_snapshot
+from aptl.validation.participant_profile import ResolvedParticipantProfile
+from aptl.validation.techvault_live_gate import (
+    CATEGORY_ACES_SPECIFICATION,
+    CATEGORY_BACKEND_INSTANTIATION,
+    CATEGORY_BACKEND_INTERPRETATION,
+    CATEGORY_DEFENSIVE_STACK_READINESS,
+    CATEGORY_EVIDENCE_CAPTURE,
+    LiveGateCheck,
+)
+
+_DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+
+
+class ParticipantQualificationError(ValueError):
+    """Qualification evidence is invalid or outside the project boundary."""
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class QualificationHardware(_StrictModel):
+    architecture: Literal["x86_64", "aarch64"]
+    vcpus: int = Field(ge=1)
+    memory_bytes: int = Field(gt=0)
+    disk_bytes: int = Field(gt=0)
+    hypervisor: str = Field(min_length=1)
+    engine: str = Field(min_length=1)
+
+
+class QualificationSurface(_StrictModel):
+    selected_profiles: tuple[str, ...]
+    expected_services: tuple[str, ...]
+    actual_services: tuple[str, ...]
+    expected_networks: tuple[str, ...]
+    actual_networks: tuple[str, ...]
+    actual_workbench_profiles: tuple[str, ...]
+    actual_mcp_servers: tuple[str, ...]
+    actual_browser_capabilities: tuple[str, ...]
+
+    @field_validator(
+        "selected_profiles",
+        "expected_services",
+        "actual_services",
+        "expected_networks",
+        "actual_networks",
+        "actual_workbench_profiles",
+        "actual_mcp_servers",
+        "actual_browser_capabilities",
+    )
+    @classmethod
+    def validate_unique_surface(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        if len(values) != len(set(values)):
+            raise ValueError("qualification surface entries must be unique")
+        return values
+
+
+class QualificationCheckEvidence(_StrictModel):
+    check_id: str = Field(min_length=1)
+    status: Literal["passed", "failed"]
+    summary: str = Field(min_length=1)
+
+
+class OfflineEvidence(_StrictModel):
+    egress_denied: bool
+    download_attempts: int = Field(ge=0)
+    image_pulls: int = Field(ge=0)
+    image_builds: int = Field(ge=0)
+    package_resolutions: int = Field(ge=0)
+
+
+class QualificationMeasurements(_StrictModel):
+    peak_cpu_percent: float = Field(ge=0, le=100)
+    peak_memory_bytes: int = Field(ge=0)
+    staged_profile_assets_bytes: int = Field(ge=0)
+    unique_image_compressed_bytes: int = Field(ge=0)
+    unique_image_expanded_bytes: int = Field(ge=0)
+    peak_runtime_disk_bytes: int = Field(ge=0)
+    cold_start_seconds: float = Field(ge=0)
+    warm_start_seconds: float = Field(ge=0)
+    clean_reset_seconds: float = Field(ge=0)
+
+
+class QualificationAttestation(_StrictModel):
+    algorithm: Literal["ed25519"]
+    key_id: str = Field(min_length=1)
+    signature: str = Field(min_length=1)
+
+
+class ParticipantQualificationReport(_StrictModel):
+    """Machine-readable evidence for the bounded inner participant profile."""
+
+    schema_version: Literal["aptl.participant-qualification/v1"]
+    profile_id: str
+    profile_version: int = Field(ge=1)
+    profile_sha256: str
+    asset_lock_digest: str
+    run_record_ref: str = Field(min_length=1)
+    run_record_sha256: str
+    snapshot_ref: str = Field(min_length=1)
+    snapshot_sha256: str
+    hardware: QualificationHardware
+    surface: QualificationSurface
+    checks: tuple[QualificationCheckEvidence, ...]
+    offline: OfflineEvidence
+    measurements: QualificationMeasurements
+    sample_count: int = Field(ge=1)
+    aggregation: Literal["worst-conforming-sample", "maximum"]
+    attestation: QualificationAttestation
+
+    @field_validator("profile_sha256", "run_record_sha256", "snapshot_sha256")
+    @classmethod
+    def validate_profile_digest(cls, value: str) -> str:
+        if not re.fullmatch(r"[a-f0-9]{64}", value):
+            raise ValueError("evidence sha256 must be lowercase hexadecimal")
+        return value
+
+    @field_validator("asset_lock_digest")
+    @classmethod
+    def validate_release_digest(cls, value: str) -> str:
+        if not _DIGEST_RE.fullmatch(value):
+            raise ValueError("release digest must use sha256:<hex>")
+        return value
+
+    @field_validator("run_record_ref", "snapshot_ref")
+    @classmethod
+    def validate_evidence_ref(cls, value: str) -> str:
+        path = Path(value)
+        if path.is_absolute() or "." in path.parts or ".." in path.parts:
+            raise ValueError("evidence ref must be a safe relative path")
+        return value
+
+    @field_validator("checks")
+    @classmethod
+    def validate_unique_checks(
+        cls, checks: tuple[QualificationCheckEvidence, ...]
+    ) -> tuple[QualificationCheckEvidence, ...]:
+        ids = [check.check_id for check in checks]
+        if len(ids) != len(set(ids)):
+            raise ValueError("qualification check ids must be unique")
+        return checks
+
+
+@dataclass(frozen=True)
+class VerifiedParticipantQualification:
+    """Authenticated report plus the content-addressed canonical evidence."""
+
+    report: ParticipantQualificationReport
+    run_record: dict[str, object]
+    snapshot: dict[str, object]
+
+
+def participant_qualification_attestation_payload(
+    report: ParticipantQualificationReport,
+) -> bytes:
+    """Return the canonical bytes signed by the qualification pipeline."""
+
+    document = report.model_dump(mode="json", exclude={"attestation"})
+    return json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def verify_participant_qualification_attestation(
+    report: ParticipantQualificationReport,
+    public_key_pem: bytes,
+) -> None:
+    """Verify the report against a release-pipeline trust anchor."""
+
+    try:
+        key = serialization.load_pem_public_key(public_key_pem)
+        signature = base64.b64decode(
+            report.attestation.signature,
+            validate=True,
+        )
+        if not isinstance(key, Ed25519PublicKey):
+            raise ValueError("qualification key must be Ed25519")
+        key_der = key.public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        expected_key_id = f"sha256:{hashlib.sha256(key_der).hexdigest()}"
+        if report.attestation.key_id != expected_key_id:
+            raise ValueError("qualification key id does not match the trust anchor")
+        key.verify(
+            signature,
+            participant_qualification_attestation_payload(report),
+        )
+    except (InvalidSignature, UnsupportedAlgorithm, TypeError, ValueError) as exc:
+        raise ParticipantQualificationError(
+            "participant qualification attestation is invalid"
+        ) from exc
+
+
+def _load_evidence_json(
+    project_root: Path,
+    reference: str,
+    expected_sha256: str,
+    *,
+    label: str,
+) -> dict[str, object]:
+    try:
+        payload = read_contained_nofollow(project_root, reference)
+    except PathContainmentError as exc:
+        raise ParticipantQualificationError(
+            f"unsafe participant qualification {label} path"
+        ) from exc
+    if hashlib.sha256(payload).hexdigest() != expected_sha256:
+        raise ParticipantQualificationError(
+            f"participant qualification {label} digest mismatch"
+        )
+    try:
+        document = json.loads(payload)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ParticipantQualificationError(
+            f"invalid participant qualification {label}"
+        ) from exc
+    if not isinstance(document, dict):
+        raise ParticipantQualificationError(
+            f"invalid participant qualification {label}"
+        )
+    return document
+
+
+def _validate_canonical_evidence(
+    report: ParticipantQualificationReport,
+    run_record: dict[str, object],
+    snapshot: dict[str, object],
+) -> None:
+    backend_evidence = run_record.get("backend_evidence")
+    if not isinstance(backend_evidence, dict):
+        raise ParticipantQualificationError("invalid participant run record")
+    selected_profiles = backend_evidence.get("selected_profiles")
+    if not isinstance(selected_profiles, list) or not all(
+        isinstance(profile, str) for profile in selected_profiles
+    ):
+        raise ParticipantQualificationError("invalid participant run record")
+    matches = (
+        run_record.get("schema_version") == "aptl.run-record/v1"
+        and run_record.get("outcome") == "success"
+        and set(selected_profiles) == set(report.surface.selected_profiles)
+        and backend_evidence.get("range_snapshot") == snapshot
+    )
+    if not matches:
+        raise ParticipantQualificationError(
+            "participant qualification evidence is not correlated"
+        )
+
+
+def load_participant_qualification_report(
+    project_dir: Path,
+    report_path: Path,
+    public_key_path: Path,
+) -> VerifiedParticipantQualification:
+    """Load and authenticate one project-contained qualification bundle."""
+
+    project_root = project_dir.resolve()
+    candidate = report_path if report_path.is_absolute() else project_root / report_path
+    try:
+        relative = candidate.relative_to(project_root)
+        payload = read_contained_nofollow(project_root, relative)
+    except (ValueError, PathContainmentError) as exc:
+        raise ParticipantQualificationError(
+            "unsafe participant qualification report path"
+        ) from exc
+    try:
+        report = ParticipantQualificationReport.model_validate_json(payload)
+    except (ValidationError, ValueError) as exc:
+        raise ParticipantQualificationError(
+            "invalid participant qualification report"
+        ) from exc
+    try:
+        key_relative = (
+            public_key_path
+            if not public_key_path.is_absolute()
+            else public_key_path.relative_to(project_root)
+        )
+        public_key_pem = read_contained_nofollow(project_root, key_relative)
+    except (ValueError, PathContainmentError) as exc:
+        raise ParticipantQualificationError(
+            "unsafe participant qualification public key path"
+        ) from exc
+    verify_participant_qualification_attestation(report, public_key_pem)
+    run_record = _load_evidence_json(
+        project_root,
+        report.run_record_ref,
+        report.run_record_sha256,
+        label="run record",
+    )
+    snapshot = _load_evidence_json(
+        project_root,
+        report.snapshot_ref,
+        report.snapshot_sha256,
+        label="snapshot",
+    )
+    _validate_canonical_evidence(report, run_record, snapshot)
+    return VerifiedParticipantQualification(report, run_record, snapshot)
+
+
+@dataclass(frozen=True)
+class ParticipantQualificationEvaluation:
+    """Conformance result expressed with the existing live-gate check shape."""
+
+    checks: tuple[LiveGateCheck, ...]
+
+    @property
+    def passed(self) -> bool:
+        return all(check.passed for check in self.checks)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "conforming": self.passed,
+            "checks": [
+                {
+                    "name": check.name,
+                    "category": check.category,
+                    "outcome": "pass" if check.passed else "fail",
+                    "diagnostics": list(check.diagnostics),
+                }
+                for check in self.checks
+            ],
+        }
+
+
+def _check(
+    name: str,
+    category: str,
+    diagnostics: list[str],
+) -> LiveGateCheck:
+    return LiveGateCheck(
+        name=name,
+        category=category,
+        passed=not diagnostics,
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def _identity_check(
+    profile: ResolvedParticipantProfile,
+    report: ParticipantQualificationReport,
+) -> LiveGateCheck:
+    matches = (
+        report.profile_id == profile.manifest.profile_id
+        and report.profile_version == profile.manifest.version
+        and report.profile_sha256 == profile.manifest_sha256
+        and report.asset_lock_digest
+        == f"sha256:{profile.manifest.release_evidence.asset_lock_sha256}"
+    )
+    diagnostics = [] if matches else ["profile identity or digest does not match"]
+    return _check("profile_identity", CATEGORY_ACES_SPECIFICATION, diagnostics)
+
+
+def _hardware_check(
+    profile: ResolvedParticipantProfile,
+    report: ParticipantQualificationReport,
+) -> LiveGateCheck:
+    minimum = profile.manifest.budgets.minimum_hardware
+    actual = report.hardware
+    passes = (
+        actual.architecture == minimum.architecture
+        and actual.vcpus >= minimum.vcpus
+        and actual.memory_bytes >= minimum.memory_bytes
+        and actual.disk_bytes >= minimum.disk_bytes
+    )
+    diagnostics = [] if passes else ["qualification hardware is below the minimum"]
+    return _check("minimum_hardware", CATEGORY_BACKEND_INSTANTIATION, diagnostics)
+
+
+def _surface_check(
+    profile: ResolvedParticipantProfile,
+    report: ParticipantQualificationReport,
+    snapshot: dict[str, object],
+) -> LiveGateCheck:
+    _, diagnostics = compare_to_snapshot(profile.expected_matrix, snapshot)
+    if set(report.surface.selected_profiles) != set(
+        profile.expected_matrix.selected_profiles
+    ):
+        diagnostics.append(
+            "reported selected profiles do not match the admitted profile surface"
+        )
+    if set(report.surface.expected_services) != set(
+        profile.expected_matrix.expected_services
+    ):
+        diagnostics.append(
+            "reported expected services do not match the derived profile surface"
+        )
+    if set(report.surface.expected_networks) != set(
+        profile.expected_matrix.expected_networks
+    ):
+        diagnostics.append(
+            "reported expected networks do not match the derived profile surface"
+        )
+    actual_services = {
+        str(container.get("name"))
+        for container in snapshot.get("containers", ())
+        if isinstance(container, dict)
+        and str(container.get("status", "")).startswith("Up")
+    }
+    actual_networks = {
+        str(network.get("name"))
+        for network in snapshot.get("networks", ())
+        if isinstance(network, dict)
+    }
+    if set(report.surface.actual_services) != actual_services:
+        diagnostics.append(
+            "reported actual services do not match the authenticated snapshot"
+        )
+    if set(report.surface.actual_networks) != actual_networks:
+        diagnostics.append(
+            "reported actual networks do not match the authenticated snapshot"
+        )
+    return _check(
+        "runtime_surface",
+        CATEGORY_BACKEND_INTERPRETATION,
+        diagnostics,
+    )
+
+
+def _semantic_check(
+    profile: ResolvedParticipantProfile,
+    report: ParticipantQualificationReport,
+) -> LiveGateCheck:
+    observed = {check.check_id: check.status for check in report.checks}
+    required_ids = {check.check_id for check in profile.readiness.checks}
+    if set(observed) != required_ids:
+        diagnostics = ["qualification checks do not exactly match the readiness suite"]
+    elif any(status != "passed" for status in observed.values()):
+        diagnostics = ["required readiness checks did not pass"]
+    else:
+        diagnostics = []
+    return _check(
+        "semantic_readiness",
+        CATEGORY_DEFENSIVE_STACK_READINESS,
+        diagnostics,
+    )
+
+
+def _disabled_surface_check(
+    profile: ResolvedParticipantProfile,
+    report: ParticipantQualificationReport,
+) -> LiveGateCheck:
+    surface = report.surface
+    allowed_workbenches = {
+        profile_id.value
+        for profile_id in profile.manifest.capabilities.workbench_profiles
+    }
+    allowed_mcp = set(profile.mcp_server_ids)
+    allowed_browser = set(profile.browser_refs)
+    exact_allow_list = (
+        set(surface.actual_workbench_profiles) == allowed_workbenches
+        and set(surface.actual_mcp_servers) == allowed_mcp
+        and set(surface.actual_browser_capabilities) == allowed_browser
+    )
+    diagnostics: list[str] = []
+    if not exact_allow_list:
+        diagnostics.append(
+            "participant workbench, MCP, or browser surface does not match the allow-list"
+        )
+    return _check(
+        "disabled_capability_absence",
+        CATEGORY_DEFENSIVE_STACK_READINESS,
+        diagnostics,
+    )
+
+
+def _offline_check(report: ParticipantQualificationReport) -> LiveGateCheck:
+    evidence = report.offline
+    attempts = (
+        evidence.download_attempts
+        + evidence.image_pulls
+        + evidence.image_builds
+        + evidence.package_resolutions
+    )
+    passes = evidence.egress_denied and attempts == 0
+    diagnostics = (
+        []
+        if passes
+        else ["staged startup attempted a download, pull, build, or package resolution"]
+    )
+    return _check(
+        "staged_offline_start",
+        CATEGORY_BACKEND_INSTANTIATION,
+        diagnostics,
+    )
+
+
+def _budget_check(
+    profile: ResolvedParticipantProfile,
+    report: ParticipantQualificationReport,
+) -> LiveGateCheck:
+    maximums = profile.manifest.budgets.maximums
+    measured = report.measurements
+    fields = (
+        "peak_cpu_percent",
+        "peak_memory_bytes",
+        "staged_profile_assets_bytes",
+        "unique_image_compressed_bytes",
+        "unique_image_expanded_bytes",
+        "peak_runtime_disk_bytes",
+        "cold_start_seconds",
+        "warm_start_seconds",
+        "clean_reset_seconds",
+    )
+    passes = all(
+        getattr(measured, field) <= getattr(maximums, field) for field in fields
+    )
+    diagnostics = [] if passes else ["measured resource or lifecycle budget exceeded"]
+    return _check("resource_budgets", CATEGORY_EVIDENCE_CAPTURE, diagnostics)
+
+
+def evaluate_participant_qualification(
+    profile: ResolvedParticipantProfile,
+    evidence: VerifiedParticipantQualification,
+) -> ParticipantQualificationEvaluation:
+    """Evaluate every APP-2 layer from authenticated, correlated evidence."""
+
+    report = evidence.report
+    return ParticipantQualificationEvaluation(
+        checks=(
+            _identity_check(profile, report),
+            _hardware_check(profile, report),
+            _surface_check(profile, report, evidence.snapshot),
+            _semantic_check(profile, report),
+            _disabled_surface_check(profile, report),
+            _offline_check(report),
+            _budget_check(profile, report),
+        )
+    )
+
+
+def persist_participant_qualification(
+    store: RunStorageBackend,
+    run_id: str,
+    evidence: VerifiedParticipantQualification,
+    evaluation: ParticipantQualificationEvaluation,
+) -> Path:
+    """Persist structured qualification evidence through run-store redaction."""
+
+    relative_path = "participant-profile/qualification.json"
+    store.write_json(
+        run_id,
+        relative_path,
+        {
+            "report": evidence.report.model_dump(mode="json"),
+            "run_record_sha256": evidence.report.run_record_sha256,
+            "snapshot_sha256": evidence.report.snapshot_sha256,
+            "evaluation": evaluation.to_dict(),
+        },
+    )
+    return store.get_run_path(run_id) / relative_path

--- a/src/aptl/validation/participant_qualification.py
+++ b/src/aptl/validation/participant_qualification.py
@@ -2,23 +2,26 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import json
-import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
-
-from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from aptl.core.runstore import RunStorageBackend
-from aptl.utils.pathsafe import PathContainmentError, read_contained_nofollow
 from aptl.validation.curated_live_proof import compare_to_snapshot
 from aptl.validation.participant_profile import ResolvedParticipantProfile
+from aptl.validation.participant_qualification_evidence import (
+    OfflineEvidence,
+    ParticipantQualificationError,
+    ParticipantQualificationReport,
+    QualificationAttestation,
+    QualificationCheckEvidence,
+    QualificationHardware,
+    QualificationMeasurements,
+    QualificationSurface,
+    VerifiedParticipantQualification,
+    load_participant_qualification_report,
+    participant_qualification_attestation_payload,
+    verify_participant_qualification_attestation,
+)
 from aptl.validation.techvault_live_gate import (
     CATEGORY_ACES_SPECIFICATION,
     CATEGORY_BACKEND_INSTANTIATION,
@@ -28,291 +31,20 @@ from aptl.validation.techvault_live_gate import (
     LiveGateCheck,
 )
 
-_DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
-
-
-class ParticipantQualificationError(ValueError):
-    """Qualification evidence is invalid or outside the project boundary."""
-
-
-class _StrictModel(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-
-class QualificationHardware(_StrictModel):
-    architecture: Literal["x86_64", "aarch64"]
-    vcpus: int = Field(ge=1)
-    memory_bytes: int = Field(gt=0)
-    disk_bytes: int = Field(gt=0)
-    hypervisor: str = Field(min_length=1)
-    engine: str = Field(min_length=1)
-
-
-class QualificationSurface(_StrictModel):
-    selected_profiles: tuple[str, ...]
-    expected_services: tuple[str, ...]
-    actual_services: tuple[str, ...]
-    expected_networks: tuple[str, ...]
-    actual_networks: tuple[str, ...]
-    actual_workbench_profiles: tuple[str, ...]
-    actual_mcp_servers: tuple[str, ...]
-    actual_browser_capabilities: tuple[str, ...]
-
-    @field_validator(
-        "selected_profiles",
-        "expected_services",
-        "actual_services",
-        "expected_networks",
-        "actual_networks",
-        "actual_workbench_profiles",
-        "actual_mcp_servers",
-        "actual_browser_capabilities",
-    )
-    @classmethod
-    def validate_unique_surface(cls, values: tuple[str, ...]) -> tuple[str, ...]:
-        if len(values) != len(set(values)):
-            raise ValueError("qualification surface entries must be unique")
-        return values
-
-
-class QualificationCheckEvidence(_StrictModel):
-    check_id: str = Field(min_length=1)
-    status: Literal["passed", "failed"]
-    summary: str = Field(min_length=1)
-
-
-class OfflineEvidence(_StrictModel):
-    egress_denied: bool
-    download_attempts: int = Field(ge=0)
-    image_pulls: int = Field(ge=0)
-    image_builds: int = Field(ge=0)
-    package_resolutions: int = Field(ge=0)
-
-
-class QualificationMeasurements(_StrictModel):
-    peak_cpu_percent: float = Field(ge=0, le=100)
-    peak_memory_bytes: int = Field(ge=0)
-    staged_profile_assets_bytes: int = Field(ge=0)
-    unique_image_compressed_bytes: int = Field(ge=0)
-    unique_image_expanded_bytes: int = Field(ge=0)
-    peak_runtime_disk_bytes: int = Field(ge=0)
-    cold_start_seconds: float = Field(ge=0)
-    warm_start_seconds: float = Field(ge=0)
-    clean_reset_seconds: float = Field(ge=0)
-
-
-class QualificationAttestation(_StrictModel):
-    algorithm: Literal["ed25519"]
-    key_id: str = Field(min_length=1)
-    signature: str = Field(min_length=1)
-
-
-class ParticipantQualificationReport(_StrictModel):
-    """Machine-readable evidence for the bounded inner participant profile."""
-
-    schema_version: Literal["aptl.participant-qualification/v1"]
-    profile_id: str
-    profile_version: int = Field(ge=1)
-    profile_sha256: str
-    asset_lock_digest: str
-    run_record_ref: str = Field(min_length=1)
-    run_record_sha256: str
-    snapshot_ref: str = Field(min_length=1)
-    snapshot_sha256: str
-    hardware: QualificationHardware
-    surface: QualificationSurface
-    checks: tuple[QualificationCheckEvidence, ...]
-    offline: OfflineEvidence
-    measurements: QualificationMeasurements
-    sample_count: int = Field(ge=1)
-    aggregation: Literal["worst-conforming-sample", "maximum"]
-    attestation: QualificationAttestation
-
-    @field_validator("profile_sha256", "run_record_sha256", "snapshot_sha256")
-    @classmethod
-    def validate_profile_digest(cls, value: str) -> str:
-        if not re.fullmatch(r"[a-f0-9]{64}", value):
-            raise ValueError("evidence sha256 must be lowercase hexadecimal")
-        return value
-
-    @field_validator("asset_lock_digest")
-    @classmethod
-    def validate_release_digest(cls, value: str) -> str:
-        if not _DIGEST_RE.fullmatch(value):
-            raise ValueError("release digest must use sha256:<hex>")
-        return value
-
-    @field_validator("run_record_ref", "snapshot_ref")
-    @classmethod
-    def validate_evidence_ref(cls, value: str) -> str:
-        path = Path(value)
-        if path.is_absolute() or "." in path.parts or ".." in path.parts:
-            raise ValueError("evidence ref must be a safe relative path")
-        return value
-
-    @field_validator("checks")
-    @classmethod
-    def validate_unique_checks(
-        cls, checks: tuple[QualificationCheckEvidence, ...]
-    ) -> tuple[QualificationCheckEvidence, ...]:
-        ids = [check.check_id for check in checks]
-        if len(ids) != len(set(ids)):
-            raise ValueError("qualification check ids must be unique")
-        return checks
-
-
-@dataclass(frozen=True)
-class VerifiedParticipantQualification:
-    """Authenticated report plus the content-addressed canonical evidence."""
-
-    report: ParticipantQualificationReport
-    run_record: dict[str, object]
-    snapshot: dict[str, object]
-
-
-def participant_qualification_attestation_payload(
-    report: ParticipantQualificationReport,
-) -> bytes:
-    """Return the canonical bytes signed by the qualification pipeline."""
-
-    document = report.model_dump(mode="json", exclude={"attestation"})
-    return json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
-
-
-def verify_participant_qualification_attestation(
-    report: ParticipantQualificationReport,
-    public_key_pem: bytes,
-) -> None:
-    """Verify the report against a release-pipeline trust anchor."""
-
-    try:
-        key = serialization.load_pem_public_key(public_key_pem)
-        signature = base64.b64decode(
-            report.attestation.signature,
-            validate=True,
-        )
-        if not isinstance(key, Ed25519PublicKey):
-            raise ValueError("qualification key must be Ed25519")
-        key_der = key.public_bytes(
-            encoding=serialization.Encoding.DER,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        expected_key_id = f"sha256:{hashlib.sha256(key_der).hexdigest()}"
-        if report.attestation.key_id != expected_key_id:
-            raise ValueError("qualification key id does not match the trust anchor")
-        key.verify(
-            signature,
-            participant_qualification_attestation_payload(report),
-        )
-    except (InvalidSignature, UnsupportedAlgorithm, TypeError, ValueError) as exc:
-        raise ParticipantQualificationError(
-            "participant qualification attestation is invalid"
-        ) from exc
-
-
-def _load_evidence_json(
-    project_root: Path,
-    reference: str,
-    expected_sha256: str,
-    *,
-    label: str,
-) -> dict[str, object]:
-    try:
-        payload = read_contained_nofollow(project_root, reference)
-    except PathContainmentError as exc:
-        raise ParticipantQualificationError(
-            f"unsafe participant qualification {label} path"
-        ) from exc
-    if hashlib.sha256(payload).hexdigest() != expected_sha256:
-        raise ParticipantQualificationError(
-            f"participant qualification {label} digest mismatch"
-        )
-    try:
-        document = json.loads(payload)
-    except (json.JSONDecodeError, TypeError) as exc:
-        raise ParticipantQualificationError(
-            f"invalid participant qualification {label}"
-        ) from exc
-    if not isinstance(document, dict):
-        raise ParticipantQualificationError(
-            f"invalid participant qualification {label}"
-        )
-    return document
-
-
-def _validate_canonical_evidence(
-    report: ParticipantQualificationReport,
-    run_record: dict[str, object],
-    snapshot: dict[str, object],
-) -> None:
-    backend_evidence = run_record.get("backend_evidence")
-    if not isinstance(backend_evidence, dict):
-        raise ParticipantQualificationError("invalid participant run record")
-    selected_profiles = backend_evidence.get("selected_profiles")
-    if not isinstance(selected_profiles, list) or not all(
-        isinstance(profile, str) for profile in selected_profiles
-    ):
-        raise ParticipantQualificationError("invalid participant run record")
-    matches = (
-        run_record.get("schema_version") == "aptl.run-record/v1"
-        and run_record.get("outcome") == "success"
-        and set(selected_profiles) == set(report.surface.selected_profiles)
-        and backend_evidence.get("range_snapshot") == snapshot
-    )
-    if not matches:
-        raise ParticipantQualificationError(
-            "participant qualification evidence is not correlated"
-        )
-
-
-def load_participant_qualification_report(
-    project_dir: Path,
-    report_path: Path,
-    public_key_path: Path,
-) -> VerifiedParticipantQualification:
-    """Load and authenticate one project-contained qualification bundle."""
-
-    project_root = project_dir.resolve()
-    candidate = report_path if report_path.is_absolute() else project_root / report_path
-    try:
-        relative = candidate.relative_to(project_root)
-        payload = read_contained_nofollow(project_root, relative)
-    except (ValueError, PathContainmentError) as exc:
-        raise ParticipantQualificationError(
-            "unsafe participant qualification report path"
-        ) from exc
-    try:
-        report = ParticipantQualificationReport.model_validate_json(payload)
-    except (ValidationError, ValueError) as exc:
-        raise ParticipantQualificationError(
-            "invalid participant qualification report"
-        ) from exc
-    try:
-        key_relative = (
-            public_key_path
-            if not public_key_path.is_absolute()
-            else public_key_path.relative_to(project_root)
-        )
-        public_key_pem = read_contained_nofollow(project_root, key_relative)
-    except (ValueError, PathContainmentError) as exc:
-        raise ParticipantQualificationError(
-            "unsafe participant qualification public key path"
-        ) from exc
-    verify_participant_qualification_attestation(report, public_key_pem)
-    run_record = _load_evidence_json(
-        project_root,
-        report.run_record_ref,
-        report.run_record_sha256,
-        label="run record",
-    )
-    snapshot = _load_evidence_json(
-        project_root,
-        report.snapshot_ref,
-        report.snapshot_sha256,
-        label="snapshot",
-    )
-    _validate_canonical_evidence(report, run_record, snapshot)
-    return VerifiedParticipantQualification(report, run_record, snapshot)
+__all__ = [
+    "OfflineEvidence",
+    "ParticipantQualificationError",
+    "ParticipantQualificationReport",
+    "QualificationAttestation",
+    "QualificationCheckEvidence",
+    "QualificationHardware",
+    "QualificationMeasurements",
+    "QualificationSurface",
+    "VerifiedParticipantQualification",
+    "load_participant_qualification_report",
+    "participant_qualification_attestation_payload",
+    "verify_participant_qualification_attestation",
+]
 
 
 @dataclass(frozen=True)
@@ -323,9 +55,13 @@ class ParticipantQualificationEvaluation:
 
     @property
     def passed(self) -> bool:
+        """Return whether every conformance layer passed."""
+
         return all(check.passed for check in self.checks)
 
     def to_dict(self) -> dict[str, object]:
+        """Serialize the evaluation without changing diagnostic content."""
+
         return {
             "conforming": self.passed,
             "checks": [
@@ -345,6 +81,8 @@ def _check(
     category: str,
     diagnostics: list[str],
 ) -> LiveGateCheck:
+    """Build one existing live-gate check from accumulated diagnostics."""
+
     return LiveGateCheck(
         name=name,
         category=category,
@@ -357,6 +95,8 @@ def _identity_check(
     profile: ResolvedParticipantProfile,
     report: ParticipantQualificationReport,
 ) -> LiveGateCheck:
+    """Bind the report to the exact profile and release asset lock."""
+
     matches = (
         report.profile_id == profile.manifest.profile_id
         and report.profile_version == profile.manifest.version
@@ -372,6 +112,8 @@ def _hardware_check(
     profile: ResolvedParticipantProfile,
     report: ParticipantQualificationReport,
 ) -> LiveGateCheck:
+    """Require the qualification fixture to meet the declared minimum."""
+
     minimum = profile.manifest.budgets.minimum_hardware
     actual = report.hardware
     passes = (
@@ -389,6 +131,8 @@ def _surface_check(
     report: ParticipantQualificationReport,
     snapshot: dict[str, object],
 ) -> LiveGateCheck:
+    """Compare authenticated runtime evidence to the derived exact surface."""
+
     _, diagnostics = compare_to_snapshot(profile.expected_matrix, snapshot)
     if set(report.surface.selected_profiles) != set(
         profile.expected_matrix.selected_profiles
@@ -438,6 +182,8 @@ def _semantic_check(
     profile: ResolvedParticipantProfile,
     report: ParticipantQualificationReport,
 ) -> LiveGateCheck:
+    """Require exactly one passing outcome per readiness operation."""
+
     observed = {check.check_id: check.status for check in report.checks}
     required_ids = {check.check_id for check in profile.readiness.checks}
     if set(observed) != required_ids:
@@ -457,6 +203,8 @@ def _disabled_surface_check(
     profile: ResolvedParticipantProfile,
     report: ParticipantQualificationReport,
 ) -> LiveGateCheck:
+    """Require the observed participant capabilities to equal the allow-list."""
+
     surface = report.surface
     allowed_workbenches = {
         profile_id.value
@@ -482,6 +230,8 @@ def _disabled_surface_check(
 
 
 def _offline_check(report: ParticipantQualificationReport) -> LiveGateCheck:
+    """Require denied egress and zero post-stage network resolution."""
+
     evidence = report.offline
     attempts = (
         evidence.download_attempts
@@ -506,6 +256,8 @@ def _budget_check(
     profile: ResolvedParticipantProfile,
     report: ParticipantQualificationReport,
 ) -> LiveGateCheck:
+    """Require every resource and lifecycle measurement within its ceiling."""
+
     maximums = profile.manifest.budgets.maximums
     measured = report.measurements
     fields = (

--- a/src/aptl/validation/participant_qualification_evidence.py
+++ b/src/aptl/validation/participant_qualification_evidence.py
@@ -1,0 +1,332 @@
+"""Authenticated evidence models and loading for participant qualification."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from aptl.utils.pathsafe import PathContainmentError, read_contained_nofollow
+
+_DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+
+
+class ParticipantQualificationError(ValueError):
+    """Qualification evidence is invalid or outside the project boundary."""
+
+
+class _StrictModel(BaseModel):
+    """Immutable evidence model that rejects undeclared input fields."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class QualificationHardware(_StrictModel):
+    """Hardware and runtime engine used for one qualification sample."""
+
+    architecture: Literal["x86_64", "aarch64"]
+    vcpus: int = Field(ge=1)
+    memory_bytes: int = Field(gt=0)
+    disk_bytes: int = Field(gt=0)
+    hypervisor: str = Field(min_length=1)
+    engine: str = Field(min_length=1)
+
+
+class QualificationSurface(_StrictModel):
+    """Expected and observed runtime and participant capability surfaces."""
+
+    selected_profiles: tuple[str, ...]
+    expected_services: tuple[str, ...]
+    actual_services: tuple[str, ...]
+    expected_networks: tuple[str, ...]
+    actual_networks: tuple[str, ...]
+    actual_workbench_profiles: tuple[str, ...]
+    actual_mcp_servers: tuple[str, ...]
+    actual_browser_capabilities: tuple[str, ...]
+
+    @field_validator(
+        "selected_profiles",
+        "expected_services",
+        "actual_services",
+        "expected_networks",
+        "actual_networks",
+        "actual_workbench_profiles",
+        "actual_mcp_servers",
+        "actual_browser_capabilities",
+    )
+    @classmethod
+    def validate_unique_surface(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        """Reject duplicate identifiers in every reported surface."""
+
+        if len(values) != len(set(values)):
+            raise ValueError("qualification surface entries must be unique")
+        return values
+
+
+class QualificationCheckEvidence(_StrictModel):
+    """Outcome of one bound semantic readiness operation."""
+
+    check_id: str = Field(min_length=1)
+    status: Literal["passed", "failed"]
+    summary: str = Field(min_length=1)
+
+
+class OfflineEvidence(_StrictModel):
+    """Counters proving that a staged start required no network resolution."""
+
+    egress_denied: bool
+    download_attempts: int = Field(ge=0)
+    image_pulls: int = Field(ge=0)
+    image_builds: int = Field(ge=0)
+    package_resolutions: int = Field(ge=0)
+
+
+class QualificationMeasurements(_StrictModel):
+    """Measured resource and lifecycle values for the profile."""
+
+    peak_cpu_percent: float = Field(ge=0, le=100)
+    peak_memory_bytes: int = Field(ge=0)
+    staged_profile_assets_bytes: int = Field(ge=0)
+    unique_image_compressed_bytes: int = Field(ge=0)
+    unique_image_expanded_bytes: int = Field(ge=0)
+    peak_runtime_disk_bytes: int = Field(ge=0)
+    cold_start_seconds: float = Field(ge=0)
+    warm_start_seconds: float = Field(ge=0)
+    clean_reset_seconds: float = Field(ge=0)
+
+
+class QualificationAttestation(_StrictModel):
+    """Detached Ed25519 signature metadata for a qualification report."""
+
+    algorithm: Literal["ed25519"]
+    key_id: str = Field(min_length=1)
+    signature: str = Field(min_length=1)
+
+
+class ParticipantQualificationReport(_StrictModel):
+    """Machine-readable evidence for the bounded inner participant profile."""
+
+    schema_version: Literal["aptl.participant-qualification/v1"]
+    profile_id: str
+    profile_version: int = Field(ge=1)
+    profile_sha256: str
+    asset_lock_digest: str
+    run_record_ref: str = Field(min_length=1)
+    run_record_sha256: str
+    snapshot_ref: str = Field(min_length=1)
+    snapshot_sha256: str
+    hardware: QualificationHardware
+    surface: QualificationSurface
+    checks: tuple[QualificationCheckEvidence, ...]
+    offline: OfflineEvidence
+    measurements: QualificationMeasurements
+    sample_count: int = Field(ge=1)
+    aggregation: Literal["worst-conforming-sample", "maximum"]
+    attestation: QualificationAttestation
+
+    @field_validator("profile_sha256", "run_record_sha256", "snapshot_sha256")
+    @classmethod
+    def validate_profile_digest(cls, value: str) -> str:
+        """Require lowercase SHA-256 evidence digests."""
+
+        if not re.fullmatch(r"[a-f0-9]{64}", value):
+            raise ValueError("evidence sha256 must be lowercase hexadecimal")
+        return value
+
+    @field_validator("asset_lock_digest")
+    @classmethod
+    def validate_release_digest(cls, value: str) -> str:
+        """Require the release digest's explicit algorithm prefix."""
+
+        if not _DIGEST_RE.fullmatch(value):
+            raise ValueError("release digest must use sha256:<hex>")
+        return value
+
+    @field_validator("run_record_ref", "snapshot_ref")
+    @classmethod
+    def validate_evidence_ref(cls, value: str) -> str:
+        """Keep canonical evidence references inside the project."""
+
+        path = Path(value)
+        if path.is_absolute() or "." in path.parts or ".." in path.parts:
+            raise ValueError("evidence ref must be a safe relative path")
+        return value
+
+    @field_validator("checks")
+    @classmethod
+    def validate_unique_checks(
+        cls, checks: tuple[QualificationCheckEvidence, ...]
+    ) -> tuple[QualificationCheckEvidence, ...]:
+        """Require one result for each named semantic check."""
+
+        ids = [check.check_id for check in checks]
+        if len(ids) != len(set(ids)):
+            raise ValueError("qualification check ids must be unique")
+        return checks
+
+
+@dataclass(frozen=True)
+class VerifiedParticipantQualification:
+    """Authenticated report plus the content-addressed canonical evidence."""
+
+    report: ParticipantQualificationReport
+    run_record: dict[str, object]
+    snapshot: dict[str, object]
+
+
+def participant_qualification_attestation_payload(
+    report: ParticipantQualificationReport,
+) -> bytes:
+    """Return the canonical bytes signed by the qualification pipeline."""
+
+    document = report.model_dump(mode="json", exclude={"attestation"})
+    return json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def verify_participant_qualification_attestation(
+    report: ParticipantQualificationReport,
+    public_key_pem: bytes,
+) -> None:
+    """Verify the report against a release-pipeline trust anchor."""
+
+    try:
+        key = serialization.load_pem_public_key(public_key_pem)
+        signature = base64.b64decode(
+            report.attestation.signature,
+            validate=True,
+        )
+        if not isinstance(key, Ed25519PublicKey):
+            raise ValueError("qualification key must be Ed25519")
+        key_der = key.public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        expected_key_id = f"sha256:{hashlib.sha256(key_der).hexdigest()}"
+        if report.attestation.key_id != expected_key_id:
+            raise ValueError("qualification key id does not match the trust anchor")
+        key.verify(
+            signature,
+            participant_qualification_attestation_payload(report),
+        )
+    except (InvalidSignature, UnsupportedAlgorithm, TypeError, ValueError) as exc:
+        raise ParticipantQualificationError(
+            "participant qualification attestation is invalid"
+        ) from exc
+
+
+def _load_evidence_json(
+    project_root: Path,
+    reference: str,
+    expected_sha256: str,
+    *,
+    label: str,
+) -> dict[str, object]:
+    """Load one no-follow JSON artifact and verify its exact bytes."""
+
+    try:
+        payload = read_contained_nofollow(project_root, reference)
+    except PathContainmentError as exc:
+        raise ParticipantQualificationError(
+            f"unsafe participant qualification {label} path"
+        ) from exc
+    if hashlib.sha256(payload).hexdigest() != expected_sha256:
+        raise ParticipantQualificationError(
+            f"participant qualification {label} digest mismatch"
+        )
+    try:
+        document = json.loads(payload)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ParticipantQualificationError(
+            f"invalid participant qualification {label}"
+        ) from exc
+    if not isinstance(document, dict):
+        raise ParticipantQualificationError(
+            f"invalid participant qualification {label}"
+        )
+    return document
+
+
+def _validate_canonical_evidence(
+    report: ParticipantQualificationReport,
+    run_record: dict[str, object],
+    snapshot: dict[str, object],
+) -> None:
+    """Require a successful run record to embed the authenticated snapshot."""
+
+    backend_evidence = run_record.get("backend_evidence")
+    if not isinstance(backend_evidence, dict):
+        raise ParticipantQualificationError("invalid participant run record")
+    selected_profiles = backend_evidence.get("selected_profiles")
+    if not isinstance(selected_profiles, list) or not all(
+        isinstance(profile, str) for profile in selected_profiles
+    ):
+        raise ParticipantQualificationError("invalid participant run record")
+    matches = (
+        run_record.get("schema_version") == "aptl.run-record/v1"
+        and run_record.get("outcome") == "success"
+        and set(selected_profiles) == set(report.surface.selected_profiles)
+        and backend_evidence.get("range_snapshot") == snapshot
+    )
+    if not matches:
+        raise ParticipantQualificationError(
+            "participant qualification evidence is not correlated"
+        )
+
+
+def load_participant_qualification_report(
+    project_dir: Path,
+    report_path: Path,
+    public_key_path: Path,
+) -> VerifiedParticipantQualification:
+    """Load and authenticate one project-contained qualification bundle."""
+
+    project_root = project_dir.resolve()
+    candidate = report_path if report_path.is_absolute() else project_root / report_path
+    try:
+        relative = candidate.relative_to(project_root)
+        payload = read_contained_nofollow(project_root, relative)
+    except (ValueError, PathContainmentError) as exc:
+        raise ParticipantQualificationError(
+            "unsafe participant qualification report path"
+        ) from exc
+    try:
+        report = ParticipantQualificationReport.model_validate_json(payload)
+    except (ValidationError, ValueError) as exc:
+        raise ParticipantQualificationError(
+            "invalid participant qualification report"
+        ) from exc
+    try:
+        key_relative = (
+            public_key_path
+            if not public_key_path.is_absolute()
+            else public_key_path.relative_to(project_root)
+        )
+        public_key_pem = read_contained_nofollow(project_root, key_relative)
+    except (ValueError, PathContainmentError) as exc:
+        raise ParticipantQualificationError(
+            "unsafe participant qualification public key path"
+        ) from exc
+    verify_participant_qualification_attestation(report, public_key_pem)
+    run_record = _load_evidence_json(
+        project_root,
+        report.run_record_ref,
+        report.run_record_sha256,
+        label="run record",
+    )
+    snapshot = _load_evidence_json(
+        project_root,
+        report.snapshot_ref,
+        report.snapshot_sha256,
+        label="snapshot",
+    )
+    _validate_canonical_evidence(report, run_record, snapshot)
+    return VerifiedParticipantQualification(report, run_record, snapshot)

--- a/src/aptl/workbench/profiles.py
+++ b/src/aptl/workbench/profiles.py
@@ -22,6 +22,7 @@ class ProfileId(str, Enum):
     """The only participant capability compartments admitted by this release."""
 
     RED = "red"
+    GUIDED_BLUE = "guided-blue"
     BLUE = "blue"
 
 
@@ -81,6 +82,34 @@ _RED = WorkbenchProfile(
         ),
     ),
     bookmark_refs=("aptl-guide", "kali-desktop"),
+)
+
+_GUIDED_BLUE = WorkbenchProfile(
+    profile_id=ProfileId.GUIDED_BLUE,
+    servers=(
+        ServerProfile(
+            "aptl-indexer",
+            "mcp/mcp-indexer/build/index.js",
+            ("INDEXER_PASSWORD",),
+            (
+                "indexer_query",
+                "indexer_create_rule",
+                "indexer_restart_manager",
+                "indexer_get_rule_file",
+            ),
+        ),
+        ServerProfile(
+            "aptl-wazuh",
+            "mcp/mcp-wazuh/build/index.js",
+            ("INDEXER_PASSWORD",),
+            (
+                "wazuh_query_alerts",
+                "wazuh_query_logs",
+                "wazuh_create_detection_rule",
+            ),
+        ),
+    ),
+    bookmark_refs=("aptl-guide", "soc-wazuh"),
 )
 
 _BLUE = WorkbenchProfile(
@@ -146,7 +175,7 @@ _BLUE = WorkbenchProfile(
         ServerProfile(
             "aptl-wazuh",
             "mcp/mcp-wazuh/build/index.js",
-            ("WAZUH_PASSWORD",),
+            ("INDEXER_PASSWORD",),
             (
                 "wazuh_query_alerts",
                 "wazuh_query_logs",
@@ -157,7 +186,9 @@ _BLUE = WorkbenchProfile(
     bookmark_refs=("aptl-guide", "soc-wazuh", "soc-thehive", "soc-misp", "soc-shuffle"),
 )
 
-_PROFILES = {profile.profile_id: profile for profile in (_RED, _BLUE)}
+_PROFILES = {
+    profile.profile_id: profile for profile in (_RED, _GUIDED_BLUE, _BLUE)
+}
 
 
 def profile_for(profile: ProfileId | str) -> WorkbenchProfile:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import selectors
 import subprocess
 import time
 from pathlib import Path
@@ -10,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from aptl.core.env import load_dotenv
+from aptl.validation.mcp_protocol import McpProtocolError, exchange_jsonrpc
 
 # ---------------------------------------------------------------------------
 # Live-lab shared constants
@@ -231,28 +231,6 @@ def mcp_server_cmd(name: str) -> tuple[list[str], dict]:
     return cfg["cmd"], cfg["env"]
 
 
-def _read_jsonrpc_response(
-    stdout, deadline: float,
-) -> dict | None:
-    """Read one JSON-RPC response line with timeout."""
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        return None
-    sel = selectors.DefaultSelector()
-    sel.register(stdout, selectors.EVENT_READ)
-    ready = sel.select(timeout=remaining)
-    sel.close()
-    if not ready:
-        return None
-    line = stdout.readline().strip()
-    if not line:
-        return None
-    try:
-        return json.loads(line)
-    except json.JSONDecodeError:
-        return None
-
-
 def mcp_jsonrpc(
     server_name: str,
     messages: list[dict],
@@ -266,52 +244,18 @@ def mcp_jsonrpc(
     cmd, extra_env = mcp_server_cmd(server_name)
     env = {**os.environ, **extra_env}
 
-    proc = subprocess.Popen(
-        cmd,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env,
-    )
-
-    deadline = time.monotonic() + timeout
-    responses = []
-
     try:
-        for msg in messages:
-            if time.monotonic() > deadline:
-                break
-            proc.stdin.write(json.dumps(msg) + "\n")
-            proc.stdin.flush()
-
-            # Notifications (no id) don't get responses
-            if "id" not in msg:
-                time.sleep(0.2)
-                continue
-
-            resp = _read_jsonrpc_response(
-                proc.stdout, deadline,
-            )
-            if resp is not None:
-                responses.append(resp)
-    except BrokenPipeError:
-        pass
-    finally:
-        proc.stdin.close()
-        try:
-            proc.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
-
-    if not responses:
-        pytest.fail(
-            f"MCP server '{server_name}' produced no "
-            f"responses within {timeout}s"
+        return exchange_jsonrpc(
+            cmd,
+            messages,
+            cwd=Path(PROJECT_ROOT),
+            env=env,
+            timeout_seconds=timeout,
         )
-
-    return responses
+    except McpProtocolError as exc:
+        pytest.fail(
+            f"MCP server '{server_name}' protocol exchange failed: {exc}"
+        )
 
 
 _INIT_MSG = {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from aptl.core.env import load_dotenv
-from aptl.validation.mcp_protocol import McpProtocolError, exchange_jsonrpc
+from aptl.validation.mcp_protocol import exchange_jsonrpc
 
 # ---------------------------------------------------------------------------
 # Live-lab shared constants
@@ -244,18 +244,13 @@ def mcp_jsonrpc(
     cmd, extra_env = mcp_server_cmd(server_name)
     env = {**os.environ, **extra_env}
 
-    try:
-        return exchange_jsonrpc(
-            cmd,
-            messages,
-            cwd=Path(PROJECT_ROOT),
-            env=env,
-            timeout_seconds=timeout,
-        )
-    except McpProtocolError as exc:
-        pytest.fail(
-            f"MCP server '{server_name}' protocol exchange failed: {exc}"
-        )
+    return exchange_jsonrpc(
+        cmd,
+        messages,
+        cwd=Path(PROJECT_ROOT),
+        env=env,
+        timeout_seconds=timeout,
+    )
 
 
 _INIT_MSG = {

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -1,0 +1,132 @@
+"""Tests for the shared bounded MCP stdio protocol driver."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+from aptl.validation.mcp_protocol import (
+    McpProtocolError,
+    call_mcp_tool,
+    exchange_jsonrpc,
+)
+
+
+_SERVER = r"""
+import json
+import sys
+
+for line in sys.stdin:
+    message = json.loads(line)
+    if "id" not in message:
+        continue
+    if message["method"] == "initialize":
+        result = {"protocolVersion": "2024-11-05", "capabilities": {}}
+    elif message["method"] == "tools/list":
+        result = {"tools": [{"name": "kali_run_command"}]}
+    elif message["method"] == "tools/call":
+        result = {"content": [{"type": "text", "text": "uid=1000(kali)"}]}
+    else:
+        result = {}
+    print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+"""
+
+_SIDE_EFFECT_SERVER = r"""
+import json
+import os
+import sys
+
+for line in sys.stdin:
+    message = json.loads(line)
+    if "id" not in message:
+        continue
+    if message["method"] == "initialize":
+        result = {"protocolVersion": "2024-11-05", "capabilities": {}}
+    elif message["method"] == "tools/list":
+        result = {"tools": [{"name": "kali_run_command"}]}
+    else:
+        with open(os.environ["SIDE_EFFECT"], "w", encoding="utf-8") as output:
+            output.write("called")
+        result = {"content": [{"type": "text", "text": "called"}]}
+    print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+"""
+
+
+def test_call_mcp_tool_performs_real_initialize_and_tool_exchange(
+    tmp_path: Path,
+) -> None:
+    result = call_mcp_tool(
+        [sys.executable, "-c", _SERVER],
+        "kali_run_command",
+        {"command": "id"},
+        cwd=tmp_path,
+        timeout_seconds=5,
+    )
+
+    assert result["content"] == [{"type": "text", "text": "uid=1000(kali)"}]
+
+
+def test_call_mcp_tool_requires_the_tool_to_be_registered(tmp_path: Path) -> None:
+    with pytest.raises(McpProtocolError, match="not registered"):
+        call_mcp_tool(
+            [sys.executable, "-c", _SERVER],
+            "wazuh_query_alerts",
+            {},
+            cwd=tmp_path,
+            timeout_seconds=5,
+        )
+
+
+def test_call_mcp_tool_can_require_the_exact_profile_inventory(
+    tmp_path: Path,
+) -> None:
+    side_effect = tmp_path / "side-effect"
+    with pytest.raises(McpProtocolError, match="inventory does not match"):
+        call_mcp_tool(
+            [sys.executable, "-c", _SIDE_EFFECT_SERVER],
+            "kali_run_command",
+            {"command": "id"},
+            cwd=tmp_path,
+            env={**os.environ, "SIDE_EFFECT": str(side_effect)},
+            timeout_seconds=5,
+            expected_tool_names=("kali_run_command", "kali_info"),
+        )
+    assert not side_effect.exists()
+
+
+def test_exchange_rejects_timeout_without_leaking_child_stderr(
+    tmp_path: Path,
+) -> None:
+    secret = "qualification-secret-value"
+    server = (
+        "import os,sys,time;"
+        "sys.stderr.write(os.environ['QUALIFICATION_SECRET']);"
+        "sys.stderr.flush();time.sleep(5)"
+    )
+
+    with pytest.raises(McpProtocolError) as error:
+        exchange_jsonrpc(
+            [sys.executable, "-c", server],
+            [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {},
+                }
+            ],
+            cwd=tmp_path,
+            env={**os.environ, "QUALIFICATION_SECRET": secret},
+            timeout_seconds=0.1,
+        )
+
+    assert secret not in str(error.value)
+    assert str(error.value) == "MCP server did not return a complete response"
+
+
+def test_exchange_rejects_empty_argv(tmp_path: Path) -> None:
+    with pytest.raises(McpProtocolError, match="MCP command is empty"):
+        exchange_jsonrpc([], [], cwd=tmp_path)

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -84,13 +84,15 @@ def test_call_mcp_tool_can_require_the_exact_profile_inventory(
     tmp_path: Path,
 ) -> None:
     side_effect = tmp_path / "side-effect"
+    command = [sys.executable, "-c", _SIDE_EFFECT_SERVER]
+    environment = {**os.environ, "SIDE_EFFECT": str(side_effect)}
     with pytest.raises(McpProtocolError, match="inventory does not match"):
         call_mcp_tool(
-            [sys.executable, "-c", _SIDE_EFFECT_SERVER],
+            command,
             "kali_run_command",
             {"command": "id"},
             cwd=tmp_path,
-            env={**os.environ, "SIDE_EFFECT": str(side_effect)},
+            env=environment,
             timeout_seconds=5,
             expected_tool_names=("kali_run_command", "kali_info"),
         )

--- a/tests/test_participant_mcp_smoke.py
+++ b/tests/test_participant_mcp_smoke.py
@@ -1,0 +1,198 @@
+"""Semantic MCP smoke tests for the guided participant profile."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+from aptl.validation.participant_mcp_smoke import (
+    McpRegistration,
+    ParticipantMcpSmokeError,
+    run_participant_mcp_smoke,
+)
+from aptl.validation.participant_profile import load_participant_profile
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROFILE_PATH = (
+    PROJECT_ROOT / "participant-profiles" / "guided-purple-v1" / "profile.json"
+)
+
+_SERVER = r"""
+import json
+import sys
+
+TOOLS = __TOOLS__
+FAIL_RED = __FAIL_RED__
+FAIL_ATTACK = __FAIL_ATTACK__
+EMPTY_ALERTS = __EMPTY_ALERTS__
+
+for line in sys.stdin:
+    message = json.loads(line)
+    if "id" not in message:
+        continue
+    if message["method"] == "initialize":
+        result = {"protocolVersion": "2024-11-05", "capabilities": {}}
+    elif message["method"] == "tools/list":
+        result = {"tools": [{"name": name} for name in TOOLS]}
+    else:
+        tool = message["params"]["name"]
+        arguments = message["params"]["arguments"]
+        if tool == "kali_run_command" and arguments["command"] == "id":
+            text = (
+                "uid=0(root) gid=0(root)"
+                if FAIL_RED
+                else "uid=1000(kali) gid=1000(kali)"
+            )
+        elif tool == "kali_run_command":
+            text = json.dumps({
+                "success": True,
+                "output": {
+                    "stdout": "attack incomplete\n" if FAIL_ATTACK else "done\n",
+                    "code": 0
+                }
+            })
+        else:
+            rows = [] if EMPTY_ALERTS else [{"_id": "alert-1"}]
+            text = json.dumps({"data": {"hits": {"hits": rows}}})
+        result = {"content": [{"type": "text", "text": text}]}
+    print(
+        json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}),
+        flush=True,
+    )
+"""
+
+
+def _profile():
+    return load_participant_profile(PROJECT_ROOT, PROFILE_PATH)
+
+
+def _server_for(
+    server_id: str,
+    *,
+    fail_red: bool = False,
+    fail_attack: bool = False,
+    empty_alerts: bool = False,
+) -> str:
+    profile = _profile()
+    tools = next(
+        server.tool_names
+        for workbench in profile.workbench_profiles
+        for server in workbench.servers
+        if server.server_id == server_id
+    )
+    return (
+        _SERVER.replace("__TOOLS__", repr(tools))
+        .replace("__FAIL_RED__", repr(fail_red and server_id == "aptl-red"))
+        .replace("__FAIL_ATTACK__", repr(fail_attack and server_id == "aptl-red"))
+        .replace(
+            "__EMPTY_ALERTS__",
+            repr(empty_alerts and server_id in {"aptl-indexer", "aptl-wazuh"}),
+        )
+    )
+
+
+def _registrations(
+    tmp_path: Path,
+    *,
+    fail_red: bool = False,
+    fail_attack: bool = False,
+    empty_alerts: bool = False,
+):
+    return {
+        server_id: McpRegistration(
+            argv=(
+                sys.executable,
+                "-c",
+                _server_for(
+                    server_id,
+                    fail_red=fail_red,
+                    fail_attack=fail_attack,
+                    empty_alerts=empty_alerts,
+                ),
+            ),
+            cwd=tmp_path,
+            env={},
+        )
+        for server_id in _profile().mcp_server_ids
+    }
+
+
+def test_profile_smoke_calls_every_allowed_real_backend_operation(
+    tmp_path: Path,
+) -> None:
+    evidence = run_participant_mcp_smoke(
+        _profile(),
+        _registrations(tmp_path),
+    )
+
+    assert {item.check_id for item in evidence} == {
+        "mcp.red.kali-command",
+        "mcp.red.ssh-authentication-attack",
+        "mcp.blue.indexer-investigation",
+        "mcp.blue.wazuh-investigation",
+    }
+    assert {item.status for item in evidence} == {"passed"}
+
+
+def test_profile_smoke_rejects_missing_or_extra_registration(
+    tmp_path: Path,
+) -> None:
+    registrations = _registrations(tmp_path)
+    registrations.pop("aptl-wazuh")
+    registrations["aptl-casemgmt"] = next(iter(registrations.values()))
+
+    with pytest.raises(
+        ParticipantMcpSmokeError,
+        match="registration surface does not match",
+    ):
+        run_participant_mcp_smoke(_profile(), registrations)
+
+
+def test_profile_smoke_records_semantic_failure_without_child_output(
+    tmp_path: Path,
+) -> None:
+    evidence = run_participant_mcp_smoke(
+        _profile(),
+        _registrations(tmp_path, fail_red=True),
+    )
+
+    red = next(item for item in evidence if item.check_id == "mcp.red.kali-command")
+    assert red.status == "failed"
+    assert red.summary == "semantic backend operation failed"
+    assert "uid=0" not in red.summary
+
+
+def test_profile_smoke_rejects_incomplete_attack_semantics(
+    tmp_path: Path,
+) -> None:
+    evidence = run_participant_mcp_smoke(
+        _profile(),
+        _registrations(tmp_path, fail_attack=True),
+    )
+
+    attack = next(
+        item
+        for item in evidence
+        if item.check_id == "mcp.red.ssh-authentication-attack"
+    )
+    assert attack.status == "failed"
+
+
+def test_profile_smoke_rejects_empty_alert_results(tmp_path: Path) -> None:
+    evidence = run_participant_mcp_smoke(
+        _profile(),
+        _registrations(tmp_path, empty_alerts=True),
+    )
+
+    assert {
+        item.check_id
+        for item in evidence
+        if item.status == "failed"
+    } == {
+        "mcp.blue.indexer-investigation",
+        "mcp.blue.wazuh-investigation",
+    }

--- a/tests/test_participant_mcp_smoke.py
+++ b/tests/test_participant_mcp_smoke.py
@@ -144,12 +144,13 @@ def test_profile_smoke_rejects_missing_or_extra_registration(
     registrations = _registrations(tmp_path)
     registrations.pop("aptl-wazuh")
     registrations["aptl-casemgmt"] = next(iter(registrations.values()))
+    profile = _profile()
 
     with pytest.raises(
         ParticipantMcpSmokeError,
         match="registration surface does not match",
     ):
-        run_participant_mcp_smoke(_profile(), registrations)
+        run_participant_mcp_smoke(profile, registrations)
 
 
 def test_profile_smoke_records_semantic_failure_without_child_output(
@@ -188,11 +189,7 @@ def test_profile_smoke_rejects_empty_alert_results(tmp_path: Path) -> None:
         _registrations(tmp_path, empty_alerts=True),
     )
 
-    assert {
-        item.check_id
-        for item in evidence
-        if item.status == "failed"
-    } == {
+    assert {item.check_id for item in evidence if item.status == "failed"} == {
         "mcp.blue.indexer-investigation",
         "mcp.blue.wazuh-investigation",
     }

--- a/tests/test_participant_profile.py
+++ b/tests/test_participant_profile.py
@@ -1,0 +1,165 @@
+"""Contract tests for the versioned bounded participant profile (APP-2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aptl.validation.participant_profile import (
+    ParticipantProfileError,
+    load_participant_profile,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROFILE_PATH = (
+    PROJECT_ROOT / "participant-profiles" / "guided-purple-v1" / "profile.json"
+)
+
+
+def _write_modified_manifest(
+    tmp_path: Path,
+    mutate,
+    *,
+    copy_narrative: bool = False,
+) -> Path:
+    manifest = json.loads(PROFILE_PATH.read_text(encoding="utf-8"))
+    mutate(manifest)
+    path = tmp_path / "participant-profiles" / "guided-purple-v1" / "profile.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    if copy_narrative:
+        source = PROFILE_PATH.with_name("narrative.json")
+        path.with_name("narrative.json").write_bytes(source.read_bytes())
+    return path
+
+
+def test_guided_profile_resolves_existing_content_derived_surface() -> None:
+    profile = load_participant_profile(PROJECT_ROOT, PROFILE_PATH)
+
+    assert profile.manifest.profile_id == "guided-purple"
+    assert profile.manifest.version == 1
+    assert profile.manifest.scenario.catalog_id == "techvault-attacker-target"
+    assert profile.manifest.capabilities.workbench_profiles == (
+        "red",
+        "guided-blue",
+    )
+    assert set(profile.mcp_server_ids) == {
+        "aptl-red",
+        "aptl-indexer",
+        "aptl-wazuh",
+    }
+    assert set(profile.browser_refs) == {
+        "aptl-guide",
+        "kali-desktop",
+        "soc-wazuh",
+    }
+    assert (
+        profile.manifest.release_evidence.asset_lock_ref
+        == "participant-profiles/guided-purple-v1/asset-lock.json"
+    )
+    assert (
+        profile.manifest.release_evidence.qualification_report_ref
+        == "release/qualification/guided-purple-v1.json"
+    )
+    assert profile.manifest.budgets.minimum_hardware.vcpus == 8
+    assert profile.manifest.budgets.minimum_hardware.memory_bytes == 16 * 1024**3
+    assert set(profile.expected_matrix.selected_profiles) == {
+        "kali",
+        "victim",
+        "wazuh",
+        "otel",
+    }
+    assert "wazuh.manager" in profile.expected_matrix.expected_services
+    assert "kali" in profile.expected_matrix.expected_services
+    assert "victim" in profile.expected_matrix.expected_services
+    assert "suricata" not in profile.expected_matrix.expected_services
+    assert "misp" not in profile.expected_matrix.expected_services
+    assert "thehive" not in profile.expected_matrix.expected_services
+    assert "shuffle-backend" not in profile.expected_matrix.expected_services
+    locked_ids = {asset.asset_id for asset in profile.asset_lock.assets}
+    assert {
+        "aces-scenario",
+        "compose-model",
+        "mcp-red-build",
+        "mcp-indexer-build",
+        "mcp-wazuh-build",
+        "image-kali",
+        "image-victim",
+        "image-wazuh-manager",
+        "image-wazuh-indexer",
+        "image-wazuh-dashboard",
+        "image-otel-collector",
+        "image-tempo",
+        "image-grafana",
+    } <= locked_ids
+    assert {
+        service
+        for asset in profile.asset_lock.assets
+        if asset.kind == "oci-image"
+        for service in asset.services
+    } == set(profile.expected_matrix.expected_services)
+
+
+def test_manifest_rejects_unknown_fields(tmp_path: Path) -> None:
+    path = _write_modified_manifest(
+        tmp_path,
+        lambda manifest: manifest.update(event_name="black-hat"),
+    )
+
+    with pytest.raises(ParticipantProfileError, match="invalid participant profile"):
+        load_participant_profile(tmp_path, path)
+
+
+def test_manifest_rejects_digest_drift(tmp_path: Path) -> None:
+    def mutate(manifest: dict) -> None:
+        manifest["narrative"]["sha256"] = "0" * 64
+
+    path = _write_modified_manifest(tmp_path, mutate, copy_narrative=True)
+
+    with pytest.raises(ParticipantProfileError, match="digest mismatch"):
+        load_participant_profile(tmp_path, path)
+
+
+def test_manifest_rejects_reference_traversal(tmp_path: Path) -> None:
+    def mutate(manifest: dict) -> None:
+        manifest["narrative"]["path"] = "../outside.json"
+
+    path = _write_modified_manifest(tmp_path, mutate)
+
+    with pytest.raises(ParticipantProfileError, match="unsafe profile reference"):
+        load_participant_profile(tmp_path, path)
+
+
+def test_required_narrative_operations_have_readiness_checks() -> None:
+    profile = load_participant_profile(PROJECT_ROOT, PROFILE_PATH)
+
+    required_capabilities = {
+        operation.capability_id
+        for operation in profile.narrative.operations
+        if operation.classification == "required"
+    }
+    checked_capabilities = {check.capability_id for check in profile.readiness.checks}
+    assert required_capabilities <= checked_capabilities
+    assert {
+        "red.kali-command",
+        "red.ssh-authentication-attack",
+        "blue.indexer-investigation",
+        "blue.wazuh-investigation",
+        "browser.aptl-guide",
+        "browser.kali-desktop",
+        "browser.soc-wazuh",
+    } <= required_capabilities
+    assert {
+        check.subject_id
+        for check in profile.readiness.checks
+        if check.kind == "browser-operation"
+    } == set(profile.browser_refs)
+
+
+def test_participant_profiles_are_packaged_lab_assets() -> None:
+    from aptl._asset_manifest import ASSET_ROOTS
+
+    assert "participant-profiles" in ASSET_ROOTS

--- a/tests/test_participant_qualification.py
+++ b/tests/test_participant_qualification.py
@@ -1,0 +1,625 @@
+"""Behavioral tests for participant-profile conformance evaluation (APP-2)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+import shutil
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from typer.testing import CliRunner
+
+from aptl.cli.lab import app as lab_app
+from aptl.core.runstore import LocalRunStore
+from aptl.validation.participant_profile import (
+    ParticipantProfileError,
+    load_participant_profile,
+)
+from aptl.validation.participant_qualification import (
+    ParticipantQualificationError,
+    ParticipantQualificationReport,
+    VerifiedParticipantQualification,
+    evaluate_participant_qualification,
+    load_participant_qualification_report,
+    participant_qualification_attestation_payload,
+    persist_participant_qualification,
+    verify_participant_qualification_attestation,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROFILE_PATH = (
+    PROJECT_ROOT / "participant-profiles" / "guided-purple-v1" / "profile.json"
+)
+_QUALIFICATION_PRIVATE_KEY = Ed25519PrivateKey.generate()
+_QUALIFICATION_PUBLIC_KEY_PEM = _QUALIFICATION_PRIVATE_KEY.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+_QUALIFICATION_PUBLIC_KEY_ID = (
+    "sha256:"
+    + hashlib.sha256(
+        _QUALIFICATION_PRIVATE_KEY.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    ).hexdigest()
+)
+
+
+def _profile():
+    return load_participant_profile(PROJECT_ROOT, PROFILE_PATH)
+
+
+def _passing_report_payload() -> dict:
+    profile = _profile()
+    matrix = profile.expected_matrix
+    return {
+        "schema_version": "aptl.participant-qualification/v1",
+        "profile_id": profile.manifest.profile_id,
+        "profile_version": profile.manifest.version,
+        "profile_sha256": profile.manifest_sha256,
+        "asset_lock_digest": (
+            "sha256:" + profile.manifest.release_evidence.asset_lock_sha256
+        ),
+        "run_record_ref": "runs/profile-proof/run-record.json",
+        "run_record_sha256": "0" * 64,
+        "snapshot_ref": "runs/profile-proof/snapshot.json",
+        "snapshot_sha256": "0" * 64,
+        "hardware": {
+            "architecture": "x86_64",
+            "vcpus": 8,
+            "memory_bytes": 17179869184,
+            "disk_bytes": 107374182400,
+            "hypervisor": "kvm",
+            "engine": "docker",
+        },
+        "surface": {
+            "selected_profiles": list(matrix.selected_profiles),
+            "expected_services": list(matrix.expected_services),
+            "actual_services": list(matrix.expected_services),
+            "expected_networks": list(matrix.expected_networks),
+            "actual_networks": list(matrix.expected_networks),
+            "actual_workbench_profiles": list(
+                profile.manifest.capabilities.workbench_profiles
+            ),
+            "actual_mcp_servers": list(profile.mcp_server_ids),
+            "actual_browser_capabilities": list(profile.browser_refs),
+        },
+        "checks": [
+            {
+                "check_id": check.check_id,
+                "status": "passed",
+                "summary": "semantic operation passed",
+            }
+            for check in profile.readiness.checks
+        ],
+        "offline": {
+            "egress_denied": True,
+            "download_attempts": 0,
+            "image_pulls": 0,
+            "image_builds": 0,
+            "package_resolutions": 0,
+        },
+        "measurements": {
+            "peak_cpu_percent": 60.0,
+            "peak_memory_bytes": 8589934592,
+            "staged_profile_assets_bytes": 32212254720,
+            "unique_image_compressed_bytes": 10737418240,
+            "unique_image_expanded_bytes": 26843545600,
+            "peak_runtime_disk_bytes": 16106127360,
+            "cold_start_seconds": 600.0,
+            "warm_start_seconds": 180.0,
+            "clean_reset_seconds": 420.0,
+        },
+        "sample_count": 3,
+        "aggregation": "worst-conforming-sample",
+        "attestation": {
+            "algorithm": "ed25519",
+            "key_id": _QUALIFICATION_PUBLIC_KEY_ID,
+            "signature": "AA==",
+        },
+    }
+
+
+def _canonical_json_bytes(document: dict[str, object]) -> bytes:
+    return json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _canonical_evidence(
+    payload: dict,
+) -> tuple[dict[str, object], dict[str, object]]:
+    snapshot: dict[str, object] = {
+        "containers": [
+            {"name": service, "status": "Up"}
+            for service in payload["surface"]["actual_services"]
+        ],
+        "networks": [
+            {"name": network} for network in payload["surface"]["actual_networks"]
+        ],
+    }
+    run_record: dict[str, object] = {
+        "schema_version": "aptl.run-record/v1",
+        "run_id": "profile-proof",
+        "outcome": "success",
+        "backend_evidence": {
+            "selected_profiles": payload["surface"]["selected_profiles"],
+            "range_snapshot": snapshot,
+        },
+    }
+    return run_record, snapshot
+
+
+def _attested_evidence(payload: dict) -> VerifiedParticipantQualification:
+    run_record, snapshot = _canonical_evidence(payload)
+    payload["run_record_sha256"] = hashlib.sha256(
+        _canonical_json_bytes(run_record)
+    ).hexdigest()
+    payload["snapshot_sha256"] = hashlib.sha256(
+        _canonical_json_bytes(snapshot)
+    ).hexdigest()
+    unsigned = ParticipantQualificationReport.model_validate(payload)
+    payload["attestation"]["signature"] = base64.b64encode(
+        _QUALIFICATION_PRIVATE_KEY.sign(
+            participant_qualification_attestation_payload(unsigned)
+        )
+    ).decode("ascii")
+    report = ParticipantQualificationReport.model_validate(payload)
+    verify_participant_qualification_attestation(
+        report,
+        _QUALIFICATION_PUBLIC_KEY_PEM,
+    )
+    return VerifiedParticipantQualification(report, run_record, snapshot)
+
+
+def _evaluate(payload: dict):
+    return evaluate_participant_qualification(
+        _profile(),
+        _attested_evidence(payload),
+    )
+
+
+def _write_attested_bundle(
+    project: Path,
+    payload: dict,
+) -> tuple[Path, Path, VerifiedParticipantQualification]:
+    evidence = _attested_evidence(payload)
+    report_path = project / "evidence" / "report.json"
+    public_key_path = project / "evidence" / "qualification-public-key.pem"
+    run_record_path = project / evidence.report.run_record_ref
+    snapshot_path = project / evidence.report.snapshot_ref
+    for path in (report_path, run_record_path, snapshot_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        evidence.report.model_dump_json(),
+        encoding="utf-8",
+    )
+    run_record_path.write_bytes(_canonical_json_bytes(evidence.run_record))
+    snapshot_path.write_bytes(_canonical_json_bytes(evidence.snapshot))
+    public_key_path.write_bytes(_QUALIFICATION_PUBLIC_KEY_PEM)
+    return report_path, public_key_path, evidence
+
+
+def _materialized_profile_project(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    shutil.copytree(
+        PROJECT_ROOT / "participant-profiles",
+        project / "participant-profiles",
+    )
+    (project / "scenarios").mkdir()
+    shutil.copy2(
+        PROJECT_ROOT / "scenarios" / "catalog.json",
+        project / "scenarios" / "catalog.json",
+    )
+    shutil.copy2(
+        PROJECT_ROOT / "scenarios" / "techvault-attacker-target.sdl.yaml",
+        project / "scenarios" / "techvault-attacker-target.sdl.yaml",
+    )
+    shutil.copy2(PROJECT_ROOT / "docker-compose.yml", project / "docker-compose.yml")
+    workbench_profile = Path("src/aptl/workbench/profiles.py")
+    (project / workbench_profile).parent.mkdir(parents=True)
+    shutil.copy2(PROJECT_ROOT / workbench_profile, project / workbench_profile)
+    for package in ("mcp-red", "mcp-indexer", "mcp-wazuh"):
+        for filename in (
+            "package-lock.json",
+            "docker-lab-config.json",
+            "build/index.js",
+        ):
+            source = PROJECT_ROOT / "mcp" / package / filename
+            target = project / "mcp" / package / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+    return project
+
+
+def test_complete_report_passes_every_conformance_layer() -> None:
+    evaluation = _evaluate(_passing_report_payload())
+
+    assert evaluation.passed
+    assert {check.name for check in evaluation.checks} == {
+        "profile_identity",
+        "minimum_hardware",
+        "runtime_surface",
+        "semantic_readiness",
+        "disabled_capability_absence",
+        "staged_offline_start",
+        "resource_budgets",
+    }
+
+
+def test_profile_identity_or_asset_lock_drift_fails() -> None:
+    payload = _passing_report_payload()
+    payload["profile_sha256"] = "0" * 64
+    payload["asset_lock_digest"] = "sha256:" + "1" * 64
+
+    evaluation = _evaluate(payload)
+
+    check = next(c for c in evaluation.checks if c.name == "profile_identity")
+    assert not check.passed
+    assert check.diagnostics == ("profile identity or digest does not match",)
+
+
+def test_missing_or_unexpected_runtime_service_fails() -> None:
+    payload = _passing_report_payload()
+    payload["surface"]["actual_services"].pop()
+    payload["surface"]["actual_services"].append("thehive")
+
+    evaluation = _evaluate(payload)
+
+    check = next(c for c in evaluation.checks if c.name == "runtime_surface")
+    assert not check.passed
+    assert any("expected service" in item for item in check.diagnostics)
+    assert any(
+        "unexpected steady-state container" in item for item in check.diagnostics
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "diagnostic"),
+    [
+        (
+            "selected_profiles",
+            ["kali", "victim", "wazuh"],
+            "reported selected profiles do not match the admitted profile surface",
+        ),
+        (
+            "expected_networks",
+            ["security"],
+            "reported expected networks do not match the derived profile surface",
+        ),
+    ],
+)
+def test_reported_profile_or_network_surface_must_match_derivation(
+    field: str,
+    value: list[str],
+    diagnostic: str,
+) -> None:
+    payload = _passing_report_payload()
+    payload["surface"][field] = value
+
+    evaluation = _evaluate(payload)
+
+    check = next(c for c in evaluation.checks if c.name == "runtime_surface")
+    assert not check.passed
+    assert diagnostic in check.diagnostics
+
+
+def test_failed_required_semantic_operation_fails() -> None:
+    payload = _passing_report_payload()
+    payload["checks"][0]["status"] = "failed"
+    payload["checks"][0]["summary"] = "backend operation did not pass"
+
+    evaluation = _evaluate(payload)
+
+    check = next(c for c in evaluation.checks if c.name == "semantic_readiness")
+    assert not check.passed
+    assert check.diagnostics == ("required readiness checks did not pass",)
+
+
+def test_unexpected_semantic_check_fails() -> None:
+    payload = _passing_report_payload()
+    payload["checks"].append(
+        {
+            "check_id": "unexpected.check",
+            "status": "passed",
+            "summary": "not part of the bound readiness suite",
+        }
+    )
+
+    evaluation = _evaluate(payload)
+
+    check = next(c for c in evaluation.checks if c.name == "semantic_readiness")
+    assert not check.passed
+    assert check.diagnostics == (
+        "qualification checks do not exactly match the readiness suite",
+    )
+
+
+def test_disabled_participant_surface_must_be_absent() -> None:
+    payload = _passing_report_payload()
+    payload["surface"]["actual_mcp_servers"].append("aptl-casemgmt")
+    payload["surface"]["actual_browser_capabilities"].append("thehive")
+    payload["surface"]["actual_workbench_profiles"].append("blue")
+
+    evaluation = _evaluate(payload)
+
+    check = next(
+        c for c in evaluation.checks if c.name == "disabled_capability_absence"
+    )
+    assert not check.passed
+    assert check.diagnostics == (
+        "participant workbench, MCP, or browser surface does not match the allow-list",
+    )
+
+
+def test_missing_allowed_participant_surface_fails() -> None:
+    payload = _passing_report_payload()
+    payload["surface"]["actual_mcp_servers"].remove("aptl-wazuh")
+    payload["surface"]["actual_browser_capabilities"] = []
+
+    evaluation = _evaluate(payload)
+
+    check = next(
+        c for c in evaluation.checks if c.name == "disabled_capability_absence"
+    )
+    assert not check.passed
+    assert check.diagnostics == (
+        "participant workbench, MCP, or browser surface does not match the allow-list",
+    )
+
+
+def test_reported_expected_matrix_must_match_profile_derivation() -> None:
+    payload = _passing_report_payload()
+    payload["surface"]["expected_services"].append("thehive")
+
+    evaluation = _evaluate(payload)
+
+    check = next(c for c in evaluation.checks if c.name == "runtime_surface")
+    assert not check.passed
+    assert any("reported expected services" in item for item in check.diagnostics)
+
+
+def test_post_stage_network_dependency_fails() -> None:
+    payload = _passing_report_payload()
+    payload["offline"]["image_pulls"] = 1
+
+    evaluation = _evaluate(payload)
+
+    check = next(c for c in evaluation.checks if c.name == "staged_offline_start")
+    assert not check.passed
+    assert check.diagnostics == (
+        "staged startup attempted a download, pull, build, or package resolution",
+    )
+
+
+def test_hardware_or_budget_breach_fails() -> None:
+    payload = _passing_report_payload()
+    payload["hardware"]["memory_bytes"] = 8 * 1024**3
+    payload["measurements"]["cold_start_seconds"] = 901.0
+
+    evaluation = _evaluate(payload)
+
+    hardware = next(c for c in evaluation.checks if c.name == "minimum_hardware")
+    budgets = next(c for c in evaluation.checks if c.name == "resource_budgets")
+    assert not hardware.passed
+    assert not budgets.passed
+    assert budgets.diagnostics == ("measured resource or lifecycle budget exceeded",)
+
+
+def test_persistence_uses_runstore_redaction(tmp_path: Path) -> None:
+    profile = _profile()
+    payload = _passing_report_payload()
+    payload["checks"][0]["summary"] = "password=should-not-persist"
+    evidence = _attested_evidence(payload)
+    evaluation = evaluate_participant_qualification(profile, evidence)
+    store = LocalRunStore(tmp_path / "runs")
+    store.create_run("profile-proof")
+
+    path = persist_participant_qualification(
+        store,
+        "profile-proof",
+        evidence,
+        evaluation,
+    )
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert "should-not-persist" not in path.read_text(encoding="utf-8")
+    assert persisted["evaluation"]["conforming"] is True
+    assert {item["outcome"] for item in persisted["evaluation"]["checks"]} == {"pass"}
+
+
+def test_cli_qualifies_and_persists_a_contained_report(tmp_path: Path) -> None:
+    project = _materialized_profile_project(tmp_path)
+    report, public_key, _ = _write_attested_bundle(
+        project,
+        _passing_report_payload(),
+    )
+
+    result = CliRunner().invoke(
+        lab_app,
+        [
+            "qualify-profile",
+            "--project-dir",
+            str(project),
+            "--report",
+            str(report),
+            "--public-key",
+            str(public_key),
+            "--run-id",
+            "profile-proof",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    summary = json.loads(result.stdout)
+    assert summary["conforming"] is True
+    assert (
+        project
+        / "runs"
+        / "profile-proof"
+        / "participant-profile"
+        / "qualification.json"
+    ).is_file()
+
+
+def test_cli_fails_on_nonconforming_report(tmp_path: Path) -> None:
+    project = _materialized_profile_project(tmp_path)
+    payload = _passing_report_payload()
+    payload["offline"]["download_attempts"] = 1
+    report, public_key, _ = _write_attested_bundle(project, payload)
+
+    result = CliRunner().invoke(
+        lab_app,
+        [
+            "qualify-profile",
+            "--project-dir",
+            str(project),
+            "--report",
+            str(report),
+            "--public-key",
+            str(public_key),
+            "--run-id",
+            "profile-proof",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["conforming"] is False
+
+
+def test_report_rejects_unsafe_canonical_evidence_reference(
+    tmp_path: Path,
+) -> None:
+    payload = _passing_report_payload()
+    payload["snapshot_ref"] = "../outside.json"
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ParticipantQualificationError,
+        match="invalid participant qualification report",
+    ):
+        load_participant_qualification_report(
+            tmp_path,
+            report,
+            tmp_path / "qualification-public-key.pem",
+        )
+
+
+def test_report_tampering_invalidates_attestation(tmp_path: Path) -> None:
+    project = _materialized_profile_project(tmp_path)
+    report_path, public_key_path, evidence = _write_attested_bundle(
+        project,
+        _passing_report_payload(),
+    )
+    tampered = evidence.report.model_dump(mode="json")
+    tampered["offline"]["download_attempts"] = 1
+    report_path.write_text(json.dumps(tampered), encoding="utf-8")
+
+    with pytest.raises(
+        ParticipantQualificationError,
+        match="attestation is invalid",
+    ):
+        load_participant_qualification_report(
+            project,
+            report_path,
+            public_key_path,
+        )
+
+
+@pytest.mark.parametrize("artifact", ["run_record", "snapshot"])
+def test_canonical_evidence_digest_drift_is_rejected(
+    tmp_path: Path,
+    artifact: str,
+) -> None:
+    project = _materialized_profile_project(tmp_path)
+    report_path, public_key_path, evidence = _write_attested_bundle(
+        project,
+        _passing_report_payload(),
+    )
+    reference = getattr(evidence.report, f"{artifact}_ref")
+    (project / reference).write_text("{}", encoding="utf-8")
+
+    with pytest.raises(
+        ParticipantQualificationError,
+        match=f"{artifact.replace('_', ' ')} digest mismatch",
+    ):
+        load_participant_qualification_report(
+            project,
+            report_path,
+            public_key_path,
+        )
+
+
+def test_run_record_and_snapshot_must_be_correlated(tmp_path: Path) -> None:
+    project = _materialized_profile_project(tmp_path)
+    payload = _passing_report_payload()
+    report_path, public_key_path, evidence = _write_attested_bundle(project, payload)
+    altered_run_record = json.loads(json.dumps(evidence.run_record))
+    altered_run_record["backend_evidence"]["range_snapshot"] = {
+        "containers": [],
+        "networks": [],
+    }
+    run_record_bytes = _canonical_json_bytes(altered_run_record)
+    (project / evidence.report.run_record_ref).write_bytes(run_record_bytes)
+    payload["run_record_sha256"] = hashlib.sha256(run_record_bytes).hexdigest()
+    payload["attestation"]["signature"] = "AA=="
+    unsigned = ParticipantQualificationReport.model_validate(payload)
+    payload["attestation"]["signature"] = base64.b64encode(
+        _QUALIFICATION_PRIVATE_KEY.sign(
+            participant_qualification_attestation_payload(unsigned)
+        )
+    ).decode("ascii")
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ParticipantQualificationError,
+        match="evidence is not correlated",
+    ):
+        load_participant_qualification_report(
+            project,
+            report_path,
+            public_key_path,
+        )
+
+
+def test_reported_surface_must_match_authenticated_snapshot() -> None:
+    payload = _passing_report_payload()
+    evidence = _attested_evidence(payload)
+    mismatched_snapshot = {
+        **evidence.snapshot,
+        "containers": evidence.snapshot["containers"][:-1],
+    }
+    evidence = VerifiedParticipantQualification(
+        evidence.report,
+        evidence.run_record,
+        mismatched_snapshot,
+    )
+
+    evaluation = evaluate_participant_qualification(_profile(), evidence)
+
+    check = next(c for c in evaluation.checks if c.name == "runtime_surface")
+    assert not check.passed
+    assert (
+        "reported actual services do not match the authenticated snapshot"
+        in check.diagnostics
+    )
+
+
+def test_mcp_artifact_bytes_must_match_asset_lock(tmp_path: Path) -> None:
+    project = _materialized_profile_project(tmp_path)
+    artifact = project / "mcp" / "mcp-red" / "build" / "index.js"
+    artifact.write_bytes(artifact.read_bytes() + b"\n// drift")
+
+    with pytest.raises(
+        ParticipantProfileError,
+        match="profile reference digest mismatch",
+    ):
+        load_participant_profile(
+            project,
+            project / "participant-profiles" / "guided-purple-v1" / "profile.json",
+        )

--- a/tests/test_participant_workbench.py
+++ b/tests/test_participant_workbench.py
@@ -16,6 +16,10 @@ def test_profiles_expose_exactly_the_allowed_mcp_servers() -> None:
     from aptl.workbench import ProfileId, profile_for
 
     assert profile_for(ProfileId.RED).server_ids == ("aptl-red",)
+    assert profile_for(ProfileId.GUIDED_BLUE).server_ids == (
+        "aptl-indexer",
+        "aptl-wazuh",
+    )
     assert profile_for(ProfileId.BLUE).server_ids == (
         "aptl-casemgmt",
         "aptl-indexer",
@@ -77,6 +81,18 @@ def test_profiles_expose_exactly_the_allowed_mcp_servers() -> None:
             "wazuh_create_detection_rule",
         ),
     }
+    assert {
+        server.server_id: server.tool_names
+        for server in profile_for(ProfileId.GUIDED_BLUE).servers
+    } == {
+        server.server_id: server.tool_names
+        for server in profile_for(ProfileId.BLUE).servers
+        if server.server_id in {"aptl-indexer", "aptl-wazuh"}
+    }
+    assert profile_for(ProfileId.GUIDED_BLUE).bookmark_refs == (
+        "aptl-guide",
+        "soc-wazuh",
+    )
 
 
 def test_profile_renderer_keeps_credentials_out_of_client_config(
@@ -104,7 +120,6 @@ def test_profile_renderer_keeps_credentials_out_of_client_config(
         run_id="a" * 32,
         credential_aliases={
             "INDEXER_PASSWORD",
-            "WAZUH_PASSWORD",
             "MISP_API_KEY",
             "THEHIVE_API_KEY",
             "SHUFFLE_API_KEY",
@@ -144,7 +159,6 @@ def test_profile_renderer_rejects_missing_required_credential_alias(
             run_id="a" * 32,
             credential_aliases={
                 "INDEXER_PASSWORD",
-                "WAZUH_PASSWORD",
                 "THEHIVE_API_KEY",
                 "SHUFFLE_API_KEY",
             },
@@ -198,16 +212,16 @@ def test_profile_switch_closes_the_previous_runtime_and_records_the_active_trace
     )
 
     red = runtime.start(ProfileId.RED)
-    blue = runtime.switch(ProfileId.BLUE)
+    blue = runtime.switch(ProfileId.GUIDED_BLUE)
 
     assert red.run_id == active_session.trace_id
     assert blue.run_id == active_session.trace_id
     assert adapter.closed_profiles == [ProfileId.RED]
     assert [launch.profile for launch in adapter.launches] == [
         ProfileId.RED,
-        ProfileId.BLUE,
+        ProfileId.GUIDED_BLUE,
     ]
-    assert credentials.prepared_profiles == [ProfileId.RED, ProfileId.BLUE]
+    assert credentials.prepared_profiles == [ProfileId.RED, ProfileId.GUIDED_BLUE]
     assert credentials.destroyed_profiles == [ProfileId.RED]
     records = (
         tmp_path / "runs" / active_session.trace_id / "workbench" / "events.jsonl"
@@ -399,6 +413,16 @@ def test_browser_workbench_is_a_separate_authenticated_profile_surface(
     assert view.status_code == 200
     assert view.json()["mcp_servers"] == ["aptl-red"]
     assert "docker" not in view.json()
+
+    response = client.post(
+        "/workbench/profiles/guided-blue",
+        headers={"X-APTL-Participant-Session": "seat"},
+    )
+    assert response.status_code == 200
+    view = client.get("/workbench", headers={"X-APTL-Participant-Session": "seat"})
+    assert view.json()["profile"] == "guided-blue"
+    assert view.json()["mcp_servers"] == ["aptl-indexer", "aptl-wazuh"]
+    assert view.json()["bookmarks"] == ["aptl-guide", "soc-wazuh"]
 
 
 class _FakeAdapter:


### PR DESCRIPTION
## Summary

Define and validate the resource-bounded `guided-purple` participant lab profile consumed by the sealed appliance workflow.

## Requirement UIDs

- APP-2

## Related Issues

Closes #820

## ADR Impact

- ADR-049

## Changes

- Add the versioned participant profile, narrative, semantic readiness suite, asset lock, and explicit resource and lifecycle budgets.
- Derive the bounded runtime, workbench, MCP, and browser surfaces from the ACES scenario and the participant workbench delivered by #821.
- Add fail-closed MCP protocol smoke checks and qualification evaluation backed by Ed25519-attested, content-addressed run records and snapshots.
- Verify the bytes of staged MCP entrypoints and exact OCI service coverage in the release asset lock.
- Update workshop, architecture, workbench, and profile reference documentation while keeping the inner profile separate from the outer appliance owned by #823.

## Test Plan

- [x] Unit tests pass (`pre-commit run --all-files`)
- [x] Integration tests pass if applicable (`PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q -m integration tests/test_techvault_static_gate.py`)
- [x] Repository policy passes (`make policy`)
- [x] No coverage regression

Focused participant profile, MCP, qualification, and workbench suite: 48 passed. Static TechVault gate: 2 passed. All pre-commit gates passed, including the Python, MCP TypeScript, and web frontend suites.

## Ground Control Checks

- [x] `make policy` passes
- [x] APP-2 was loaded from Ground Control and implemented without changing its UID
- [x] Pre-push test-quality and production-readiness findings were fixed and locally verified

## Traceability

- IMPLEMENTS: APP-2 ← participant-profiles/guided-purple-v1/profile.json, APP-2 ← src/aptl/validation/participant_profile.py, APP-2 ← src/aptl/validation/participant_qualification.py, APP-2 ← src/aptl/validation/participant_mcp_smoke.py, APP-2 ← src/aptl/workbench/profiles.py
- TESTS: APP-2 ← tests/test_participant_profile.py, APP-2 ← tests/test_participant_qualification.py, APP-2 ← tests/test_participant_mcp_smoke.py, APP-2 ← tests/test_mcp_protocol.py, APP-2 ← tests/test_participant_workbench.py

## Checklist

- [x] Code follows project coding standards
- [x] No business logic was added to an API layer
- [x] Changelog is owned by Release Please; no per-PR fragment is required
- [x] Architectural and participant-facing documentation is updated

## Documentation

Updated: see diff.
