### PR TITLE
feat: enforce appliance network boundary

### DIFF
--- a/containers/appliance-egress-proxy/Dockerfile
+++ b/containers/appliance-egress-proxy/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+
+RUN apk add --no-cache python3=3.12.13-r0 \
+    && adduser -D -H -u 65532 proxy
+
+COPY containers/appliance-egress-proxy/proxy.py /usr/local/bin/aptl-egress-proxy
+
+USER 65532:65532
+ENTRYPOINT ["python3", "/usr/local/bin/aptl-egress-proxy"]

--- a/containers/appliance-egress-proxy/proxy.py
+++ b/containers/appliance-egress-proxy/proxy.py
@@ -16,19 +16,43 @@ _AUTHORITY = re.compile(
     r"^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+"
     r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
 )
-_MAX_HEADER_BYTES = 4096
-_HEADER_TIMEOUT_SECONDS = 5
-_CONNECT_TIMEOUT_SECONDS = 10
 _NAT64_WELL_KNOWN = ipaddress.ip_network("64:ff9b::/96")
+
+
+class ProxyLimits:
+    __slots__ = (
+        "max_connections",
+        "max_header_bytes",
+        "header_timeout_seconds",
+        "connect_timeout_seconds",
+        "idle_timeout_seconds",
+    )
+
+    def __init__(
+        self,
+        *,
+        max_connections: int,
+        max_header_bytes: int,
+        header_timeout_seconds: int,
+        connect_timeout_seconds: int,
+        idle_timeout_seconds: int,
+    ) -> None:
+        self.max_connections = max_connections
+        self.max_header_bytes = max_header_bytes
+        self.header_timeout_seconds = header_timeout_seconds
+        self.connect_timeout_seconds = connect_timeout_seconds
+        self.idle_timeout_seconds = idle_timeout_seconds
 
 
 def parse_connect(
     request: bytes,
     allowed: set[tuple[str, int]],
+    *,
+    max_header_bytes: int = 4096,
 ) -> tuple[str, int]:
     """Return an exact admitted CONNECT target or reject the request."""
 
-    if len(request) > _MAX_HEADER_BYTES or b"\r\n\r\n" not in request:
+    if len(request) > max_header_bytes or b"\r\n\r\n" not in request:
         raise ValueError("CONNECT header is incomplete")
     try:
         first_line = request.split(b"\r\n", 1)[0].decode("ascii")
@@ -105,9 +129,14 @@ async def _resolve(host: str, port: int) -> tuple[tuple[str, int], ...]:
 async def _pipe(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
+    *,
+    idle_timeout_seconds: int,
 ) -> None:
     try:
-        while data := await reader.read(65536):
+        while data := await asyncio.wait_for(
+            reader.read(65536),
+            timeout=idle_timeout_seconds,
+        ):
             writer.write(data)
             await writer.drain()
     finally:
@@ -119,14 +148,19 @@ async def _handle(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
     allowed: set[tuple[str, int]],
+    limits: ProxyLimits,
 ) -> None:
     upstream_writer: asyncio.StreamWriter | None = None
     try:
         request = await asyncio.wait_for(
             reader.readuntil(b"\r\n\r\n"),
-            timeout=_HEADER_TIMEOUT_SECONDS,
+            timeout=limits.header_timeout_seconds,
         )
-        host, port = parse_connect(request, allowed)
+        host, port = parse_connect(
+            request,
+            allowed,
+            max_header_bytes=limits.max_header_bytes,
+        )
         answers = await _resolve(host, port)
         last_error: OSError | None = None
         upstream_reader: asyncio.StreamReader | None = None
@@ -134,7 +168,7 @@ async def _handle(
             try:
                 upstream_reader, upstream_writer = await asyncio.wait_for(
                     asyncio.open_connection(address, resolved_port),
-                    timeout=_CONNECT_TIMEOUT_SECONDS,
+                    timeout=limits.connect_timeout_seconds,
                 )
                 break
             except OSError as exc:
@@ -144,8 +178,16 @@ async def _handle(
         writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
         await writer.drain()
         await asyncio.gather(
-            _pipe(reader, upstream_writer),
-            _pipe(upstream_reader, writer),
+            _pipe(
+                reader,
+                upstream_writer,
+                idle_timeout_seconds=limits.idle_timeout_seconds,
+            ),
+            _pipe(
+                upstream_reader,
+                writer,
+                idle_timeout_seconds=limits.idle_timeout_seconds,
+            ),
         )
     except (
         asyncio.IncompleteReadError,
@@ -164,9 +206,34 @@ async def _handle(
             await upstream_writer.wait_closed()
 
 
-def _load_policy(path: Path) -> set[tuple[str, int]]:
+async def _bounded_handle(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    allowed: set[tuple[str, int]],
+    limits: ProxyLimits,
+    capacity: asyncio.Semaphore,
+) -> None:
+    acquired = False
+    try:
+        await asyncio.wait_for(capacity.acquire(), timeout=0.1)
+        acquired = True
+        await _handle(reader, writer, allowed, limits)
+    except asyncio.TimeoutError:
+        writer.write(b"HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\n")
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        if acquired:
+            capacity.release()
+
+
+def _load_policy(path: Path) -> tuple[set[tuple[str, int]], ProxyLimits]:
     payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, Mapping) or set(payload) != {"authorities"}:
+    if not isinstance(payload, Mapping) or set(payload) != {
+        "authorities",
+        "limits",
+    }:
         raise ValueError("egress proxy policy is invalid")
     authorities = payload["authorities"]
     if not isinstance(authorities, list):
@@ -192,16 +259,47 @@ def _load_policy(path: Path) -> set[tuple[str, int]]:
         allowed.add((authority, port))
     if not allowed:
         raise ValueError("egress proxy policy must admit at least one authority")
-    return allowed
+    return allowed, _parse_limits(payload["limits"])
+
+
+def _parse_limits(raw: object) -> ProxyLimits:
+    fields = {
+        "max_connections": (1, 256),
+        "max_header_bytes": (1024, 16384),
+        "header_timeout_seconds": (1, 30),
+        "connect_timeout_seconds": (1, 60),
+        "idle_timeout_seconds": (5, 600),
+    }
+    if not isinstance(raw, Mapping) or set(raw) != set(fields):
+        raise ValueError("egress proxy limits are invalid")
+    values: dict[str, int] = {}
+    for name, (minimum, maximum) in fields.items():
+        value = raw[name]
+        if (
+            not isinstance(value, int)
+            or isinstance(value, bool)
+            or not minimum <= value <= maximum
+        ):
+            raise ValueError("egress proxy limits are invalid")
+        values[name] = value
+    return ProxyLimits(**values)
 
 
 async def _serve(policy_path: Path, host: str, port: int) -> None:
-    allowed = _load_policy(policy_path)
+    allowed, limits = _load_policy(policy_path)
+    capacity = asyncio.Semaphore(limits.max_connections)
     server = await asyncio.start_server(
-        lambda reader, writer: _handle(reader, writer, allowed),
+        lambda reader, writer: _bounded_handle(
+            reader,
+            writer,
+            allowed,
+            limits,
+            capacity,
+        ),
         host,
         port,
-        limit=_MAX_HEADER_BYTES,
+        limit=limits.max_header_bytes,
+        backlog=limits.max_connections,
     )
     async with server:
         await server.serve_forever()

--- a/containers/appliance-egress-proxy/proxy.py
+++ b/containers/appliance-egress-proxy/proxy.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Small exact-authority CONNECT broker for appliance model egress."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import ipaddress
+import json
+import re
+import socket
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+_AUTHORITY = re.compile(
+    r"^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+"
+    r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+)
+_MAX_HEADER_BYTES = 4096
+_HEADER_TIMEOUT_SECONDS = 5
+_CONNECT_TIMEOUT_SECONDS = 10
+_NAT64_WELL_KNOWN = ipaddress.ip_network("64:ff9b::/96")
+
+
+def parse_connect(
+    request: bytes,
+    allowed: set[tuple[str, int]],
+) -> tuple[str, int]:
+    """Return an exact admitted CONNECT target or reject the request."""
+
+    if len(request) > _MAX_HEADER_BYTES or b"\r\n\r\n" not in request:
+        raise ValueError("CONNECT header is incomplete")
+    try:
+        first_line = request.split(b"\r\n", 1)[0].decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ValueError("CONNECT request must be ASCII") from exc
+    parts = first_line.split(" ")
+    if len(parts) != 3 or parts[0] != "CONNECT" or parts[2] != "HTTP/1.1":
+        raise ValueError("only HTTP/1.1 CONNECT is supported")
+    target = parts[1]
+    if target.count(":") != 1:
+        raise ValueError("CONNECT target must be DNS-authority:port")
+    host, raw_port = target.rsplit(":", 1)
+    host = host.rstrip(".").lower()
+    if not _AUTHORITY.fullmatch(host):
+        raise ValueError("CONNECT target must be an exact DNS authority")
+    try:
+        port = int(raw_port)
+    except ValueError as exc:
+        raise ValueError("CONNECT port is invalid") from exc
+    if not 0 < port <= 65535:
+        raise ValueError("CONNECT port is invalid")
+    if (host, port) not in allowed:
+        raise ValueError("CONNECT authority is not admitted")
+    return host, port
+
+
+def is_safe_destination(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Reject every non-global address and private IPv4 embedded in IPv6."""
+
+    if not address.is_global:
+        return False
+    if isinstance(address, ipaddress.IPv6Address):
+        embedded = address.ipv4_mapped
+        if embedded is None and address in _NAT64_WELL_KNOWN:
+            embedded = ipaddress.IPv4Address(int(address) & 0xFFFFFFFF)
+        if embedded is not None and not embedded.is_global:
+            return False
+    return True
+
+
+def validate_resolved_addresses(
+    answers: Iterable[tuple[str, int]],
+) -> tuple[tuple[str, int], ...]:
+    """Require a non-empty DNS result set containing only global addresses."""
+
+    normalized: list[tuple[str, int]] = []
+    for raw_address, port in answers:
+        address = ipaddress.ip_address(raw_address)
+        if not is_safe_destination(address):
+            raise ValueError("DNS result contains an unsafe destination")
+        normalized.append((str(address), port))
+    if not normalized:
+        raise ValueError("DNS returned no usable destination")
+    return tuple(normalized)
+
+
+async def _resolve(host: str, port: int) -> tuple[tuple[str, int], ...]:
+    loop = asyncio.get_running_loop()
+    records = await loop.getaddrinfo(
+        host,
+        port,
+        family=socket.AF_UNSPEC,
+        type=socket.SOCK_STREAM,
+        proto=socket.IPPROTO_TCP,
+    )
+    answers = {
+        (str(record[4][0]), int(record[4][1]))
+        for record in records
+        if isinstance(record[4], tuple) and len(record[4]) >= 2
+    }
+    return validate_resolved_addresses(sorted(answers))
+
+
+async def _pipe(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    try:
+        while data := await reader.read(65536):
+            writer.write(data)
+            await writer.drain()
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+async def _handle(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    allowed: set[tuple[str, int]],
+) -> None:
+    upstream_writer: asyncio.StreamWriter | None = None
+    try:
+        request = await asyncio.wait_for(
+            reader.readuntil(b"\r\n\r\n"),
+            timeout=_HEADER_TIMEOUT_SECONDS,
+        )
+        host, port = parse_connect(request, allowed)
+        answers = await _resolve(host, port)
+        last_error: OSError | None = None
+        upstream_reader: asyncio.StreamReader | None = None
+        for address, resolved_port in answers:
+            try:
+                upstream_reader, upstream_writer = await asyncio.wait_for(
+                    asyncio.open_connection(address, resolved_port),
+                    timeout=_CONNECT_TIMEOUT_SECONDS,
+                )
+                break
+            except OSError as exc:
+                last_error = exc
+        if upstream_reader is None or upstream_writer is None:
+            raise OSError("admitted authority was unreachable") from last_error
+        writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        await writer.drain()
+        await asyncio.gather(
+            _pipe(reader, upstream_writer),
+            _pipe(upstream_reader, writer),
+        )
+    except (
+        asyncio.IncompleteReadError,
+        asyncio.LimitOverrunError,
+        asyncio.TimeoutError,
+        OSError,
+        ValueError,
+    ):
+        if not writer.is_closing():
+            writer.write(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+        if upstream_writer is not None and not upstream_writer.is_closing():
+            upstream_writer.close()
+            await upstream_writer.wait_closed()
+
+
+def _load_policy(path: Path) -> set[tuple[str, int]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping) or set(payload) != {"authorities"}:
+        raise ValueError("egress proxy policy is invalid")
+    authorities = payload["authorities"]
+    if not isinstance(authorities, list):
+        raise ValueError("egress proxy authorities must be a list")
+    allowed: set[tuple[str, int]] = set()
+    for item in authorities:
+        if not isinstance(item, Mapping) or set(item) != {"authority", "port"}:
+            raise ValueError("egress proxy authority is invalid")
+        authority = item["authority"]
+        port = item["port"]
+        if (
+            not isinstance(authority, str)
+            or not isinstance(port, int)
+            or isinstance(port, bool)
+        ):
+            raise ValueError("egress proxy authority is invalid")
+        parse_connect(
+            f"CONNECT {authority}:{port} HTTP/1.1\r\n\r\n".encode(),
+            {(authority, port)},
+        )
+        if (authority, port) in allowed:
+            raise ValueError("egress proxy authorities must be unique")
+        allowed.add((authority, port))
+    if not allowed:
+        raise ValueError("egress proxy policy must admit at least one authority")
+    return allowed
+
+
+async def _serve(policy_path: Path, host: str, port: int) -> None:
+    allowed = _load_policy(policy_path)
+    server = await asyncio.start_server(
+        lambda reader, writer: _handle(reader, writer, allowed),
+        host,
+        port,
+        limit=_MAX_HEADER_BYTES,
+    )
+    async with server:
+        await server.serve_forever()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy", type=Path, required=True)
+    parser.add_argument("--listen-host", default="0.0.0.0")
+    parser.add_argument("--listen-port", type=int, default=3128)
+    args = parser.parse_args()
+    try:
+        asyncio.run(_serve(args.policy, args.listen_host, args.listen_port))
+    except (OSError, ValueError):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/containers/network-boundary-helper/Dockerfile
+++ b/containers/network-boundary-helper/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+
+RUN apk add --no-cache nftables=1.1.3-r0 python3=3.12.13-r0 \
+    && adduser -D -H -u 65532 boundary
+
+COPY containers/network-boundary-helper/helper.py /usr/local/bin/aptl-boundary-helper
+
+ENTRYPOINT ["python3", "/usr/local/bin/aptl-boundary-helper"]

--- a/containers/network-boundary-helper/helper.py
+++ b/containers/network-boundary-helper/helper.py
@@ -1,0 +1,803 @@
+#!/usr/bin/env python3
+"""Closed nftables apply/observe/cleanup helper for one boundary authority."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import ipaddress
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+
+_TOKEN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,159}$")
+_BRIDGE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,14}$")
+_DIGEST = re.compile(r"^sha256:[a-f0-9]{64}$")
+_ACTIONS = frozenset({"allow", "deny"})
+_PROTOCOLS = frozenset({"any", "tcp", "udp", "icmp"})
+_DIRECTIONS = frozenset({"in", "out", "inout"})
+_ZONES = frozenset({"participant", "management", "egress"})
+
+
+def _canonical(policy: Mapping[str, object]) -> str:
+    return json.dumps(policy, sort_keys=True, separators=(",", ":"))
+
+
+def _digest(policy: Mapping[str, object]) -> str:
+    return "sha256:" + hashlib.sha256(_canonical(policy).encode()).hexdigest()
+
+
+def _table_name(owner: str, authority: str) -> str:
+    suffix = hashlib.sha256(f"{owner}:{authority}".encode()).hexdigest()[:12]
+    return f"aptl_bnd_{suffix}"
+
+
+def _owner_marker(owner: str) -> str:
+    return hashlib.sha256(owner.encode()).hexdigest()[:16]
+
+
+def _quoted(value: str) -> str:
+    return json.dumps(value)
+
+
+def validate_policy(policy: object) -> dict[str, object]:
+    """Validate one closed authority payload before rendering native syntax."""
+
+    if not isinstance(policy, dict):
+        raise ValueError("policy must be an object")
+    authority = policy.get("authority")
+    if authority == "aces":
+        return _validate_aces(policy)
+    if authority == "platform":
+        return _validate_platform(policy)
+    raise ValueError("policy authority is invalid")
+
+
+def _validate_common(policy: Mapping[str, object], fields: set[str]) -> None:
+    if set(policy) != fields:
+        raise ValueError("policy fields are invalid")
+    owner = policy.get("owner")
+    if not isinstance(owner, str) or not _TOKEN.fullmatch(owner):
+        raise ValueError("owner is invalid")
+
+
+def _validate_network(network: object) -> dict[str, object]:
+    fields = {"name", "bridge", "ipv4_cidr", "ipv6_cidr", "labels"}
+    if not isinstance(network, dict) or set(network) != fields:
+        raise ValueError("network is invalid")
+    name = network["name"]
+    bridge = network["bridge"]
+    labels = network["labels"]
+    if (
+        not isinstance(name, str)
+        or not _TOKEN.fullmatch(name)
+        or not isinstance(bridge, str)
+        or not _BRIDGE.fullmatch(bridge)
+        or not isinstance(labels, list)
+    ):
+        raise ValueError("network identity is invalid")
+    for key in ("ipv4_cidr", "ipv6_cidr"):
+        value = network[key]
+        if value is not None:
+            if not isinstance(value, str):
+                raise ValueError("network CIDR is invalid")
+            ipaddress.ip_network(value, strict=False)
+    return network
+
+
+def _validate_aces(policy: dict[str, object]) -> dict[str, object]:
+    _validate_common(
+        policy,
+        {"authority", "owner", "networks", "owner_bindings", "rules"},
+    )
+    networks = policy["networks"]
+    bindings = policy["owner_bindings"]
+    rules = policy["rules"]
+    if not all(isinstance(value, list) for value in (networks, bindings, rules)):
+        raise ValueError("ACES policy collections must be lists")
+    network_index = {
+        network["name"]: _validate_network(network)
+        for network in networks
+        if isinstance(network, dict)
+    }
+    if len(network_index) != len(networks):
+        raise ValueError("ACES network identities must be unique")
+    binding_index: dict[str, dict[str, object]] = {}
+    for binding in bindings:
+        if not isinstance(binding, dict) or set(binding) != {
+            "owner_address",
+            "owner_resource_type",
+            "ipv4_by_network",
+            "ipv6_by_network",
+        }:
+            raise ValueError("ACES owner binding is invalid")
+        address = binding["owner_address"]
+        kind = binding["owner_resource_type"]
+        if (
+            not isinstance(address, str)
+            or not _TOKEN.fullmatch(address)
+            or kind not in {"node", "network"}
+            or address in binding_index
+        ):
+            raise ValueError("ACES owner identity is invalid")
+        for family_key in ("ipv4_by_network", "ipv6_by_network"):
+            pairs = binding[family_key]
+            if not isinstance(pairs, list):
+                raise ValueError("ACES owner addresses are invalid")
+            for pair in pairs:
+                if (
+                    not isinstance(pair, list)
+                    or len(pair) != 2
+                    or pair[0] not in network_index
+                    or not isinstance(pair[1], str)
+                ):
+                    raise ValueError("ACES owner address is invalid")
+                ipaddress.ip_address(pair[1])
+        binding_index[address] = binding
+    prior: tuple[str, int, str] | None = None
+    for rule in rules:
+        if not isinstance(rule, dict) or set(rule) != {
+            "owner_address",
+            "owner_resource_type",
+            "owner_name",
+            "name",
+            "order",
+            "direction",
+            "from_network",
+            "to_network",
+            "protocol",
+            "ports",
+            "action",
+        }:
+            raise ValueError("ACES rule is invalid")
+        address = rule["owner_address"]
+        binding = binding_index.get(address) if isinstance(address, str) else None
+        if binding is None or binding["owner_resource_type"] != rule["owner_resource_type"]:
+            raise ValueError("ACES rule owner is invalid")
+        if rule["direction"] not in _DIRECTIONS:
+            raise ValueError("ACES rule direction is invalid")
+        if rule["protocol"] not in _PROTOCOLS or rule["action"] not in _ACTIONS:
+            raise ValueError("ACES rule semantics are invalid")
+        for endpoint in ("from_network", "to_network"):
+            value = rule[endpoint]
+            if value is not None and value not in network_index:
+                raise ValueError("ACES rule endpoint is invalid")
+        _validate_ports(rule["ports"], str(rule["protocol"]))
+        identity = rule["name"]
+        order = rule["order"]
+        if (
+            not isinstance(identity, str)
+            or not _TOKEN.fullmatch(identity)
+            or not isinstance(order, int)
+            or isinstance(order, bool)
+            or order < 0
+        ):
+            raise ValueError("ACES rule ordering is invalid")
+        current = (str(address), order, identity)
+        if prior is not None and current < prior:
+            raise ValueError("ACES rules are not deterministically ordered")
+        prior = current
+    return policy
+
+
+def _validate_platform(policy: dict[str, object]) -> dict[str, object]:
+    _validate_common(
+        policy,
+        {
+            "authority",
+            "owner",
+            "policy_digest",
+            "networks",
+            "anchors",
+            "crossings",
+            "egress_ports",
+            "default_deny",
+        },
+    )
+    if not isinstance(policy["policy_digest"], str) or not _DIGEST.fullmatch(
+        policy["policy_digest"]
+    ):
+        raise ValueError("platform policy digest is invalid")
+    if policy["default_deny"] is not True:
+        raise ValueError("platform policy must be default deny")
+    anchors = policy["anchors"]
+    crossings = policy["crossings"]
+    networks = policy["networks"]
+    egress_ports = policy["egress_ports"]
+    if (
+        not isinstance(anchors, list)
+        or not isinstance(crossings, list)
+        or not isinstance(networks, list)
+    ):
+        raise ValueError("platform policy collections must be lists")
+    network_index = {
+        network["name"]: _validate_network(network)
+        for network in networks
+        if isinstance(network, dict)
+    }
+    if len(network_index) != len(networks):
+        raise ValueError("platform network identities must be unique")
+    _validate_ports(egress_ports, "tcp")
+    zones: set[str] = set()
+    for anchor in anchors:
+        if (
+            not isinstance(anchor, dict)
+            or set(anchor) != {"zone", "workload"}
+            or anchor["zone"] not in _ZONES
+            or anchor["zone"] in zones
+        ):
+            raise ValueError("platform anchor is invalid")
+        zones.add(str(anchor["zone"]))
+        workload = anchor["workload"]
+        if not isinstance(workload, dict) or set(workload) != {
+            "identity",
+            "labels",
+            "ipv4_by_network",
+            "ipv6_by_network",
+        }:
+            raise ValueError("platform workload is invalid")
+        if not isinstance(workload["identity"], str) or not _TOKEN.fullmatch(
+            workload["identity"]
+        ):
+            raise ValueError("platform workload identity is invalid")
+        for family_key in ("ipv4_by_network", "ipv6_by_network"):
+            pairs = workload[family_key]
+            if not isinstance(pairs, list):
+                raise ValueError("platform workload addresses are invalid")
+            for pair in pairs:
+                if (
+                    not isinstance(pair, list)
+                    or len(pair) != 2
+                    or pair[0] not in network_index
+                    or not isinstance(pair[1], str)
+                ):
+                    raise ValueError("platform workload address is invalid")
+                ipaddress.ip_address(pair[1])
+    for crossing in crossings:
+        if not isinstance(crossing, dict) or set(crossing) != {
+            "source",
+            "destination",
+            "protocol",
+            "ports",
+            "purpose",
+        }:
+            raise ValueError("platform crossing is invalid")
+        if (
+            crossing["source"] not in zones
+            or crossing["destination"] not in zones
+            or crossing["protocol"] not in {"tcp", "udp"}
+            or not isinstance(crossing["purpose"], str)
+            or not crossing["purpose"]
+        ):
+            raise ValueError("platform crossing semantics are invalid")
+        _validate_ports(crossing["ports"], str(crossing["protocol"]), required=True)
+    return policy
+
+
+def _validate_ports(value: object, protocol: str, *, required: bool = False) -> None:
+    if (
+        not isinstance(value, list)
+        or (required and not value)
+        or any(
+            not isinstance(port, int)
+            or isinstance(port, bool)
+            or not 0 < port <= 65535
+            for port in value
+        )
+        or (value and protocol not in {"tcp", "udp"})
+    ):
+        raise ValueError("ports are invalid")
+
+
+def _network_index(policy: Mapping[str, object]) -> dict[str, dict[str, object]]:
+    networks = policy["networks"]
+    assert isinstance(networks, list)
+    return {
+        str(network["name"]): network
+        for network in networks
+        if isinstance(network, dict)
+    }
+
+
+def _transport(rule: Mapping[str, object]) -> str:
+    protocol = str(rule["protocol"])
+    if protocol in {"tcp", "udp"}:
+        ports = rule["ports"]
+        suffix = ""
+        if isinstance(ports, list) and ports:
+            rendered = (
+                str(ports[0])
+                if len(ports) == 1
+                else "{ " + ", ".join(str(port) for port in ports) + " }"
+            )
+            suffix = f" dport {rendered}"
+        return f"{protocol}{suffix}"
+    if protocol == "icmp":
+        return "meta l4proto { icmp, ipv6-icmp }"
+    return ""
+
+
+def _interface_expression(
+    source: str | None,
+    destination: str | None,
+    networks: Mapping[str, Mapping[str, object]],
+    *,
+    family: str,
+) -> list[str]:
+    parts: list[str] = []
+    ingress = "ibrname" if family == "bridge" else "iifname"
+    egress = "obrname" if family == "bridge" else "oifname"
+    if source is not None:
+        parts.extend([ingress, _quoted(str(networks[source]["bridge"]))])
+    if destination is not None:
+        parts.extend([egress, _quoted(str(networks[destination]["bridge"]))])
+    return parts
+
+
+def _address_expression(
+    source: str | None,
+    destination: str | None,
+    networks: Mapping[str, Mapping[str, object]],
+) -> list[str]:
+    parts: list[str] = []
+    for reference, direction in ((source, "saddr"), (destination, "daddr")):
+        if reference is None:
+            continue
+        network = networks[reference]
+        cidr = network.get("ipv4_cidr")
+        if isinstance(cidr, str):
+            parts.extend(["ip", direction, cidr])
+    return parts
+
+
+def _binding_addresses(
+    binding: Mapping[str, object], network: str | None
+) -> list[str]:
+    pairs = binding["ipv4_by_network"]
+    assert isinstance(pairs, list)
+    return [
+        str(pair[1])
+        for pair in pairs
+        if isinstance(pair, list) and (network is None or pair[0] == network)
+    ]
+
+
+def _aces_rule_expressions(
+    policy: Mapping[str, object],
+    rule: Mapping[str, object],
+    *,
+    family: str,
+) -> list[str]:
+    networks = _network_index(policy)
+    bindings = policy["owner_bindings"]
+    assert isinstance(bindings, list)
+    binding = next(
+        item
+        for item in bindings
+        if isinstance(item, dict) and item["owner_address"] == rule["owner_address"]
+    )
+    directions = (
+        ("in", "out")
+        if rule["direction"] == "inout"
+        else (str(rule["direction"]),)
+    )
+    expressions: list[str] = []
+    for direction in directions:
+        source = rule["from_network"]
+        destination = rule["to_network"]
+        source_ref = source if isinstance(source, str) else None
+        destination_ref = destination if isinstance(destination, str) else None
+        parts = _interface_expression(
+            source_ref, destination_ref, networks, family=family
+        )
+        if family == "inet":
+            parts.extend(
+                _address_expression(source_ref, destination_ref, networks)
+            )
+        if binding["owner_resource_type"] == "network":
+            owner_name = str(rule["owner_name"])
+            if direction == "in":
+                parts.extend(
+                    _interface_expression(None, owner_name, networks, family=family)
+                )
+            else:
+                parts.extend(
+                    _interface_expression(owner_name, None, networks, family=family)
+                )
+        else:
+            owner_network = destination_ref if direction == "in" else source_ref
+            addresses = _binding_addresses(binding, owner_network)
+            if not addresses:
+                raise ValueError("node ACL owner has no exact address")
+            rendered = (
+                addresses[0]
+                if len(addresses) == 1
+                else "{ " + ", ".join(addresses) + " }"
+            )
+            parts.extend(["ip", "daddr" if direction == "in" else "saddr", rendered])
+        transport = _transport(rule)
+        if transport:
+            parts.append(transport)
+        parts.append("return" if rule["action"] == "allow" else "drop")
+        identity = (
+            f"{rule['owner_address']}/{rule['name']}/{direction}"
+        )
+        parts.extend(["comment", _quoted(identity)])
+        expressions.append("    " + " ".join(parts))
+    return expressions
+
+
+def _aces_table(
+    policy: Mapping[str, object], family: str, table_name: str
+) -> list[str]:
+    owner = str(policy["owner"])
+    digest = _digest(policy)
+    bindings = policy["owner_bindings"]
+    rules = policy["rules"]
+    assert isinstance(bindings, list)
+    assert isinstance(rules, list)
+    lines = [
+        f"table {family} {table_name} {{",
+        (
+            "  comment "
+            + _quoted(
+                f"aptl-owner={_owner_marker(owner)},"
+                f"authority=aces,digest={digest}"
+            )
+        ),
+    ]
+    chain_by_owner: dict[str, str] = {}
+    for binding in bindings:
+        if not isinstance(binding, Mapping):
+            continue
+        owner_address = str(binding["owner_address"])
+        chain = "owner_" + hashlib.sha256(owner_address.encode()).hexdigest()[:12]
+        chain_by_owner[owner_address] = chain
+        lines.append(f"  chain {chain} {{")
+        for rule in rules:
+            if (
+                isinstance(rule, Mapping)
+                and rule["owner_address"] == owner_address
+            ):
+                lines.extend(
+                    _aces_rule_expressions(policy, rule, family=family)
+                )
+        lines.extend(["    return", "  }"])
+    lines.extend(
+        [
+            "  chain forward {",
+            "    type filter hook forward priority -200; policy accept;",
+        ]
+    )
+    networks = _network_index(policy)
+    for binding in bindings:
+        if not isinstance(binding, Mapping):
+            continue
+        owner_address = str(binding["owner_address"])
+        chain = chain_by_owner[owner_address]
+        if binding["owner_resource_type"] == "node":
+            addresses = _binding_addresses(binding, None)
+            rendered = (
+                addresses[0]
+                if len(addresses) == 1
+                else "{ " + ", ".join(addresses) + " }"
+            )
+            lines.append(f"    ip daddr {rendered} jump {chain}")
+            lines.append(f"    ip saddr {rendered} jump {chain}")
+        else:
+            owner_rules = [
+                rule
+                for rule in rules
+                if isinstance(rule, Mapping)
+                and rule["owner_address"] == owner_address
+            ]
+            owner_names = {
+                str(rule["owner_name"]) for rule in owner_rules
+            }
+            for owner_name in sorted(owner_names):
+                bridge = str(networks[owner_name]["bridge"])
+                ingress = "ibrname" if family == "bridge" else "iifname"
+                egress = "obrname" if family == "bridge" else "oifname"
+                lines.append(
+                    f"    {egress} {_quoted(bridge)} jump {chain}"
+                )
+                lines.append(
+                    f"    {ingress} {_quoted(bridge)} jump {chain}"
+                )
+    lines.extend(["  }", "}"])
+    return lines
+
+
+def _platform_index(
+    policy: Mapping[str, object],
+) -> dict[str, Mapping[str, object]]:
+    anchors = policy["anchors"]
+    assert isinstance(anchors, list)
+    return {
+        str(anchor["zone"]): anchor["workload"]
+        for anchor in anchors
+        if isinstance(anchor, dict) and isinstance(anchor["workload"], dict)
+    }
+
+
+def _workload_ipv4(workload: Mapping[str, object]) -> dict[str, str]:
+    pairs = workload["ipv4_by_network"]
+    assert isinstance(pairs, list)
+    return {
+        str(pair[0]): str(pair[1])
+        for pair in pairs
+        if isinstance(pair, list) and len(pair) == 2
+    }
+
+
+def _platform_table(
+    policy: Mapping[str, object], family: str, table_name: str
+) -> list[str]:
+    owner = str(policy["owner"])
+    digest = _digest(policy)
+    anchors = _platform_index(policy)
+    networks = _network_index(policy)
+    lines = [
+        f"table {family} {table_name} {{",
+        (
+            "  comment "
+            + _quoted(
+                f"aptl-owner={_owner_marker(owner)},"
+                f"authority=platform,digest={digest}"
+            )
+        ),
+        "  chain forward {",
+        "    type filter hook forward priority -300; policy accept;",
+    ]
+    crossings = policy["crossings"]
+    assert isinstance(crossings, list)
+    if family == "bridge":
+        for bridge in sorted(str(item["bridge"]) for item in networks.values()):
+            # Link-local address resolution is not an inter-zone grant. Without
+            # these bounded L2 control frames, an otherwise-authorized IP flow
+            # depends on a stale neighbor cache and fails after a clean boot.
+            lines.append(
+                f"    ibrname {_quoted(bridge)} obrname {_quoted(bridge)} "
+                "ether type arp accept comment \"platform/arp\""
+            )
+            lines.append(
+                f"    ibrname {_quoted(bridge)} obrname {_quoted(bridge)} "
+                "ether type ip6 meta l4proto ipv6-icmp "
+                "icmpv6 type { nd-neighbor-solicit, nd-neighbor-advert } "
+                "accept comment \"platform/nd\""
+            )
+    for crossing in crossings:
+        if not isinstance(crossing, Mapping):
+            continue
+        source_addresses = _workload_ipv4(anchors[str(crossing["source"])])
+        destination_addresses = _workload_ipv4(
+            anchors[str(crossing["destination"])]
+        )
+        ingress = "ibrname" if family == "bridge" else "iifname"
+        egress = "obrname" if family == "bridge" else "oifname"
+        ports = crossing["ports"]
+        assert isinstance(ports, list)
+        rendered_ports = (
+            str(ports[0])
+            if len(ports) == 1
+            else "{ " + ", ".join(str(port) for port in ports) + " }"
+        )
+        identity = f"platform/{crossing['purpose']}"
+        for network_name in sorted(
+            set(source_addresses) & set(destination_addresses)
+        ):
+            bridge = str(networks[network_name]["bridge"])
+            source = source_addresses[network_name]
+            destination = destination_addresses[network_name]
+            lines.append(
+                f"    {ingress} {_quoted(bridge)} {egress} {_quoted(bridge)} "
+                f"ip saddr {source} ip daddr {destination} "
+                f"{crossing['protocol']} dport {rendered_ports} accept "
+                f"comment {_quoted(identity)}"
+            )
+            lines.append(
+                f"    {ingress} {_quoted(bridge)} {egress} {_quoted(bridge)} "
+                f"ip saddr {destination} ip daddr {source} "
+                f"ct state established,related accept "
+                f"comment {_quoted(identity + '/reply')}"
+            )
+    if family == "inet":
+        egress_anchor = anchors.get("egress")
+        egress_ports = policy["egress_ports"]
+        assert isinstance(egress_ports, list)
+        if egress_anchor is not None and egress_ports:
+            rendered_ports = (
+                str(egress_ports[0])
+                if len(egress_ports) == 1
+                else "{ " + ", ".join(str(port) for port in egress_ports) + " }"
+            )
+            denied_ipv4 = (
+                "{ 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, "
+                "127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, "
+                "192.0.0.0/24, 192.168.0.0/16, 198.18.0.0/15, "
+                "224.0.0.0/4, 240.0.0.0/4 }"
+            )
+            for network_name, source in sorted(
+                _workload_ipv4(egress_anchor).items()
+            ):
+                bridge = str(networks[network_name]["bridge"])
+                lines.append(
+                    f"    iifname {_quoted(bridge)} ip saddr {source} "
+                    f"ip daddr {denied_ipv4} drop "
+                    f"comment {_quoted('platform/egress-denied-range')}"
+                )
+                lines.append(
+                    f"    iifname {_quoted(bridge)} ip saddr {source} "
+                    f"tcp dport {rendered_ports} accept "
+                    f"comment {_quoted('platform/egress-broker')}"
+                )
+    for bridge in sorted(str(item["bridge"]) for item in networks.values()):
+        ingress = "ibrname" if family == "bridge" else "iifname"
+        egress = "obrname" if family == "bridge" else "oifname"
+        lines.append(f"    {ingress} {_quoted(bridge)} drop")
+        lines.append(f"    {egress} {_quoted(bridge)} drop")
+    lines.extend(["  }"])
+    if family == "inet":
+        for chain, hook, interface in (
+            ("host_input", "input", "iifname"),
+            ("host_output", "output", "oifname"),
+        ):
+            lines.extend(
+                [
+                    f"  chain {chain} {{",
+                    f"    type filter hook {hook} priority -300; policy accept;",
+                ]
+            )
+            for bridge in sorted(str(item["bridge"]) for item in networks.values()):
+                lines.append(f"    {interface} {_quoted(bridge)} drop")
+            lines.append("  }")
+    lines.append("}")
+    return lines
+
+
+def render_ruleset(
+    raw_policy: object,
+    *,
+    existing_families: Sequence[str],
+) -> str:
+    """Render one atomic transaction for exactly one policy authority."""
+
+    policy = validate_policy(raw_policy)
+    authority = str(policy["authority"])
+    table_name = _table_name(str(policy["owner"]), authority)
+    lines: list[str] = []
+    for family in ("inet", "bridge"):
+        if family in existing_families:
+            lines.append(f"delete table {family} {table_name}")
+    renderer = _aces_table if authority == "aces" else _platform_table
+    lines.extend(renderer(policy, "inet", table_name))
+    lines.extend(renderer(policy, "bridge", table_name))
+    return "\n".join(lines) + "\n"
+
+
+def _nft_json(*args: str, input_text: str | None = None) -> dict[str, object]:
+    result = subprocess.run(
+        ["nft", "-j", *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("nft operation failed")
+    if not result.stdout.strip():
+        return {}
+    parsed = json.loads(result.stdout)
+    if not isinstance(parsed, dict):
+        raise RuntimeError("nft observation was invalid")
+    return parsed
+
+
+def _table_comment(family: str, table_name: str) -> str | None:
+    try:
+        payload = _nft_json("list", "table", family, table_name)
+    except RuntimeError:
+        return None
+    nftables = payload.get("nftables", [])
+    if not isinstance(nftables, list):
+        return None
+    for item in nftables:
+        if not isinstance(item, dict):
+            continue
+        table = item.get("table")
+        if isinstance(table, dict) and isinstance(table.get("comment"), str):
+            return table["comment"]
+    return None
+
+
+def _owned_families(policy: Mapping[str, object]) -> tuple[str, ...]:
+    owner = str(policy["owner"])
+    authority = str(policy["authority"])
+    table_name = _table_name(owner, authority)
+    owned: list[str] = []
+    prefix = f"aptl-owner={_owner_marker(owner)},authority={authority},"
+    for family in ("bridge", "inet"):
+        comment = _table_comment(family, table_name)
+        if comment is None:
+            continue
+        if not comment.startswith(prefix):
+            raise RuntimeError("boundary table ownership conflict")
+        owned.append(family)
+    return tuple(owned)
+
+
+def _receipt(
+    policy: Mapping[str, object],
+    families: Sequence[str],
+) -> dict[str, object]:
+    return {
+        "authority": policy["authority"],
+        "owner": policy["owner"],
+        "enforcement_digest": _digest(policy),
+        "families": list(families),
+        "default_deny": policy["authority"] == "platform",
+    }
+
+
+def _apply(policy: dict[str, object]) -> dict[str, object]:
+    existing = _owned_families(policy)
+    rendered = render_ruleset(policy, existing_families=existing)
+    _nft_json("-f", "-", input_text=rendered)
+    observed = _owned_families(policy)
+    if observed != ("bridge", "inet"):
+        raise RuntimeError("boundary tables were not observed")
+    return _receipt(policy, observed)
+
+
+def _cleanup(policy: dict[str, object]) -> dict[str, object]:
+    existing = _owned_families(policy)
+    table_name = _table_name(str(policy["owner"]), str(policy["authority"]))
+    if existing:
+        rendered = "\n".join(
+            f"delete table {family} {table_name}" for family in existing
+        )
+        _nft_json("-f", "-", input_text=rendered + "\n")
+    return _receipt(policy, ())
+
+
+def _observe(policy: dict[str, object]) -> dict[str, object]:
+    families = _owned_families(policy)
+    if families != ("bridge", "inet"):
+        raise RuntimeError("boundary tables are incomplete")
+    digest = _digest(policy)
+    table_name = _table_name(str(policy["owner"]), str(policy["authority"]))
+    for family in families:
+        comment = _table_comment(family, table_name) or ""
+        if f"digest={digest}" not in comment:
+            raise RuntimeError("boundary policy digest mismatch")
+    return _receipt(policy, families)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=("apply", "observe", "cleanup"))
+    parser.add_argument("--stdin", action="store_true", required=True)
+    args = parser.parse_args()
+    try:
+        policy = validate_policy(json.load(sys.stdin))
+        action = {"apply": _apply, "observe": _observe, "cleanup": _cleanup}[
+            args.action
+        ]
+        print(json.dumps(action(policy), sort_keys=True, separators=(",", ":")))
+        return 0
+    except (
+        ValueError,
+        RuntimeError,
+        OSError,
+        subprocess.SubprocessError,
+        json.JSONDecodeError,
+    ):
+        print("boundary helper failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/containers/network-boundary-helper/helper.py
+++ b/containers/network-boundary-helper/helper.py
@@ -38,6 +38,10 @@ def _owner_marker(owner: str) -> str:
     return hashlib.sha256(owner.encode()).hexdigest()[:16]
 
 
+def _rule_marker(identity: str) -> str:
+    return "aptl-rule=" + hashlib.sha256(identity.encode()).hexdigest()[:24]
+
+
 def _quoted(value: str) -> str:
     return json.dumps(value)
 
@@ -78,13 +82,30 @@ def _validate_network(network: object) -> dict[str, object]:
         or not isinstance(labels, list)
     ):
         raise ValueError("network identity is invalid")
-    for key in ("ipv4_cidr", "ipv6_cidr"):
+    for key, version in (("ipv4_cidr", 4), ("ipv6_cidr", 6)):
         value = network[key]
         if value is not None:
             if not isinstance(value, str):
                 raise ValueError("network CIDR is invalid")
-            ipaddress.ip_network(value, strict=False)
+            if ipaddress.ip_network(value, strict=False).version != version:
+                raise ValueError("network CIDR family is invalid")
+    _validate_labels(labels)
     return network
+
+
+def _validate_labels(labels: object) -> None:
+    if (
+        not isinstance(labels, list)
+        or any(
+            not isinstance(item, list)
+            or len(item) != 2
+            or not all(isinstance(value, str) for value in item)
+            for item in labels
+        )
+        or labels != sorted(labels)
+        or len({item[0] for item in labels}) != len(labels)
+    ):
+        raise ValueError("network labels are invalid")
 
 
 def _validate_aces(policy: dict[str, object]) -> dict[str, object]:
@@ -97,89 +118,184 @@ def _validate_aces(policy: dict[str, object]) -> dict[str, object]:
     rules = policy["rules"]
     if not all(isinstance(value, list) for value in (networks, bindings, rules)):
         raise ValueError("ACES policy collections must be lists")
-    network_index = {
-        network["name"]: _validate_network(network)
-        for network in networks
-        if isinstance(network, dict)
-    }
-    if len(network_index) != len(networks):
-        raise ValueError("ACES network identities must be unique")
+    network_index = _validated_network_index(networks, authority="ACES")
+    if any(network["ipv6_cidr"] is not None for network in network_index.values()):
+        raise ValueError("ACES ACL networks must remain IPv4-only")
     binding_index: dict[str, dict[str, object]] = {}
     for binding in bindings:
-        if not isinstance(binding, dict) or set(binding) != {
-            "owner_address",
-            "owner_resource_type",
-            "ipv4_by_network",
-            "ipv6_by_network",
-        }:
-            raise ValueError("ACES owner binding is invalid")
-        address = binding["owner_address"]
-        kind = binding["owner_resource_type"]
-        if (
-            not isinstance(address, str)
-            or not _TOKEN.fullmatch(address)
-            or kind not in {"node", "network"}
-            or address in binding_index
-        ):
-            raise ValueError("ACES owner identity is invalid")
-        for family_key in ("ipv4_by_network", "ipv6_by_network"):
-            pairs = binding[family_key]
-            if not isinstance(pairs, list):
-                raise ValueError("ACES owner addresses are invalid")
-            for pair in pairs:
-                if (
-                    not isinstance(pair, list)
-                    or len(pair) != 2
-                    or pair[0] not in network_index
-                    or not isinstance(pair[1], str)
-                ):
-                    raise ValueError("ACES owner address is invalid")
-                ipaddress.ip_address(pair[1])
-        binding_index[address] = binding
+        _validate_aces_binding(binding, network_index, binding_index)
     prior: tuple[str, int, str] | None = None
+    seen_orders: set[tuple[str, int]] = set()
+    seen_names: set[tuple[str, str]] = set()
     for rule in rules:
-        if not isinstance(rule, dict) or set(rule) != {
-            "owner_address",
-            "owner_resource_type",
-            "owner_name",
-            "name",
-            "order",
-            "direction",
-            "from_network",
-            "to_network",
-            "protocol",
-            "ports",
-            "action",
-        }:
-            raise ValueError("ACES rule is invalid")
-        address = rule["owner_address"]
-        binding = binding_index.get(address) if isinstance(address, str) else None
-        if binding is None or binding["owner_resource_type"] != rule["owner_resource_type"]:
-            raise ValueError("ACES rule owner is invalid")
-        if rule["direction"] not in _DIRECTIONS:
-            raise ValueError("ACES rule direction is invalid")
-        if rule["protocol"] not in _PROTOCOLS or rule["action"] not in _ACTIONS:
-            raise ValueError("ACES rule semantics are invalid")
-        for endpoint in ("from_network", "to_network"):
-            value = rule[endpoint]
-            if value is not None and value not in network_index:
-                raise ValueError("ACES rule endpoint is invalid")
-        _validate_ports(rule["ports"], str(rule["protocol"]))
-        identity = rule["name"]
-        order = rule["order"]
-        if (
-            not isinstance(identity, str)
-            or not _TOKEN.fullmatch(identity)
-            or not isinstance(order, int)
-            or isinstance(order, bool)
-            or order < 0
-        ):
-            raise ValueError("ACES rule ordering is invalid")
-        current = (str(address), order, identity)
+        current = _validate_aces_rule(
+            rule,
+            binding_index,
+            network_index,
+            seen_orders,
+            seen_names,
+        )
         if prior is not None and current < prior:
             raise ValueError("ACES rules are not deterministically ordered")
         prior = current
     return policy
+
+
+def _validated_network_index(
+    networks: Sequence[object],
+    *,
+    authority: str,
+) -> dict[str, dict[str, object]]:
+    index: dict[str, dict[str, object]] = {}
+    for network in networks:
+        validated = _validate_network(network)
+        name = str(validated["name"])
+        if name in index:
+            raise ValueError(f"{authority} network identities must be unique")
+        index[name] = validated
+    return index
+
+
+def _validate_address_pairs(
+    pairs: object,
+    family_key: str,
+    version: int,
+    networks: Mapping[str, Mapping[str, object]],
+) -> None:
+    if not isinstance(pairs, list):
+        raise ValueError("boundary owner addresses are invalid")
+    seen_networks: set[str] = set()
+    for pair in pairs:
+        if (
+            not isinstance(pair, list)
+            or len(pair) != 2
+            or not isinstance(pair[0], str)
+            or pair[0] not in networks
+            or not isinstance(pair[1], str)
+            or pair[0] in seen_networks
+        ):
+            raise ValueError("boundary owner address is invalid")
+        parsed = ipaddress.ip_address(pair[1])
+        cidr = networks[pair[0]][family_key.replace("_by_network", "_cidr")]
+        if (
+            parsed.version != version
+            or not isinstance(cidr, str)
+            or parsed not in ipaddress.ip_network(cidr, strict=False)
+        ):
+            raise ValueError("boundary owner address is outside its network")
+        seen_networks.add(pair[0])
+
+
+def _validate_aces_binding(
+    binding: object,
+    networks: Mapping[str, Mapping[str, object]],
+    index: dict[str, dict[str, object]],
+) -> None:
+    if not isinstance(binding, dict) or set(binding) != {
+        "owner_address",
+        "owner_resource_type",
+        "ipv4_by_network",
+        "ipv6_by_network",
+    }:
+        raise ValueError("ACES owner binding is invalid")
+    owner = binding["owner_address"]
+    kind = binding["owner_resource_type"]
+    if (
+        not isinstance(owner, str)
+        or not _TOKEN.fullmatch(owner)
+        or not isinstance(kind, str)
+        or kind not in {"node", "network"}
+        or owner in index
+    ):
+        raise ValueError("ACES owner identity is invalid")
+    _validate_address_pairs(binding["ipv4_by_network"], "ipv4_by_network", 4, networks)
+    _validate_address_pairs(binding["ipv6_by_network"], "ipv6_by_network", 6, networks)
+    if binding["ipv6_by_network"]:
+        raise ValueError("ACES ACL owner addresses must remain IPv4-only")
+    if kind == "node" and not (
+        binding["ipv4_by_network"] or binding["ipv6_by_network"]
+    ):
+        raise ValueError("ACES node owner has no exact address")
+    index[owner] = binding
+
+
+def _validate_aces_rule(
+    rule: object,
+    bindings: Mapping[str, Mapping[str, object]],
+    networks: Mapping[str, Mapping[str, object]],
+    seen_orders: set[tuple[str, int]],
+    seen_names: set[tuple[str, str]],
+) -> tuple[str, int, str]:
+    fields = {
+        "owner_address",
+        "owner_resource_type",
+        "owner_name",
+        "name",
+        "order",
+        "direction",
+        "from_network",
+        "to_network",
+        "protocol",
+        "ports",
+        "action",
+    }
+    if not isinstance(rule, dict) or set(rule) != fields:
+        raise ValueError("ACES rule is invalid")
+    owner = rule["owner_address"]
+    binding = bindings.get(owner) if isinstance(owner, str) else None
+    if binding is None or binding["owner_resource_type"] != rule["owner_resource_type"]:
+        raise ValueError("ACES rule owner is invalid")
+    _validate_aces_rule_semantics(rule, binding, networks)
+    identity = str(rule["name"])
+    order = int(rule["order"])
+    order_key = (owner, order)
+    name_key = (owner, identity)
+    if order_key in seen_orders or name_key in seen_names:
+        raise ValueError("ACES rule identity is not unique")
+    seen_orders.add(order_key)
+    seen_names.add(name_key)
+    return owner, order, identity
+
+
+def _validate_aces_rule_semantics(
+    rule: Mapping[str, object],
+    binding: Mapping[str, object],
+    networks: Mapping[str, Mapping[str, object]],
+) -> None:
+    direction = rule["direction"]
+    protocol = rule["protocol"]
+    action = rule["action"]
+    owner_name = rule["owner_name"]
+    identity = rule["name"]
+    order = rule["order"]
+    if not isinstance(direction, str) or direction not in _DIRECTIONS:
+        raise ValueError("ACES rule direction is invalid")
+    if (
+        not isinstance(protocol, str)
+        or protocol not in _PROTOCOLS
+        or not isinstance(action, str)
+        or action not in _ACTIONS
+    ):
+        raise ValueError("ACES rule semantics are invalid")
+    if any(
+        rule[endpoint] is not None
+        and (not isinstance(rule[endpoint], str) or rule[endpoint] not in networks)
+        for endpoint in ("from_network", "to_network")
+    ):
+        raise ValueError("ACES rule endpoint is invalid")
+    _validate_ports(rule["ports"], protocol)
+    if (
+        not isinstance(identity, str)
+        or not _TOKEN.fullmatch(identity)
+        or not isinstance(owner_name, str)
+        or not _TOKEN.fullmatch(owner_name)
+        or not isinstance(order, int)
+        or isinstance(order, bool)
+        or order < 0
+    ):
+        raise ValueError("ACES rule ordering is invalid")
+    if binding["owner_resource_type"] == "network" and owner_name not in networks:
+        raise ValueError("ACES network owner is unresolved")
 
 
 def _validate_platform(policy: dict[str, object]) -> dict[str, object]:
@@ -190,6 +306,7 @@ def _validate_platform(policy: dict[str, object]) -> dict[str, object]:
             "owner",
             "policy_digest",
             "networks",
+            "zone_networks",
             "anchors",
             "crossings",
             "egress_ports",
@@ -203,77 +320,128 @@ def _validate_platform(policy: dict[str, object]) -> dict[str, object]:
     if policy["default_deny"] is not True:
         raise ValueError("platform policy must be default deny")
     anchors = policy["anchors"]
+    zone_networks = policy["zone_networks"]
     crossings = policy["crossings"]
     networks = policy["networks"]
     egress_ports = policy["egress_ports"]
     if (
         not isinstance(anchors, list)
+        or not isinstance(zone_networks, list)
         or not isinstance(crossings, list)
         or not isinstance(networks, list)
     ):
         raise ValueError("platform policy collections must be lists")
-    network_index = {
-        network["name"]: _validate_network(network)
-        for network in networks
-        if isinstance(network, dict)
-    }
-    if len(network_index) != len(networks):
-        raise ValueError("platform network identities must be unique")
+    network_index = _validated_platform_networks(networks)
     _validate_ports(egress_ports, "tcp")
+    zone_network_index = _validated_zone_networks(zone_networks, network_index)
     zones: set[str] = set()
     for anchor in anchors:
-        if (
-            not isinstance(anchor, dict)
-            or set(anchor) != {"zone", "workload"}
-            or anchor["zone"] not in _ZONES
-            or anchor["zone"] in zones
-        ):
-            raise ValueError("platform anchor is invalid")
-        zones.add(str(anchor["zone"]))
-        workload = anchor["workload"]
-        if not isinstance(workload, dict) or set(workload) != {
-            "identity",
-            "labels",
-            "ipv4_by_network",
-            "ipv6_by_network",
-        }:
-            raise ValueError("platform workload is invalid")
-        if not isinstance(workload["identity"], str) or not _TOKEN.fullmatch(
-            workload["identity"]
-        ):
-            raise ValueError("platform workload identity is invalid")
-        for family_key in ("ipv4_by_network", "ipv6_by_network"):
-            pairs = workload[family_key]
-            if not isinstance(pairs, list):
-                raise ValueError("platform workload addresses are invalid")
-            for pair in pairs:
-                if (
-                    not isinstance(pair, list)
-                    or len(pair) != 2
-                    or pair[0] not in network_index
-                    or not isinstance(pair[1], str)
-                ):
-                    raise ValueError("platform workload address is invalid")
-                ipaddress.ip_address(pair[1])
+        zones.add(
+            _validate_platform_anchor(
+                anchor,
+                networks=network_index,
+                zone_networks=zone_network_index,
+                seen=zones,
+            )
+        )
+    if zones != _ZONES:
+        raise ValueError("platform zones are incomplete")
     for crossing in crossings:
-        if not isinstance(crossing, dict) or set(crossing) != {
-            "source",
-            "destination",
-            "protocol",
-            "ports",
-            "purpose",
-        }:
-            raise ValueError("platform crossing is invalid")
-        if (
-            crossing["source"] not in zones
-            or crossing["destination"] not in zones
-            or crossing["protocol"] not in {"tcp", "udp"}
-            or not isinstance(crossing["purpose"], str)
-            or not crossing["purpose"]
-        ):
-            raise ValueError("platform crossing semantics are invalid")
-        _validate_ports(crossing["ports"], str(crossing["protocol"]), required=True)
+        _validate_platform_crossing(crossing, zones)
     return policy
+
+
+def _validated_platform_networks(
+    networks: Sequence[object],
+) -> dict[str, dict[str, object]]:
+    index = _validated_network_index(networks, authority="platform")
+    if len(index) != 3 or any(
+        network["ipv6_cidr"] is not None for network in index.values()
+    ):
+        raise ValueError("platform requires three IPv4-only networks")
+    return index
+
+
+def _validated_zone_networks(
+    values: Sequence[object],
+    networks: Mapping[str, object],
+) -> dict[str, str]:
+    index: dict[str, str] = {}
+    for item in values:
+        if not isinstance(item, dict) or set(item) != {"zone", "network"}:
+            raise ValueError("platform zone network is invalid")
+        zone = item["zone"]
+        network = item["network"]
+        if (
+            not isinstance(zone, str)
+            or not isinstance(network, str)
+            or zone not in _ZONES
+            or zone in index
+            or network not in networks
+        ):
+            raise ValueError("platform zone network is invalid")
+        index[zone] = network
+    if set(index) != _ZONES or set(index.values()) != set(networks):
+        raise ValueError("platform zone networks must be exact and distinct")
+    return index
+
+
+def _validate_platform_anchor(
+    anchor: object,
+    *,
+    networks: Mapping[str, Mapping[str, object]],
+    zone_networks: Mapping[str, str],
+    seen: set[str],
+) -> str:
+    if not isinstance(anchor, dict) or set(anchor) != {"zone", "workload"}:
+        raise ValueError("platform anchor is invalid")
+    zone = anchor["zone"]
+    if not isinstance(zone, str) or zone not in _ZONES or zone in seen:
+        raise ValueError("platform anchor is invalid")
+    workload = anchor["workload"]
+    fields = {"identity", "labels", "ipv4_by_network", "ipv6_by_network"}
+    if not isinstance(workload, dict) or set(workload) != fields:
+        raise ValueError("platform workload is invalid")
+    _validate_labels(workload["labels"])
+    identity = workload["identity"]
+    if not isinstance(identity, str) or not _TOKEN.fullmatch(identity):
+        raise ValueError("platform workload identity is invalid")
+    ipv4 = workload["ipv4_by_network"]
+    if not isinstance(ipv4, list) or not ipv4 or workload["ipv6_by_network"] != []:
+        raise ValueError("platform workload must have an IPv4 attachment")
+    _validate_address_pairs(ipv4, "ipv4_by_network", 4, networks)
+    _validate_address_pairs(workload["ipv6_by_network"], "ipv6_by_network", 6, networks)
+    attached = {
+        str(pair[0]) for pair in ipv4 if isinstance(pair, list) and len(pair) == 2
+    }
+    if zone_networks[zone] not in attached:
+        raise ValueError("platform anchor is absent from its policy network")
+    return zone
+
+
+def _validate_platform_crossing(
+    crossing: object,
+    zones: set[str],
+) -> None:
+    fields = {"source", "destination", "protocol", "ports", "purpose"}
+    if not isinstance(crossing, dict) or set(crossing) != fields:
+        raise ValueError("platform crossing is invalid")
+    source = crossing["source"]
+    destination = crossing["destination"]
+    protocol = crossing["protocol"]
+    purpose = crossing["purpose"]
+    if (
+        not isinstance(source, str)
+        or not isinstance(destination, str)
+        or not isinstance(protocol, str)
+        or source not in zones
+        or destination not in zones
+        or protocol not in {"tcp", "udp"}
+        or not isinstance(purpose, str)
+        or not purpose
+    ):
+        raise ValueError("platform crossing semantics are invalid")
+    _validate_ports(crossing["ports"], protocol, required=True)
 
 
 def _validate_ports(value: object, protocol: str, *, required: bool = False) -> None:
@@ -281,9 +449,7 @@ def _validate_ports(value: object, protocol: str, *, required: bool = False) -> 
         not isinstance(value, list)
         or (required and not value)
         or any(
-            not isinstance(port, int)
-            or isinstance(port, bool)
-            or not 0 < port <= 65535
+            not isinstance(port, int) or isinstance(port, bool) or not 0 < port <= 65535
             for port in value
         )
         or (value and protocol not in {"tcp", "udp"})
@@ -315,7 +481,7 @@ def _transport(rule: Mapping[str, object]) -> str:
             suffix = f" dport {rendered}"
         return f"{protocol}{suffix}"
     if protocol == "icmp":
-        return "meta l4proto { icmp, ipv6-icmp }"
+        return "meta l4proto icmp"
     return ""
 
 
@@ -352,9 +518,7 @@ def _address_expression(
     return parts
 
 
-def _binding_addresses(
-    binding: Mapping[str, object], network: str | None
-) -> list[str]:
+def _binding_addresses(binding: Mapping[str, object], network: str | None) -> list[str]:
     pairs = binding["ipv4_by_network"]
     assert isinstance(pairs, list)
     return [
@@ -379,9 +543,7 @@ def _aces_rule_expressions(
         if isinstance(item, dict) and item["owner_address"] == rule["owner_address"]
     )
     directions = (
-        ("in", "out")
-        if rule["direction"] == "inout"
-        else (str(rule["direction"]),)
+        ("in", "out") if rule["direction"] == "inout" else (str(rule["direction"]),)
     )
     expressions: list[str] = []
     for direction in directions:
@@ -393,9 +555,7 @@ def _aces_rule_expressions(
             source_ref, destination_ref, networks, family=family
         )
         if family == "inet":
-            parts.extend(
-                _address_expression(source_ref, destination_ref, networks)
-            )
+            parts.extend(_address_expression(source_ref, destination_ref, networks))
         if binding["owner_resource_type"] == "network":
             owner_name = str(rule["owner_name"])
             if direction == "in":
@@ -421,10 +581,8 @@ def _aces_rule_expressions(
         if transport:
             parts.append(transport)
         parts.append("return" if rule["action"] == "allow" else "drop")
-        identity = (
-            f"{rule['owner_address']}/{rule['name']}/{direction}"
-        )
-        parts.extend(["comment", _quoted(identity)])
+        identity = f"{rule['owner_address']}/{rule['name']}/{direction}"
+        parts.extend(["comment", _quoted(_rule_marker(identity))])
         expressions.append("    " + " ".join(parts))
     return expressions
 
@@ -443,8 +601,7 @@ def _aces_table(
         (
             "  comment "
             + _quoted(
-                f"aptl-owner={_owner_marker(owner)},"
-                f"authority=aces,digest={digest}"
+                f"aptl-owner={_owner_marker(owner)},authority=aces,digest={digest}"
             )
         ),
     ]
@@ -457,14 +614,17 @@ def _aces_table(
         chain_by_owner[owner_address] = chain
         lines.append(f"  chain {chain} {{")
         for rule in rules:
-            if (
-                isinstance(rule, Mapping)
-                and rule["owner_address"] == owner_address
-            ):
-                lines.extend(
-                    _aces_rule_expressions(policy, rule, family=family)
-                )
-        lines.extend(["    return", "  }"])
+            if isinstance(rule, Mapping) and rule["owner_address"] == owner_address:
+                lines.extend(_aces_rule_expressions(policy, rule, family=family))
+        lines.extend(
+            [
+                (
+                    "    return comment "
+                    + _quoted(_rule_marker(f"{owner_address}/default"))
+                ),
+                "  }",
+            ]
+        )
     lines.extend(
         [
             "  chain forward {",
@@ -484,27 +644,32 @@ def _aces_table(
                 if len(addresses) == 1
                 else "{ " + ", ".join(addresses) + " }"
             )
-            lines.append(f"    ip daddr {rendered} jump {chain}")
-            lines.append(f"    ip saddr {rendered} jump {chain}")
+            lines.append(
+                f"    ip daddr {rendered} jump {chain} comment "
+                + _quoted(_rule_marker(f"{owner_address}/dispatch/in"))
+            )
+            lines.append(
+                f"    ip saddr {rendered} jump {chain} comment "
+                + _quoted(_rule_marker(f"{owner_address}/dispatch/out"))
+            )
         else:
             owner_rules = [
                 rule
                 for rule in rules
-                if isinstance(rule, Mapping)
-                and rule["owner_address"] == owner_address
+                if isinstance(rule, Mapping) and rule["owner_address"] == owner_address
             ]
-            owner_names = {
-                str(rule["owner_name"]) for rule in owner_rules
-            }
+            owner_names = {str(rule["owner_name"]) for rule in owner_rules}
             for owner_name in sorted(owner_names):
                 bridge = str(networks[owner_name]["bridge"])
                 ingress = "ibrname" if family == "bridge" else "iifname"
                 egress = "obrname" if family == "bridge" else "oifname"
                 lines.append(
-                    f"    {egress} {_quoted(bridge)} jump {chain}"
+                    f"    {egress} {_quoted(bridge)} jump {chain} comment "
+                    + _quoted(_rule_marker(f"{owner_address}/dispatch/in"))
                 )
                 lines.append(
-                    f"    {ingress} {_quoted(bridge)} jump {chain}"
+                    f"    {ingress} {_quoted(bridge)} jump {chain} comment "
+                    + _quoted(_rule_marker(f"{owner_address}/dispatch/out"))
                 )
     lines.extend(["  }", "}"])
     return lines
@@ -544,8 +709,7 @@ def _platform_table(
         (
             "  comment "
             + _quoted(
-                f"aptl-owner={_owner_marker(owner)},"
-                f"authority=platform,digest={digest}"
+                f"aptl-owner={_owner_marker(owner)},authority=platform,digest={digest}"
             )
         ),
         "  chain forward {",
@@ -560,21 +724,19 @@ def _platform_table(
             # depends on a stale neighbor cache and fails after a clean boot.
             lines.append(
                 f"    ibrname {_quoted(bridge)} obrname {_quoted(bridge)} "
-                "ether type arp accept comment \"platform/arp\""
+                'ether type arp accept comment "platform/arp"'
             )
             lines.append(
                 f"    ibrname {_quoted(bridge)} obrname {_quoted(bridge)} "
                 "ether type ip6 meta l4proto ipv6-icmp "
                 "icmpv6 type { nd-neighbor-solicit, nd-neighbor-advert } "
-                "accept comment \"platform/nd\""
+                'accept comment "platform/nd"'
             )
     for crossing in crossings:
         if not isinstance(crossing, Mapping):
             continue
         source_addresses = _workload_ipv4(anchors[str(crossing["source"])])
-        destination_addresses = _workload_ipv4(
-            anchors[str(crossing["destination"])]
-        )
+        destination_addresses = _workload_ipv4(anchors[str(crossing["destination"])])
         ingress = "ibrname" if family == "bridge" else "iifname"
         egress = "obrname" if family == "bridge" else "oifname"
         ports = crossing["ports"]
@@ -585,9 +747,7 @@ def _platform_table(
             else "{ " + ", ".join(str(port) for port in ports) + " }"
         )
         identity = f"platform/{crossing['purpose']}"
-        for network_name in sorted(
-            set(source_addresses) & set(destination_addresses)
-        ):
+        for network_name in sorted(set(source_addresses) & set(destination_addresses)):
             bridge = str(networks[network_name]["bridge"])
             source = source_addresses[network_name]
             destination = destination_addresses[network_name]
@@ -595,13 +755,13 @@ def _platform_table(
                 f"    {ingress} {_quoted(bridge)} {egress} {_quoted(bridge)} "
                 f"ip saddr {source} ip daddr {destination} "
                 f"{crossing['protocol']} dport {rendered_ports} accept "
-                f"comment {_quoted(identity)}"
+                f"comment {_quoted(_rule_marker(identity))}"
             )
             lines.append(
                 f"    {ingress} {_quoted(bridge)} {egress} {_quoted(bridge)} "
                 f"ip saddr {destination} ip daddr {source} "
                 f"ct state established,related accept "
-                f"comment {_quoted(identity + '/reply')}"
+                f"comment {_quoted(_rule_marker(identity + '/reply'))}"
             )
     if family == "inet":
         egress_anchor = anchors.get("egress")
@@ -619,25 +779,46 @@ def _platform_table(
                 "192.0.0.0/24, 192.168.0.0/16, 198.18.0.0/15, "
                 "224.0.0.0/4, 240.0.0.0/4 }"
             )
-            for network_name, source in sorted(
-                _workload_ipv4(egress_anchor).items()
-            ):
+            zone_networks = policy["zone_networks"]
+            assert isinstance(zone_networks, list)
+            egress_network = next(
+                str(item["network"])
+                for item in zone_networks
+                if isinstance(item, Mapping) and item["zone"] == "egress"
+            )
+            egress_sources = _workload_ipv4(egress_anchor)
+            for network_name, source in sorted(egress_sources.items()):
+                if network_name != egress_network:
+                    continue
                 bridge = str(networks[network_name]["bridge"])
+                lines.append(
+                    f"    oifname {_quoted(bridge)} ip daddr {source} "
+                    "ct state established,related accept comment "
+                    + _quoted(
+                        _rule_marker("platform/egress-broker-reply/" + network_name)
+                    )
+                )
                 lines.append(
                     f"    iifname {_quoted(bridge)} ip saddr {source} "
                     f"ip daddr {denied_ipv4} drop "
-                    f"comment {_quoted('platform/egress-denied-range')}"
+                    f"comment {_quoted(_rule_marker('platform/egress-denied-range/' + network_name))}"
                 )
                 lines.append(
                     f"    iifname {_quoted(bridge)} ip saddr {source} "
                     f"tcp dport {rendered_ports} accept "
-                    f"comment {_quoted('platform/egress-broker')}"
+                    f"comment {_quoted(_rule_marker('platform/egress-broker/' + network_name))}"
                 )
     for bridge in sorted(str(item["bridge"]) for item in networks.values()):
         ingress = "ibrname" if family == "bridge" else "iifname"
         egress = "obrname" if family == "bridge" else "oifname"
-        lines.append(f"    {ingress} {_quoted(bridge)} drop")
-        lines.append(f"    {egress} {_quoted(bridge)} drop")
+        lines.append(
+            f"    {ingress} {_quoted(bridge)} drop comment "
+            + _quoted(_rule_marker(f"platform/default-ingress/{bridge}"))
+        )
+        lines.append(
+            f"    {egress} {_quoted(bridge)} drop comment "
+            + _quoted(_rule_marker(f"platform/default-egress/{bridge}"))
+        )
     lines.extend(["  }"])
     if family == "inet":
         for chain, hook, interface in (
@@ -651,7 +832,10 @@ def _platform_table(
                 ]
             )
             for bridge in sorted(str(item["bridge"]) for item in networks.values()):
-                lines.append(f"    {interface} {_quoted(bridge)} drop")
+                lines.append(
+                    f"    {interface} {_quoted(bridge)} drop comment "
+                    + _quoted(_rule_marker(f"platform/{chain}/{bridge}"))
+                )
             lines.append("  }")
     lines.append("}")
     return lines
@@ -713,6 +897,87 @@ def _table_comment(family: str, table_name: str) -> str | None:
     return None
 
 
+def _table_payload(family: str, table_name: str) -> dict[str, object]:
+    try:
+        return _nft_json("list", "table", family, table_name)
+    except RuntimeError:
+        return {}
+
+
+def _expected_chains(
+    policy: Mapping[str, object],
+    family: str,
+) -> dict[str, tuple[str | None, int | None, str | None]]:
+    if policy["authority"] == "platform":
+        expected = {"forward": ("forward", -300, "accept")}
+        if family == "inet":
+            expected.update(
+                {
+                    "host_input": ("input", -300, "accept"),
+                    "host_output": ("output", -300, "accept"),
+                }
+            )
+        return expected
+    bindings = policy["owner_bindings"]
+    assert isinstance(bindings, list)
+    expected = {"forward": ("forward", -200, "accept")}
+    for binding in bindings:
+        if isinstance(binding, Mapping):
+            address = str(binding["owner_address"])
+            chain = "owner_" + hashlib.sha256(address.encode()).hexdigest()[:12]
+            expected[chain] = (None, None, None)
+    return expected
+
+
+def _expected_rule_comments(
+    policy: Mapping[str, object],
+    family: str,
+    table_name: str,
+) -> list[str]:
+    renderer = _aces_table if policy["authority"] == "aces" else _platform_table
+    comments: list[str] = []
+    for line in renderer(policy, family, table_name):
+        if not line.startswith("    ") or " comment " not in line:
+            continue
+        raw = line.rsplit(" comment ", 1)[1]
+        value = json.loads(raw)
+        if not isinstance(value, str):
+            raise RuntimeError("boundary expected rule identity was invalid")
+        comments.append(value)
+    return sorted(comments)
+
+
+def _verify_observed_family(
+    policy: Mapping[str, object],
+    family: str,
+) -> bool:
+    table_name = _table_name(str(policy["owner"]), str(policy["authority"]))
+    payload = _table_payload(family, table_name)
+    nftables = payload.get("nftables", [])
+    if not isinstance(nftables, list):
+        return False
+    chains: dict[str, tuple[str | None, int | None, str | None]] = {}
+    comments: list[str] = []
+    for item in nftables:
+        if not isinstance(item, dict):
+            continue
+        chain = item.get("chain")
+        if isinstance(chain, dict) and isinstance(chain.get("name"), str):
+            chains[str(chain["name"])] = (
+                chain.get("hook") if isinstance(chain.get("hook"), str) else None,
+                chain.get("prio") if isinstance(chain.get("prio"), int) else None,
+                chain.get("policy") if isinstance(chain.get("policy"), str) else None,
+            )
+        rule = item.get("rule")
+        if isinstance(rule, dict) and isinstance(rule.get("comment"), str):
+            comments.append(str(rule["comment"]))
+        elif isinstance(rule, dict):
+            return False
+    return chains == _expected_chains(policy, family) and sorted(
+        comments
+    ) == _expected_rule_comments(policy, family, table_name)
+
+
 def _owned_families(policy: Mapping[str, object]) -> tuple[str, ...]:
     owner = str(policy["owner"])
     authority = str(policy["authority"])
@@ -749,6 +1014,8 @@ def _apply(policy: dict[str, object]) -> dict[str, object]:
     observed = _owned_families(policy)
     if observed != ("bridge", "inet"):
         raise RuntimeError("boundary tables were not observed")
+    if not all(_verify_observed_family(policy, family) for family in observed):
+        raise RuntimeError("boundary rule readback did not match")
     return _receipt(policy, observed)
 
 
@@ -773,6 +1040,8 @@ def _observe(policy: dict[str, object]) -> dict[str, object]:
         comment = _table_comment(family, table_name) or ""
         if f"digest={digest}" not in comment:
             raise RuntimeError("boundary policy digest mismatch")
+        if not _verify_observed_family(policy, family):
+            raise RuntimeError("boundary rule readback did not match")
     return _receipt(policy, families)
 
 
@@ -791,6 +1060,8 @@ def main() -> int:
     except (
         ValueError,
         RuntimeError,
+        KeyError,
+        TypeError,
         OSError,
         subprocess.SubprocessError,
         json.JSONDecodeError,

--- a/docs/aces/app-1-appliance-boundary-materialization-preflight.md
+++ b/docs/aces/app-1-appliance-boundary-materialization-preflight.md
@@ -1,0 +1,318 @@
+# APP-1 Appliance Boundary Materialization Preflight
+
+This note is the architecture preflight for APP-1 / issue #822. It narrows
+[ADR-049](../adrs/adr-049-sealed-disposable-lab-appliance.md) for boundary
+materialization and verification; it is guidance, not an implementation plan.
+
+## Authority And Contract Boundaries
+
+APP-1 composes two policy authorities. It must not merge them into an
+appliance-owned topology model.
+
+| Authority | Owns | Must Not Own |
+| --- | --- | --- |
+| Admitted ACES realization | Scenario nodes, networks, links, domain bindings, infrastructure ACLs, services, runtime publications, and exercise effects | Participant, management, egress, physical-host, recovery, or Docker-daemon policy |
+| Signed appliance platform policy | Participant/management/egress placement, default-deny inter-zone baseline, controlled external destinations, guest-Docker authority, guest-host publications, and the outer host/recovery contract | Scenario node identity, red/blue/target membership, scenario service lists, target subnets, or a copy of ACES ACLs |
+
+The effective policy is the intersection of those authorities. Platform policy
+may further deny an ACES flow but cannot add a scenario flow; admitted ACES
+policy cannot weaken host, management, egress, metadata, Docker-authority, or
+participant-ingress controls. A conflict is a fatal admission/materialization
+diagnostic, never a precedence guess.
+
+ACES remains authoritative through `ACLRule`, SDL parsing and semantic
+validation, scenario instantiation, the compiler's `ProvisioningPlan`, planner
+diagnostics, and `RuntimeManager`. APTL must lower the admitted ACL values into
+the existing `AptlRealization` to `DeploymentRealizationSpec` seam. It must not
+add an APTL ACL authoring schema, parse the scenario file a second time, or
+derive policy from Compose networks.
+
+The backend-facing typed value must retain the owning ACES resource address,
+source and destination references, direction, action, protocol, ports, and
+deterministic authored order. Descriptive prose is not policy. The provider
+boundary must reject malformed direct `ProvisioningPlan` payloads and any
+direction, endpoint form, action, protocol, port combination, wildcard, or rule
+precedence it cannot enforce exactly. This is provider capability validation,
+not a duplicate SDL schema.
+
+`create_aptl_manifest()` currently declares `supports_acls=False`. That claim
+must remain false until the selected backend can validate, materialize, read
+back, and negatively test the complete supported ACL subset. Flipping the bit
+after translation alone would bypass the planner's existing
+`provisioner.acls-unsupported` fail-closed gate.
+
+The platform half is one versioned, signed appliance-boundary policy contract.
+It is payload policy, not mutable `aptl.json` configuration and not an
+environment-variable bag. It carries only platform-owned zone classes,
+allowed participant ingress and recovery exposure, controlled egress
+destinations and purposes, Docker-authority constraints, resource limits, and
+policy version/identity. Egress credentials remain in the ADR-049
+secret-bootstrap channel and never enter this contract.
+
+## Materialize Then Observe
+
+The existing interpret-then-driver design remains binding:
+
+1. ACES parsing, planning, manifest gating, and APTL provider validation produce
+   one complete typed desired boundary without native side effects.
+2. `DeploymentBackend.realize()` applies the typed scenario realization and
+   appliance policy through narrow backend operations using the existing
+   project scope, runner, argv-list, timeout, logging, and `LabResult`
+   behavior.
+3. Provider readback produces one fresh, redacted boundary inventory. Desired
+   data, generated firewall text, a successful command, and a running
+   container are not observed enforcement.
+4. The desired-versus-observed gate blocks a successful ACES `ApplyResult` and
+   appliance readiness on any missing, extra, ambiguous, stale, unsupported,
+   or unverifiable boundary fact.
+
+All validation that can be performed without side effects must finish before
+the first mutation. Enforcement must have a deny baseline before an untrusted
+workload can run. Policy updates must be atomic or staged so a failure retains
+the last verified deny posture; rollback must never reopen traffic.
+
+This ordering exposes an existing incompatibility that implementation must
+address. `_compose_base_substrate.start_base_container()` currently starts an
+image-free node on Docker's implicit default bridge, and package refresh/install
+occurs before `_disconnect_default_bridge()` runs during later network
+reconciliation. Supported appliance mode cannot reuse that window. A node must
+start with no ambient network and receive only admitted attachments; any
+provisioning download must traverse an explicit platform-owned update path.
+Kali and target nodes must never receive temporary general egress because
+materialization is still in progress.
+
+Likewise, a Docker network marked `internal`, a loopback bind, a listener, a
+successful TCP probe, and a firewall authorization are distinct facts. None is
+proof of another. Multi-homed ordinary workloads must have forwarding disabled;
+only a platform-owned gateway may route, resolve, proxy, or inspect across
+zones.
+
+## Fail-Closed Boundary Inventory
+
+APP-1 needs one versioned appliance-boundary inventory because neither existing
+inventory surface has the required semantics:
+
+- `RuntimeSnapshot` is the ACES realization/SEM-218 disclosure surface.
+- `RangeSnapshot` is a broader operational snapshot whose capture failure is
+  deliberately non-fatal under ADR-030.
+
+The boundary inventory is a security verdict, so it may reuse their normalized
+backend observations but must not be represented as an optional
+`RangeSnapshot` section or a second ACES runtime snapshot. Image qualification
+and every appliance start consume the same contract and verifier. A
+qualification report proves the qualified payload; it is not fresh evidence
+for a later boot.
+
+The inventory must carry bounded, non-secret facts:
+
+- schema, policy, payload, ACES plan, and verifier identities/digests;
+- qualification/start phase plus a fresh appliance-boot and guest-Docker
+  instance identity;
+- desired policy digest and observed enforcement mechanism/version;
+- observed networks, zone classifications, node attachments, routing and
+  forwarding disposition;
+- guest-host publications and separately supplied physical-host forwards and
+  listeners;
+- controlled DNS, time, proxy, and egress disposition, including denied
+  private, link-local, metadata, venue, host, and arbitrary-internet classes;
+- Docker authority holders, socket/API endpoint identity, privileged/container
+  authority features, and proof that the daemon is the disposable guest
+  daemon;
+- positive and negative probe verdicts, stable finding codes, observation
+  completeness, and the final pass/fail decision.
+
+It must omit credentials, authorization headers, environment values, raw
+Docker inspect payloads, raw firewall/routing output, command lines, host
+absolute paths, generated secret-bearing config, and evidence bytes.
+Structured serialization must pass through `redact()` before logging,
+persistence, API projection, or packaging. Runtime persistence uses the
+existing `RunStorageBackend`/`LocalRunStore` boundary; qualification packages
+reference the same canonical redacted bytes and digest rather than defining a
+second report shape.
+
+The guest backend cannot observe the physical host from inside the security
+boundary. The appliance envelope/launcher therefore supplies an authenticated,
+fresh outer-host observation using the same inventory contract. Missing host
+observation, an unrecognized observation capability, or a boot/daemon identity
+mismatch is fatal in supported appliance mode. Issue #824 may provide the
+launcher mechanics; APP-1 must define and require the input rather than infer
+physical-host safety from guest loopback bindings.
+
+## Required Existing Cross-Cutting Owners
+
+| Concern | Canonical incumbent to extend or consume |
+| --- | --- |
+| ACES shape and semantics | `aces_sdl.infrastructure.ACLRule`, `parse_sdl_file()`, semantic validation, instantiation, compiler, `ProvisioningPlan`, planner diagnostics, `RuntimeManager`, and ACES `Diagnostic` |
+| Capability honesty | `src/aptl/backends/aces_manifest.py` and its current `supports_acls=False` claim |
+| Interpretation | `aces_realization.py`, `aces_realization_values.py`, `aces_realization_networks.py`, `aces_realization_model.py`, and `aces_diagnostics.py` |
+| Apply and observation | `AptlProvisioner`, `observe_realization()`, `ObservedResource`, `snapshot_after_apply()`, and ACES's existing realization-disclosure gate |
+| Deployment authority | `DeploymentRealizationSpec`, `DeploymentBackend`, `DockerComposeBackend`, SSH transport parity where supported, Compose project labels, bounded runner calls, and `BackendTimeoutError` |
+| Runtime inventory | Backend host/container/network inventory, `ContainerSnapshot`, `NetworkSnapshot`, `container_networks()`, `list_container_snapshots()`, and runtime port normalization |
+| Host exposure | `runtime.network.published_ports`, `DeploymentPublishedPort`, `core.host_ports`, ADR-034, ADR-036, and `tests/test_docker_compose_port_bindings.py` |
+| Startup workflow | `core.lab`'s flat `_LAB_START_STEPS`, `LabResult`, `StartupOutcome`, `StartupDiagnostic`, and ADR-030/031 |
+| Config and secrets | Strict `AptlConfig`, `load_dotenv()`, `EnvVars`, placeholder checks, generated-state containment, ADR-025/028/029, and the ADR-049 bootstrap channel |
+| Persistence and redaction | `RunStorageBackend`, `LocalRunStore`, evidence/content-store writers, `RangeSnapshot.to_dict()`, `redact()`, `get_logger()`, and ADR-012/029/044 |
+| API/auth if projected | Management-only FastAPI assembly, Pydantic schemas, `verify_token`, BFF Host/CSRF/session controls, narrow HTTP/WebSocket errors, and ADR-039/040 |
+| Repository gates | `.ground-control.yaml`, `.gc/plan-rules.md`, pytest, pre-commit, ACES static/live gates, Compose security tests, and clean-lab validation |
+
+Do not introduce an appliance-wide exception hierarchy, repository layer,
+policy service graph, second redactor, second readiness taxonomy, or generic
+Docker/firewall command passthrough. Stable ACES/provider failures use
+`Diagnostic` plus `render_aces_diagnostics()`. Backend failures use
+`LabResult`/`BackendTimeoutError`. At CLI/API/web edges the outcome is
+`StartupOutcome.FAILED` with bounded, redacted messages. Boundary uncertainty
+is not `DEGRADED_USABLE` or `DEGRADED_UNUSABLE`.
+
+## Security Layer Passage
+
+- **ACES admission:** closed-world SDL/Pydantic shape, reference validation,
+  variable instantiation, semantic checks, planner capability checks, and
+  planner diagnostics run before APTL translation. APTL never accepts raw ACL
+  YAML or treats a manifest flag as proof of enforcement.
+- **Provider validation:** the interpreter shape-checks public plan mappings,
+  resolves every endpoint to one admitted resource, preserves rule order, and
+  rejects unsupported IPv4/IPv6, protocol, direction, port, wildcard, and
+  precedence semantics before backend mutation.
+- **Platform-policy integrity:** the payload manifest verifies the boundary
+  policy version and digest. Unsupported schema versions, unsigned policy,
+  unknown delivery mode, or an unavailable enforcement/observation capability
+  fail closed.
+- **First-party config:** `AptlConfig(extra="forbid")` remains durable
+  non-secret operator configuration. It may select a supported delivery mode or
+  policy reference only where ADR-049's envelope permits; it does not mirror
+  policy rules, zones, ACES topology, or destination lists.
+- **Environment and secret binding:** existing `.env` and service-local strict
+  parsers remain authoritative for current secrets. Appliance/model credentials
+  use the narrow bootstrap parser, never ACL fields, policy documents, Docker
+  labels, frontend state, URLs, or inventory.
+- **Deployment/OS enforcement:** every Docker, network, route, firewall,
+  publication, mount, and inspect operation stays behind typed backend/envelope
+  operations. Enforcement and observation cover IPv4 and IPv6, forwarding,
+  DNS bypass, direct egress, metadata/link-local ranges, host/venue routes, and
+  daemon identity. An unavailable kernel/backend feature is fatal.
+- **Docker authority:** observed mounts, endpoints, namespaces, capabilities,
+  devices, privileged flags, and daemon identity are compared with one exact
+  platform allow-list. `/var/run/docker.sock` path matching alone is
+  insufficient. Unknown holders, a host/remote daemon, a generic Docker proxy,
+  or an uninspectable authority path fail closed.
+- **Process exposure:** argv lists remain mandatory. Policy/secret material does
+  not enter shell strings, process titles, healthchecks, exception text, or raw
+  support logs. Firewall/routing command output is parsed inside the backend
+  into bounded observations and never forwarded.
+- **API/auth:** APP-1 adds no participant API. Any management inventory
+  projection remains behind the existing operator auth/BFF/session/Host/CSRF
+  boundary and returns a narrow redacted DTO. The participant gateway receives
+  only coarse readiness, not the inventory or its raw findings.
+- **Error envelopes:** stable finding/diagnostic codes and safe resource
+  addresses cross ACES, core, CLI, and API boundaries. Raw exceptions, policy
+  documents, subprocess output, and inspect payloads do not.
+- **Persistence and observability:** redaction occurs before the first
+  structured write. Logs/traces contain policy/payload digests, stable codes,
+  counts, elapsed time, and verdict only. Opaque evidence remains governed by
+  the existing evidence sensitivity/export boundary.
+
+## Egress And Exposure Guardrails
+
+Controlled egress is a platform gateway/proxy/resolver concern, never a
+multi-homed Kali, target, DNS, Wazuh, or Suricata side effect. An exception is
+typed by purpose, source platform class, destination authority, protocol/port,
+resolution behavior, and failure disposition. Redirects, DNS rebinding, proxy
+`CONNECT`, direct DNS/DoH, QUIC/UDP alternatives, IPv6, and provider addresses
+that resolve into denied ranges must not bypass that decision. Secret material
+is referenced from management state, not embedded in the exception.
+
+Container-to-guest publishing and guest-to-physical-host forwarding are
+separate inventory fields. ACES `Node.services` is listener intent;
+`runtime.network.published_ports` is container-to-guest publication; the
+appliance envelope alone owns physical-host participant/recovery forwarding.
+None implies firewall authorization. In appliance mode, an explicit ACES
+all-interface publication may still be rejected by platform policy even though
+developer-local mode allows it.
+
+Current raw Docker socket mounts in `docker-compose.yml` (Shuffle components,
+Cortex, and the web API) are migration findings, not approved inventory
+defaults. A participant payload either disables the dependent feature or
+replaces it with fixed service-specific typed operations. A generic Docker API
+proxy remains guest-root authority and does not satisfy least privilege.
+
+The generic base substrate also requests host cgroup namespace access, a
+writable cgroup filesystem, Linux capabilities, and sometimes unconfined
+seccomp. Those are guest-host authority inside the appliance. The platform
+contract must explicitly admit and observe every such feature per workload;
+“inside a VM” is not blanket approval.
+
+## Extensibility And Whole-Repository Scope
+
+The extensibility seam is the versioned pair of a platform boundary policy
+reference and a boundary-observation adapter carried by ADR-049's appliance
+envelope. A future local hypervisor, hosted seat gateway, model provider, or
+approved update mirror varies that pair and its declared capabilities; it does
+not fork scenarios, Compose files, API DTOs, frontend bundles, or the verifier.
+Scenario variation remains entirely in admitted ACES resources.
+
+Implementation must reconcile all repository/runtime surfaces that can grant or
+observe authority:
+
+- the locked ACES dependency in `pyproject.toml`/`uv.lock`, backend manifest,
+  ACES adapter, provisioner, observation, diagnostics, and materializer;
+- deployment realization DTOs, backend Protocol/concrete backends, Compose
+  generated overrides, runner/timeout/error behavior, network reconciliation,
+  base-container startup, cleanup, and runtime inventory;
+- `docker-compose.yml`, `aptl.json`, `.env.example`, MCP configs, container
+  Dockerfiles, capabilities, devices, namespaces, socket/bind mounts,
+  healthchecks, networks, publications, and guest Docker-daemon configuration;
+- lab startup/readiness, snapshot/endpoint/host-port consumers, run/evidence
+  persistence, export, redaction, logging, and telemetry;
+- management API/web projections if any, participant route isolation, MCP
+  transport/config only where internal endpoint or egress placement changes;
+- guest firewall/routing/DNS/proxy state and the external launcher/hypervisor
+  listener, forwarding, device-sharing, and recovery observation supplied by
+  issue #824;
+- deployment/security/workshop/recovery documentation, `.ground-control.yaml`
+  boundary declarations, static policy tests, backend unit/integration tests,
+  qualification/live gates, and the clean-lab completion gate required for
+  Compose/container/config changes.
+
+## Gotchas And Anti-Patterns
+
+- Do not conflate service declaration, listener state, Docker publication,
+  firewall authorization, route existence, probe success, and end-to-end
+  reachability.
+- Do not flatten ACES ACLs and platform policy into one rule list with guessed
+  precedence, or let platform policy name current red/blue/target nodes.
+- Do not treat `internal: true`, network attachment, loopback, NAT, CORS, TLS,
+  or the VM boundary as enforcement proof.
+- Do not accept a policy because generated rules match desired text. Read back
+  effective kernel/provider state and run negative probes from the relevant
+  source zones.
+- Do not start workloads on Docker's default bridge and remove it later. Do not
+  permit temporary internet access for package installation.
+- Do not inspect only checked-in Compose. Generated overrides, image-free
+  `docker run` containers, runtime drift, outer-host forwarding, IPv6, and
+  alternate Docker endpoints are part of the observed surface.
+- Do not reuse a qualification inventory as runtime readiness, accept a prior
+  boot's report, or let incomplete observation pass with a warning.
+- Do not copy `RangeSnapshot`, endpoint registry, ACES runtime snapshot, or
+  Docker inspect schemas into the boundary inventory. Consume their normalized
+  facts and retain distinct semantics.
+- Do not put policy or credentials in argv, environment-driven rule fragments,
+  Docker labels, exception messages, support bundles, or participant-visible
+  status.
+- Do not advertise `supports_acls=True` until apply, observation, failure
+  atomicity, and live positive/negative conformance are all real.
+
+## Non-Goals And Implementation Boundary
+
+- Do not implement the disposable payload/image builder (#823), physical-host
+  launcher mechanics (#824), hosted fleet, participant UI, or model agent.
+- Do not redefine ACES ACLs, scenario topology, domain membership, services,
+  exercise effects, participant contracts, or evidence contracts.
+- Do not replace Docker/Compose as the inner deployment mechanism or make the
+  outer VM an ACES node provider.
+- Do not make developer-local Compose satisfy the supported participant
+  appliance contract; it may remain an explicitly separate mode.
+- Do not redesign current operator API auth, MCP schemas, run archive layout,
+  evidence acquisition, or lifecycle/reset semantics.
+- Do not broaden Kali/target egress, preserve unsafe socket-dependent optional
+  features, or weaken a required control because an enforcement or observation
+  mechanism is unavailable.

--- a/docs/components/appliance-boundary.md
+++ b/docs/components/appliance-boundary.md
@@ -1,0 +1,125 @@
+# Appliance Network Boundary
+
+The appliance boundary is the reusable materialization surface for
+[ADR-049](../adrs/adr-049-sealed-disposable-lab-appliance.md). It is not a
+TechVault topology and it does not assign scenario roles. It consumes two
+authorities without merging them:
+
+- The admitted ACES provisioning plan owns scenario networks, node
+  attachments, ACL owners, rule order, direction, endpoints, protocol, ports,
+  and action.
+- The signed appliance policy owns the participant, management, and egress
+  networks and workloads, fixed platform crossings, external authorities,
+  guest publications, and Docker authority constraints.
+
+The effective result is the intersection of these authorities. A policy
+conflict or an observation gap fails the boundary gate; neither authority
+wins through implicit precedence.
+
+## Materialization
+
+ACES ACLs pass through `AptlRealization`, `DeploymentRealizationSpec`, and the
+typed `DeploymentBackend` boundary. The Docker backend binds each ACES
+network and ACL owner to an observed bridge and address. It then installs a
+project-owned nftables table for the ACES authority. Node and network owners,
+authored order, `in`, `out`, `inout`, `allow`, `deny`, TCP, UDP, ICMP, and
+protocol-independent rules remain distinct.
+
+The supported ACL subset resolves named endpoints to exact IPv4 networks and
+preserves an authored omitted endpoint as ACES `any`, still scoped by the ACL
+owner. Unresolved networks, IPv6 endpoints, invalid port combinations,
+ambiguous owners, and malformed direct plans fail before native mutation.
+IPv6 remains default denied at the platform floor until dual-stack crossing
+realization is supported.
+
+The signed platform policy uses exact Docker label selectors for three
+distinct platform networks and three exact workload anchors. Scenario
+networks that do not carry those signed selectors are excluded from the
+platform table. This prevents the platform implementation from becoming a
+second authority for red, blue, or target topology.
+
+A participant or egress gateway may be multi-homed only across those three
+selected platform networks. A fixed crossing is emitted only when its exact
+source and destination anchors share an observed platform path. External
+egress is still authorized solely from the egress anchor's separately signed
+egress-side network.
+
+Both authorities use separate nftables tables. Replacement is one native
+transaction. Readback checks table ownership, policy digest, chain hooks,
+priority, default policy, and every expected rule identity. A missing,
+changed, or extra owned rule is fatal.
+
+Image-free nodes are created on their first declared ACES network and attached
+to all remaining declared networks before they start. There is no temporary
+Docker default-bridge or package-install egress window.
+
+## Participant Workbench
+
+The [participant workbench](participant-workbench.md) remains the source of
+the closed `red` and `blue` profile launch contracts. The boundary does not
+copy that profile model or infer a profile from a scenario name.
+
+The appliance payload places the participant browser gateway on the signed
+participant anchor and the installed agent and selected MCP processes on the
+signed management anchor. Fixed platform crossings authorize only the
+required participant-to-management and management-to-egress services.
+Profile-specific MCP destinations remain the typed, released server
+inventories from `aptl.workbench`; ACES remains authoritative for the
+scenario-side endpoints those servers use.
+
+## Controlled Egress
+
+External access uses the dedicated egress anchor. Management can reach the
+egress service only through a declared fixed crossing. The egress firewall
+drops private, loopback, link-local, carrier-grade NAT, benchmark, multicast,
+reserved, and metadata destinations before allowing the declared upstream
+TCP ports.
+
+The CONNECT broker receives a narrow projection of the signed exact DNS
+authorities and ports. It rejects IP literals, wildcard names, URLs,
+unapproved ports, redirects that do not create a new CONNECT request, empty
+DNS results, and any DNS result set containing a non-global address. IPv4
+addresses embedded through IPv4-mapped IPv6 or well-known NAT64 are checked
+the same way. Signed bounds cap concurrent connections, header size, header
+wait, upstream connect time, and tunnel idle time.
+
+An unavailable proxy, failed DNS lookup, unsafe DNS answer, timeout, refused
+upstream, policy mismatch, or missing firewall readback denies the request.
+There is no direct DNS, DoH, QUIC, UDP, or arbitrary Internet fallback.
+Version 1 admits TCP CONNECT authorities only. Browser, update, and
+model-provider exceptions must be exact signed authorities and must pass
+qualification probes. Participant processes do not receive direct NTP
+egress; appliance time comes from the sealed guest and outer lifecycle. A
+future external time service requires a new typed policy and enforcement
+version rather than a port-only exception.
+
+## Qualification And Start Gate
+
+Image qualification and every appliance start call the same boundary gate
+with a different phase value. The gate requires:
+
+- the exact signed policy, payload, and ACES plan digests;
+- the current boot identity and selected guest Docker daemon identity;
+- a fresh authenticated outer-host observation supplied by the launcher;
+- separate ACES and platform enforcement observations;
+- at least one successful allowed-flow probe and one successful denied-flow
+  probe;
+- an exact Docker authority-holder inventory with no privileged, host PID,
+  host network, device, or unapproved daemon access; and
+- only the signed participant and recovery publications on the physical host.
+
+The result is a bounded, redacted, machine-readable inventory. Missing host
+evidence, stale boot identity, an incomplete scan, an unapproved listener,
+rule drift, a failed probe, or an unknown Docker authority holder is fatal.
+The participant surface receives only coarse readiness.
+
+Appliance mode also binds the helper and egress-proxy images by full
+`name@sha256` references. A missing signed helper fails readiness; the backend
+does not build or substitute a mutable local tag. Developer-local ACES runs
+may build the checked-in helper, but that path is not appliance evidence.
+
+Issue #823 supplies the signed payload, policy file, packaged helper images,
+and image-qualification invocation. Issue #824 supplies the authenticated
+physical-host observation and invokes the same gate during seat launch. Those
+issues consume this boundary contract; they do not define its policy,
+enforcement semantics, or verdict rules.

--- a/docs/components/appliance-boundary.md
+++ b/docs/components/appliance-boundary.md
@@ -56,8 +56,11 @@ Docker default-bridge or package-install egress window.
 ## Participant Workbench
 
 The [participant workbench](participant-workbench.md) remains the source of
-the closed `red` and `blue` profile launch contracts. The boundary does not
-copy that profile model or infer a profile from a scenario name.
+the closed workbench launch contracts. The boundary does not copy that
+profile model or infer a profile from a scenario name. The bounded participant
+profile introduced by #820 currently composes `red` and `guided-blue`; another
+participant profile can select a different admitted sequence without changing
+the boundary schema or enforcement implementation.
 
 The appliance payload places the participant browser gateway on the signed
 participant anchor and the installed agent and selected MCP processes on the
@@ -66,6 +69,13 @@ required participant-to-management and management-to-egress services.
 Profile-specific MCP destinations remain the typed, released server
 inventories from `aptl.workbench`; ACES remains authoritative for the
 scenario-side endpoints those servers use.
+
+The participant-profile manifest, asset lock, and qualification report are
+independent signed-payload inputs. Issue #823 binds those #820 outputs together
+with this boundary policy and its helper/proxy image identities. The boundary
+therefore validates the shared workbench policy version and observed placement,
+but it does not duplicate the participant profile's capability inventory,
+resource budgets, or readiness suite.
 
 ## Controlled Egress
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Authoring Boundary: sdl/index.md
     - Curated ACES Variants: sdl/techvault-curated-variants.md
   - ACES:
+    - APP-1 Appliance Boundary Materialization Preflight: aces/app-1-appliance-boundary-materialization-preflight.md
     - TechVault Static Validation Preflight: aces/techvault-static-validation-preflight.md
     - TechVault Static Validation Gate: aces/techvault-static-validation-gate.md
     - TechVault Live Validation Preflight: aces/techvault-live-validation-preflight.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
     - MCP Integration: components/mcp-integration.md
     - MCP Smoke-Test Protocol: components/mcp-smoke-test-protocol.md
     - Participant Workbench: components/participant-workbench.md
+    - Appliance Network Boundary: components/appliance-boundary.md
   - Scenarios:
     - Authoring Boundary: sdl/index.md
     - Curated ACES Variants: sdl/techvault-curated-variants.md

--- a/src/aptl/backends/aces_acl_realization.py
+++ b/src/aptl/backends/aces_acl_realization.py
@@ -96,9 +96,7 @@ def _realize_acl(
         return None
     return DeploymentAclRealization(
         owner_address=resource.address,
-        owner_resource_type=cast(
-            Literal["node", "network"], resource.resource_type
-        ),
+        owner_resource_type=cast(Literal["node", "network"], resource.resource_type),
         owner_name=(
             network_names.get(resource.address, "")
             if resource.resource_type == "network"
@@ -150,14 +148,8 @@ def _validate_endpoint(
     diagnostics: list[Diagnostic],
 ) -> None:
     if not value:
-        diagnostics.append(
-            _acl_diagnostic(
-                resource,
-                "endpoint-wildcard-unsupported",
-                "ACES ACL wildcard endpoints are unsupported by this backend.",
-            )
-        )
-    elif value not in network_lookup:
+        return
+    if value not in network_lookup:
         diagnostics.append(
             _acl_diagnostic(
                 resource,
@@ -165,20 +157,20 @@ def _validate_endpoint(
                 "ACES ACL endpoint does not resolve to an admitted network.",
             )
         )
-    else:
-        cidr = network_lookup[value].cidr
-        try:
-            supported = bool(cidr) and ip_network(cidr, strict=False).version == 4
-        except ValueError:
-            supported = False
-        if not supported:
-            diagnostics.append(
-                _acl_diagnostic(
-                    resource,
-                    "endpoint-family-unsupported",
-                    "ACES ACL endpoint requires an observed IPv4 network.",
-                )
+        return
+    cidr = network_lookup[value].cidr
+    try:
+        supported = bool(cidr) and ip_network(cidr, strict=False).version == 4
+    except ValueError:
+        supported = False
+    if not supported:
+        diagnostics.append(
+            _acl_diagnostic(
+                resource,
+                "endpoint-family-unsupported",
+                "ACES ACL endpoint requires an observed IPv4 network.",
             )
+        )
 
 
 def _ports(
@@ -193,9 +185,7 @@ def _ports(
         )
         return ()
     if any(
-        not isinstance(port, int)
-        or isinstance(port, bool)
-        or not 0 < port <= 65535
+        not isinstance(port, int) or isinstance(port, bool) or not 0 < port <= 65535
         for port in raw
     ):
         diagnostics.append(

--- a/src/aptl/backends/aces_acl_realization.py
+++ b/src/aptl/backends/aces_acl_realization.py
@@ -54,17 +54,19 @@ def realize_acls(
 
 
 def _raw_acls(resource: PlannedResource) -> Sequence[object]:
+    """Return an ACL sequence only from the canonical infrastructure field."""
+
     payload = resource.payload
-    if not isinstance(payload, Mapping):
-        return ()
-    spec = payload.get("spec")
-    if not isinstance(spec, Mapping):
-        return ()
-    infrastructure = spec.get("infrastructure")
-    if not isinstance(infrastructure, Mapping):
-        return ()
-    raw = infrastructure.get("acls", ())
-    return raw if isinstance(raw, list | tuple) else ()
+    result: Sequence[object] = ()
+    if isinstance(payload, Mapping):
+        spec = payload.get("spec")
+        if isinstance(spec, Mapping):
+            infrastructure = spec.get("infrastructure")
+            if isinstance(infrastructure, Mapping):
+                raw = infrastructure.get("acls", ())
+                if isinstance(raw, list | tuple):
+                    result = raw
+    return result
 
 
 def _realize_acl(
@@ -75,6 +77,8 @@ def _realize_acl(
     network_names: Mapping[str, str],
     diagnostics: list[Diagnostic],
 ) -> DeploymentAclRealization | None:
+    """Validate and lower one admitted ACL rule."""
+
     if not isinstance(raw, Mapping):
         diagnostics.append(
             _acl_diagnostic(resource, "shape-invalid", "ACL entry is not a mapping.")
@@ -114,11 +118,15 @@ def _realize_acl(
 
 
 def _token(raw: Mapping[object, object], key: str) -> str:
+    """Normalize a string token without coercing other input types."""
+
     value = raw.get(key)
     return value.strip().lower() if isinstance(value, str) else ""
 
 
 def _payload_name(resource: PlannedResource) -> str:
+    """Read a node name from the admitted resource payload."""
+
     payload = resource.payload
     name = payload.get("name") if isinstance(payload, Mapping) else None
     return name if isinstance(name, str) else ""
@@ -131,6 +139,8 @@ def _validate_token(
     allowed: frozenset[str],
     diagnostics: list[Diagnostic],
 ) -> None:
+    """Record a stable diagnostic for an unsupported ACL token."""
+
     if value not in allowed:
         diagnostics.append(
             _acl_diagnostic(
@@ -147,6 +157,8 @@ def _validate_endpoint(
     network_lookup: Mapping[str, NetworkRealization],
     diagnostics: list[Diagnostic],
 ) -> None:
+    """Require an ACL endpoint to resolve to an admitted IPv4 network."""
+
     if not value:
         return
     if value not in network_lookup:
@@ -179,20 +191,21 @@ def _ports(
     protocol: str,
     diagnostics: list[Diagnostic],
 ) -> tuple[int, ...]:
+    """Validate transport ports and return an immutable ordered sequence."""
+
+    result: tuple[int, ...] = ()
     if not isinstance(raw, list | tuple):
         diagnostics.append(
             _acl_diagnostic(resource, "ports-invalid", "ACES ACL ports are invalid.")
         )
-        return ()
-    if any(
+    elif any(
         not isinstance(port, int) or isinstance(port, bool) or not 0 < port <= 65535
         for port in raw
     ):
         diagnostics.append(
             _acl_diagnostic(resource, "ports-invalid", "ACES ACL ports are invalid.")
         )
-        return ()
-    if raw and protocol in _PROTOCOLS and protocol not in {"tcp", "udp"}:
+    elif raw and protocol in _PROTOCOLS and protocol not in {"tcp", "udp"}:
         diagnostics.append(
             _acl_diagnostic(
                 resource,
@@ -200,8 +213,9 @@ def _ports(
                 "ACES ACL ports require TCP or UDP.",
             )
         )
-        return ()
-    return tuple(cast(int, port) for port in raw)
+    else:
+        result = tuple(cast(int, port) for port in raw)
+    return result
 
 
 def _acl_diagnostic(
@@ -209,6 +223,8 @@ def _acl_diagnostic(
     suffix: str,
     message: str,
 ) -> Diagnostic:
+    """Build one resource-scoped ACL admission diagnostic."""
+
     return diagnostic(
         f"aptl.provisioner.acl-{suffix}",
         resource.address,

--- a/src/aptl/backends/aces_acl_realization.py
+++ b/src/aptl/backends/aces_acl_realization.py
@@ -1,0 +1,226 @@
+"""Fail-closed ACES infrastructure ACL lowering."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from ipaddress import ip_network
+from typing import Literal, cast
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import PlannedResource
+
+from aptl.backends.aces_diagnostics import diagnostic
+from aptl.backends.aces_realization_model import NetworkRealization
+from aptl.core.deployment.realization import (
+    AclAction,
+    AclDirection,
+    AclProtocol,
+    DeploymentAclRealization,
+)
+
+_ACTIONS = frozenset({"allow", "deny"})
+_DIRECTIONS = frozenset({"in", "out", "inout"})
+_PROTOCOLS = frozenset({"any", "tcp", "udp", "icmp"})
+
+
+def realize_acls(
+    resources: Sequence[PlannedResource],
+    networks: Sequence[NetworkRealization],
+    diagnostics: list[Diagnostic],
+) -> list[DeploymentAclRealization]:
+    """Lower valid ACLs without creating a second authoring model."""
+
+    network_lookup = {
+        ref: network
+        for network in networks
+        for ref in (network.address, network.name)
+        if ref
+    }
+    network_names = {network.address: network.name for network in networks}
+    realized: list[DeploymentAclRealization] = []
+    for resource in resources:
+        for order, raw in enumerate(_raw_acls(resource)):
+            acl = _realize_acl(
+                resource,
+                raw,
+                order,
+                network_lookup,
+                network_names,
+                diagnostics,
+            )
+            if acl is not None:
+                realized.append(acl)
+    return realized
+
+
+def _raw_acls(resource: PlannedResource) -> Sequence[object]:
+    payload = resource.payload
+    if not isinstance(payload, Mapping):
+        return ()
+    spec = payload.get("spec")
+    if not isinstance(spec, Mapping):
+        return ()
+    infrastructure = spec.get("infrastructure")
+    if not isinstance(infrastructure, Mapping):
+        return ()
+    raw = infrastructure.get("acls", ())
+    return raw if isinstance(raw, list | tuple) else ()
+
+
+def _realize_acl(
+    resource: PlannedResource,
+    raw: object,
+    order: int,
+    network_lookup: Mapping[str, NetworkRealization],
+    network_names: Mapping[str, str],
+    diagnostics: list[Diagnostic],
+) -> DeploymentAclRealization | None:
+    if not isinstance(raw, Mapping):
+        diagnostics.append(
+            _acl_diagnostic(resource, "shape-invalid", "ACL entry is not a mapping.")
+        )
+        return None
+    before = len(diagnostics)
+    action = _token(raw, "action")
+    direction = _token(raw, "direction") or "inout"
+    protocol = _token(raw, "protocol") or "any"
+    from_network = _token(raw, "from_net")
+    to_network = _token(raw, "to_net")
+    ports = _ports(resource, raw.get("ports", ()), protocol, diagnostics)
+    _validate_token(resource, "action", action, _ACTIONS, diagnostics)
+    _validate_token(resource, "direction", direction, _DIRECTIONS, diagnostics)
+    _validate_token(resource, "protocol", protocol, _PROTOCOLS, diagnostics)
+    _validate_endpoint(resource, from_network, network_lookup, diagnostics)
+    _validate_endpoint(resource, to_network, network_lookup, diagnostics)
+    if len(diagnostics) != before:
+        return None
+    return DeploymentAclRealization(
+        owner_address=resource.address,
+        owner_resource_type=cast(
+            Literal["node", "network"], resource.resource_type
+        ),
+        owner_name=(
+            network_names.get(resource.address, "")
+            if resource.resource_type == "network"
+            else _payload_name(resource)
+        ),
+        name=_token(raw, "name") or f"acl-{order}",
+        order=order,
+        direction=cast(AclDirection, direction),
+        from_network=from_network or None,
+        to_network=to_network or None,
+        protocol=cast(AclProtocol, protocol),
+        ports=ports,
+        action=cast(AclAction, action),
+    )
+
+
+def _token(raw: Mapping[object, object], key: str) -> str:
+    value = raw.get(key)
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
+def _payload_name(resource: PlannedResource) -> str:
+    payload = resource.payload
+    name = payload.get("name") if isinstance(payload, Mapping) else None
+    return name if isinstance(name, str) else ""
+
+
+def _validate_token(
+    resource: PlannedResource,
+    field: str,
+    value: str,
+    allowed: frozenset[str],
+    diagnostics: list[Diagnostic],
+) -> None:
+    if value not in allowed:
+        diagnostics.append(
+            _acl_diagnostic(
+                resource,
+                f"{field}-unsupported",
+                f"ACES ACL {field} is unsupported by this backend.",
+            )
+        )
+
+
+def _validate_endpoint(
+    resource: PlannedResource,
+    value: str,
+    network_lookup: Mapping[str, NetworkRealization],
+    diagnostics: list[Diagnostic],
+) -> None:
+    if not value:
+        diagnostics.append(
+            _acl_diagnostic(
+                resource,
+                "endpoint-wildcard-unsupported",
+                "ACES ACL wildcard endpoints are unsupported by this backend.",
+            )
+        )
+    elif value not in network_lookup:
+        diagnostics.append(
+            _acl_diagnostic(
+                resource,
+                "endpoint-unresolved",
+                "ACES ACL endpoint does not resolve to an admitted network.",
+            )
+        )
+    else:
+        cidr = network_lookup[value].cidr
+        try:
+            supported = bool(cidr) and ip_network(cidr, strict=False).version == 4
+        except ValueError:
+            supported = False
+        if not supported:
+            diagnostics.append(
+                _acl_diagnostic(
+                    resource,
+                    "endpoint-family-unsupported",
+                    "ACES ACL endpoint requires an observed IPv4 network.",
+                )
+            )
+
+
+def _ports(
+    resource: PlannedResource,
+    raw: object,
+    protocol: str,
+    diagnostics: list[Diagnostic],
+) -> tuple[int, ...]:
+    if not isinstance(raw, list | tuple):
+        diagnostics.append(
+            _acl_diagnostic(resource, "ports-invalid", "ACES ACL ports are invalid.")
+        )
+        return ()
+    if any(
+        not isinstance(port, int)
+        or isinstance(port, bool)
+        or not 0 < port <= 65535
+        for port in raw
+    ):
+        diagnostics.append(
+            _acl_diagnostic(resource, "ports-invalid", "ACES ACL ports are invalid.")
+        )
+        return ()
+    if raw and protocol in _PROTOCOLS and protocol not in {"tcp", "udp"}:
+        diagnostics.append(
+            _acl_diagnostic(
+                resource,
+                "ports-protocol-unsupported",
+                "ACES ACL ports require TCP or UDP.",
+            )
+        )
+        return ()
+    return tuple(cast(int, port) for port in raw)
+
+
+def _acl_diagnostic(
+    resource: PlannedResource,
+    suffix: str,
+    message: str,
+) -> Diagnostic:
+    return diagnostic(
+        f"aptl.provisioner.acl-{suffix}",
+        resource.address,
+        message,
+    )

--- a/src/aptl/backends/aces_manifest.py
+++ b/src/aptl/backends/aces_manifest.py
@@ -90,8 +90,7 @@ _CURRENT_PARTICIPANT_CONTRACT_VERSIONS = frozenset(
 )
 
 _SUPPORTED_CONTRACT_VERSIONS = _BASE_SUPPORTED_CONTRACT_VERSIONS | (
-    _CURRENT_PARTICIPANT_CONTRACT_VERSIONS
-    & frozenset(BACKEND_SUPPORTED_CONTRACT_IDS)
+    _CURRENT_PARTICIPANT_CONTRACT_VERSIONS & frozenset(BACKEND_SUPPORTED_CONTRACT_IDS)
 )
 
 # Orchestrator capability declaration. APTL's RTE-001 runtime engine drives
@@ -158,15 +157,17 @@ _PROVISIONER = ProvisionerCapabilities(
     # / home / shell are neither carried nor realized, so they are not claimed;
     # an account placement that exercises one is a blocking ACES diagnostic, not
     # a silently dropped field. No scenario declares those terms today.
-    supported_account_features=frozenset(
-        {"disabled", "groups", "mail", "spn"}
-    ),
+    supported_account_features=frozenset({"disabled", "groups", "mail", "spn"}),
     # The Samba AD provider realizes and read-verifies the operational
     # scenario's domain-bound accounts and SPNs (#577). ACES 0.23 makes that
     # domain profile an explicit admission capability rather than inferring it
     # from account fields.
     supported_domain_profiles=frozenset({"active_directory"}),
-    supports_acls=False,
+    # ACES ACLs pass through the typed realization surface to separate,
+    # owner-scoped nftables tables. The backend rejects unsupported dual-stack
+    # inputs, applies replacements atomically, and reads back every rule before
+    # reporting success.
+    supports_acls=True,
     supports_accounts=True,
     supports_generated_artifacts=True,
     supports_persistent_volumes=True,
@@ -237,7 +238,9 @@ def create_aptl_manifest() -> BackendManifest:
     supported_contract_versions = _SUPPORTED_CONTRACT_VERSIONS
     capability_options: dict[str, object] = {}
     if observation is not None:
-        supported_contract_versions = supported_contract_versions | OBSERVATION_EVIDENCE_CONTRACTS
+        supported_contract_versions = (
+            supported_contract_versions | OBSERVATION_EVIDENCE_CONTRACTS
+        )
         capability_options["observation"] = observation
     return BackendManifest(
         name=APTL_ACES_TARGET_NAME,

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -57,11 +57,6 @@ from aptl.backends.aces_realization_values import (
     static_addresses as _static_addresses,
 )
 from aptl.core.config import AptlConfig
-from aptl.core.deployment.realization import (
-    DeploymentAclRealization,
-    DeploymentGeneratedArtifactRealization,
-    DeploymentPersistentVolumeRealization,
-)
 from aptl.utils.redaction import redact
 
 
@@ -113,15 +108,19 @@ def interpret_provisioning_plan(
     if not _all_nodes_image_free(nodes):
         _append_profile_diagnostics(profiles, config, diagnostics)
 
-    return _realization_from_parts(
-        nodes,
-        networks,
-        placements,
-        generated_artifacts,
-        persistent_volumes,
-        profiles,
-        diagnostics,
-        acls,
+    return AptlRealization(
+        profiles=frozenset(profiles),
+        nodes=tuple(sorted(nodes, key=lambda item: item.address)),
+        networks=tuple(sorted(networks, key=lambda item: item.address)),
+        placements=tuple(sorted(placements, key=lambda item: item.address)),
+        diagnostics=tuple(diagnostics),
+        acls=tuple(acls),
+        generated_artifacts=tuple(
+            sorted(generated_artifacts, key=lambda item: item.address)
+        ),
+        persistent_volumes=tuple(
+            sorted(persistent_volumes, key=lambda item: item.address)
+        ),
     )
 
 
@@ -261,34 +260,6 @@ def _append_profile_diagnostics(
                 ),
             )
         )
-
-
-def _realization_from_parts(
-    nodes: list[NodeRealization],
-    networks: list[NetworkRealization],
-    placements: list[PlacementRealization],
-    generated_artifacts: list[DeploymentGeneratedArtifactRealization],
-    persistent_volumes: list[DeploymentPersistentVolumeRealization],
-    profiles: set[str],
-    diagnostics: list[Diagnostic],
-    acls: list[DeploymentAclRealization],
-) -> AptlRealization:
-    """Build the stable realization value from collected resource parts."""
-
-    return AptlRealization(
-        profiles=frozenset(profiles),
-        nodes=tuple(sorted(nodes, key=lambda item: item.address)),
-        networks=tuple(sorted(networks, key=lambda item: item.address)),
-        placements=tuple(sorted(placements, key=lambda item: item.address)),
-        diagnostics=tuple(diagnostics),
-        acls=tuple(acls),
-        generated_artifacts=tuple(
-            sorted(generated_artifacts, key=lambda item: item.address)
-        ),
-        persistent_volumes=tuple(
-            sorted(persistent_volumes, key=lambda item: item.address)
-        ),
-    )
 
 
 def _empty_realization(diagnostics: list[Diagnostic]) -> AptlRealization:

--- a/src/aptl/backends/aces_realization.py
+++ b/src/aptl/backends/aces_realization.py
@@ -18,6 +18,7 @@ from aptl.backends.aces_diagnostics import (
     unsupported_resource_diagnostics,
 )
 from aptl.backends.aces_dependency_closure import append_dependency_closure
+from aptl.backends.aces_acl_realization import realize_acls
 from aces_sdl.runtime_configuration import RuntimeConfiguration
 
 from aptl.backends.aces_image_realization import resolve_node_image
@@ -57,6 +58,7 @@ from aptl.backends.aces_realization_values import (
 )
 from aptl.core.config import AptlConfig
 from aptl.core.deployment.realization import (
+    DeploymentAclRealization,
     DeploymentGeneratedArtifactRealization,
     DeploymentPersistentVolumeRealization,
 )
@@ -95,6 +97,7 @@ def interpret_provisioning_plan(
         diagnostics,
     )
     append_network_topology_diagnostics(nodes, networks, diagnostics)
+    acls = realize_acls(payload_resources, networks, diagnostics)
     placements = _realize_placements(
         payload_resources,
         _node_lookup(nodes),
@@ -118,6 +121,7 @@ def interpret_provisioning_plan(
         persistent_volumes,
         profiles,
         diagnostics,
+        acls,
     )
 
 
@@ -267,6 +271,7 @@ def _realization_from_parts(
     persistent_volumes: list[DeploymentPersistentVolumeRealization],
     profiles: set[str],
     diagnostics: list[Diagnostic],
+    acls: list[DeploymentAclRealization],
 ) -> AptlRealization:
     """Build the stable realization value from collected resource parts."""
 
@@ -276,6 +281,7 @@ def _realization_from_parts(
         networks=tuple(sorted(networks, key=lambda item: item.address)),
         placements=tuple(sorted(placements, key=lambda item: item.address)),
         diagnostics=tuple(diagnostics),
+        acls=tuple(acls),
         generated_artifacts=tuple(
             sorted(generated_artifacts, key=lambda item: item.address)
         ),

--- a/src/aptl/backends/aces_realization_model.py
+++ b/src/aptl/backends/aces_realization_model.py
@@ -9,6 +9,7 @@ from aces_sdl.runtime_configuration import RuntimeConfiguration
 
 from aptl.core.deployment.realization import (
     DeploymentAccountRealization,
+    DeploymentAclRealization,
     DeploymentContentRealization,
     DeploymentGeneratedArtifactRealization,
     DeploymentImageRealization,
@@ -146,6 +147,7 @@ class AptlRealization(object):
     networks: tuple[NetworkRealization, ...]
     placements: tuple[PlacementRealization, ...]
     diagnostics: tuple[Diagnostic, ...]
+    acls: tuple[DeploymentAclRealization, ...] = ()
     generated_artifacts: tuple[DeploymentGeneratedArtifactRealization, ...] = ()
     persistent_volumes: tuple[DeploymentPersistentVolumeRealization, ...] = ()
 
@@ -169,6 +171,7 @@ class AptlRealization(object):
                 )
                 for network in self.networks
             ),
+            acls=self.acls,
             images=tuple(node.image for node in self.nodes if node.image is not None),
             content=tuple(
                 placement.content
@@ -210,6 +213,7 @@ class AptlRealization(object):
             },
             "nodes": [node.details() for node in self.nodes],
             "networks": [network.details() for network in self.networks],
+            "acls": [acl.details() for acl in self.acls],
             "placements": [placement.details() for placement in self.placements],
             "generated_artifacts": [
                 artifact.details() for artifact in self.generated_artifacts

--- a/src/aptl/core/appliance_boundary.py
+++ b/src/aptl/core/appliance_boundary.py
@@ -1,0 +1,176 @@
+"""Strict platform-owned appliance boundary policy contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import re
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+_DIGEST = re.compile(r"^sha256:[a-f0-9]{64}$")
+_AUTHORITY = re.compile(
+    r"^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+"
+    r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+)
+_LABEL_SELECTOR = re.compile(r"^[a-z0-9][a-z0-9._/-]*=[a-z0-9][a-z0-9._-]*$")
+
+Digest = Annotated[str, Field(pattern=_DIGEST.pattern)]
+PlatformZone = Literal["participant", "management", "egress"]
+Transport = Literal["tcp", "udp"]
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class PlatformAnchors(_StrictModel):
+    participant: str
+    management: str
+    egress: str
+
+    @field_validator("participant", "management", "egress")
+    @classmethod
+    def validate_label_selector(cls, value: str) -> str:
+        if not _LABEL_SELECTOR.fullmatch(value):
+            raise ValueError("platform anchors must be exact label selectors")
+        return value
+
+
+class FixedCrossing(_StrictModel):
+    source: PlatformZone
+    destination: PlatformZone
+    protocol: Transport
+    ports: list[int] = Field(min_length=1)
+    purpose: str = Field(min_length=1, max_length=80)
+
+    @field_validator("ports")
+    @classmethod
+    def validate_ports(cls, values: list[int]) -> list[int]:
+        if len(values) != len(set(values)) or any(
+            isinstance(value, bool) or not 0 < value <= 65535 for value in values
+        ):
+            raise ValueError("ports must be unique integers in 1..65535")
+        return values
+
+
+class EgressAuthority(_StrictModel):
+    authority: str
+    port: int = Field(ge=1, le=65535)
+    purpose: str = Field(min_length=1, max_length=80)
+
+    @field_validator("authority")
+    @classmethod
+    def validate_authority(cls, value: str) -> str:
+        normalized = value.rstrip(".").lower()
+        try:
+            ipaddress.ip_address(normalized.strip("[]"))
+        except ValueError:
+            pass
+        else:
+            raise ValueError("egress authority must not be an IP literal")
+        if "*" in normalized or "://" in normalized or not _AUTHORITY.fullmatch(
+            normalized
+        ):
+            raise ValueError("egress authority must be one exact DNS authority")
+        return normalized
+
+
+class GuestPublication(_StrictModel):
+    audience: Literal["participant", "recovery"]
+    address: str
+    port: int = Field(ge=1, le=65535)
+    protocol: Transport
+
+    @field_validator("address")
+    @classmethod
+    def validate_address(cls, value: str) -> str:
+        parsed = ipaddress.ip_address(value)
+        if not parsed.is_loopback:
+            raise ValueError("guest publications must bind loopback")
+        return str(parsed)
+
+
+class DockerAuthorityPolicy(_StrictModel):
+    allowed_holder_labels: list[str] = Field(default_factory=list)
+    require_guest_daemon: Literal[True] = True
+
+    @field_validator("allowed_holder_labels")
+    @classmethod
+    def validate_holder_labels(cls, values: list[str]) -> list[str]:
+        if len(values) != len(set(values)) or any(
+            not _LABEL_SELECTOR.fullmatch(value) for value in values
+        ):
+            raise ValueError("Docker authority holders require unique exact labels")
+        return values
+
+
+class ApplianceBoundaryPolicy(_StrictModel):
+    """Platform policy that deliberately cannot contain scenario topology."""
+
+    schema_version: Literal["aptl.appliance-boundary/v1"]
+    policy_id: str = Field(pattern=r"^[a-z0-9][a-z0-9._-]{0,79}$")
+    generation: int = Field(ge=1)
+    default_deny: Literal[True]
+    platform_anchors: PlatformAnchors
+    fixed_crossings: list[FixedCrossing] = Field(default_factory=list)
+    egress_authorities: list[EgressAuthority] = Field(default_factory=list)
+    guest_publications: list[GuestPublication] = Field(default_factory=list)
+    docker_authority: DockerAuthorityPolicy
+
+    @model_validator(mode="after")
+    def validate_unique_entries(self) -> ApplianceBoundaryPolicy:
+        crossings = [
+            (item.source, item.destination, item.protocol, tuple(item.ports))
+            for item in self.fixed_crossings
+        ]
+        authorities = [
+            (item.authority, item.port) for item in self.egress_authorities
+        ]
+        publications = [
+            (item.audience, item.address, item.port, item.protocol)
+            for item in self.guest_publications
+        ]
+        if len(crossings) != len(set(crossings)):
+            raise ValueError("fixed crossings must be unique")
+        if len(authorities) != len(set(authorities)):
+            raise ValueError("egress authorities must be unique")
+        if len(publications) != len(set(publications)):
+            raise ValueError("guest publications must be unique")
+        return self
+
+
+class ApplianceBoundaryBinding(_StrictModel):
+    """Trusted projection supplied by the signed envelope and launcher."""
+
+    policy_digest: Digest
+    payload_digest: Digest
+    aces_plan_digest: Digest
+    boot_id: str = Field(min_length=1, max_length=128)
+    guest_daemon_id: str = Field(min_length=1, max_length=128)
+    host_observation_id: str = Field(min_length=1, max_length=128)
+
+
+def load_boundary_policy(
+    path: Path,
+    binding: ApplianceBoundaryBinding,
+) -> ApplianceBoundaryPolicy:
+    """Load a strict policy whose exact bytes match the envelope projection."""
+
+    payload = path.read_bytes()
+    actual = "sha256:" + hashlib.sha256(payload).hexdigest()
+    if actual != binding.policy_digest:
+        raise ValueError("appliance boundary policy digest does not match binding")
+    parsed = json.loads(payload)
+    if not isinstance(parsed, dict):
+        raise ValueError("appliance boundary policy must be a JSON object")
+    return ApplianceBoundaryPolicy.model_validate(parsed)

--- a/src/aptl/core/appliance_boundary.py
+++ b/src/aptl/core/appliance_boundary.py
@@ -31,10 +31,14 @@ Transport = Literal["tcp", "udp"]
 
 
 class _StrictModel(BaseModel):
+    """Base for closed appliance-boundary policy records."""
+
     model_config = ConfigDict(extra="forbid", strict=True)
 
 
 class PlatformAnchors(_StrictModel):
+    """Exact workload selectors for the three platform trust anchors."""
+
     participant: str
     management: str
     egress: str
@@ -63,6 +67,8 @@ class PlatformNetworks(_StrictModel):
 
 
 class FixedCrossing(_StrictModel):
+    """One narrow transport crossing between platform-owned zones."""
+
     source: PlatformZone
     destination: PlatformZone
     protocol: Transport
@@ -80,6 +86,8 @@ class FixedCrossing(_StrictModel):
 
 
 class EgressAuthority(_StrictModel):
+    """One exact externally reachable authority admitted through the broker."""
+
     source: Literal["egress"]
     authority: str
     protocol: Literal["tcp"]
@@ -108,6 +116,8 @@ class EgressAuthority(_StrictModel):
 
 
 class GuestPublication(_StrictModel):
+    """One loopback-only guest endpoint projected to the physical host."""
+
     audience: Literal["participant", "recovery"]
     address: str
     port: int = Field(ge=1, le=65535)
@@ -123,6 +133,8 @@ class GuestPublication(_StrictModel):
 
 
 class DockerAuthorityPolicy(_StrictModel):
+    """Constraints on workloads allowed to control the guest Docker daemon."""
+
     allowed_holder_labels: list[str] = Field(default_factory=list)
     require_guest_daemon: Literal[True] = True
 
@@ -137,6 +149,8 @@ class DockerAuthorityPolicy(_StrictModel):
 
 
 class EgressProxyLimits(_StrictModel):
+    """Signed resource and timeout bounds for the egress broker."""
+
     max_connections: int = Field(ge=1, le=256)
     max_header_bytes: int = Field(ge=1024, le=16384)
     header_timeout_seconds: int = Field(ge=1, le=30)

--- a/src/aptl/core/appliance_boundary.py
+++ b/src/aptl/core/appliance_boundary.py
@@ -23,6 +23,7 @@ _AUTHORITY = re.compile(
     r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
 )
 _LABEL_SELECTOR = re.compile(r"^[a-z0-9][a-z0-9._/-]*=[a-z0-9][a-z0-9._-]*$")
+_IMAGE_DIGEST = re.compile(r"^[a-z0-9][a-z0-9._/:~-]{0,254}@sha256:[a-f0-9]{64}$")
 
 Digest = Annotated[str, Field(pattern=_DIGEST.pattern)]
 PlatformZone = Literal["participant", "management", "egress"]
@@ -30,7 +31,7 @@ Transport = Literal["tcp", "udp"]
 
 
 class _StrictModel(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", strict=True)
 
 
 class PlatformAnchors(_StrictModel):
@@ -43,6 +44,21 @@ class PlatformAnchors(_StrictModel):
     def validate_label_selector(cls, value: str) -> str:
         if not _LABEL_SELECTOR.fullmatch(value):
             raise ValueError("platform anchors must be exact label selectors")
+        return value
+
+
+class PlatformNetworks(_StrictModel):
+    """Exact signed selectors for platform-owned policy domains."""
+
+    participant: str
+    management: str
+    egress: str
+
+    @field_validator("participant", "management", "egress")
+    @classmethod
+    def validate_label_selector(cls, value: str) -> str:
+        if not _LABEL_SELECTOR.fullmatch(value):
+            raise ValueError("platform networks must be exact label selectors")
         return value
 
 
@@ -64,9 +80,13 @@ class FixedCrossing(_StrictModel):
 
 
 class EgressAuthority(_StrictModel):
+    source: Literal["egress"]
     authority: str
+    protocol: Literal["tcp"]
     port: int = Field(ge=1, le=65535)
     purpose: str = Field(min_length=1, max_length=80)
+    resolution: Literal["proxy-resolved-all-global"]
+    failure_disposition: Literal["deny"]
 
     @field_validator("authority")
     @classmethod
@@ -78,8 +98,10 @@ class EgressAuthority(_StrictModel):
             pass
         else:
             raise ValueError("egress authority must not be an IP literal")
-        if "*" in normalized or "://" in normalized or not _AUTHORITY.fullmatch(
-            normalized
+        if (
+            "*" in normalized
+            or "://" in normalized
+            or not _AUTHORITY.fullmatch(normalized)
         ):
             raise ValueError("egress authority must be one exact DNS authority")
         return normalized
@@ -114,16 +136,27 @@ class DockerAuthorityPolicy(_StrictModel):
         return values
 
 
+class EgressProxyLimits(_StrictModel):
+    max_connections: int = Field(ge=1, le=256)
+    max_header_bytes: int = Field(ge=1024, le=16384)
+    header_timeout_seconds: int = Field(ge=1, le=30)
+    connect_timeout_seconds: int = Field(ge=1, le=60)
+    idle_timeout_seconds: int = Field(ge=5, le=600)
+
+
 class ApplianceBoundaryPolicy(_StrictModel):
     """Platform policy that deliberately cannot contain scenario topology."""
 
     schema_version: Literal["aptl.appliance-boundary/v1"]
     policy_id: str = Field(pattern=r"^[a-z0-9][a-z0-9._-]{0,79}$")
     generation: int = Field(ge=1)
+    workbench_policy_version: str = Field(pattern=r"^[a-z0-9][a-z0-9._/-]{0,127}$")
     default_deny: Literal[True]
+    platform_networks: PlatformNetworks
     platform_anchors: PlatformAnchors
     fixed_crossings: list[FixedCrossing] = Field(default_factory=list)
     egress_authorities: list[EgressAuthority] = Field(default_factory=list)
+    egress_proxy_limits: EgressProxyLimits
     guest_publications: list[GuestPublication] = Field(default_factory=list)
     docker_authority: DockerAuthorityPolicy
 
@@ -133,9 +166,7 @@ class ApplianceBoundaryPolicy(_StrictModel):
             (item.source, item.destination, item.protocol, tuple(item.ports))
             for item in self.fixed_crossings
         ]
-        authorities = [
-            (item.authority, item.port) for item in self.egress_authorities
-        ]
+        authorities = [(item.authority, item.port) for item in self.egress_authorities]
         publications = [
             (item.audience, item.address, item.port, item.protocol)
             for item in self.guest_publications
@@ -155,6 +186,9 @@ class ApplianceBoundaryBinding(_StrictModel):
     policy_digest: Digest
     payload_digest: Digest
     aces_plan_digest: Digest
+    aces_boundary_required: bool
+    boundary_helper_image: str = Field(pattern=_IMAGE_DIGEST.pattern)
+    egress_proxy_image: str = Field(pattern=_IMAGE_DIGEST.pattern)
     boot_id: str = Field(min_length=1, max_length=128)
     guest_daemon_id: str = Field(min_length=1, max_length=128)
     host_observation_id: str = Field(min_length=1, max_length=128)
@@ -174,3 +208,20 @@ def load_boundary_policy(
     if not isinstance(parsed, dict):
         raise ValueError("appliance boundary policy must be a JSON object")
     return ApplianceBoundaryPolicy.model_validate(parsed)
+
+
+def render_egress_proxy_policy(policy: ApplianceBoundaryPolicy) -> bytes:
+    """Project only exact signed authorities into the closed CONNECT broker."""
+
+    authorities = sorted(
+        {(item.authority, item.port) for item in policy.egress_authorities}
+    )
+    if not authorities:
+        raise ValueError("egress proxy requires at least one admitted authority")
+    payload = {
+        "authorities": [
+            {"authority": authority, "port": port} for authority, port in authorities
+        ],
+        "limits": policy.egress_proxy_limits.model_dump(),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()

--- a/src/aptl/core/appliance_boundary_gate.py
+++ b/src/aptl/core/appliance_boundary_gate.py
@@ -1,0 +1,62 @@
+"""One qualification/start gate over the ADR-049 trust inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, Protocol
+
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+    load_boundary_policy,
+)
+from aptl.core.appliance_boundary_inventory import (
+    BoundaryQualificationResult,
+    GuestBoundaryObservation,
+    HostBoundaryObservation,
+    qualify_appliance_boundary,
+)
+
+BoundaryPhase = Literal["image-qualification", "start"]
+
+
+class BoundaryObservationAdapter(Protocol):
+    """Narrow guest adapter implemented by a supported appliance backend."""
+
+    def materialize_and_observe_boundary(
+        self,
+        policy: ApplianceBoundaryPolicy,
+        binding: ApplianceBoundaryBinding,
+        *,
+        phase: BoundaryPhase,
+    ) -> GuestBoundaryObservation: ...
+
+
+def run_appliance_boundary_gate(
+    *,
+    policy_path: Path,
+    binding: ApplianceBoundaryBinding,
+    host_observation: HostBoundaryObservation | None,
+    adapter: BoundaryObservationAdapter,
+    phase: BoundaryPhase,
+) -> BoundaryQualificationResult:
+    """Use the same fatal verifier for image qualification and every start.
+
+    The binding and host observation are trusted projections supplied by the
+    signed envelope/launcher work. This function does not manufacture either
+    input and cannot downgrade a missing outer observation to a warning.
+    """
+
+    policy = load_boundary_policy(policy_path, binding)
+    guest = adapter.materialize_and_observe_boundary(
+        policy,
+        binding,
+        phase=phase,
+    )
+    return qualify_appliance_boundary(
+        policy,
+        binding,
+        host_observation,
+        guest,
+        phase=phase,
+    )

--- a/src/aptl/core/appliance_boundary_inventory.py
+++ b/src/aptl/core/appliance_boundary_inventory.py
@@ -1,0 +1,286 @@
+"""Fresh fatal appliance-boundary inventory and verdict."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+    Digest,
+)
+from aptl.utils.redaction import redact
+
+
+class _StrictObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class BoundaryEndpoint(_StrictObservation):
+    audience: Literal["participant", "recovery"]
+    address: str
+    port: int = Field(ge=1, le=65535)
+    protocol: Literal["tcp", "udp"]
+
+
+class HostBoundaryObservation(_StrictObservation):
+    """Authenticated outer observation produced by the #824 adapter."""
+
+    observation_id: str = Field(min_length=1, max_length=128)
+    policy_digest: Digest
+    payload_digest: Digest
+    boot_id: str = Field(min_length=1, max_length=128)
+    complete: bool
+    listeners: tuple[BoundaryEndpoint, ...]
+    forbidden_reachability_passed: bool
+
+
+class BoundaryEnforcementObservation(_StrictObservation):
+    authority: Literal["aces", "platform"]
+    source_digest: Digest
+    enforcement_digest: Digest
+    families: tuple[Literal["bridge", "inet"], ...]
+    default_deny_observed: bool
+
+
+class BoundaryProbeObservation(_StrictObservation):
+    identity: str = Field(min_length=1, max_length=128)
+    expectation: Literal["reachable", "blocked"]
+    passed: bool
+
+
+class DockerAuthorityHolder(_StrictObservation):
+    identity: str = Field(min_length=1, max_length=128)
+    label_selector: str = Field(min_length=1, max_length=160)
+    daemon_id: str = Field(min_length=1, max_length=128)
+    access: Literal["socket", "api"]
+    privileged: bool
+    host_pid_namespace: bool
+    host_network_namespace: bool
+    device_count: int = Field(ge=0)
+
+
+class GuestBoundaryObservation(_StrictObservation):
+    """Normalized selected-daemon and kernel observation."""
+
+    policy_digest: Digest
+    aces_plan_digest: Digest
+    boot_id: str = Field(min_length=1, max_length=128)
+    guest_daemon_id: str = Field(min_length=1, max_length=128)
+    enforcements: tuple[BoundaryEnforcementObservation, ...]
+    observation_complete: bool
+    probes: tuple[BoundaryProbeObservation, ...]
+    docker_authority_holders: tuple[DockerAuthorityHolder, ...]
+
+
+@dataclass(frozen=True)
+class BoundaryQualificationResult:
+    passed: bool
+    findings: tuple[str, ...]
+    inventory: dict[str, object]
+
+
+def qualify_appliance_boundary(
+    policy: ApplianceBoundaryPolicy,
+    binding: ApplianceBoundaryBinding,
+    host: HostBoundaryObservation | None,
+    guest: GuestBoundaryObservation,
+    *,
+    phase: Literal["image-qualification", "start"] = "start",
+) -> BoundaryQualificationResult:
+    """Compare both trust domains and return bounded redacted evidence."""
+
+    findings: list[str] = []
+    if host is None:
+        findings.append("boundary.host-observation-missing")
+    else:
+        _append_host_findings(policy, binding, host, findings)
+    _append_guest_findings(policy, binding, guest, findings)
+    inventory = _inventory(policy, binding, host, guest, findings, phase)
+    return BoundaryQualificationResult(
+        passed=not findings,
+        findings=tuple(findings),
+        inventory=redact(inventory),
+    )
+
+
+def _append_host_findings(
+    policy: ApplianceBoundaryPolicy,
+    binding: ApplianceBoundaryBinding,
+    host: HostBoundaryObservation,
+    findings: list[str],
+) -> None:
+    if host.observation_id != binding.host_observation_id:
+        findings.append("boundary.host-observation-identity-mismatch")
+    if host.policy_digest != binding.policy_digest:
+        findings.append("boundary.host-policy-digest-mismatch")
+    if host.payload_digest != binding.payload_digest:
+        findings.append("boundary.host-payload-digest-mismatch")
+    if host.boot_id != binding.boot_id:
+        findings.append("boundary.host-boot-identity-mismatch")
+    if not host.complete:
+        findings.append("boundary.host-observation-incomplete")
+    if not host.forbidden_reachability_passed:
+        findings.append("boundary.host-forbidden-reachability")
+    expected = {
+        (item.audience, item.address, item.port, item.protocol)
+        for item in policy.guest_publications
+    }
+    observed = {
+        (item.audience, item.address, item.port, item.protocol)
+        for item in host.listeners
+    }
+    if observed - expected:
+        findings.append("boundary.host-listener-unapproved")
+    if expected - observed:
+        findings.append("boundary.host-listener-missing")
+
+
+def _append_guest_findings(
+    policy: ApplianceBoundaryPolicy,
+    binding: ApplianceBoundaryBinding,
+    guest: GuestBoundaryObservation,
+    findings: list[str],
+) -> None:
+    comparisons = (
+        (
+            guest.policy_digest != binding.policy_digest,
+            "boundary.guest-policy-digest-mismatch",
+        ),
+        (
+            guest.aces_plan_digest != binding.aces_plan_digest,
+            "boundary.guest-aces-plan-digest-mismatch",
+        ),
+        (
+            guest.boot_id != binding.boot_id,
+            "boundary.guest-boot-identity-mismatch",
+        ),
+        (
+            guest.guest_daemon_id != binding.guest_daemon_id,
+            "boundary.guest-daemon-identity-mismatch",
+        ),
+        (
+            not guest.observation_complete,
+            "boundary.guest-observation-incomplete",
+        ),
+    )
+    findings.extend(code for failed, code in comparisons if failed)
+    _append_enforcement_findings(policy, binding, guest, findings)
+    _append_probe_findings(guest, findings)
+    allowed = set(policy.docker_authority.allowed_holder_labels)
+    if {
+        holder.label_selector for holder in guest.docker_authority_holders
+    } - allowed:
+        findings.append("boundary.guest-docker-authority-unapproved")
+    if any(
+        holder.daemon_id != binding.guest_daemon_id
+        for holder in guest.docker_authority_holders
+    ):
+        findings.append("boundary.guest-docker-daemon-mismatch")
+    if any(
+        holder.privileged
+        or holder.host_pid_namespace
+        or holder.host_network_namespace
+        or holder.device_count
+        for holder in guest.docker_authority_holders
+    ):
+        findings.append("boundary.guest-docker-authority-overprivileged")
+
+
+def _append_enforcement_findings(
+    policy: ApplianceBoundaryPolicy,
+    binding: ApplianceBoundaryBinding,
+    guest: GuestBoundaryObservation,
+    findings: list[str],
+) -> None:
+    by_authority = {item.authority: item for item in guest.enforcements}
+    if len(by_authority) != len(guest.enforcements) or "platform" not in by_authority:
+        findings.append("boundary.guest-enforcement-incomplete")
+        return
+    platform = by_authority["platform"]
+    if platform.source_digest != binding.policy_digest:
+        findings.append("boundary.guest-platform-source-mismatch")
+    if set(platform.families) != {"bridge", "inet"}:
+        findings.append("boundary.guest-enforcement-incomplete")
+    if policy.default_deny and not platform.default_deny_observed:
+        findings.append("boundary.guest-default-deny-missing")
+    aces = by_authority.get("aces")
+    if aces is not None and aces.source_digest != binding.aces_plan_digest:
+        findings.append("boundary.guest-aces-source-mismatch")
+
+
+def _append_probe_findings(
+    guest: GuestBoundaryObservation,
+    findings: list[str],
+) -> None:
+    positive = [
+        item for item in guest.probes if item.expectation == "reachable"
+    ]
+    negative = [item for item in guest.probes if item.expectation == "blocked"]
+    if not positive or any(not item.passed for item in positive):
+        findings.append("boundary.guest-positive-probe-failed")
+    if not negative or any(not item.passed for item in negative):
+        findings.append("boundary.guest-negative-probe-failed")
+
+
+def _inventory(
+    policy: ApplianceBoundaryPolicy,
+    binding: ApplianceBoundaryBinding,
+    host: HostBoundaryObservation | None,
+    guest: GuestBoundaryObservation,
+    findings: list[str],
+    phase: Literal["image-qualification", "start"],
+) -> dict[str, object]:
+    return {
+        "schema_version": "aptl.appliance-boundary-inventory/v1",
+        "phase": phase,
+        "policy": {
+            "id": policy.policy_id,
+            "generation": policy.generation,
+            "digest": binding.policy_digest,
+        },
+        "payload_digest": binding.payload_digest,
+        "aces_plan_digest": binding.aces_plan_digest,
+        "boot_id": binding.boot_id,
+        "host": (
+            {"observation_id": host.observation_id, "complete": host.complete}
+            if host is not None
+            else {"missing": True}
+        ),
+        "guest": {
+            "guest_daemon_id": guest.guest_daemon_id,
+            "enforcements": [
+                {
+                    "authority": item.authority,
+                    "source_digest": item.source_digest,
+                    "enforcement_digest": item.enforcement_digest,
+                    "families": list(item.families),
+                    "default_deny_observed": item.default_deny_observed,
+                }
+                for item in guest.enforcements
+            ],
+            "probes": [
+                {
+                    "identity": item.identity,
+                    "expectation": item.expectation,
+                    "passed": item.passed,
+                }
+                for item in guest.probes
+            ],
+            "docker_authority_holders": [
+                {
+                    "identity": item.identity,
+                    "label_selector": item.label_selector,
+                    "daemon_id": item.daemon_id,
+                    "access": item.access,
+                }
+                for item in guest.docker_authority_holders
+            ],
+            "observation_complete": guest.observation_complete,
+        },
+        "findings": list(findings),
+        "passed": not findings,
+    }

--- a/src/aptl/core/appliance_boundary_inventory.py
+++ b/src/aptl/core/appliance_boundary_inventory.py
@@ -16,10 +16,14 @@ from aptl.utils.redaction import redact
 
 
 class _StrictObservation(BaseModel):
+    """Base for immutable, closed boundary-observation records."""
+
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
 
 class BoundaryEndpoint(_StrictObservation):
+    """One physical-host endpoint attributed to an approved audience."""
+
     audience: Literal["participant", "recovery"]
     address: str
     port: int = Field(ge=1, le=65535)
@@ -39,6 +43,8 @@ class HostBoundaryObservation(_StrictObservation):
 
 
 class BoundaryEnforcementObservation(_StrictObservation):
+    """Kernel readback evidence for one independent policy authority."""
+
     authority: Literal["aces", "platform"]
     source_digest: Digest
     enforcement_digest: Digest
@@ -47,6 +53,8 @@ class BoundaryEnforcementObservation(_StrictObservation):
 
 
 class BoundaryProbeObservation(_StrictObservation):
+    """One positive or negative reachability proof."""
+
     identity: str = Field(min_length=1, max_length=128)
     authority: Literal["aces", "platform"]
     source: str = Field(min_length=1, max_length=160)
@@ -64,6 +72,8 @@ class BoundaryProbeObservation(_StrictObservation):
 
 
 class DockerAuthorityHolder(_StrictObservation):
+    """Observed guest-daemon authority held by one workload."""
+
     identity: str = Field(min_length=1, max_length=128)
     label_selector: str = Field(min_length=1, max_length=160)
     daemon_id: str = Field(min_length=1, max_length=128)
@@ -90,6 +100,8 @@ class GuestBoundaryObservation(_StrictObservation):
 
 @dataclass(frozen=True)
 class BoundaryQualificationResult:
+    """Fatal boundary verdict plus its redacted evidence inventory."""
+
     passed: bool
     findings: tuple[str, ...]
     inventory: dict[str, object]
@@ -125,6 +137,8 @@ def _append_host_findings(
     host: HostBoundaryObservation,
     findings: list[str],
 ) -> None:
+    """Compare fresh outer-host evidence with the signed binding."""
+
     if host.observation_id != binding.host_observation_id:
         findings.append("boundary.host-observation-identity-mismatch")
     if host.policy_digest != binding.policy_digest:
@@ -157,6 +171,8 @@ def _append_guest_findings(
     guest: GuestBoundaryObservation,
     findings: list[str],
 ) -> None:
+    """Compare guest policy, daemon, enforcement, and authority evidence."""
+
     comparisons = (
         (
             guest.policy_digest != binding.policy_digest,
@@ -210,6 +226,8 @@ def _append_enforcement_findings(
     guest: GuestBoundaryObservation,
     findings: list[str],
 ) -> None:
+    """Require complete, digest-bound readback for every active authority."""
+
     by_authority = {item.authority: item for item in guest.enforcements}
     if len(by_authority) != len(guest.enforcements) or "platform" not in by_authority:
         findings.append("boundary.guest-enforcement-incomplete")
@@ -233,6 +251,8 @@ def _append_probe_findings(
     guest: GuestBoundaryObservation,
     findings: list[str],
 ) -> None:
+    """Require passing positive and negative probes for each authority."""
+
     required_authorities = {"platform"}
     if binding.aces_boundary_required:
         required_authorities.add("aces")
@@ -254,6 +274,8 @@ def _inventory(
     findings: list[str],
     phase: Literal["image-qualification", "start"],
 ) -> dict[str, object]:
+    """Render bounded machine evidence without raw policy or probe output."""
+
     return {
         "schema_version": "aptl.appliance-boundary-inventory/v1",
         "phase": phase,

--- a/src/aptl/core/appliance_boundary_inventory.py
+++ b/src/aptl/core/appliance_boundary_inventory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from aptl.core.appliance_boundary import (
     ApplianceBoundaryBinding,
@@ -16,7 +16,7 @@ from aptl.utils.redaction import redact
 
 
 class _StrictObservation(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
 
 class BoundaryEndpoint(_StrictObservation):
@@ -48,8 +48,19 @@ class BoundaryEnforcementObservation(_StrictObservation):
 
 class BoundaryProbeObservation(_StrictObservation):
     identity: str = Field(min_length=1, max_length=128)
+    authority: Literal["aces", "platform"]
+    source: str = Field(min_length=1, max_length=160)
+    destination: str = Field(min_length=1, max_length=160)
+    protocol: Literal["any", "tcp", "udp", "icmp"]
+    port: int | None = Field(default=None, ge=1, le=65535)
     expectation: Literal["reachable", "blocked"]
     passed: bool
+
+    @model_validator(mode="after")
+    def validate_transport_port(self) -> BoundaryProbeObservation:
+        if (self.protocol in {"tcp", "udp"}) != (self.port is not None):
+            raise ValueError("probe port must match its transport")
+        return self
 
 
 class DockerAuthorityHolder(_StrictObservation):
@@ -70,6 +81,7 @@ class GuestBoundaryObservation(_StrictObservation):
     aces_plan_digest: Digest
     boot_id: str = Field(min_length=1, max_length=128)
     guest_daemon_id: str = Field(min_length=1, max_length=128)
+    workbench_policy_version: str = Field(min_length=1, max_length=128)
     enforcements: tuple[BoundaryEnforcementObservation, ...]
     observation_complete: bool
     probes: tuple[BoundaryProbeObservation, ...]
@@ -163,17 +175,19 @@ def _append_guest_findings(
             "boundary.guest-daemon-identity-mismatch",
         ),
         (
+            guest.workbench_policy_version != policy.workbench_policy_version,
+            "boundary.guest-workbench-policy-mismatch",
+        ),
+        (
             not guest.observation_complete,
             "boundary.guest-observation-incomplete",
         ),
     )
     findings.extend(code for failed, code in comparisons if failed)
     _append_enforcement_findings(policy, binding, guest, findings)
-    _append_probe_findings(guest, findings)
+    _append_probe_findings(binding, guest, findings)
     allowed = set(policy.docker_authority.allowed_holder_labels)
-    if {
-        holder.label_selector for holder in guest.docker_authority_holders
-    } - allowed:
+    if {holder.label_selector for holder in guest.docker_authority_holders} - allowed:
         findings.append("boundary.guest-docker-authority-unapproved")
     if any(
         holder.daemon_id != binding.guest_daemon_id
@@ -208,22 +222,28 @@ def _append_enforcement_findings(
     if policy.default_deny and not platform.default_deny_observed:
         findings.append("boundary.guest-default-deny-missing")
     aces = by_authority.get("aces")
-    if aces is not None and aces.source_digest != binding.aces_plan_digest:
+    if binding.aces_boundary_required and aces is None:
+        findings.append("boundary.guest-aces-enforcement-missing")
+    elif aces is not None and aces.source_digest != binding.aces_plan_digest:
         findings.append("boundary.guest-aces-source-mismatch")
 
 
 def _append_probe_findings(
+    binding: ApplianceBoundaryBinding,
     guest: GuestBoundaryObservation,
     findings: list[str],
 ) -> None:
-    positive = [
-        item for item in guest.probes if item.expectation == "reachable"
-    ]
-    negative = [item for item in guest.probes if item.expectation == "blocked"]
-    if not positive or any(not item.passed for item in positive):
-        findings.append("boundary.guest-positive-probe-failed")
-    if not negative or any(not item.passed for item in negative):
-        findings.append("boundary.guest-negative-probe-failed")
+    required_authorities = {"platform"}
+    if binding.aces_boundary_required:
+        required_authorities.add("aces")
+    for authority in sorted(required_authorities):
+        scoped = [item for item in guest.probes if item.authority == authority]
+        positive = [item for item in scoped if item.expectation == "reachable"]
+        negative = [item for item in scoped if item.expectation == "blocked"]
+        if not positive or any(not item.passed for item in positive):
+            findings.append(f"boundary.guest-{authority}-positive-probe-failed")
+        if not negative or any(not item.passed for item in negative):
+            findings.append(f"boundary.guest-{authority}-negative-probe-failed")
 
 
 def _inventory(
@@ -244,6 +264,11 @@ def _inventory(
         },
         "payload_digest": binding.payload_digest,
         "aces_plan_digest": binding.aces_plan_digest,
+        "aces_boundary_required": binding.aces_boundary_required,
+        "images": {
+            "boundary_helper": binding.boundary_helper_image,
+            "egress_proxy": binding.egress_proxy_image,
+        },
         "boot_id": binding.boot_id,
         "host": (
             {"observation_id": host.observation_id, "complete": host.complete}
@@ -252,6 +277,7 @@ def _inventory(
         ),
         "guest": {
             "guest_daemon_id": guest.guest_daemon_id,
+            "workbench_policy_version": guest.workbench_policy_version,
             "enforcements": [
                 {
                     "authority": item.authority,
@@ -265,6 +291,11 @@ def _inventory(
             "probes": [
                 {
                     "identity": item.identity,
+                    "authority": item.authority,
+                    "source": item.source,
+                    "destination": item.destination,
+                    "protocol": item.protocol,
+                    "port": item.port,
                     "expectation": item.expectation,
                     "passed": item.passed,
                 }

--- a/src/aptl/core/deployment/__init__.py
+++ b/src/aptl/core/deployment/__init__.py
@@ -24,6 +24,7 @@ from aptl.core.deployment.backend import DeploymentBackend
 from aptl.core.deployment.docker_compose import DockerComposeBackend
 from aptl.core.deployment.realization import (
     DeploymentAccountRealization,
+    DeploymentAclRealization,
     DeploymentContentRealization,
     DeploymentGeneratedArtifactOutput,
     DeploymentGeneratedArtifactRealization,
@@ -44,6 +45,7 @@ __all__ = [
     "DeploymentBackend",
     "DockerComposeBackend",
     "DeploymentAccountRealization",
+    "DeploymentAclRealization",
     "DeploymentContentRealization",
     "DeploymentGeneratedArtifactOutput",
     "DeploymentGeneratedArtifactRealization",

--- a/src/aptl/core/deployment/_compose_base_substrate.py
+++ b/src/aptl/core/deployment/_compose_base_substrate.py
@@ -116,6 +116,17 @@ class ComposeBaseSubstrateMixin(object):
         network_bindings = getattr(self, "_base_networks_by_address", {}).get(
             spec.node_address
         )
+        argv = self._base_container_create_command(spec, network_bindings)
+        result = self._run(argv, timeout=180)
+        self._complete_base_container_start(spec, network_bindings, result)
+
+    def _base_container_create_command(
+        self,
+        spec: "BaseContainerSpec",
+        network_bindings: (tuple[tuple[str, DeploymentNetworkAttachment], ...] | None),
+    ) -> list[str]:
+        """Build a create/run command with exact declared network identity."""
+
         argv = [
             "docker",
             "create" if network_bindings is not None else "run",
@@ -156,7 +167,16 @@ class ComposeBaseSubstrateMixin(object):
             argv.append(spec.image_ref)
         else:
             argv += [spec.image_ref, "sleep", "infinity"]
-        result = self._run(argv, timeout=180)
+        return argv
+
+    def _complete_base_container_start(
+        self,
+        spec: "BaseContainerSpec",
+        network_bindings: (tuple[tuple[str, DeploymentNetworkAttachment], ...] | None),
+        result: subprocess.CompletedProcess,
+    ) -> None:
+        """Attach remaining admitted networks, start, and clean failed creates."""
+
         if result.returncode == 0 and network_bindings is not None:
             result = self._attach_and_start_base_container(
                 spec.container_name,

--- a/src/aptl/core/deployment/_compose_base_substrate.py
+++ b/src/aptl/core/deployment/_compose_base_substrate.py
@@ -13,9 +13,14 @@ declared init requirements, and copy checked-in project content into it.
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 
+from aptl.core.deployment._compose_realization_networks import (
+    _match_managed_network,
+)
 from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
+from aptl.core.deployment.realization import DeploymentNetworkAttachment
 
 if TYPE_CHECKING:
     from aptl.backends.aces_base_substrate import BaseContainerSpec, InitRequirements
@@ -74,7 +79,9 @@ class ComposeBaseSubstrateMixin(object):
         build_context = _GENERIC_BASE_IMAGE_BUILD_CONTEXTS.get(image_ref)
         if build_context is None:
             return []
-        inspect_result = self._run(["docker", "image", "inspect", image_ref], timeout=30)
+        inspect_result = self._run(
+            ["docker", "image", "inspect", image_ref], timeout=30
+        )
         if inspect_result.returncode == 0:
             return []
         build_result = self._run(
@@ -106,10 +113,12 @@ class ComposeBaseSubstrateMixin(object):
         """
 
         self._run(["docker", "rm", "-f", spec.container_name])
+        network_bindings = getattr(self, "_base_networks_by_address", {}).get(
+            spec.node_address
+        )
         argv = [
             "docker",
-            "run",
-            "-d",
+            "create" if network_bindings is not None else "run",
             "--name",
             spec.container_name,
             "--label",
@@ -124,13 +133,22 @@ class ComposeBaseSubstrateMixin(object):
             "--label",
             f"com.docker.compose.project={self._project_name}",
         ]
+        if network_bindings is None:
+            argv.insert(2, "-d")
+        if network_bindings is not None:
+            first_network, first_attachment = network_bindings[0]
+            argv += ["--network", first_network]
+            if first_attachment.ipv4_address:
+                argv += ["--ip", first_attachment.ipv4_address]
         for mount in spec.volume_mounts:
             source = f"{self._project_name}_{mount.source}"
             suffix = ":ro" if mount.read_only else ""
             argv += ["-v", f"{source}:{mount.target}{suffix}"]
         for port in spec.published_ports:
             host = f"{port.host_ip}:" if port.host_ip else ""
-            host_port = port.host_port if port.host_port is not None else port.container_port
+            host_port = (
+                port.host_port if port.host_port is not None else port.container_port
+            )
             argv += ["-p", f"{host}{host_port}:{port.container_port}/{port.protocol}"]
         if spec.init is not None:
             argv += _init_run_flags(spec.init)
@@ -139,10 +157,37 @@ class ComposeBaseSubstrateMixin(object):
         else:
             argv += [spec.image_ref, "sleep", "infinity"]
         result = self._run(argv, timeout=180)
+        if result.returncode == 0 and network_bindings is not None:
+            result = self._attach_and_start_base_container(
+                spec.container_name,
+                network_bindings[1:],
+            )
         if result.returncode != 0:
+            if network_bindings is not None:
+                self._run(["docker", "rm", "-f", spec.container_name], timeout=30)
             raise BackendSeedError(
                 f"failed to start base container for node {spec.node_address}"
             )
+
+    def _attach_and_start_base_container(
+        self,
+        container_name: str,
+        bindings: tuple[tuple[str, DeploymentNetworkAttachment], ...],
+    ) -> subprocess.CompletedProcess:
+        """Attach only admitted networks to a stopped node, then start it."""
+
+        for concrete, attachment in bindings:
+            connected = self.connect_container_network(
+                container_name,
+                concrete,
+                ipv4_address=attachment.ipv4_address,
+            )
+            if not connected.success:
+                return subprocess.CompletedProcess(
+                    args=["docker", "network", "connect"],
+                    returncode=1,
+                )
+        return self._run(["docker", "start", container_name], timeout=60)
 
     def copy_into_container(
         self, container: str, source_path: str, dest_path: str, is_directory: bool
@@ -155,7 +200,9 @@ class ComposeBaseSubstrateMixin(object):
         """
 
         source = f"{source_path}/." if is_directory else source_path
-        result = self._run(["docker", "cp", source, f"{container}:{dest_path}"], timeout=120)
+        result = self._run(
+            ["docker", "cp", source, f"{container}:{dest_path}"], timeout=120
+        )
         if result.returncode != 0:
             raise BackendSeedError(
                 f"failed to copy project content into container {container}"
@@ -195,5 +242,40 @@ class ComposeBaseSubstrateMixin(object):
         return (
             []
             if result.returncode == 0
-            else [f"failed to remove generic-materializer containers: {result.stderr.strip()}"]
+            else [
+                f"failed to remove generic-materializer containers: {result.stderr.strip()}"
+            ]
         )
+
+    def configure_base_container_networks(self, nodes: tuple[object, ...]) -> None:
+        """Bind image-free nodes to admitted networks before they are created."""
+
+        strict = getattr(
+            self, "_appliance_boundary", None
+        ) is not None or "aces" in getattr(self, "_boundary_receipts", {})
+        if not strict:
+            self._base_networks_by_address = {}
+            return
+        managed = set(self.host_list_lab_networks(self._project_name))
+        bindings: dict[str, tuple[tuple[str, DeploymentNetworkAttachment], ...]] = {}
+        for node in nodes:
+            attachments = getattr(node, "network_attachments", ())
+            resolved: list[tuple[str, DeploymentNetworkAttachment]] = []
+            for attachment in attachments:
+                concrete = _match_managed_network(
+                    attachment.network,
+                    managed,
+                    self._project_name,
+                )
+                if concrete is None:
+                    raise BackendSeedError(
+                        "image-free node network binding was not observed"
+                    )
+                resolved.append((concrete, attachment))
+            if resolved:
+                bindings[getattr(node, "address")] = tuple(resolved)
+            elif getattr(self, "_appliance_boundary", None) is not None:
+                raise BackendSeedError(
+                    "appliance image-free node has no admitted network"
+                )
+        self._base_networks_by_address = bindings

--- a/src/aptl/core/deployment/_compose_boundary.py
+++ b/src/aptl/core/deployment/_compose_boundary.py
@@ -18,6 +18,8 @@ _BOUNDARY_TIMEOUT = 30
 
 
 class _BoundaryRunner(Protocol):
+    """Narrow selected-daemon operation surface used by the fixed helper."""
+
     @property
     def project_dir(self) -> Path: ...
 
@@ -41,6 +43,8 @@ def _helper_command(
     action: str,
     image: str = DEFAULT_BOUNDARY_HELPER_IMAGE,
 ) -> list[str]:
+    """Build the fixed, capability-minimal helper invocation."""
+
     return [
         "docker",
         "run",
@@ -83,21 +87,34 @@ def realize_boundary(
     )
     if mutation.returncode != 0:
         return LabResult(success=False, error="Boundary policy mutation failed.")
-    observation = mutation
-    if action == "apply":
-        observation = backend._run_with_input(
+    observation = (
+        backend._run_with_input(
             _helper_command("observe", helper_image),
             payload,
             timeout=_BOUNDARY_TIMEOUT,
         )
+        if action == "apply"
+        else mutation
+    )
+    return _boundary_observation_result(policy, action, observation)
+
+
+def _boundary_observation_result(
+    policy: BoundaryEnforcementSpec,
+    action: str,
+    observation: subprocess.CompletedProcess,
+) -> LabResult:
+    """Validate the helper's exact normalized kernel-readback receipt."""
+
+    error: str | None = None
+    receipt: object = None
     if observation.returncode != 0:
-        return LabResult(success=False, error="Boundary policy observation failed.")
+        error = "Boundary policy observation failed."
     try:
-        receipt = json.loads(observation.stdout)
+        if error is None:
+            receipt = json.loads(observation.stdout)
     except (TypeError, ValueError):
-        return LabResult(
-            success=False, error="Boundary policy observation was invalid."
-        )
+        error = "Boundary policy observation was invalid."
     expected_families = [] if action == "cleanup" else ["bridge", "inet"]
     expected = {
         "authority": policy.authority,
@@ -106,45 +123,50 @@ def realize_boundary(
         "families": expected_families,
         "default_deny": policy.authority == "platform",
     }
-    if receipt != expected:
-        return LabResult(
-            success=False,
-            error="Boundary policy readback did not match desired state.",
-        )
-    return LabResult(success=True, message="Boundary policy enforced and observed.")
+    if error is None and receipt != expected:
+        error = "Boundary policy readback did not match desired state."
+    return (
+        LabResult(success=False, error=error)
+        if error is not None
+        else LabResult(success=True, message="Boundary policy enforced and observed.")
+    )
 
 
 def _ensure_helper(
     backend: _BoundaryRunner,
     helper_image: str,
 ) -> LabResult | None:
+    """Require the selected helper image, building only the developer tag."""
+
     inspection = backend._run(
         ["docker", "image", "inspect", helper_image],
         timeout=_BOUNDARY_TIMEOUT,
     )
-    if inspection.returncode == 0:
-        return None
-    if helper_image != DEFAULT_BOUNDARY_HELPER_IMAGE:
-        return LabResult(
+    result: LabResult | None = None
+    if inspection.returncode != 0 and helper_image != DEFAULT_BOUNDARY_HELPER_IMAGE:
+        result = LabResult(
             success=False,
             error="Signed boundary enforcement helper was unavailable.",
         )
-    dockerfile = backend.project_dir / "containers/network-boundary-helper/Dockerfile"
-    build = backend._run(
-        [
-            "docker",
-            "build",
-            "-t",
-            helper_image,
-            "-f",
-            str(dockerfile),
-            str(backend.project_dir),
-        ],
-        timeout=600,
-    )
-    if build.returncode != 0:
-        return LabResult(
-            success=False,
-            error="Boundary enforcement helper was unavailable.",
+    elif inspection.returncode != 0:
+        dockerfile = (
+            backend.project_dir / "containers/network-boundary-helper/Dockerfile"
         )
-    return None
+        build = backend._run(
+            [
+                "docker",
+                "build",
+                "-t",
+                helper_image,
+                "-f",
+                str(dockerfile),
+                str(backend.project_dir),
+            ],
+            timeout=600,
+        )
+        if build.returncode != 0:
+            result = LabResult(
+                success=False,
+                error="Boundary enforcement helper was unavailable.",
+            )
+    return result

--- a/src/aptl/core/deployment/_compose_boundary.py
+++ b/src/aptl/core/deployment/_compose_boundary.py
@@ -1,0 +1,135 @@
+"""Selected-daemon host enforcement for appliance boundary policy."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+from aptl.core.deployment.boundary import (
+    AcesBoundarySpec,
+    BoundaryEnforcementSpec,
+)
+from aptl.core.lab_types import LabResult
+
+_HELPER_IMAGE = "aptl-network-boundary-helper:1"
+_BOUNDARY_TIMEOUT = 30
+
+
+class _BoundaryRunner(Protocol):
+    @property
+    def project_dir(self) -> Path: ...
+
+    def _run(
+        self,
+        cmd: list[str],
+        *,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess: ...
+
+    def _run_with_input(
+        self,
+        cmd: list[str],
+        payload: str,
+        *,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess: ...
+
+
+def _helper_command(action: str) -> list[str]:
+    return [
+        "docker",
+        "run",
+        "--rm",
+        "--network",
+        "host",
+        "--cap-drop=ALL",
+        "--cap-add=NET_ADMIN",
+        "--security-opt=no-new-privileges",
+        "--read-only",
+        "--tmpfs=/run:rw,noexec,nosuid,nodev,size=1m",
+        "-i",
+        _HELPER_IMAGE,
+        action,
+        "--stdin",
+    ]
+
+
+def realize_boundary(
+    backend: _BoundaryRunner,
+    policy: BoundaryEnforcementSpec,
+) -> LabResult:
+    """Atomically apply/clean one owned policy and verify effective readback."""
+
+    helper = _ensure_helper(backend)
+    if helper is not None:
+        return helper
+    payload = policy.canonical_json()
+    action = (
+        "cleanup"
+        if isinstance(policy, AcesBoundarySpec) and not policy.rules
+        else "apply"
+    )
+    mutation = backend._run_with_input(
+        _helper_command(action),
+        payload,
+        timeout=_BOUNDARY_TIMEOUT,
+    )
+    if mutation.returncode != 0:
+        return LabResult(success=False, error="Boundary policy mutation failed.")
+    observation = mutation
+    if action == "apply":
+        observation = backend._run_with_input(
+            _helper_command("observe"),
+            payload,
+            timeout=_BOUNDARY_TIMEOUT,
+        )
+    if observation.returncode != 0:
+        return LabResult(success=False, error="Boundary policy observation failed.")
+    try:
+        receipt = json.loads(observation.stdout)
+    except (TypeError, ValueError):
+        return LabResult(success=False, error="Boundary policy observation was invalid.")
+    expected_families = [] if action == "cleanup" else ["bridge", "inet"]
+    expected = {
+        "authority": policy.authority,
+        "owner": policy.owner,
+        "enforcement_digest": policy.digest(),
+        "families": expected_families,
+        "default_deny": policy.authority == "platform",
+    }
+    if receipt != expected:
+        return LabResult(
+            success=False,
+            error="Boundary policy readback did not match desired state.",
+        )
+    return LabResult(success=True, message="Boundary policy enforced and observed.")
+
+
+def _ensure_helper(backend: _BoundaryRunner) -> LabResult | None:
+    inspection = backend._run(
+        ["docker", "image", "inspect", _HELPER_IMAGE],
+        timeout=_BOUNDARY_TIMEOUT,
+    )
+    if inspection.returncode == 0:
+        return None
+    dockerfile = backend.project_dir / "containers/network-boundary-helper/Dockerfile"
+    build = backend._run(
+        [
+            "docker",
+            "build",
+            "-t",
+            _HELPER_IMAGE,
+            "-f",
+            str(dockerfile),
+            str(backend.project_dir),
+        ],
+        timeout=600,
+    )
+    if build.returncode != 0:
+        return LabResult(
+            success=False,
+            error="Boundary enforcement helper was unavailable.",
+        )
+    return None

--- a/src/aptl/core/deployment/_compose_boundary.py
+++ b/src/aptl/core/deployment/_compose_boundary.py
@@ -13,7 +13,7 @@ from aptl.core.deployment.boundary import (
 )
 from aptl.core.lab_types import LabResult
 
-_HELPER_IMAGE = "aptl-network-boundary-helper:1"
+DEFAULT_BOUNDARY_HELPER_IMAGE = "aptl-network-boundary-helper:1"
 _BOUNDARY_TIMEOUT = 30
 
 
@@ -37,7 +37,10 @@ class _BoundaryRunner(Protocol):
     ) -> subprocess.CompletedProcess: ...
 
 
-def _helper_command(action: str) -> list[str]:
+def _helper_command(
+    action: str,
+    image: str = DEFAULT_BOUNDARY_HELPER_IMAGE,
+) -> list[str]:
     return [
         "docker",
         "run",
@@ -50,7 +53,7 @@ def _helper_command(action: str) -> list[str]:
         "--read-only",
         "--tmpfs=/run:rw,noexec,nosuid,nodev,size=1m",
         "-i",
-        _HELPER_IMAGE,
+        image,
         action,
         "--stdin",
     ]
@@ -59,10 +62,12 @@ def _helper_command(action: str) -> list[str]:
 def realize_boundary(
     backend: _BoundaryRunner,
     policy: BoundaryEnforcementSpec,
+    *,
+    helper_image: str = DEFAULT_BOUNDARY_HELPER_IMAGE,
 ) -> LabResult:
     """Atomically apply/clean one owned policy and verify effective readback."""
 
-    helper = _ensure_helper(backend)
+    helper = _ensure_helper(backend, helper_image)
     if helper is not None:
         return helper
     payload = policy.canonical_json()
@@ -72,7 +77,7 @@ def realize_boundary(
         else "apply"
     )
     mutation = backend._run_with_input(
-        _helper_command(action),
+        _helper_command(action, helper_image),
         payload,
         timeout=_BOUNDARY_TIMEOUT,
     )
@@ -81,7 +86,7 @@ def realize_boundary(
     observation = mutation
     if action == "apply":
         observation = backend._run_with_input(
-            _helper_command("observe"),
+            _helper_command("observe", helper_image),
             payload,
             timeout=_BOUNDARY_TIMEOUT,
         )
@@ -90,7 +95,9 @@ def realize_boundary(
     try:
         receipt = json.loads(observation.stdout)
     except (TypeError, ValueError):
-        return LabResult(success=False, error="Boundary policy observation was invalid.")
+        return LabResult(
+            success=False, error="Boundary policy observation was invalid."
+        )
     expected_families = [] if action == "cleanup" else ["bridge", "inet"]
     expected = {
         "authority": policy.authority,
@@ -107,20 +114,28 @@ def realize_boundary(
     return LabResult(success=True, message="Boundary policy enforced and observed.")
 
 
-def _ensure_helper(backend: _BoundaryRunner) -> LabResult | None:
+def _ensure_helper(
+    backend: _BoundaryRunner,
+    helper_image: str,
+) -> LabResult | None:
     inspection = backend._run(
-        ["docker", "image", "inspect", _HELPER_IMAGE],
+        ["docker", "image", "inspect", helper_image],
         timeout=_BOUNDARY_TIMEOUT,
     )
     if inspection.returncode == 0:
         return None
+    if helper_image != DEFAULT_BOUNDARY_HELPER_IMAGE:
+        return LabResult(
+            success=False,
+            error="Signed boundary enforcement helper was unavailable.",
+        )
     dockerfile = backend.project_dir / "containers/network-boundary-helper/Dockerfile"
     build = backend._run(
         [
             "docker",
             "build",
             "-t",
-            _HELPER_IMAGE,
+            helper_image,
             "-f",
             str(dockerfile),
             str(backend.project_dir),

--- a/src/aptl/core/deployment/_compose_boundary_realization.py
+++ b/src/aptl/core/deployment/_compose_boundary_realization.py
@@ -1,0 +1,281 @@
+"""Compose-side compilation and enforcement of independent boundary authorities."""
+
+from __future__ import annotations
+
+import ipaddress
+
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+)
+from aptl.core.deployment._compose_boundary import (
+    DEFAULT_BOUNDARY_HELPER_IMAGE,
+    realize_boundary as _realize_boundary,
+)
+from aptl.core.deployment._compose_realization_networks import (
+    _match_managed_network,
+)
+from aptl.core.deployment.boundary import (
+    AcesBoundarySpec,
+    BoundaryEnforcementSpec,
+    BoundaryNetwork,
+    BoundaryWorkload,
+)
+from aptl.core.deployment.boundary_compiler import (
+    BoundaryCompileError,
+    compile_aces_boundary,
+    compile_platform_boundary,
+)
+from aptl.core.deployment.realization import DeploymentRealizationSpec
+from aptl.core.lab_types import LabResult
+
+
+def _boundary_ip_families(
+    subnets: list[object],
+) -> tuple[str | None, str | None]:
+    """Return the first observed IPv4 and IPv6 subnet without guessing."""
+
+    ipv4: str | None = None
+    ipv6: str | None = None
+    for value in subnets:
+        if not isinstance(value, str) or not value:
+            continue
+        try:
+            version = ipaddress.ip_network(value, strict=False).version
+        except ValueError as exc:
+            raise BoundaryCompileError("boundary network subnet was invalid") from exc
+        if version == 4 and ipv4 is None:
+            ipv4 = value
+        elif version == 6 and ipv6 is None:
+            ipv6 = value
+    return ipv4, ipv6
+
+
+def _sorted_labels(raw: object) -> tuple[tuple[str, str], ...]:
+    """Normalize an observed label mapping into deterministic string pairs."""
+
+    if not isinstance(raw, dict):
+        return ()
+    return tuple(sorted((str(key), str(value)) for key, value in raw.items()))
+
+
+def _network_observation(
+    name: str,
+    details: dict[str, object],
+) -> BoundaryNetwork:
+    """Build one strict network observation from bounded backend fields."""
+
+    bridge = details.get("bridge")
+    if not isinstance(bridge, str) or not bridge:
+        raise BoundaryCompileError("realized network bridge was not observable")
+    subnets = details.get("subnets")
+    if not isinstance(subnets, list):
+        subnets = [details.get("subnet", "")]
+    ipv4, ipv6 = _boundary_ip_families(subnets)
+    return BoundaryNetwork(
+        name=name,
+        bridge=bridge,
+        ipv4_cidr=ipv4,
+        ipv6_cidr=ipv6,
+        labels=_sorted_labels(details.get("labels")),
+    )
+
+
+def _workload_addresses(
+    attached: object,
+    known_networks: set[str],
+) -> tuple[tuple[tuple[str, str], ...], tuple[tuple[str, str], ...]]:
+    """Extract exact known-network addresses from one container inspection."""
+
+    if not isinstance(attached, dict):
+        return (), ()
+    ipv4: list[tuple[str, str]] = []
+    ipv6: list[tuple[str, str]] = []
+    for network_name, network in attached.items():
+        if network_name not in known_networks or not isinstance(network, dict):
+            continue
+        ipv4_address = network.get("IPAddress")
+        if isinstance(ipv4_address, str) and ipv4_address:
+            ipv4.append((network_name, ipv4_address))
+        ipv6_address = network.get("GlobalIPv6Address")
+        if isinstance(ipv6_address, str) and ipv6_address:
+            ipv6.append((network_name, ipv6_address))
+    return tuple(sorted(ipv4)), tuple(sorted(ipv6))
+
+
+class ComposeBoundaryRealizationMixin:
+    """Apply platform and ACES policy on the selected Compose daemon host."""
+
+    def configure_appliance_boundary(
+        self,
+        policy: ApplianceBoundaryPolicy,
+        binding: ApplianceBoundaryBinding,
+    ) -> None:
+        """Install trusted release and launcher projections for realization."""
+
+        self._appliance_boundary = (policy, binding)
+        self._boundary_helper_image = binding.boundary_helper_image
+
+    def realize_boundary(self, policy: BoundaryEnforcementSpec) -> LabResult:
+        """Apply and observe policy on the selected Docker daemon host."""
+
+        result = _realize_boundary(
+            self,
+            policy,
+            helper_image=self._boundary_helper_image,
+        )
+        if result.success:
+            self._record_boundary_receipt(policy)
+        return result
+
+    def _record_boundary_receipt(self, policy: BoundaryEnforcementSpec) -> None:
+        """Store only normalized enforcement identity needed by qualification."""
+
+        if policy.authority == "aces" and not policy.rules:
+            self._boundary_receipts.pop("aces", None)
+            return
+        binding = (
+            self._appliance_boundary[1]
+            if self._appliance_boundary is not None
+            else None
+        )
+        source_digest = (
+            policy.policy_digest
+            if policy.authority == "platform"
+            else (binding.aces_plan_digest if binding is not None else "")
+        )
+        self._boundary_receipts[policy.authority] = {
+            "source_digest": source_digest,
+            "enforcement_digest": policy.digest(),
+            "families": ("bridge", "inet"),
+            "default_deny": policy.authority == "platform",
+        }
+
+    def _realize_authority_boundaries(
+        self,
+        realization: DeploymentRealizationSpec,
+    ) -> LabResult | None:
+        """Apply platform policy first, then the independent ACES authority."""
+
+        platform = self._realize_platform_boundary()
+        if platform is not None:
+            return platform
+        return self._realize_aces_boundary(realization)
+
+    def _realize_platform_boundary(self) -> LabResult | None:
+        """Compile and enforce the configured signed platform policy."""
+
+        configured = getattr(self, "_appliance_boundary", None)
+        if configured is None:
+            return None
+        policy, binding = configured
+        try:
+            networks = self._project_boundary_network_observations()
+            workloads = self._platform_workload_observations(networks)
+            enforcement = compile_platform_boundary(
+                policy,
+                policy_digest=binding.policy_digest,
+                networks=networks,
+                workloads=workloads,
+                owner=self._project_name,
+            )
+        except BoundaryCompileError:
+            return LabResult(
+                success=False,
+                error="Platform boundary anchors were not observed exactly.",
+            )
+        result = self.realize_boundary(enforcement)
+        return None if result.success else result
+
+    def _realize_aces_boundary(
+        self,
+        realization: DeploymentRealizationSpec,
+    ) -> LabResult | None:
+        """Apply admitted ACES ACLs before a scenario workload can start."""
+
+        if not realization.acls:
+            configured = getattr(self, "_appliance_boundary", None)
+            receipts = getattr(self, "_boundary_receipts", {})
+            if configured is None and "aces" not in receipts:
+                return None
+            enforcement = AcesBoundarySpec.empty(self._project_name)
+        else:
+            try:
+                networks = self._boundary_network_observations(realization)
+                enforcement = compile_aces_boundary(
+                    realization,
+                    networks,
+                    owner=self._project_name,
+                )
+            except BoundaryCompileError:
+                return LabResult(
+                    success=False,
+                    error="ACES boundary could not be bound without widening policy.",
+                )
+        result = self.realize_boundary(enforcement)
+        return None if result.success else result
+
+    def _boundary_network_observations(
+        self,
+        realization: DeploymentRealizationSpec,
+    ) -> tuple[BoundaryNetwork, ...]:
+        """Return concrete bridge identities for scenario-declared networks."""
+
+        if not realization.acls:
+            return ()
+        managed = set(self.host_list_lab_networks(self._project_name))
+        observed: list[BoundaryNetwork] = []
+        for desired in realization.networks:
+            concrete = _match_managed_network(
+                desired.name,
+                managed,
+                self._project_name,
+            )
+            details = self.host_inspect_network(concrete) if concrete else {}
+            observed.append(_network_observation(desired.name, details))
+        return tuple(observed)
+
+    def _project_boundary_network_observations(
+        self,
+    ) -> tuple[BoundaryNetwork, ...]:
+        """Observe all project-scoped platform networks."""
+
+        observed = tuple(
+            _network_observation(concrete, self.host_inspect_network(concrete))
+            for concrete in sorted(self.host_list_lab_networks(self._project_name))
+        )
+        if not observed:
+            raise BoundaryCompileError("platform networks were not observed")
+        return observed
+
+    def _platform_workload_observations(
+        self,
+        networks: tuple[BoundaryNetwork, ...],
+    ) -> tuple[BoundaryWorkload, ...]:
+        """Normalize exact labeled workload addresses without raw inspect output."""
+
+        known = {network.name for network in networks}
+        workloads: list[BoundaryWorkload] = []
+        for row in self.host_list_lab_containers():
+            name = row.get("name")
+            labels = row.get("labels")
+            if not isinstance(name, str) or not isinstance(labels, dict):
+                continue
+            details = self.container_inspect(name)
+            network_settings = details.get("NetworkSettings", {})
+            attached = (
+                network_settings.get("Networks", {})
+                if isinstance(network_settings, dict)
+                else {}
+            )
+            ipv4, ipv6 = _workload_addresses(attached, known)
+            if ipv4 or ipv6:
+                workloads.append(
+                    BoundaryWorkload(
+                        identity=name,
+                        labels=_sorted_labels(labels),
+                        ipv4_by_network=ipv4,
+                        ipv6_by_network=ipv6,
+                    )
+                )
+        return tuple(sorted(workloads, key=lambda item: item.identity))

--- a/src/aptl/core/deployment/_compose_image_free_realization.py
+++ b/src/aptl/core/deployment/_compose_image_free_realization.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from typing import cast
 
 from aptl.core.deployment.realization import DeploymentRealizationSpec
+from aptl.core.deployment.errors import BackendSeedError
 from aptl.core.lab_types import LabResult
 
 
@@ -33,16 +34,22 @@ def _strip_image_free_published_ports(
     """
 
     legacy_nodes = tuple(
-        replace(node, published_ports=()) if node.address in image_free_addresses else node
+        replace(node, published_ports=())
+        if node.address in image_free_addresses
+        else node
         for node in realization.nodes
     )
     return cast(DeploymentRealizationSpec, replace(realization, nodes=legacy_nodes))
 
 
-def _image_free_node_addresses(realization: DeploymentRealizationSpec) -> frozenset[str]:
+def _image_free_node_addresses(
+    realization: DeploymentRealizationSpec,
+) -> frozenset[str]:
     """Return the addresses of every node declaring runtime desired state."""
 
-    return frozenset(node.address for node in realization.nodes if node.runtime is not None)
+    return frozenset(
+        node.address for node in realization.nodes if node.runtime is not None
+    )
 
 
 def _image_free_service_names(
@@ -91,7 +98,10 @@ def _realize_node_subset(
     for image_ref in sorted(
         {
             base_container_spec(
-                node.address, os=node.os, os_version=node.os_version, runtime=node.runtime
+                node.address,
+                os=node.os,
+                os_version=node.os_version,
+                runtime=node.runtime,
             ).image_ref
             for node in nodes
         }
@@ -99,13 +109,25 @@ def _realize_node_subset(
         image_build_failures.extend(backend.ensure_generic_base_image(image_ref))
     if image_build_failures:
         return LabResult(success=False, error="; ".join(image_build_failures[:5]))
+    configure_networks = getattr(backend, "configure_base_container_networks", None)
+    if callable(configure_networks):
+        try:
+            configure_networks(nodes)
+        except BackendSeedError:
+            return LabResult(
+                success=False,
+                error="Image-free network binding failed.",
+            )
 
     content_by_node: dict[str, list[object]] = {}
     for item in content:
         dest = "/" + item.dest_relpath.lstrip("/")
         if item.source_kind == "inline-text" and item.inline_text is not None:
             op: object = PlaceFileOp(path=dest, content=item.inline_text)
-        elif item.source_kind in ("project-file", "project-directory") and item.source_relpath:
+        elif (
+            item.source_kind in ("project-file", "project-directory")
+            and item.source_relpath
+        ):
             op = PlaceProjectContentOp(
                 dest_path=dest,
                 source_relpath=item.source_relpath,

--- a/src/aptl/core/deployment/_compose_queries.py
+++ b/src/aptl/core/deployment/_compose_queries.py
@@ -83,6 +83,38 @@ def _decode_first_object(stdout: str) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _string_mapping(raw: object) -> dict[str, str]:
+    """Normalize an observed mapping without accepting other JSON shapes."""
+
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): str(value) for key, value in raw.items()}
+
+
+def _network_ipam_configs(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return valid Docker IPAM configuration records or one empty record."""
+
+    ipam = payload.get("IPAM")
+    raw = ipam.get("Config") if isinstance(ipam, dict) else None
+    if not isinstance(raw, list):
+        return [{}]
+    configs = [item for item in raw if isinstance(item, dict)]
+    return configs or [{}]
+
+
+def _network_bridge(
+    payload: dict[str, Any],
+    options: dict[str, str],
+    network_id: str,
+) -> str:
+    """Return the explicit or deterministic default bridge interface name."""
+
+    bridge = options.get("com.docker.network.bridge.name", "")
+    if not bridge and payload.get("Driver") == "bridge" and network_id:
+        return f"br-{network_id[:12]}"
+    return bridge
+
+
 def _decode_compose_ps(stdout: str) -> list[dict[str, Any]]:
     """Parse ``docker compose ps --format json`` output (NDJSON or array)."""
     stripped = stdout.strip()
@@ -136,10 +168,15 @@ class ComposeQueryMixin(object):
         fmt = "{{.Names}}\t{{.Image}}\t{{.ID}}\t{{.Status}}\t{{.Labels}}\t{{.Ports}}"
         result = self._run(
             [
-                "docker", "ps", "-a",
-                "--filter", f"label=com.docker.compose.project={self._project_name}",
-                "--filter", "name=aptl-",
-                "--format", fmt,
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"label=com.docker.compose.project={self._project_name}",
+                "--filter",
+                "name=aptl-",
+                "--format",
+                fmt,
             ],
             timeout=_HOST_INVENTORY_TIMEOUT,
         )
@@ -157,20 +194,21 @@ class ComposeQueryMixin(object):
         # tenants' aptl-* networks on a shared SSH daemon.
         result = self._run(
             [
-                "docker", "network", "ls",
-                "--filter", f"label=com.docker.compose.project={self._project_name}",
-                "--filter", f"name={name_prefix}",
-                "--format", "{{.Name}}",
+                "docker",
+                "network",
+                "ls",
+                "--filter",
+                f"label=com.docker.compose.project={self._project_name}",
+                "--filter",
+                f"name={name_prefix}",
+                "--format",
+                "{{.Name}}",
             ],
             timeout=_HOST_INVENTORY_TIMEOUT,
         )
         if result.returncode != 0:
             return []
-        return [
-            line.strip()
-            for line in result.stdout.splitlines()
-            if line.strip()
-        ]
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
     def host_list_networks(self) -> list[str]:
         """List every Docker network visible to the backend daemon."""
@@ -181,13 +219,11 @@ class ComposeQueryMixin(object):
         )
         if result.returncode != 0:
             return []
-        return [
-            line.strip()
-            for line in result.stdout.splitlines()
-            if line.strip()
-        ]
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
     def host_inspect_network(self, name: str) -> dict[str, Any]:
+        """Return bounded network identity, labels, addresses, and membership."""
+
         result = self._run(
             ["docker", "network", "inspect", name],
             timeout=_HOST_INVENTORY_TIMEOUT,
@@ -199,19 +235,13 @@ class ComposeQueryMixin(object):
         )
         if not payload:
             return {}
-        ipam_configs = payload.get("IPAM", {}).get("Config") or [{}]
+        ipam_configs = _network_ipam_configs(payload)
         ipam = ipam_configs[0]
         containers_map = payload.get("Containers", {})
-        labels = payload.get("Labels")
-        options = payload.get("Options")
-        if not isinstance(labels, dict):
-            labels = {}
-        if not isinstance(options, dict):
-            options = {}
+        labels = _string_mapping(payload.get("Labels"))
+        options = _string_mapping(payload.get("Options"))
         network_id = str(payload.get("Id", ""))
-        bridge = str(options.get("com.docker.network.bridge.name", ""))
-        if not bridge and payload.get("Driver") == "bridge" and network_id:
-            bridge = f"br-{network_id[:12]}"
+        bridge = _network_bridge(payload, options, network_id)
         subnets = [
             str(config.get("Subnet", ""))
             for config in ipam_configs
@@ -226,16 +256,14 @@ class ComposeQueryMixin(object):
             "subnet": ipam.get("Subnet", ""),
             "subnets": subnets,
             "gateway": ipam.get("Gateway", ""),
-            "labels": {str(key): str(value) for key, value in labels.items()},
-            "options": {str(key): str(value) for key, value in options.items()},
+            "labels": labels,
+            "options": options,
             "containers": sorted(c.get("Name", "") for c in containers_map.values()),
         }
 
     # Container interaction (CLI-004, ADR-023) ----------------------------
 
-    def container_list(
-        self, *, all_containers: bool = True
-    ) -> list[dict[str, Any]]:
+    def container_list(self, *, all_containers: bool = True) -> list[dict[str, Any]]:
         cmd = ["docker", "compose", "-p", self._project_name, "ps"]
         if all_containers:
             cmd.append("-a")
@@ -277,9 +305,7 @@ class ComposeQueryMixin(object):
         cmd.append(name)
         return self._run(cmd, timeout=timeout)
 
-    def container_shell(
-        self, name: str, *, shell: str | None = None
-    ) -> int:
+    def container_shell(self, name: str, *, shell: str | None = None) -> int:
         if shell is not None:
             return self._run_streaming(["docker", "exec", "-it", name, shell])
         # Probe non-interactively for bash before launching the TTY,
@@ -289,7 +315,9 @@ class ComposeQueryMixin(object):
         if not should_run:
             log.warning(
                 "container_shell probe of %s failed (exit %d): %s",
-                name, probe.returncode, probe.stderr.strip(),
+                name,
+                probe.returncode,
+                probe.stderr.strip(),
             )
             return probe.returncode
         if chosen == "/bin/sh":
@@ -341,6 +369,8 @@ class ComposeQueryMixin(object):
             timeout=_HOST_INVENTORY_TIMEOUT,
         )
         if result.returncode != 0:
-            log.debug("container_inspect failed for %s: %s", name, result.stderr.strip())
+            log.debug(
+                "container_inspect failed for %s: %s", name, result.stderr.strip()
+            )
             return {}
         return _decode_first_object(result.stdout)

--- a/src/aptl/core/deployment/_compose_queries.py
+++ b/src/aptl/core/deployment/_compose_queries.py
@@ -199,17 +199,35 @@ class ComposeQueryMixin(object):
         )
         if not payload:
             return {}
-        ipam = (payload.get("IPAM", {}).get("Config") or [{}])[0]
+        ipam_configs = payload.get("IPAM", {}).get("Config") or [{}]
+        ipam = ipam_configs[0]
         containers_map = payload.get("Containers", {})
         labels = payload.get("Labels")
+        options = payload.get("Options")
         if not isinstance(labels, dict):
             labels = {}
+        if not isinstance(options, dict):
+            options = {}
+        network_id = str(payload.get("Id", ""))
+        bridge = str(options.get("com.docker.network.bridge.name", ""))
+        if not bridge and payload.get("Driver") == "bridge" and network_id:
+            bridge = f"br-{network_id[:12]}"
+        subnets = [
+            str(config.get("Subnet", ""))
+            for config in ipam_configs
+            if isinstance(config, dict) and config.get("Subnet")
+        ]
         return {
             "name": name,
+            "id": network_id,
+            "driver": str(payload.get("Driver", "")),
+            "bridge": bridge,
             "internal": bool(payload.get("Internal", False)),
             "subnet": ipam.get("Subnet", ""),
+            "subnets": subnets,
             "gateway": ipam.get("Gateway", ""),
             "labels": {str(key): str(value) for key, value in labels.items()},
+            "options": {str(key): str(value) for key, value in options.items()},
             "containers": sorted(c.get("Name", "") for c in containers_map.values()),
         }
 

--- a/src/aptl/core/deployment/_compose_realization.py
+++ b/src/aptl/core/deployment/_compose_realization.py
@@ -43,10 +43,15 @@ from aptl.core.deployment._compose_realization_networks import (
     _resolve_realization_networks,
 )
 from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
-from aptl.core.deployment.boundary import BoundaryNetwork
+from aptl.core.deployment.boundary import (
+    AcesBoundarySpec,
+    BoundaryNetwork,
+    BoundaryWorkload,
+)
 from aptl.core.deployment.boundary_compiler import (
     BoundaryCompileError,
     compile_aces_boundary,
+    compile_platform_boundary,
 )
 from aptl.core.deployment.realization import DeploymentRealizationSpec
 from aptl.core.lab_types import LabResult
@@ -63,6 +68,33 @@ __all__ = [
 ]
 
 _COMPOSE_MODEL_VALIDATION_ERROR = "Generated Compose model validation failed."
+
+
+def _boundary_ip_families(
+    subnets: list[object],
+) -> tuple[str | None, str | None]:
+    """Return the first observed IPv4/IPv6 subnet without guessing."""
+
+    ipv4: str | None = None
+    ipv6: str | None = None
+    for value in subnets:
+        if not isinstance(value, str) or not value:
+            continue
+        try:
+            version = ipaddress.ip_network(value, strict=False).version
+        except ValueError as exc:
+            raise BoundaryCompileError("boundary network subnet was invalid") from exc
+        if version == 4 and ipv4 is None:
+            ipv4 = value
+        elif version == 6 and ipv6 is None:
+            ipv6 = value
+    return ipv4, ipv6
+
+
+def _sorted_labels(raw: object) -> tuple[tuple[str, str], ...]:
+    if not isinstance(raw, dict):
+        return ()
+    return tuple(sorted((str(key), str(value)) for key, value in raw.items()))
 
 
 class ComposeRealizationMixin(
@@ -111,7 +143,9 @@ class ComposeRealizationMixin(
             )
             if node_result is not None:
                 return node_result
-            excluded_services = _image_free_service_names(realization, image_free_addresses)
+            excluded_services = _image_free_service_names(
+                realization, image_free_addresses
+            )
             legacy_content = tuple(
                 item
                 for item in realization.content
@@ -120,7 +154,9 @@ class ComposeRealizationMixin(
             realization = cast(
                 DeploymentRealizationSpec, replace(realization, content=legacy_content)
             )
-            realization = _strip_image_free_published_ports(realization, image_free_addresses)
+            realization = _strip_image_free_published_ports(
+                realization, image_free_addresses
+            )
         else:
             excluded_services = ()
 
@@ -140,14 +176,16 @@ class ComposeRealizationMixin(
             network_failures = self._ensure_realization_networks(realization)
             if network_failures:
                 return LabResult(success=False, error="; ".join(network_failures[:5]))
-            return self._realize_aces_boundary(realization)
+            return self._realize_authority_boundaries(realization)
 
         def _compose_model() -> LabResult | None:
             """Render and validate the generated Compose model."""
 
             nonlocal compose_files
             compose_files = self._realization_compose_files(compose_files, realization)
-            return self._validate_realization_compose_model(profiles, compose_files, realization)
+            return self._validate_realization_compose_model(
+                profiles, compose_files, realization
+            )
 
         def _start() -> LabResult:
             """Start the realized services and return the final realization result."""
@@ -196,7 +234,7 @@ class ComposeRealizationMixin(
         network_failures = self._ensure_realization_networks(realization)
         if network_failures:
             return LabResult(success=False, error="; ".join(network_failures[:5]))
-        boundary_result = self._realize_aces_boundary(realization)
+        boundary_result = self._realize_authority_boundaries(realization)
         if boundary_result is not None:
             return boundary_result
         nodes = tuple(n for n in realization.nodes if n.address in addresses)
@@ -221,11 +259,45 @@ class ComposeRealizationMixin(
         network_failures = self._ensure_realization_networks(realization)
         if network_failures:
             return LabResult(success=False, error="; ".join(network_failures[:5]))
-        boundary_result = self._realize_aces_boundary(realization)
+        boundary_result = self._realize_authority_boundaries(realization)
         if boundary_result is not None:
             return boundary_result
         node_result = _realize_node_subset(self, realization.nodes, realization.content)
         return node_result if node_result is not None else LabResult(success=True)
+
+    def _realize_authority_boundaries(
+        self,
+        realization: DeploymentRealizationSpec,
+    ) -> LabResult | None:
+        """Apply platform policy first, then the independent ACES authority."""
+
+        platform = self._realize_platform_boundary()
+        if platform is not None:
+            return platform
+        return self._realize_aces_boundary(realization)
+
+    def _realize_platform_boundary(self) -> LabResult | None:
+        configured = getattr(self, "_appliance_boundary", None)
+        if configured is None:
+            return None
+        policy, binding = configured
+        try:
+            networks = self._project_boundary_network_observations()
+            workloads = self._platform_workload_observations(networks)
+            enforcement = compile_platform_boundary(
+                policy,
+                policy_digest=binding.policy_digest,
+                networks=networks,
+                workloads=workloads,
+                owner=self._project_name,
+            )
+        except BoundaryCompileError:
+            return LabResult(
+                success=False,
+                error="Platform boundary anchors were not observed exactly.",
+            )
+        result = self.realize_boundary(enforcement)
+        return None if result.success else result
 
     def _realize_aces_boundary(
         self,
@@ -234,7 +306,12 @@ class ComposeRealizationMixin(
         """Apply admitted ACES ACLs before a scenario workload can start."""
 
         if not realization.acls:
-            return None
+            configured = getattr(self, "_appliance_boundary", None)
+            receipts = getattr(self, "_boundary_receipts", {})
+            if configured is None and "aces" not in receipts:
+                return None
+            cleanup = self.realize_boundary(AcesBoundarySpec.empty(self._project_name))
+            return None if cleanup.success else cleanup
         try:
             networks = self._boundary_network_observations(realization)
             policy = compile_aces_boundary(
@@ -269,9 +346,7 @@ class ComposeRealizationMixin(
             details = self.host_inspect_network(concrete) if concrete else {}
             bridge = details.get("bridge")
             if not isinstance(bridge, str) or not bridge:
-                raise BoundaryCompileError(
-                    "realized network bridge was not observable"
-                )
+                raise BoundaryCompileError("realized network bridge was not observable")
             subnets = details.get("subnets")
             if not isinstance(subnets, list):
                 subnets = [details.get("subnet", "")]
@@ -313,6 +388,74 @@ class ComposeRealizationMixin(
                 )
             )
         return tuple(observed)
+
+    def _project_boundary_network_observations(
+        self,
+    ) -> tuple[BoundaryNetwork, ...]:
+        """Observe all project-scoped platform networks."""
+
+        observed: list[BoundaryNetwork] = []
+        for concrete in sorted(self.host_list_lab_networks(self._project_name)):
+            details = self.host_inspect_network(concrete)
+            bridge = details.get("bridge")
+            if not isinstance(bridge, str) or not bridge:
+                raise BoundaryCompileError("platform network bridge was not observable")
+            subnets = details.get("subnets")
+            if not isinstance(subnets, list):
+                subnets = [details.get("subnet", "")]
+            ipv4, ipv6 = _boundary_ip_families(subnets)
+            labels = details.get("labels")
+            observed.append(
+                BoundaryNetwork(
+                    name=concrete,
+                    bridge=bridge,
+                    ipv4_cidr=ipv4,
+                    ipv6_cidr=ipv6,
+                    labels=_sorted_labels(labels),
+                )
+            )
+        if not observed:
+            raise BoundaryCompileError("platform networks were not observed")
+        return tuple(observed)
+
+    def _platform_workload_observations(
+        self,
+        networks: tuple[BoundaryNetwork, ...],
+    ) -> tuple[BoundaryWorkload, ...]:
+        """Normalize exact labeled workload addresses without raw inspect output."""
+
+        known = {network.name for network in networks}
+        workloads: list[BoundaryWorkload] = []
+        for row in self.host_list_lab_containers():
+            name = row.get("name")
+            labels = row.get("labels")
+            if not isinstance(name, str) or not isinstance(labels, dict):
+                continue
+            details = self.container_inspect(name)
+            attached = details.get("NetworkSettings", {}).get("Networks", {})
+            if not isinstance(attached, dict):
+                continue
+            ipv4: list[tuple[str, str]] = []
+            ipv6: list[tuple[str, str]] = []
+            for network_name, network in attached.items():
+                if network_name not in known or not isinstance(network, dict):
+                    continue
+                address = network.get("IPAddress")
+                if isinstance(address, str) and address:
+                    ipv4.append((network_name, address))
+                address = network.get("GlobalIPv6Address")
+                if isinstance(address, str) and address:
+                    ipv6.append((network_name, address))
+            if ipv4 or ipv6:
+                workloads.append(
+                    BoundaryWorkload(
+                        identity=name,
+                        labels=_sorted_labels(labels),
+                        ipv4_by_network=tuple(sorted(ipv4)),
+                        ipv6_by_network=tuple(sorted(ipv6)),
+                    )
+                )
+        return tuple(sorted(workloads, key=lambda item: item.identity))
 
     def _realize_published_ports(
         self,

--- a/src/aptl/core/deployment/_compose_realization.py
+++ b/src/aptl/core/deployment/_compose_realization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import ipaddress
 from dataclasses import replace
 from pathlib import Path
 from typing import cast
@@ -37,10 +38,16 @@ from aptl.core.deployment._compose_image_free_realization import (
 )
 from aptl.core.deployment._compose_realization_networks import (
     _container_networks,
+    _match_managed_network,
     _network_name_candidates,
     _resolve_realization_networks,
 )
 from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
+from aptl.core.deployment.boundary import BoundaryNetwork
+from aptl.core.deployment.boundary_compiler import (
+    BoundaryCompileError,
+    compile_aces_boundary,
+)
 from aptl.core.deployment.realization import DeploymentRealizationSpec
 from aptl.core.lab_types import LabResult
 
@@ -133,7 +140,7 @@ class ComposeRealizationMixin(
             network_failures = self._ensure_realization_networks(realization)
             if network_failures:
                 return LabResult(success=False, error="; ".join(network_failures[:5]))
-            return None
+            return self._realize_aces_boundary(realization)
 
         def _compose_model() -> LabResult | None:
             """Render and validate the generated Compose model."""
@@ -189,6 +196,9 @@ class ComposeRealizationMixin(
         network_failures = self._ensure_realization_networks(realization)
         if network_failures:
             return LabResult(success=False, error="; ".join(network_failures[:5]))
+        boundary_result = self._realize_aces_boundary(realization)
+        if boundary_result is not None:
+            return boundary_result
         nodes = tuple(n for n in realization.nodes if n.address in addresses)
         content = tuple(
             item for item in realization.content if item.target_address in addresses
@@ -211,8 +221,98 @@ class ComposeRealizationMixin(
         network_failures = self._ensure_realization_networks(realization)
         if network_failures:
             return LabResult(success=False, error="; ".join(network_failures[:5]))
+        boundary_result = self._realize_aces_boundary(realization)
+        if boundary_result is not None:
+            return boundary_result
         node_result = _realize_node_subset(self, realization.nodes, realization.content)
         return node_result if node_result is not None else LabResult(success=True)
+
+    def _realize_aces_boundary(
+        self,
+        realization: DeploymentRealizationSpec,
+    ) -> LabResult | None:
+        """Apply admitted ACES ACLs before a scenario workload can start."""
+
+        if not realization.acls:
+            return None
+        try:
+            networks = self._boundary_network_observations(realization)
+            policy = compile_aces_boundary(
+                realization,
+                networks,
+                owner=self._project_name,
+            )
+        except BoundaryCompileError:
+            return LabResult(
+                success=False,
+                error="ACES boundary could not be bound without widening policy.",
+            )
+        result = self.realize_boundary(policy)
+        return None if result.success else result
+
+    def _boundary_network_observations(
+        self,
+        realization: DeploymentRealizationSpec,
+    ) -> tuple[BoundaryNetwork, ...]:
+        """Return concrete bridge identities for scenario-declared networks."""
+
+        if not realization.acls:
+            return ()
+        managed = set(self.host_list_lab_networks(self._project_name))
+        observed: list[BoundaryNetwork] = []
+        for desired in realization.networks:
+            concrete = _match_managed_network(
+                desired.name,
+                managed,
+                self._project_name,
+            )
+            details = self.host_inspect_network(concrete) if concrete else {}
+            bridge = details.get("bridge")
+            if not isinstance(bridge, str) or not bridge:
+                raise BoundaryCompileError(
+                    "realized network bridge was not observable"
+                )
+            subnets = details.get("subnets")
+            if not isinstance(subnets, list):
+                subnets = [details.get("subnet", "")]
+            ipv4 = next(
+                (
+                    value
+                    for value in subnets
+                    if isinstance(value, str)
+                    and value
+                    and ipaddress.ip_network(value, strict=False).version == 4
+                ),
+                None,
+            )
+            ipv6 = next(
+                (
+                    value
+                    for value in subnets
+                    if isinstance(value, str)
+                    and value
+                    and ipaddress.ip_network(value, strict=False).version == 6
+                ),
+                None,
+            )
+            labels = details.get("labels")
+            observed.append(
+                BoundaryNetwork(
+                    name=desired.name,
+                    bridge=bridge,
+                    ipv4_cidr=ipv4,
+                    ipv6_cidr=ipv6,
+                    labels=tuple(
+                        sorted(
+                            (str(key), str(value))
+                            for key, value in (
+                                labels.items() if isinstance(labels, dict) else ()
+                            )
+                        )
+                    ),
+                )
+            )
+        return tuple(observed)
 
     def _realize_published_ports(
         self,

--- a/src/aptl/core/deployment/_compose_realization.py
+++ b/src/aptl/core/deployment/_compose_realization.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import ipaddress
 from dataclasses import replace
 from pathlib import Path
 from typing import cast
@@ -14,6 +13,9 @@ from aptl.core.deployment._compose_account_realization import (
 from aptl.core.deployment._compose_content_realization import (
     CONTENT_SEEDER_IMAGE,
     ComposeRealizationContentMixin,
+)
+from aptl.core.deployment._compose_boundary_realization import (
+    ComposeBoundaryRealizationMixin,
 )
 from aptl.core.deployment._compose_port_realization import (
     published_port_conflicts,
@@ -38,21 +40,10 @@ from aptl.core.deployment._compose_image_free_realization import (
 )
 from aptl.core.deployment._compose_realization_networks import (
     _container_networks,
-    _match_managed_network,
     _network_name_candidates,
     _resolve_realization_networks,
 )
 from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
-from aptl.core.deployment.boundary import (
-    AcesBoundarySpec,
-    BoundaryNetwork,
-    BoundaryWorkload,
-)
-from aptl.core.deployment.boundary_compiler import (
-    BoundaryCompileError,
-    compile_aces_boundary,
-    compile_platform_boundary,
-)
 from aptl.core.deployment.realization import DeploymentRealizationSpec
 from aptl.core.lab_types import LabResult
 
@@ -70,34 +61,8 @@ __all__ = [
 _COMPOSE_MODEL_VALIDATION_ERROR = "Generated Compose model validation failed."
 
 
-def _boundary_ip_families(
-    subnets: list[object],
-) -> tuple[str | None, str | None]:
-    """Return the first observed IPv4/IPv6 subnet without guessing."""
-
-    ipv4: str | None = None
-    ipv6: str | None = None
-    for value in subnets:
-        if not isinstance(value, str) or not value:
-            continue
-        try:
-            version = ipaddress.ip_network(value, strict=False).version
-        except ValueError as exc:
-            raise BoundaryCompileError("boundary network subnet was invalid") from exc
-        if version == 4 and ipv4 is None:
-            ipv4 = value
-        elif version == 6 and ipv6 is None:
-            ipv6 = value
-    return ipv4, ipv6
-
-
-def _sorted_labels(raw: object) -> tuple[tuple[str, str], ...]:
-    if not isinstance(raw, dict):
-        return ()
-    return tuple(sorted((str(key), str(value)) for key, value in raw.items()))
-
-
 class ComposeRealizationMixin(
+    ComposeBoundaryRealizationMixin,
     ComposeRealizationImageMixin,
     ComposeRealizationNetworkMixin,
     ComposeRealizationContentMixin,
@@ -264,198 +229,6 @@ class ComposeRealizationMixin(
             return boundary_result
         node_result = _realize_node_subset(self, realization.nodes, realization.content)
         return node_result if node_result is not None else LabResult(success=True)
-
-    def _realize_authority_boundaries(
-        self,
-        realization: DeploymentRealizationSpec,
-    ) -> LabResult | None:
-        """Apply platform policy first, then the independent ACES authority."""
-
-        platform = self._realize_platform_boundary()
-        if platform is not None:
-            return platform
-        return self._realize_aces_boundary(realization)
-
-    def _realize_platform_boundary(self) -> LabResult | None:
-        configured = getattr(self, "_appliance_boundary", None)
-        if configured is None:
-            return None
-        policy, binding = configured
-        try:
-            networks = self._project_boundary_network_observations()
-            workloads = self._platform_workload_observations(networks)
-            enforcement = compile_platform_boundary(
-                policy,
-                policy_digest=binding.policy_digest,
-                networks=networks,
-                workloads=workloads,
-                owner=self._project_name,
-            )
-        except BoundaryCompileError:
-            return LabResult(
-                success=False,
-                error="Platform boundary anchors were not observed exactly.",
-            )
-        result = self.realize_boundary(enforcement)
-        return None if result.success else result
-
-    def _realize_aces_boundary(
-        self,
-        realization: DeploymentRealizationSpec,
-    ) -> LabResult | None:
-        """Apply admitted ACES ACLs before a scenario workload can start."""
-
-        if not realization.acls:
-            configured = getattr(self, "_appliance_boundary", None)
-            receipts = getattr(self, "_boundary_receipts", {})
-            if configured is None and "aces" not in receipts:
-                return None
-            cleanup = self.realize_boundary(AcesBoundarySpec.empty(self._project_name))
-            return None if cleanup.success else cleanup
-        try:
-            networks = self._boundary_network_observations(realization)
-            policy = compile_aces_boundary(
-                realization,
-                networks,
-                owner=self._project_name,
-            )
-        except BoundaryCompileError:
-            return LabResult(
-                success=False,
-                error="ACES boundary could not be bound without widening policy.",
-            )
-        result = self.realize_boundary(policy)
-        return None if result.success else result
-
-    def _boundary_network_observations(
-        self,
-        realization: DeploymentRealizationSpec,
-    ) -> tuple[BoundaryNetwork, ...]:
-        """Return concrete bridge identities for scenario-declared networks."""
-
-        if not realization.acls:
-            return ()
-        managed = set(self.host_list_lab_networks(self._project_name))
-        observed: list[BoundaryNetwork] = []
-        for desired in realization.networks:
-            concrete = _match_managed_network(
-                desired.name,
-                managed,
-                self._project_name,
-            )
-            details = self.host_inspect_network(concrete) if concrete else {}
-            bridge = details.get("bridge")
-            if not isinstance(bridge, str) or not bridge:
-                raise BoundaryCompileError("realized network bridge was not observable")
-            subnets = details.get("subnets")
-            if not isinstance(subnets, list):
-                subnets = [details.get("subnet", "")]
-            ipv4 = next(
-                (
-                    value
-                    for value in subnets
-                    if isinstance(value, str)
-                    and value
-                    and ipaddress.ip_network(value, strict=False).version == 4
-                ),
-                None,
-            )
-            ipv6 = next(
-                (
-                    value
-                    for value in subnets
-                    if isinstance(value, str)
-                    and value
-                    and ipaddress.ip_network(value, strict=False).version == 6
-                ),
-                None,
-            )
-            labels = details.get("labels")
-            observed.append(
-                BoundaryNetwork(
-                    name=desired.name,
-                    bridge=bridge,
-                    ipv4_cidr=ipv4,
-                    ipv6_cidr=ipv6,
-                    labels=tuple(
-                        sorted(
-                            (str(key), str(value))
-                            for key, value in (
-                                labels.items() if isinstance(labels, dict) else ()
-                            )
-                        )
-                    ),
-                )
-            )
-        return tuple(observed)
-
-    def _project_boundary_network_observations(
-        self,
-    ) -> tuple[BoundaryNetwork, ...]:
-        """Observe all project-scoped platform networks."""
-
-        observed: list[BoundaryNetwork] = []
-        for concrete in sorted(self.host_list_lab_networks(self._project_name)):
-            details = self.host_inspect_network(concrete)
-            bridge = details.get("bridge")
-            if not isinstance(bridge, str) or not bridge:
-                raise BoundaryCompileError("platform network bridge was not observable")
-            subnets = details.get("subnets")
-            if not isinstance(subnets, list):
-                subnets = [details.get("subnet", "")]
-            ipv4, ipv6 = _boundary_ip_families(subnets)
-            labels = details.get("labels")
-            observed.append(
-                BoundaryNetwork(
-                    name=concrete,
-                    bridge=bridge,
-                    ipv4_cidr=ipv4,
-                    ipv6_cidr=ipv6,
-                    labels=_sorted_labels(labels),
-                )
-            )
-        if not observed:
-            raise BoundaryCompileError("platform networks were not observed")
-        return tuple(observed)
-
-    def _platform_workload_observations(
-        self,
-        networks: tuple[BoundaryNetwork, ...],
-    ) -> tuple[BoundaryWorkload, ...]:
-        """Normalize exact labeled workload addresses without raw inspect output."""
-
-        known = {network.name for network in networks}
-        workloads: list[BoundaryWorkload] = []
-        for row in self.host_list_lab_containers():
-            name = row.get("name")
-            labels = row.get("labels")
-            if not isinstance(name, str) or not isinstance(labels, dict):
-                continue
-            details = self.container_inspect(name)
-            attached = details.get("NetworkSettings", {}).get("Networks", {})
-            if not isinstance(attached, dict):
-                continue
-            ipv4: list[tuple[str, str]] = []
-            ipv6: list[tuple[str, str]] = []
-            for network_name, network in attached.items():
-                if network_name not in known or not isinstance(network, dict):
-                    continue
-                address = network.get("IPAddress")
-                if isinstance(address, str) and address:
-                    ipv4.append((network_name, address))
-                address = network.get("GlobalIPv6Address")
-                if isinstance(address, str) and address:
-                    ipv6.append((network_name, address))
-            if ipv4 or ipv6:
-                workloads.append(
-                    BoundaryWorkload(
-                        identity=name,
-                        labels=_sorted_labels(labels),
-                        ipv4_by_network=tuple(sorted(ipv4)),
-                        ipv6_by_network=tuple(sorted(ipv6)),
-                    )
-                )
-        return tuple(sorted(workloads, key=lambda item: item.identity))
 
     def _realize_published_ports(
         self,

--- a/src/aptl/core/deployment/backend.py
+++ b/src/aptl/core/deployment/backend.py
@@ -25,6 +25,7 @@ from aptl.core.deployment.realization import (
     DeploymentNodeRealization,
     DeploymentRealizationSpec,
 )
+from aptl.core.deployment.boundary import BoundaryEnforcementSpec
 from aptl.core.seed_spec import NamedVolumeSeed
 
 # Imported from ``aptl.core.lab_types`` (the leaf module) rather than
@@ -76,6 +77,11 @@ class DeploymentBackend(Protocol):
         Returns:
             LabResult indicating success or failure.
         """
+        ...
+
+    def realize_boundary(self, policy: BoundaryEnforcementSpec) -> LabResult:
+        """Apply and read back one project-owned appliance boundary policy."""
+
         ...
 
     def stop(

--- a/src/aptl/core/deployment/backend.py
+++ b/src/aptl/core/deployment/backend.py
@@ -26,6 +26,10 @@ from aptl.core.deployment.realization import (
     DeploymentRealizationSpec,
 )
 from aptl.core.deployment.boundary import BoundaryEnforcementSpec
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+)
 from aptl.core.seed_spec import NamedVolumeSeed
 
 # Imported from ``aptl.core.lab_types`` (the leaf module) rather than
@@ -84,9 +88,16 @@ class DeploymentBackend(Protocol):
 
         ...
 
-    def stop(
-        self, profiles: list[str], *, remove_volumes: bool = False
-    ) -> LabResult:
+    def configure_appliance_boundary(
+        self,
+        policy: ApplianceBoundaryPolicy,
+        binding: ApplianceBoundaryBinding,
+    ) -> None:
+        """Bind trusted appliance policy inputs to the next realization."""
+
+        ...
+
+    def stop(self, profiles: list[str], *, remove_volumes: bool = False) -> LabResult:
         """Stop lab services.
 
         Args:
@@ -274,9 +285,7 @@ class DeploymentBackend(Protocol):
 
     # Container interaction (CLI-004) -------------------------------------
 
-    def container_list(
-        self, *, all_containers: bool = True
-    ) -> list[dict[str, Any]]:
+    def container_list(self, *, all_containers: bool = True) -> list[dict[str, Any]]:
         """List containers managed by this deployment.
 
         Args:
@@ -330,9 +339,7 @@ class DeploymentBackend(Protocol):
         """
         ...
 
-    def container_shell(
-        self, name: str, *, shell: str | None = None
-    ) -> int:
+    def container_shell(self, name: str, *, shell: str | None = None) -> int:
         """Open an interactive shell inside a running container.
 
         Inherits the parent terminal's stdin/stdout/stderr so the user

--- a/src/aptl/core/deployment/boundary.py
+++ b/src/aptl/core/deployment/boundary.py
@@ -1,0 +1,268 @@
+"""Typed, authority-preserving appliance boundary enforcement values."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from aptl.core.deployment.realization import DeploymentAclRealization
+
+_OWNER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$")
+_BRIDGE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,14}$")
+
+
+@dataclass(frozen=True)
+class BoundaryNetwork:
+    """One observed backend network used to bind authored references."""
+
+    name: str
+    bridge: str
+    ipv4_cidr: str | None = None
+    ipv6_cidr: str | None = None
+    labels: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.name or not _BRIDGE.fullmatch(self.bridge):
+            raise ValueError("invalid boundary network")
+        for cidr in (self.ipv4_cidr, self.ipv6_cidr):
+            if cidr is not None:
+                ipaddress.ip_network(cidr, strict=False)
+        if list(self.labels) != sorted(self.labels) or len(dict(self.labels)) != len(
+            self.labels
+        ):
+            raise ValueError("boundary network labels must be unique and sorted")
+
+    def details(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "bridge": self.bridge,
+            "ipv4_cidr": self.ipv4_cidr,
+            "ipv6_cidr": self.ipv6_cidr,
+            "labels": [list(item) for item in self.labels],
+        }
+
+
+@dataclass(frozen=True)
+class AcesAclOwnerBinding:
+    """Observed addresses that scope one ACES ACL owner."""
+
+    owner_address: str
+    owner_resource_type: Literal["node", "network"]
+    ipv4_by_network: tuple[tuple[str, str], ...] = ()
+    ipv6_by_network: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.owner_address:
+            raise ValueError("ACL owner address is required")
+        for network, address in (*self.ipv4_by_network, *self.ipv6_by_network):
+            if not network:
+                raise ValueError("ACL owner network is required")
+            ipaddress.ip_address(address)
+
+    def details(self) -> dict[str, object]:
+        return {
+            "owner_address": self.owner_address,
+            "owner_resource_type": self.owner_resource_type,
+            "ipv4_by_network": [list(item) for item in self.ipv4_by_network],
+            "ipv6_by_network": [list(item) for item in self.ipv6_by_network],
+        }
+
+
+@dataclass(frozen=True)
+class BoundaryWorkload:
+    """One observed platform workload and its exact network addresses."""
+
+    identity: str
+    labels: tuple[tuple[str, str], ...]
+    ipv4_by_network: tuple[tuple[str, str], ...]
+    ipv6_by_network: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.identity or list(self.labels) != sorted(self.labels):
+            raise ValueError("invalid boundary workload identity")
+        if len(dict(self.labels)) != len(self.labels):
+            raise ValueError("boundary workload labels must be unique")
+        if not self.ipv4_by_network and not self.ipv6_by_network:
+            raise ValueError("boundary workload must have an observed address")
+        for network, address in (*self.ipv4_by_network, *self.ipv6_by_network):
+            if not network:
+                raise ValueError("boundary workload network is required")
+            ipaddress.ip_address(address)
+
+    def details(self) -> dict[str, object]:
+        return {
+            "identity": self.identity,
+            "labels": [list(item) for item in self.labels],
+            "ipv4_by_network": [list(item) for item in self.ipv4_by_network],
+            "ipv6_by_network": [list(item) for item in self.ipv6_by_network],
+        }
+
+
+@dataclass(frozen=True)
+class AcesBoundarySpec:
+    """Concrete enforcement input for the admitted ACES authority only."""
+
+    owner: str
+    networks: tuple[BoundaryNetwork, ...]
+    owner_bindings: tuple[AcesAclOwnerBinding, ...]
+    rules: tuple[DeploymentAclRealization, ...]
+
+    authority: Literal["aces"] = "aces"
+
+    def __post_init__(self) -> None:
+        _validate_owner(self.owner)
+        _validate_networks(self.networks)
+        bindings = {item.owner_address: item for item in self.owner_bindings}
+        if len(bindings) != len(self.owner_bindings):
+            raise ValueError("ACL owner bindings must be unique")
+        known = {network.name for network in self.networks}
+        prior: tuple[str, int, str] | None = None
+        for rule in self.rules:
+            binding = bindings.get(rule.owner_address)
+            if (
+                binding is None
+                or binding.owner_resource_type != rule.owner_resource_type
+            ):
+                raise ValueError("ACL rule has no exact owner binding")
+            if (
+                rule.from_network is not None and rule.from_network not in known
+            ) or (rule.to_network is not None and rule.to_network not in known):
+                raise ValueError("ACL rule references an unknown network")
+            current = (rule.owner_address, rule.order, rule.name)
+            if prior is not None and current < prior:
+                raise ValueError("ACL rules must have deterministic owner order")
+            prior = current
+
+    @classmethod
+    def empty(cls, owner: str) -> AcesBoundarySpec:
+        return cls(owner=owner, networks=(), owner_bindings=(), rules=())
+
+    def details(self) -> dict[str, object]:
+        return {
+            "authority": self.authority,
+            "owner": self.owner,
+            "networks": [item.details() for item in self.networks],
+            "owner_bindings": [item.details() for item in self.owner_bindings],
+            "rules": [item.details() for item in self.rules],
+        }
+
+    def canonical_json(self) -> str:
+        return _canonical(self.details())
+
+    def digest(self) -> str:
+        return _digest(self.canonical_json())
+
+
+@dataclass(frozen=True)
+class PlatformCrossing:
+    source: Literal["participant", "management", "egress"]
+    destination: Literal["participant", "management", "egress"]
+    protocol: Literal["tcp", "udp"]
+    ports: tuple[int, ...]
+    purpose: str
+
+    def __post_init__(self) -> None:
+        if (
+            not self.ports
+            or len(self.ports) != len(set(self.ports))
+            or any(not 0 < port <= 65535 for port in self.ports)
+            or not self.purpose
+        ):
+            raise ValueError("invalid platform crossing")
+
+    def details(self) -> dict[str, object]:
+        return {
+            "source": self.source,
+            "destination": self.destination,
+            "protocol": self.protocol,
+            "ports": list(self.ports),
+            "purpose": self.purpose,
+        }
+
+
+@dataclass(frozen=True)
+class PlatformBoundarySpec:
+    """Concrete enforcement input for signed platform policy only."""
+
+    owner: str
+    policy_digest: str
+    networks: tuple[BoundaryNetwork, ...]
+    anchors: tuple[
+        tuple[Literal["participant", "management", "egress"], BoundaryWorkload],
+        ...,
+    ]
+    crossings: tuple[PlatformCrossing, ...]
+    egress_ports: tuple[int, ...]
+    default_deny: Literal[True] = True
+    authority: Literal["platform"] = "platform"
+
+    def __post_init__(self) -> None:
+        _validate_owner(self.owner)
+        if not re.fullmatch(r"sha256:[a-f0-9]{64}", self.policy_digest):
+            raise ValueError("invalid platform policy digest")
+        zones = [zone for zone, _network in self.anchors]
+        if len(zones) != len(set(zones)):
+            raise ValueError("platform anchors must be unique")
+        _validate_networks(self.networks)
+        known = {network.name for network in self.networks}
+        for _zone, workload in self.anchors:
+            if any(
+                network not in known
+                for network, _address in (
+                    *workload.ipv4_by_network,
+                    *workload.ipv6_by_network,
+                )
+            ):
+                raise ValueError("platform workload references an unknown network")
+        if len(self.egress_ports) != len(set(self.egress_ports)) or any(
+            not 0 < port <= 65535 for port in self.egress_ports
+        ):
+            raise ValueError("invalid platform egress ports")
+
+    def details(self) -> dict[str, object]:
+        return {
+            "authority": self.authority,
+            "owner": self.owner,
+            "policy_digest": self.policy_digest,
+            "networks": [network.details() for network in self.networks],
+            "anchors": [
+                {"zone": zone, "workload": workload.details()}
+                for zone, workload in self.anchors
+            ],
+            "crossings": [item.details() for item in self.crossings],
+            "egress_ports": list(self.egress_ports),
+            "default_deny": self.default_deny,
+        }
+
+    def canonical_json(self) -> str:
+        return _canonical(self.details())
+
+    def digest(self) -> str:
+        return _digest(self.canonical_json())
+
+
+BoundaryEnforcementSpec = AcesBoundarySpec | PlatformBoundarySpec
+
+
+def _validate_owner(owner: str) -> None:
+    if not _OWNER.fullmatch(owner):
+        raise ValueError("invalid boundary owner")
+
+
+def _validate_networks(networks: tuple[BoundaryNetwork, ...]) -> None:
+    names = [network.name for network in networks]
+    bridges = [network.bridge for network in networks]
+    if len(names) != len(set(names)) or len(bridges) != len(set(bridges)):
+        raise ValueError("boundary networks must have unique names and bridges")
+
+
+def _canonical(details: dict[str, object]) -> str:
+    return json.dumps(details, sort_keys=True, separators=(",", ":"))
+
+
+def _digest(payload: str) -> str:
+    return "sha256:" + hashlib.sha256(payload.encode()).hexdigest()

--- a/src/aptl/core/deployment/boundary.py
+++ b/src/aptl/core/deployment/boundary.py
@@ -13,6 +13,7 @@ from aptl.core.deployment.realization import DeploymentAclRealization
 
 _OWNER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$")
 _BRIDGE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,14}$")
+_PLATFORM_ZONES = {"participant", "management", "egress"}
 
 
 @dataclass(frozen=True)
@@ -128,9 +129,9 @@ class AcesBoundarySpec:
                 or binding.owner_resource_type != rule.owner_resource_type
             ):
                 raise ValueError("ACL rule has no exact owner binding")
-            if (
-                rule.from_network is not None and rule.from_network not in known
-            ) or (rule.to_network is not None and rule.to_network not in known):
+            if (rule.from_network is not None and rule.from_network not in known) or (
+                rule.to_network is not None and rule.to_network not in known
+            ):
                 raise ValueError("ACL rule references an unknown network")
             current = (rule.owner_address, rule.order, rule.name)
             if prior is not None and current < prior:
@@ -191,6 +192,10 @@ class PlatformBoundarySpec:
     owner: str
     policy_digest: str
     networks: tuple[BoundaryNetwork, ...]
+    zone_networks: tuple[
+        tuple[Literal["participant", "management", "egress"], str],
+        ...,
+    ]
     anchors: tuple[
         tuple[Literal["participant", "management", "egress"], BoundaryWorkload],
         ...,
@@ -205,11 +210,22 @@ class PlatformBoundarySpec:
         if not re.fullmatch(r"sha256:[a-f0-9]{64}", self.policy_digest):
             raise ValueError("invalid platform policy digest")
         zones = [zone for zone, _network in self.anchors]
-        if len(zones) != len(set(zones)):
-            raise ValueError("platform anchors must be unique")
+        if set(zones) != _PLATFORM_ZONES or len(zones) != 3:
+            raise ValueError("platform anchors must cover each policy zone")
         _validate_networks(self.networks)
+        if len(self.networks) != 3 or any(
+            network.ipv6_cidr is not None for network in self.networks
+        ):
+            raise ValueError("platform networks must be three IPv4 policy domains")
         known = {network.name for network in self.networks}
-        for _zone, workload in self.anchors:
+        zone_networks = dict(self.zone_networks)
+        if (
+            set(zone_networks) != _PLATFORM_ZONES
+            or len(self.zone_networks) != 3
+            or set(zone_networks.values()) != known
+        ):
+            raise ValueError("platform zone networks must be exact and distinct")
+        for zone, workload in self.anchors:
             if any(
                 network not in known
                 for network, _address in (
@@ -218,6 +234,15 @@ class PlatformBoundarySpec:
                 )
             ):
                 raise ValueError("platform workload references an unknown network")
+            if (
+                not workload.ipv4_by_network
+                or workload.ipv6_by_network
+                or zone_networks[zone]
+                not in {network for network, _address in workload.ipv4_by_network}
+            ):
+                raise ValueError(
+                    "platform workload requires its IPv4 policy attachment"
+                )
         if len(self.egress_ports) != len(set(self.egress_ports)) or any(
             not 0 < port <= 65535 for port in self.egress_ports
         ):
@@ -229,6 +254,10 @@ class PlatformBoundarySpec:
             "owner": self.owner,
             "policy_digest": self.policy_digest,
             "networks": [network.details() for network in self.networks],
+            "zone_networks": [
+                {"zone": zone, "network": network}
+                for zone, network in self.zone_networks
+            ],
             "anchors": [
                 {"zone": zone, "workload": workload.details()}
                 for zone, workload in self.anchors

--- a/src/aptl/core/deployment/boundary.py
+++ b/src/aptl/core/deployment/boundary.py
@@ -121,22 +121,7 @@ class AcesBoundarySpec:
         if len(bindings) != len(self.owner_bindings):
             raise ValueError("ACL owner bindings must be unique")
         known = {network.name for network in self.networks}
-        prior: tuple[str, int, str] | None = None
-        for rule in self.rules:
-            binding = bindings.get(rule.owner_address)
-            if (
-                binding is None
-                or binding.owner_resource_type != rule.owner_resource_type
-            ):
-                raise ValueError("ACL rule has no exact owner binding")
-            if (rule.from_network is not None and rule.from_network not in known) or (
-                rule.to_network is not None and rule.to_network not in known
-            ):
-                raise ValueError("ACL rule references an unknown network")
-            current = (rule.owner_address, rule.order, rule.name)
-            if prior is not None and current < prior:
-                raise ValueError("ACL rules must have deterministic owner order")
-            prior = current
+        _validate_aces_rules(self.rules, bindings, known)
 
     @classmethod
     def empty(cls, owner: str) -> AcesBoundarySpec:
@@ -160,6 +145,8 @@ class AcesBoundarySpec:
 
 @dataclass(frozen=True)
 class PlatformCrossing:
+    """One compiled transport crossing between platform policy anchors."""
+
     source: Literal["participant", "management", "egress"]
     destination: Literal["participant", "management", "egress"]
     protocol: Literal["tcp", "udp"]
@@ -209,44 +196,10 @@ class PlatformBoundarySpec:
         _validate_owner(self.owner)
         if not re.fullmatch(r"sha256:[a-f0-9]{64}", self.policy_digest):
             raise ValueError("invalid platform policy digest")
-        zones = [zone for zone, _network in self.anchors]
-        if set(zones) != _PLATFORM_ZONES or len(zones) != 3:
-            raise ValueError("platform anchors must cover each policy zone")
-        _validate_networks(self.networks)
-        if len(self.networks) != 3 or any(
-            network.ipv6_cidr is not None for network in self.networks
-        ):
-            raise ValueError("platform networks must be three IPv4 policy domains")
-        known = {network.name for network in self.networks}
-        zone_networks = dict(self.zone_networks)
-        if (
-            set(zone_networks) != _PLATFORM_ZONES
-            or len(self.zone_networks) != 3
-            or set(zone_networks.values()) != known
-        ):
-            raise ValueError("platform zone networks must be exact and distinct")
-        for zone, workload in self.anchors:
-            if any(
-                network not in known
-                for network, _address in (
-                    *workload.ipv4_by_network,
-                    *workload.ipv6_by_network,
-                )
-            ):
-                raise ValueError("platform workload references an unknown network")
-            if (
-                not workload.ipv4_by_network
-                or workload.ipv6_by_network
-                or zone_networks[zone]
-                not in {network for network, _address in workload.ipv4_by_network}
-            ):
-                raise ValueError(
-                    "platform workload requires its IPv4 policy attachment"
-                )
-        if len(self.egress_ports) != len(set(self.egress_ports)) or any(
-            not 0 < port <= 65535 for port in self.egress_ports
-        ):
-            raise ValueError("invalid platform egress ports")
+        known = _validate_platform_networks(self.networks)
+        zone_networks = _validate_zone_networks(self.zone_networks, known)
+        _validate_platform_anchors(self.anchors, known, zone_networks)
+        _validate_egress_ports(self.egress_ports)
 
     def details(self) -> dict[str, object]:
         return {
@@ -278,11 +231,15 @@ BoundaryEnforcementSpec = AcesBoundarySpec | PlatformBoundarySpec
 
 
 def _validate_owner(owner: str) -> None:
+    """Require a bounded project/seat ownership token."""
+
     if not _OWNER.fullmatch(owner):
         raise ValueError("invalid boundary owner")
 
 
 def _validate_networks(networks: tuple[BoundaryNetwork, ...]) -> None:
+    """Require unique concrete network and bridge identities."""
+
     names = [network.name for network in networks]
     bridges = [network.bridge for network in networks]
     if len(names) != len(set(names)) or len(bridges) != len(set(bridges)):
@@ -290,8 +247,96 @@ def _validate_networks(networks: tuple[BoundaryNetwork, ...]) -> None:
 
 
 def _canonical(details: dict[str, object]) -> str:
+    """Serialize enforcement input deterministically for hashing and transport."""
+
     return json.dumps(details, sort_keys=True, separators=(",", ":"))
 
 
 def _digest(payload: str) -> str:
+    """Return the lowercase SHA-256 identity of canonical policy text."""
+
     return "sha256:" + hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _validate_aces_rules(
+    rules: tuple[DeploymentAclRealization, ...],
+    bindings: dict[str, AcesAclOwnerBinding],
+    known_networks: set[str],
+) -> None:
+    """Require exact owner bindings, known endpoints, and deterministic order."""
+
+    prior: tuple[str, int, str] | None = None
+    for rule in rules:
+        binding = bindings.get(rule.owner_address)
+        if binding is None or binding.owner_resource_type != rule.owner_resource_type:
+            raise ValueError("ACL rule has no exact owner binding")
+        endpoints = (rule.from_network, rule.to_network)
+        if any(item is not None and item not in known_networks for item in endpoints):
+            raise ValueError("ACL rule references an unknown network")
+        current = (rule.owner_address, rule.order, rule.name)
+        if prior is not None and current < prior:
+            raise ValueError("ACL rules must have deterministic owner order")
+        prior = current
+
+
+def _validate_platform_networks(
+    networks: tuple[BoundaryNetwork, ...],
+) -> set[str]:
+    """Require exactly three distinct IPv4-only platform policy domains."""
+
+    _validate_networks(networks)
+    if len(networks) != 3 or any(network.ipv6_cidr is not None for network in networks):
+        raise ValueError("platform networks must be three IPv4 policy domains")
+    return {network.name for network in networks}
+
+
+def _validate_zone_networks(
+    entries: tuple[
+        tuple[Literal["participant", "management", "egress"], str],
+        ...,
+    ],
+    known_networks: set[str],
+) -> dict[str, str]:
+    """Require an exact one-to-one mapping from zones to platform networks."""
+
+    zone_networks = dict(entries)
+    if (
+        set(zone_networks) != _PLATFORM_ZONES
+        or len(entries) != 3
+        or set(zone_networks.values()) != known_networks
+    ):
+        raise ValueError("platform zone networks must be exact and distinct")
+    return zone_networks
+
+
+def _validate_platform_anchors(
+    anchors: tuple[
+        tuple[Literal["participant", "management", "egress"], BoundaryWorkload],
+        ...,
+    ],
+    known_networks: set[str],
+    zone_networks: dict[str, str],
+) -> None:
+    """Require one IPv4 anchor per zone on only signed platform networks."""
+
+    zones = [zone for zone, _workload in anchors]
+    if set(zones) != _PLATFORM_ZONES or len(zones) != 3:
+        raise ValueError("platform anchors must cover each policy zone")
+    for zone, workload in anchors:
+        attached = (*workload.ipv4_by_network, *workload.ipv6_by_network)
+        if any(network not in known_networks for network, _address in attached):
+            raise ValueError("platform workload references an unknown network")
+        ipv4_networks = {network for network, _address in workload.ipv4_by_network}
+        if (
+            not ipv4_networks
+            or workload.ipv6_by_network
+            or zone_networks[zone] not in ipv4_networks
+        ):
+            raise ValueError("platform workload requires its IPv4 policy attachment")
+
+
+def _validate_egress_ports(ports: tuple[int, ...]) -> None:
+    """Require unique, valid external TCP port numbers."""
+
+    if len(ports) != len(set(ports)) or any(not 0 < port <= 65535 for port in ports):
+        raise ValueError("invalid platform egress ports")

--- a/src/aptl/core/deployment/boundary_compiler.py
+++ b/src/aptl/core/deployment/boundary_compiler.py
@@ -30,6 +30,10 @@ def compile_aces_boundary(
 
     if not realization.acls:
         return AcesBoundarySpec.empty(owner)
+    if any(network.ipv6_cidr is not None for network in networks):
+        raise BoundaryCompileError(
+            "ACES ACL networks must remain IPv4-only for this backend"
+        )
     network_index = {network.name: network for network in networks}
     missing = sorted(
         {
@@ -114,6 +118,23 @@ def compile_platform_boundary(
 ) -> PlatformBoundarySpec:
     """Resolve exact platform workload selectors without reading ACES topology."""
 
+    selected_networks: dict[str, BoundaryNetwork] = {}
+    for zone in ("participant", "management", "egress"):
+        selector = getattr(policy.platform_networks, zone)
+        key, value = selector.split("=", 1)
+        matches = [
+            network for network in networks if dict(network.labels).get(key) == value
+        ]
+        if len(matches) != 1:
+            raise BoundaryCompileError("platform network did not resolve exactly once")
+        if matches[0].ipv6_cidr is not None:
+            raise BoundaryCompileError(
+                "platform network IPv6 is unsupported and must remain disabled"
+            )
+        selected_networks[zone] = matches[0]
+    if len({network.name for network in selected_networks.values()}) != 3:
+        raise BoundaryCompileError("platform networks must be distinct")
+
     anchors: list[tuple[str, BoundaryWorkload]] = []
     for zone in ("participant", "management", "egress"):
         selector = getattr(policy.platform_anchors, zone)
@@ -127,31 +148,56 @@ def compile_platform_boundary(
             raise BoundaryCompileError(
                 "platform boundary anchor did not resolve exactly once"
             )
-        anchors.append((zone, matches[0]))
+        network_name = selected_networks[zone].name
+        workload = matches[0]
+        admitted_networks = {network.name for network in selected_networks.values()}
+        ipv4 = tuple(
+            item for item in workload.ipv4_by_network if item[0] in admitted_networks
+        )
+        ipv6 = tuple(
+            item for item in workload.ipv6_by_network if item[0] in admitted_networks
+        )
+        if (
+            not ipv4
+            or ipv6
+            or network_name not in {network for network, _address in ipv4}
+        ):
+            raise BoundaryCompileError(
+                "platform boundary anchor requires its IPv4 policy domain"
+            )
+        anchors.append(
+            (
+                zone,
+                BoundaryWorkload(
+                    identity=workload.identity,
+                    labels=workload.labels,
+                    ipv4_by_network=ipv4,
+                    ipv6_by_network=ipv6,
+                ),
+            )
+        )
     anchor_index = dict(anchors)
     for crossing in policy.fixed_crossings:
         source_networks = {
             network
-            for network, _address in (
-                *anchor_index[crossing.source].ipv4_by_network,
-                *anchor_index[crossing.source].ipv6_by_network,
-            )
+            for network, _address in anchor_index[crossing.source].ipv4_by_network
         }
         destination_networks = {
             network
-            for network, _address in (
-                *anchor_index[crossing.destination].ipv4_by_network,
-                *anchor_index[crossing.destination].ipv6_by_network,
-            )
+            for network, _address in anchor_index[crossing.destination].ipv4_by_network
         }
         if not source_networks & destination_networks:
             raise BoundaryCompileError(
-                "platform crossing endpoints have no observed shared path"
+                "platform crossing endpoints have no shared policy path"
             )
     return PlatformBoundarySpec(
         owner=owner,
         policy_digest=policy_digest,
-        networks=tuple(sorted(networks, key=lambda item: item.name)),
+        networks=tuple(sorted(selected_networks.values(), key=lambda item: item.name)),
+        zone_networks=tuple(
+            (zone, selected_networks[zone].name)
+            for zone in ("participant", "management", "egress")
+        ),
         anchors=tuple(anchors),  # type: ignore[arg-type]
         crossings=tuple(
             PlatformCrossing(
@@ -163,9 +209,7 @@ def compile_platform_boundary(
             )
             for item in policy.fixed_crossings
         ),
-        egress_ports=tuple(
-            sorted({item.port for item in policy.egress_authorities})
-        ),
+        egress_ports=tuple(sorted({item.port for item in policy.egress_authorities})),
     )
 
 

--- a/src/aptl/core/deployment/boundary_compiler.py
+++ b/src/aptl/core/deployment/boundary_compiler.py
@@ -30,68 +30,19 @@ def compile_aces_boundary(
 
     if not realization.acls:
         return AcesBoundarySpec.empty(owner)
-    if any(network.ipv6_cidr is not None for network in networks):
-        raise BoundaryCompileError(
-            "ACES ACL networks must remain IPv4-only for this backend"
-        )
-    network_index = {network.name: network for network in networks}
-    missing = sorted(
-        {
-            reference
-            for rule in realization.acls
-            for reference in (rule.from_network, rule.to_network)
-            if reference is not None and reference not in network_index
-        }
-    )
-    if missing:
-        raise BoundaryCompileError("ACES ACL network binding is incomplete")
+    network_index = _validate_aces_networks(realization, networks)
     nodes = {node.address: node for node in realization.nodes}
     bindings: list[AcesAclOwnerBinding] = []
     for owner_address in sorted({rule.owner_address for rule in realization.acls}):
         rules = [
             rule for rule in realization.acls if rule.owner_address == owner_address
         ]
-        first = rules[0]
-        if any(
-            rule.owner_resource_type != first.owner_resource_type
-            or rule.owner_name != first.owner_name
-            for rule in rules
-        ):
-            raise BoundaryCompileError("ACES ACL owner binding is ambiguous")
-        if first.owner_resource_type == "network":
-            if first.owner_name not in network_index:
-                raise BoundaryCompileError("ACES network ACL owner is not observed")
-            bindings.append(
-                AcesAclOwnerBinding(
-                    owner_address=owner_address,
-                    owner_resource_type="network",
-                )
-            )
-            continue
-        node = nodes.get(owner_address)
-        if node is None:
-            raise BoundaryCompileError("ACES node ACL owner is not realized")
-        addresses = tuple(
-            sorted(
-                (attachment.network, attachment.ipv4_address)
-                for attachment in node.network_attachments
-                if attachment.ipv4_address is not None
-            )
-        )
-        required = _required_owner_networks(rules)
-        if required - {network for network, _address in addresses}:
-            raise BoundaryCompileError(
-                "ACES node ACL owner requires exact admitted addresses"
-            )
-        if not addresses:
-            raise BoundaryCompileError(
-                "ACES node ACL owner requires at least one exact address"
-            )
         bindings.append(
-            AcesAclOwnerBinding(
-                owner_address=owner_address,
-                owner_resource_type="node",
-                ipv4_by_network=addresses,
+            _compile_owner_binding(
+                owner_address,
+                rules,
+                nodes,
+                network_index,
             )
         )
     ordered_rules = tuple(
@@ -118,78 +69,9 @@ def compile_platform_boundary(
 ) -> PlatformBoundarySpec:
     """Resolve exact platform workload selectors without reading ACES topology."""
 
-    selected_networks: dict[str, BoundaryNetwork] = {}
-    for zone in ("participant", "management", "egress"):
-        selector = getattr(policy.platform_networks, zone)
-        key, value = selector.split("=", 1)
-        matches = [
-            network for network in networks if dict(network.labels).get(key) == value
-        ]
-        if len(matches) != 1:
-            raise BoundaryCompileError("platform network did not resolve exactly once")
-        if matches[0].ipv6_cidr is not None:
-            raise BoundaryCompileError(
-                "platform network IPv6 is unsupported and must remain disabled"
-            )
-        selected_networks[zone] = matches[0]
-    if len({network.name for network in selected_networks.values()}) != 3:
-        raise BoundaryCompileError("platform networks must be distinct")
-
-    anchors: list[tuple[str, BoundaryWorkload]] = []
-    for zone in ("participant", "management", "egress"):
-        selector = getattr(policy.platform_anchors, zone)
-        key, value = selector.split("=", 1)
-        matches = [
-            workload
-            for workload in workloads
-            if dict(workload.labels).get(key) == value
-        ]
-        if len(matches) != 1:
-            raise BoundaryCompileError(
-                "platform boundary anchor did not resolve exactly once"
-            )
-        network_name = selected_networks[zone].name
-        workload = matches[0]
-        admitted_networks = {network.name for network in selected_networks.values()}
-        ipv4 = tuple(
-            item for item in workload.ipv4_by_network if item[0] in admitted_networks
-        )
-        ipv6 = tuple(
-            item for item in workload.ipv6_by_network if item[0] in admitted_networks
-        )
-        if (
-            not ipv4
-            or ipv6
-            or network_name not in {network for network, _address in ipv4}
-        ):
-            raise BoundaryCompileError(
-                "platform boundary anchor requires its IPv4 policy domain"
-            )
-        anchors.append(
-            (
-                zone,
-                BoundaryWorkload(
-                    identity=workload.identity,
-                    labels=workload.labels,
-                    ipv4_by_network=ipv4,
-                    ipv6_by_network=ipv6,
-                ),
-            )
-        )
-    anchor_index = dict(anchors)
-    for crossing in policy.fixed_crossings:
-        source_networks = {
-            network
-            for network, _address in anchor_index[crossing.source].ipv4_by_network
-        }
-        destination_networks = {
-            network
-            for network, _address in anchor_index[crossing.destination].ipv4_by_network
-        }
-        if not source_networks & destination_networks:
-            raise BoundaryCompileError(
-                "platform crossing endpoints have no shared policy path"
-            )
+    selected_networks = _select_platform_networks(policy, networks)
+    anchors = _select_platform_anchors(policy, workloads, selected_networks)
+    _validate_crossing_paths(policy, anchors)
     return PlatformBoundarySpec(
         owner=owner,
         policy_digest=policy_digest,
@@ -214,6 +96,8 @@ def compile_platform_boundary(
 
 
 def _required_owner_networks(rules: Sequence[object]) -> set[str]:
+    """Return the owner attachment networks needed by directional ACL rules."""
+
     required: set[str] = set()
     for rule in rules:
         direction = getattr(rule, "direction")
@@ -226,3 +110,180 @@ def _required_owner_networks(rules: Sequence[object]) -> set[str]:
             if source is not None:
                 required.add(source)
     return required
+
+
+def _validate_aces_networks(
+    realization: DeploymentRealizationSpec,
+    networks: Sequence[BoundaryNetwork],
+) -> dict[str, BoundaryNetwork]:
+    """Require IPv4-only observations for every referenced ACES network."""
+
+    if any(network.ipv6_cidr is not None for network in networks):
+        raise BoundaryCompileError(
+            "ACES ACL networks must remain IPv4-only for this backend"
+        )
+    network_index = {network.name: network for network in networks}
+    missing = {
+        reference
+        for rule in realization.acls
+        for reference in (rule.from_network, rule.to_network)
+        if reference is not None and reference not in network_index
+    }
+    if missing:
+        raise BoundaryCompileError("ACES ACL network binding is incomplete")
+    return network_index
+
+
+def _compile_owner_binding(
+    owner_address: str,
+    rules: Sequence[object],
+    nodes: dict[str, object],
+    network_index: dict[str, BoundaryNetwork],
+) -> AcesAclOwnerBinding:
+    """Compile one unambiguous ACES node or network owner binding."""
+
+    first = rules[0]
+    owner_type = getattr(first, "owner_resource_type")
+    owner_name = getattr(first, "owner_name")
+    if any(
+        getattr(rule, "owner_resource_type") != owner_type
+        or getattr(rule, "owner_name") != owner_name
+        for rule in rules
+    ):
+        raise BoundaryCompileError("ACES ACL owner binding is ambiguous")
+    if owner_type == "network":
+        if owner_name not in network_index:
+            raise BoundaryCompileError("ACES network ACL owner is not observed")
+        return AcesAclOwnerBinding(
+            owner_address=owner_address,
+            owner_resource_type="network",
+        )
+    node = nodes.get(owner_address)
+    if node is None:
+        raise BoundaryCompileError("ACES node ACL owner is not realized")
+    attachments = getattr(node, "network_attachments")
+    addresses = tuple(
+        sorted(
+            (attachment.network, attachment.ipv4_address)
+            for attachment in attachments
+            if attachment.ipv4_address is not None
+        )
+    )
+    required = _required_owner_networks(rules)
+    if required - {network for network, _address in addresses}:
+        raise BoundaryCompileError(
+            "ACES node ACL owner requires exact admitted addresses"
+        )
+    if not addresses:
+        raise BoundaryCompileError(
+            "ACES node ACL owner requires at least one exact address"
+        )
+    return AcesAclOwnerBinding(
+        owner_address=owner_address,
+        owner_resource_type="node",
+        ipv4_by_network=addresses,
+    )
+
+
+def _select_platform_networks(
+    policy: ApplianceBoundaryPolicy,
+    networks: Sequence[BoundaryNetwork],
+) -> dict[str, BoundaryNetwork]:
+    """Resolve one distinct IPv4 network for each exact signed selector."""
+
+    selected: dict[str, BoundaryNetwork] = {}
+    for zone in ("participant", "management", "egress"):
+        key, value = getattr(policy.platform_networks, zone).split("=", 1)
+        matches = [
+            network for network in networks if dict(network.labels).get(key) == value
+        ]
+        if len(matches) != 1:
+            raise BoundaryCompileError("platform network did not resolve exactly once")
+        if matches[0].ipv6_cidr is not None:
+            raise BoundaryCompileError(
+                "platform network IPv6 is unsupported and must remain disabled"
+            )
+        selected[zone] = matches[0]
+    if len({network.name for network in selected.values()}) != 3:
+        raise BoundaryCompileError("platform networks must be distinct")
+    return selected
+
+
+def _select_platform_anchors(
+    policy: ApplianceBoundaryPolicy,
+    workloads: Sequence[BoundaryWorkload],
+    selected_networks: dict[str, BoundaryNetwork],
+) -> list[tuple[str, BoundaryWorkload]]:
+    """Resolve one exact workload anchor per platform zone."""
+
+    admitted = {network.name for network in selected_networks.values()}
+    anchors: list[tuple[str, BoundaryWorkload]] = []
+    for zone in ("participant", "management", "egress"):
+        key, value = getattr(policy.platform_anchors, zone).split("=", 1)
+        matches = [
+            workload
+            for workload in workloads
+            if dict(workload.labels).get(key) == value
+        ]
+        if len(matches) != 1:
+            raise BoundaryCompileError(
+                "platform boundary anchor did not resolve exactly once"
+            )
+        anchors.append(
+            (
+                zone,
+                _scope_platform_anchor(matches[0], selected_networks[zone], admitted),
+            )
+        )
+    return anchors
+
+
+def _scope_platform_anchor(
+    workload: BoundaryWorkload,
+    zone_network: BoundaryNetwork,
+    admitted_networks: set[str],
+) -> BoundaryWorkload:
+    """Restrict one anchor observation to signed platform networks."""
+
+    ipv4 = tuple(
+        item for item in workload.ipv4_by_network if item[0] in admitted_networks
+    )
+    ipv6 = tuple(
+        item for item in workload.ipv6_by_network if item[0] in admitted_networks
+    )
+    if (
+        not ipv4
+        or ipv6
+        or zone_network.name not in {network for network, _address in ipv4}
+    ):
+        raise BoundaryCompileError(
+            "platform boundary anchor requires its IPv4 policy domain"
+        )
+    return BoundaryWorkload(
+        identity=workload.identity,
+        labels=workload.labels,
+        ipv4_by_network=ipv4,
+        ipv6_by_network=ipv6,
+    )
+
+
+def _validate_crossing_paths(
+    policy: ApplianceBoundaryPolicy,
+    anchors: Sequence[tuple[str, BoundaryWorkload]],
+) -> None:
+    """Require every fixed crossing to share an observed platform path."""
+
+    anchor_index = dict(anchors)
+    for crossing in policy.fixed_crossings:
+        source = {
+            network
+            for network, _address in anchor_index[crossing.source].ipv4_by_network
+        }
+        destination = {
+            network
+            for network, _address in anchor_index[crossing.destination].ipv4_by_network
+        }
+        if not source & destination:
+            raise BoundaryCompileError(
+                "platform crossing endpoints have no shared policy path"
+            )

--- a/src/aptl/core/deployment/boundary_compiler.py
+++ b/src/aptl/core/deployment/boundary_compiler.py
@@ -1,0 +1,184 @@
+"""Bind the two boundary authorities to observed backend identities."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
+from aptl.core.deployment.boundary import (
+    AcesAclOwnerBinding,
+    AcesBoundarySpec,
+    BoundaryNetwork,
+    BoundaryWorkload,
+    PlatformBoundarySpec,
+    PlatformCrossing,
+)
+from aptl.core.deployment.realization import DeploymentRealizationSpec
+
+
+class BoundaryCompileError(ValueError):
+    """A desired boundary could not be bound without widening it."""
+
+
+def compile_aces_boundary(
+    realization: DeploymentRealizationSpec,
+    networks: Sequence[BoundaryNetwork],
+    *,
+    owner: str,
+) -> AcesBoundarySpec:
+    """Bind admitted ACES ACLs to concrete networks and owner addresses."""
+
+    if not realization.acls:
+        return AcesBoundarySpec.empty(owner)
+    network_index = {network.name: network for network in networks}
+    missing = sorted(
+        {
+            reference
+            for rule in realization.acls
+            for reference in (rule.from_network, rule.to_network)
+            if reference is not None and reference not in network_index
+        }
+    )
+    if missing:
+        raise BoundaryCompileError("ACES ACL network binding is incomplete")
+    nodes = {node.address: node for node in realization.nodes}
+    bindings: list[AcesAclOwnerBinding] = []
+    for owner_address in sorted({rule.owner_address for rule in realization.acls}):
+        rules = [
+            rule for rule in realization.acls if rule.owner_address == owner_address
+        ]
+        first = rules[0]
+        if any(
+            rule.owner_resource_type != first.owner_resource_type
+            or rule.owner_name != first.owner_name
+            for rule in rules
+        ):
+            raise BoundaryCompileError("ACES ACL owner binding is ambiguous")
+        if first.owner_resource_type == "network":
+            if first.owner_name not in network_index:
+                raise BoundaryCompileError("ACES network ACL owner is not observed")
+            bindings.append(
+                AcesAclOwnerBinding(
+                    owner_address=owner_address,
+                    owner_resource_type="network",
+                )
+            )
+            continue
+        node = nodes.get(owner_address)
+        if node is None:
+            raise BoundaryCompileError("ACES node ACL owner is not realized")
+        addresses = tuple(
+            sorted(
+                (attachment.network, attachment.ipv4_address)
+                for attachment in node.network_attachments
+                if attachment.ipv4_address is not None
+            )
+        )
+        required = _required_owner_networks(rules)
+        if required - {network for network, _address in addresses}:
+            raise BoundaryCompileError(
+                "ACES node ACL owner requires exact admitted addresses"
+            )
+        if not addresses:
+            raise BoundaryCompileError(
+                "ACES node ACL owner requires at least one exact address"
+            )
+        bindings.append(
+            AcesAclOwnerBinding(
+                owner_address=owner_address,
+                owner_resource_type="node",
+                ipv4_by_network=addresses,
+            )
+        )
+    ordered_rules = tuple(
+        sorted(
+            realization.acls,
+            key=lambda rule: (rule.owner_address, rule.order, rule.name),
+        )
+    )
+    return AcesBoundarySpec(
+        owner=owner,
+        networks=tuple(sorted(networks, key=lambda item: item.name)),
+        owner_bindings=tuple(bindings),
+        rules=ordered_rules,
+    )
+
+
+def compile_platform_boundary(
+    policy: ApplianceBoundaryPolicy,
+    *,
+    policy_digest: str,
+    networks: Sequence[BoundaryNetwork],
+    workloads: Sequence[BoundaryWorkload],
+    owner: str,
+) -> PlatformBoundarySpec:
+    """Resolve exact platform workload selectors without reading ACES topology."""
+
+    anchors: list[tuple[str, BoundaryWorkload]] = []
+    for zone in ("participant", "management", "egress"):
+        selector = getattr(policy.platform_anchors, zone)
+        key, value = selector.split("=", 1)
+        matches = [
+            workload
+            for workload in workloads
+            if dict(workload.labels).get(key) == value
+        ]
+        if len(matches) != 1:
+            raise BoundaryCompileError(
+                "platform boundary anchor did not resolve exactly once"
+            )
+        anchors.append((zone, matches[0]))
+    anchor_index = dict(anchors)
+    for crossing in policy.fixed_crossings:
+        source_networks = {
+            network
+            for network, _address in (
+                *anchor_index[crossing.source].ipv4_by_network,
+                *anchor_index[crossing.source].ipv6_by_network,
+            )
+        }
+        destination_networks = {
+            network
+            for network, _address in (
+                *anchor_index[crossing.destination].ipv4_by_network,
+                *anchor_index[crossing.destination].ipv6_by_network,
+            )
+        }
+        if not source_networks & destination_networks:
+            raise BoundaryCompileError(
+                "platform crossing endpoints have no observed shared path"
+            )
+    return PlatformBoundarySpec(
+        owner=owner,
+        policy_digest=policy_digest,
+        networks=tuple(sorted(networks, key=lambda item: item.name)),
+        anchors=tuple(anchors),  # type: ignore[arg-type]
+        crossings=tuple(
+            PlatformCrossing(
+                source=item.source,
+                destination=item.destination,
+                protocol=item.protocol,
+                ports=tuple(item.ports),
+                purpose=item.purpose,
+            )
+            for item in policy.fixed_crossings
+        ),
+        egress_ports=tuple(
+            sorted({item.port for item in policy.egress_authorities})
+        ),
+    )
+
+
+def _required_owner_networks(rules: Sequence[object]) -> set[str]:
+    required: set[str] = set()
+    for rule in rules:
+        direction = getattr(rule, "direction")
+        if direction in {"in", "inout"}:
+            destination = getattr(rule, "to_network")
+            if destination is not None:
+                required.add(destination)
+        if direction in {"out", "inout"}:
+            source = getattr(rule, "from_network")
+            if source is not None:
+                required.add(source)
+    return required

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -24,6 +24,10 @@ from aptl.core.deployment._compose_seed_safety import (
     redacted_stderr_hint,
 )
 from aptl.core.deployment._compose_stop import stop_compose_lab
+from aptl.core.deployment._compose_boundary import (
+    realize_boundary as _realize_boundary,
+)
+from aptl.core.deployment.boundary import BoundaryEnforcementSpec
 from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.core.seed_spec import NamedVolumeSeed
@@ -191,6 +195,29 @@ class DockerComposeBackend(
             raise BackendTimeoutError(
                 f"command timed out after {timeout}s: {' '.join(cmd[:3])}"
             ) from exc
+
+    def _run_with_input(
+        self,
+        cmd: list[str],
+        payload: str,
+        *,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess:
+        """Run one fixed command with non-secret structured stdin."""
+
+        kwargs = self._subprocess_kwargs(streaming=False, timeout=timeout)
+        kwargs["input"] = payload
+        try:
+            return subprocess.run(cmd, **kwargs)
+        except subprocess.TimeoutExpired as exc:
+            raise BackendTimeoutError(
+                f"command timed out after {timeout}s: {' '.join(cmd[:3])}"
+            ) from exc
+
+    def realize_boundary(self, policy: BoundaryEnforcementSpec) -> LabResult:
+        """Apply and observe policy on the selected Docker daemon host."""
+
+        return _realize_boundary(self, policy)
 
     def start(
         self,

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -25,9 +25,14 @@ from aptl.core.deployment._compose_seed_safety import (
 )
 from aptl.core.deployment._compose_stop import stop_compose_lab
 from aptl.core.deployment._compose_boundary import (
+    DEFAULT_BOUNDARY_HELPER_IMAGE,
     realize_boundary as _realize_boundary,
 )
 from aptl.core.deployment.boundary import BoundaryEnforcementSpec
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+)
 from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.core.seed_spec import NamedVolumeSeed
@@ -68,6 +73,15 @@ class DockerComposeBackend(
     ) -> None:
         self._project_dir = project_dir
         self._project_name = project_name
+        self._appliance_boundary: (
+            tuple[
+                ApplianceBoundaryPolicy,
+                ApplianceBoundaryBinding,
+            ]
+            | None
+        ) = None
+        self._boundary_receipts: dict[str, dict[str, object]] = {}
+        self._boundary_helper_image = DEFAULT_BOUNDARY_HELPER_IMAGE
 
     @property
     def project_dir(self) -> Path:
@@ -82,6 +96,16 @@ class DockerComposeBackend(
         """Return whether bind sources are visible to the Docker daemon."""
 
         return True
+
+    def configure_appliance_boundary(
+        self,
+        policy: ApplianceBoundaryPolicy,
+        binding: ApplianceBoundaryBinding,
+    ) -> None:
+        """Install trusted release/launcher projections for realization."""
+
+        self._appliance_boundary = (policy, binding)
+        self._boundary_helper_image = binding.boundary_helper_image
 
     def _build_command(
         self,
@@ -217,7 +241,31 @@ class DockerComposeBackend(
     def realize_boundary(self, policy: BoundaryEnforcementSpec) -> LabResult:
         """Apply and observe policy on the selected Docker daemon host."""
 
-        return _realize_boundary(self, policy)
+        result = _realize_boundary(
+            self,
+            policy,
+            helper_image=self._boundary_helper_image,
+        )
+        if result.success:
+            if policy.authority == "aces" and not policy.rules:
+                self._boundary_receipts.pop("aces", None)
+            else:
+                binding = (
+                    self._appliance_boundary[1]
+                    if self._appliance_boundary is not None
+                    else None
+                )
+                self._boundary_receipts[policy.authority] = {
+                    "source_digest": (
+                        policy.policy_digest
+                        if policy.authority == "platform"
+                        else (binding.aces_plan_digest if binding is not None else "")
+                    ),
+                    "enforcement_digest": policy.digest(),
+                    "families": ("bridge", "inet"),
+                    "default_deny": policy.authority == "platform",
+                }
+        return result
 
     def start(
         self,

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -26,9 +26,7 @@ from aptl.core.deployment._compose_seed_safety import (
 from aptl.core.deployment._compose_stop import stop_compose_lab
 from aptl.core.deployment._compose_boundary import (
     DEFAULT_BOUNDARY_HELPER_IMAGE,
-    realize_boundary as _realize_boundary,
 )
-from aptl.core.deployment.boundary import BoundaryEnforcementSpec
 from aptl.core.appliance_boundary import (
     ApplianceBoundaryBinding,
     ApplianceBoundaryPolicy,
@@ -96,16 +94,6 @@ class DockerComposeBackend(
         """Return whether bind sources are visible to the Docker daemon."""
 
         return True
-
-    def configure_appliance_boundary(
-        self,
-        policy: ApplianceBoundaryPolicy,
-        binding: ApplianceBoundaryBinding,
-    ) -> None:
-        """Install trusted release/launcher projections for realization."""
-
-        self._appliance_boundary = (policy, binding)
-        self._boundary_helper_image = binding.boundary_helper_image
 
     def _build_command(
         self,
@@ -237,35 +225,6 @@ class DockerComposeBackend(
             raise BackendTimeoutError(
                 f"command timed out after {timeout}s: {' '.join(cmd[:3])}"
             ) from exc
-
-    def realize_boundary(self, policy: BoundaryEnforcementSpec) -> LabResult:
-        """Apply and observe policy on the selected Docker daemon host."""
-
-        result = _realize_boundary(
-            self,
-            policy,
-            helper_image=self._boundary_helper_image,
-        )
-        if result.success:
-            if policy.authority == "aces" and not policy.rules:
-                self._boundary_receipts.pop("aces", None)
-            else:
-                binding = (
-                    self._appliance_boundary[1]
-                    if self._appliance_boundary is not None
-                    else None
-                )
-                self._boundary_receipts[policy.authority] = {
-                    "source_digest": (
-                        policy.policy_digest
-                        if policy.authority == "platform"
-                        else (binding.aces_plan_digest if binding is not None else "")
-                    ),
-                    "enforcement_digest": policy.digest(),
-                    "families": ("bridge", "inet"),
-                    "default_deny": policy.authority == "platform",
-                }
-        return result
 
     def start(
         self,

--- a/src/aptl/core/deployment/realization.py
+++ b/src/aptl/core/deployment/realization.py
@@ -16,6 +16,9 @@ GeneratedArtifactLifecycle = Literal["regenerate_on_change", "reuse_valid"]
 ResourceSensitivity = Literal["public", "restricted", "secret"]
 VolumeLifecycle = Literal["retain", "ephemeral"]
 VolumeAccessMode = Literal["read_write_once", "read_write_many", "read_only_many"]
+AclDirection = Literal["in", "out", "inout"]
+AclAction = Literal["allow", "deny"]
+AclProtocol = Literal["any", "tcp", "udp", "icmp"]
 
 # An SDL-declared host publish with no author-supplied host address binds
 # loopback. Defaulting to all interfaces would silently put a scenario-declared
@@ -74,6 +77,38 @@ class DeploymentNetworkAttachment(object):
 
     network: str
     ipv4_address: str | None = None
+
+
+@dataclass(frozen=True)
+class DeploymentAclRealization(object):
+    """One admitted ACES infrastructure ACL lowered for backend enforcement."""
+
+    owner_address: str
+    owner_resource_type: Literal["node", "network"]
+    owner_name: str
+    name: str
+    order: int
+    direction: AclDirection
+    from_network: str | None
+    to_network: str | None
+    protocol: AclProtocol
+    ports: tuple[int, ...]
+    action: AclAction
+
+    def details(self) -> dict[str, object]:
+        return {
+            "owner_address": self.owner_address,
+            "owner_resource_type": self.owner_resource_type,
+            "owner_name": self.owner_name,
+            "name": self.name,
+            "order": self.order,
+            "direction": self.direction,
+            "from_network": self.from_network,
+            "to_network": self.to_network,
+            "protocol": self.protocol,
+            "ports": list(self.ports),
+            "action": self.action,
+        }
 
 
 @dataclass(frozen=True)
@@ -311,6 +346,7 @@ class DeploymentRealizationSpec(object):
     profiles: tuple[str, ...]
     nodes: tuple[DeploymentNodeRealization, ...]
     networks: tuple[DeploymentNetworkRealization, ...]
+    acls: tuple[DeploymentAclRealization, ...] = ()
     images: tuple[DeploymentImageRealization, ...] = ()
     content: tuple[DeploymentContentRealization, ...] = ()
     accounts: tuple[DeploymentAccountRealization, ...] = ()

--- a/tests/test_aces_acl_realization.py
+++ b/tests/test_aces_acl_realization.py
@@ -175,6 +175,45 @@ def test_acl_lowering_rejects_unsupported_semantics_before_backend(tmp_path) -> 
     assert realization.deployment_spec(["victim"]).acls == ()
 
 
+def test_acl_lowering_rejects_out_of_range_ports(tmp_path) -> None:
+    _project(tmp_path)
+    orchard = _resource(
+        "orchard",
+        "network",
+        {"properties": {"cidr": "10.44.1.0/24"}},
+    )
+    sentinel = _resource(
+        "sentinel",
+        "node",
+        {
+            "links": ["orchard"],
+            "properties": [{"orchard": "10.44.1.10"}],
+            "acls": [
+                {
+                    "name": "invalid-port",
+                    "direction": "in",
+                    "from_net": "orchard",
+                    "to_net": "orchard",
+                    "protocol": "tcp",
+                    "ports": [70000],
+                    "action": "allow",
+                }
+            ],
+        },
+    )
+
+    realization = interpret_provisioning_plan(
+        plan=_plan(orchard, sentinel),
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "synthetic"}, containers={"victim": True}),
+    )
+
+    assert "aptl.provisioner.acl-ports-invalid" in {
+        item.code for item in realization.diagnostics
+    }
+    assert realization.deployment_spec(["victim"]).acls == ()
+
+
 @pytest.mark.parametrize(
     ("from_net", "cidr", "code"),
     [
@@ -301,6 +340,16 @@ def test_network_owned_acl_is_preserved_as_network_policy(tmp_path) -> None:
         if item.code.startswith("aptl.provisioner.acl-")
     ]
     acl = realization.deployment_spec(["victim"]).acls[0]
-    assert acl.owner_resource_type == "network"
-    assert acl.owner_address == "provision.network.orchard"
-    assert acl.owner_name == "orchard"
+    assert acl.details() == {
+        "owner_address": "provision.network.orchard",
+        "owner_resource_type": "network",
+        "owner_name": "orchard",
+        "name": "deny-outbound",
+        "order": 0,
+        "direction": "out",
+        "from_network": "orchard",
+        "to_network": "quartz",
+        "protocol": "any",
+        "ports": [],
+        "action": "deny",
+    }

--- a/tests/test_aces_acl_realization.py
+++ b/tests/test_aces_acl_realization.py
@@ -2,6 +2,7 @@
 
 import json
 
+import pytest
 from aces_contracts.planning import PlannedResource, ProvisioningPlan, RuntimeDomain
 
 from aptl.backends.aces_realization import interpret_provisioning_plan
@@ -172,3 +173,134 @@ def test_acl_lowering_rejects_unsupported_semantics_before_backend(tmp_path) -> 
         "aptl.provisioner.acl-protocol-unsupported",
     }
     assert realization.deployment_spec(["victim"]).acls == ()
+
+
+@pytest.mark.parametrize(
+    ("from_net", "cidr", "code"),
+    [
+        (
+            "orchard",
+            "2001:db8:44::/64",
+            "aptl.provisioner.acl-endpoint-family-unsupported",
+        ),
+    ],
+)
+def test_acl_lowering_rejects_unenforceable_endpoint_forms(
+    tmp_path,
+    from_net: str | None,
+    cidr: str,
+    code: str,
+) -> None:
+    _project(tmp_path)
+    orchard = _resource(
+        "orchard",
+        "network",
+        {"properties": {"cidr": cidr}},
+    )
+    sentinel = _resource(
+        "sentinel",
+        "node",
+        {
+            "links": ["orchard"],
+            "properties": [],
+            "acls": [
+                {
+                    "name": "bounded",
+                    "direction": "in",
+                    "from_net": from_net,
+                    "to_net": "orchard",
+                    "protocol": "tcp",
+                    "ports": [443],
+                    "action": "allow",
+                }
+            ],
+        },
+    )
+
+    realization = interpret_provisioning_plan(
+        plan=_plan(orchard, sentinel),
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "synthetic"}, containers={"victim": True}),
+    )
+
+    assert code in {item.code for item in realization.diagnostics}
+    assert realization.deployment_spec(["victim"]).acls == ()
+
+
+def test_acl_lowering_preserves_an_authored_wildcard_endpoint(tmp_path) -> None:
+    _project(tmp_path)
+    orchard = _resource(
+        "orchard",
+        "network",
+        {"properties": {"cidr": "10.44.1.0/24"}},
+    )
+    sentinel = _resource(
+        "sentinel",
+        "node",
+        {
+            "links": ["orchard"],
+            "properties": [{"orchard": "10.44.1.10"}],
+            "acls": [
+                {
+                    "name": "allow-any-source",
+                    "direction": "in",
+                    "to_net": "orchard",
+                    "protocol": "tcp",
+                    "ports": [443],
+                    "action": "allow",
+                }
+            ],
+        },
+    )
+
+    realization = interpret_provisioning_plan(
+        plan=_plan(orchard, sentinel),
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "synthetic"}, containers={"victim": True}),
+    )
+
+    assert [item.code for item in realization.diagnostics] == []
+    assert realization.deployment_spec(["victim"]).acls[0].from_network is None
+
+
+def test_network_owned_acl_is_preserved_as_network_policy(tmp_path) -> None:
+    _project(tmp_path)
+    orchard = _resource(
+        "orchard",
+        "network",
+        {
+            "properties": {"cidr": "10.44.1.0/24"},
+            "acls": [
+                {
+                    "name": "deny-outbound",
+                    "direction": "out",
+                    "from_net": "orchard",
+                    "to_net": "quartz",
+                    "protocol": "any",
+                    "ports": [],
+                    "action": "deny",
+                }
+            ],
+        },
+    )
+    quartz = _resource(
+        "quartz",
+        "network",
+        {"properties": {"cidr": "10.44.2.0/24"}},
+    )
+
+    realization = interpret_provisioning_plan(
+        plan=_plan(orchard, quartz),
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "synthetic"}, containers={"victim": True}),
+    )
+
+    assert not [
+        item.code
+        for item in realization.diagnostics
+        if item.code.startswith("aptl.provisioner.acl-")
+    ]
+    acl = realization.deployment_spec(["victim"]).acls[0]
+    assert acl.owner_resource_type == "network"
+    assert acl.owner_address == "provision.network.orchard"
+    assert acl.owner_name == "orchard"

--- a/tests/test_aces_acl_realization.py
+++ b/tests/test_aces_acl_realization.py
@@ -1,0 +1,174 @@
+"""Generic ACES ACL lowering for the APP-1 materialization surface."""
+
+import json
+
+from aces_contracts.planning import PlannedResource, ProvisioningPlan, RuntimeDomain
+
+from aptl.backends.aces_realization import interpret_provisioning_plan
+from aptl.core.config import AptlConfig
+
+
+def _resource(
+    name: str,
+    resource_type: str,
+    infrastructure: dict[str, object],
+) -> PlannedResource:
+    return PlannedResource(
+        address=f"provision.{resource_type}.{name}",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type=resource_type,
+        payload={
+            "name": name,
+            "spec": {
+                "node": {"type": "switch" if resource_type == "network" else "vm"},
+                "infrastructure": infrastructure,
+            },
+        },
+    )
+
+
+def _plan(*resources: PlannedResource) -> ProvisioningPlan:
+    return ProvisioningPlan(
+        resources={resource.address: resource for resource in resources},
+        operations=(),
+    )
+
+
+def _project(tmp_path) -> None:
+    (tmp_path / "docker-compose.yml").write_text(
+        json.dumps(
+            {
+                "services": {
+                    "sentinel": {
+                        "container_name": "sentinel",
+                        "profiles": ["victim"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_acl_lowering_preserves_aces_identity_order_and_semantics(tmp_path) -> None:
+    _project(tmp_path)
+    orchard = _resource(
+        "orchard",
+        "network",
+        {"properties": {"cidr": "10.44.1.0/24", "gateway": "10.44.1.1"}},
+    )
+    quartz = _resource(
+        "quartz",
+        "network",
+        {"properties": {"cidr": "10.44.2.0/24", "gateway": "10.44.2.1"}},
+    )
+    sentinel = _resource(
+        "sentinel",
+        "node",
+        {
+            "links": ["orchard", "quartz"],
+            "properties": [
+                {"orchard": "10.44.1.10"},
+                {"quartz": "10.44.2.10"},
+            ],
+            "acls": [
+                {
+                    "name": "allow-web",
+                    "direction": "in",
+                    "from_net": "orchard",
+                    "to_net": "quartz",
+                    "protocol": "tcp",
+                    "ports": [443, 8443],
+                    "action": "allow",
+                },
+                {
+                    "name": "deny-rest",
+                    "direction": "inout",
+                    "from_net": "orchard",
+                    "to_net": "quartz",
+                    "protocol": "any",
+                    "ports": [],
+                    "action": "deny",
+                },
+            ],
+        },
+    )
+
+    realization = interpret_provisioning_plan(
+        plan=_plan(orchard, quartz, sentinel),
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "synthetic"}, containers={"victim": True}),
+    )
+
+    assert [item.code for item in realization.diagnostics] == []
+    spec = realization.deployment_spec(["victim"])
+    assert [item.details() for item in spec.acls] == [
+        {
+            "owner_address": "provision.node.sentinel",
+            "owner_resource_type": "node",
+            "owner_name": "sentinel",
+            "name": "allow-web",
+            "order": 0,
+            "direction": "in",
+            "from_network": "orchard",
+            "to_network": "quartz",
+            "protocol": "tcp",
+            "ports": [443, 8443],
+            "action": "allow",
+        },
+        {
+            "owner_address": "provision.node.sentinel",
+            "owner_resource_type": "node",
+            "owner_name": "sentinel",
+            "name": "deny-rest",
+            "order": 1,
+            "direction": "inout",
+            "from_network": "orchard",
+            "to_network": "quartz",
+            "protocol": "any",
+            "ports": [],
+            "action": "deny",
+        },
+    ]
+
+
+def test_acl_lowering_rejects_unsupported_semantics_before_backend(tmp_path) -> None:
+    _project(tmp_path)
+    orchard = _resource(
+        "orchard",
+        "network",
+        {"properties": {"cidr": "10.44.1.0/24", "gateway": "10.44.1.1"}},
+    )
+    sentinel = _resource(
+        "sentinel",
+        "node",
+        {
+            "links": ["orchard"],
+            "properties": [{"orchard": "10.44.1.10"}],
+            "acls": [
+                {
+                    "name": "unsupported",
+                    "direction": "sideways",
+                    "from_net": "missing",
+                    "to_net": "orchard",
+                    "protocol": "sctp",
+                    "ports": [443],
+                    "action": "permit",
+                }
+            ],
+        },
+    )
+
+    realization = interpret_provisioning_plan(
+        plan=_plan(orchard, sentinel),
+        project_dir=tmp_path,
+        config=AptlConfig(lab={"name": "synthetic"}, containers={"victim": True}),
+    )
+
+    assert {item.code for item in realization.diagnostics} == {
+        "aptl.provisioner.acl-action-unsupported",
+        "aptl.provisioner.acl-direction-unsupported",
+        "aptl.provisioner.acl-endpoint-unresolved",
+        "aptl.provisioner.acl-protocol-unsupported",
+    }
+    assert realization.deployment_spec(["victim"]).acls == ()

--- a/tests/test_aces_backend.py
+++ b/tests/test_aces_backend.py
@@ -503,7 +503,10 @@ def _drive_plan_through_target(
         if not result.success:
             return result
         working = result.snapshot
-    if execution_plan.orchestration.actionable_operations and target.orchestrator is not None:
+    if (
+        execution_plan.orchestration.actionable_operations
+        and target.orchestrator is not None
+    ):
         result = target.orchestrator.start(execution_plan.orchestration, working)
         if not result.success:
             return result
@@ -595,7 +598,7 @@ def test_manifest_provisioner_declares_only_realized_capabilities():
         {"disabled", "groups", "mail", "spn"}
     )
     assert provisioner.supports_accounts is True
-    assert provisioner.supports_acls is False
+    assert provisioner.supports_acls is True
 
 
 def test_manifest_realization_support_matches_exercised_concerns():
@@ -1637,7 +1640,9 @@ def test_start_aces_scenario_threads_resolved_run_target(mocker, tmp_path):
         selected_profiles=["victim"],
         scenario_path=None,
     )
-    run_plan = mocker.patch("aptl.backends.aces._run_execution_plan", return_value=outcome)
+    run_plan = mocker.patch(
+        "aptl.backends.aces._run_execution_plan", return_value=outcome
+    )
     store = object()
     run_target = AcesRunTarget(run_store=store, run_id="run-1")
 
@@ -2270,15 +2275,11 @@ def test_provisioner_captures_failure_diagnostics_for_handoff(tmp_path):
 
     assert result.success is False
     captured = provisioner.last_failure_diagnostics
-    assert [item.code for item in captured] == [
-        "aptl.provisioner.backend-start-failed"
-    ]
+    assert [item.code for item in captured] == ["aptl.provisioner.backend-start-failed"]
     assert "172.20.0.0/16" in captured[0].message
 
     backend.realize.return_value = LabResult(success=True, message="ok")
-    recovered = provisioner.apply(
-        _plan_for_nodes("scenario-a.kali"), RuntimeSnapshot()
-    )
+    recovered = provisioner.apply(_plan_for_nodes("scenario-a.kali"), RuntimeSnapshot())
     assert recovered.success is True
     assert provisioner.last_failure_diagnostics == ()
 
@@ -2319,9 +2320,7 @@ def test_apply_failure_reattaches_backend_diagnostics_after_gate_flood(
     target = MagicMock()
     target.provisioner.last_failure_diagnostics = (backend_diag,)
 
-    failure, _snapshot, retryable = aces._apply_execution_plan(
-        target, MagicMock()
-    )
+    failure, _snapshot, retryable = aces._apply_execution_plan(target, MagicMock())
 
     assert failure is not None
     assert failure.success is False
@@ -3347,9 +3346,7 @@ def test_manifest_account_features_match_realized_dto_fields():
         "mail",
         "spn",
     }
-    assert set(manifest.provisioner.supported_domain_profiles) == {
-        "active_directory"
-    }
+    assert set(manifest.provisioner.supported_domain_profiles) == {"active_directory"}
 
 
 def _apply_single_content_placement(tmp_path, *, spec_overrides: dict) -> tuple:
@@ -3740,9 +3737,9 @@ def _apply_content_disclosure_scenario(tmp_path, observed_content_type):
         config=AptlConfig(lab={"name": "test"}),
         backend=backend,
     )
-    return RuntimeManager(
-        target, initial_snapshot=execution_plan.base_snapshot
-    ).apply(execution_plan)
+    return RuntimeManager(target, initial_snapshot=execution_plan.base_snapshot).apply(
+        execution_plan
+    )
 
 
 def test_apply_provisioning_populates_realization_and_profiles(tmp_path):
@@ -3841,9 +3838,7 @@ def test_apply_provisioning_records_realization_provenance_when_honored(tmp_path
     result = _apply_disclosure_scenario(tmp_path, backend)
 
     assert result.success is True, [d.message for d in result.diagnostics]
-    kinds = {
-        entry.requirement_kind for entry in result.snapshot.realization_provenance
-    }
+    kinds = {entry.requirement_kind for entry in result.snapshot.realization_provenance}
     assert {"node-type", "os-family"} <= kinds
 
 
@@ -3862,9 +3857,7 @@ def test_apply_provisioning_discloses_author_declared_provenance(tmp_path):
     result = _apply_disclosure_scenario(tmp_path, backend)
 
     assert result.success is True, [d.message for d in result.diagnostics]
-    provenances = {
-        entry.provenance for entry in result.snapshot.realization_provenance
-    }
+    provenances = {entry.provenance for entry in result.snapshot.realization_provenance}
     assert provenances == {ExplicitnessProvenance.AUTHOR_DECLARED}
 
 

--- a/tests/test_appliance_boundary_gate.py
+++ b/tests/test_appliance_boundary_gate.py
@@ -1,0 +1,157 @@
+"""The image and boot paths share one fatal boundary gate."""
+
+import hashlib
+import json
+
+import pytest
+
+from aptl.core.appliance_boundary import ApplianceBoundaryBinding
+from aptl.core.appliance_boundary_gate import run_appliance_boundary_gate
+from aptl.core.appliance_boundary_inventory import (
+    BoundaryEnforcementObservation,
+    BoundaryEndpoint,
+    BoundaryProbeObservation,
+    GuestBoundaryObservation,
+    HostBoundaryObservation,
+)
+
+
+def _payload() -> bytes:
+    return json.dumps(
+        {
+            "schema_version": "aptl.appliance-boundary/v1",
+            "policy_id": "default",
+            "generation": 1,
+            "default_deny": True,
+            "platform_anchors": {
+                "participant": "org.aptl.zone=participant",
+                "management": "org.aptl.zone=management",
+                "egress": "org.aptl.zone=egress",
+            },
+            "fixed_crossings": [],
+            "egress_authorities": [],
+            "guest_publications": [
+                {
+                    "audience": "participant",
+                    "address": "127.0.0.1",
+                    "port": 443,
+                    "protocol": "tcp",
+                }
+            ],
+            "docker_authority": {
+                "allowed_holder_labels": [],
+                "require_guest_daemon": True,
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+def _binding(payload: bytes) -> ApplianceBoundaryBinding:
+    return ApplianceBoundaryBinding(
+        policy_digest="sha256:" + hashlib.sha256(payload).hexdigest(),
+        payload_digest="sha256:" + "b" * 64,
+        aces_plan_digest="sha256:" + "d" * 64,
+        boot_id="boot-1",
+        guest_daemon_id="daemon-1",
+        host_observation_id="host-1",
+    )
+
+
+def _host(binding: ApplianceBoundaryBinding) -> HostBoundaryObservation:
+    return HostBoundaryObservation(
+        observation_id="host-1",
+        policy_digest=binding.policy_digest,
+        payload_digest=binding.payload_digest,
+        boot_id="boot-1",
+        complete=True,
+        listeners=(
+            BoundaryEndpoint(
+                audience="participant",
+                address="127.0.0.1",
+                port=443,
+                protocol="tcp",
+            ),
+        ),
+        forbidden_reachability_passed=True,
+    )
+
+
+class _Adapter:
+    def __init__(self, binding: ApplianceBoundaryBinding) -> None:
+        self.binding = binding
+        self.phases: list[str] = []
+
+    def materialize_and_observe_boundary(self, policy, binding, *, phase):
+        assert binding == self.binding
+        assert policy.default_deny is True
+        self.phases.append(phase)
+        return GuestBoundaryObservation(
+            policy_digest=binding.policy_digest,
+            aces_plan_digest=binding.aces_plan_digest,
+            boot_id=binding.boot_id,
+            guest_daemon_id=binding.guest_daemon_id,
+            enforcements=(
+                BoundaryEnforcementObservation(
+                    authority="platform",
+                    source_digest=binding.policy_digest,
+                    enforcement_digest="sha256:" + "c" * 64,
+                    families=("bridge", "inet"),
+                    default_deny_observed=True,
+                ),
+            ),
+            observation_complete=True,
+            probes=(
+                BoundaryProbeObservation(
+                    identity="declared-crossing",
+                    expectation="reachable",
+                    passed=True,
+                ),
+                BoundaryProbeObservation(
+                    identity="forbidden-crossing",
+                    expectation="blocked",
+                    passed=True,
+                ),
+            ),
+            docker_authority_holders=(),
+        )
+
+
+@pytest.mark.parametrize("phase", ["image-qualification", "start"])
+def test_both_phases_use_the_same_verifier(tmp_path, phase) -> None:
+    payload = _payload()
+    path = tmp_path / "boundary.json"
+    path.write_bytes(payload)
+    binding = _binding(payload)
+    adapter = _Adapter(binding)
+
+    result = run_appliance_boundary_gate(
+        policy_path=path,
+        binding=binding,
+        host_observation=_host(binding),
+        adapter=adapter,
+        phase=phase,
+    )
+
+    assert result.passed is True
+    assert result.inventory["phase"] == phase
+    assert adapter.phases == [phase]
+
+
+def test_gate_never_substitutes_for_missing_host_observation(tmp_path) -> None:
+    payload = _payload()
+    path = tmp_path / "boundary.json"
+    path.write_bytes(payload)
+    binding = _binding(payload)
+
+    result = run_appliance_boundary_gate(
+        policy_path=path,
+        binding=binding,
+        host_observation=None,
+        adapter=_Adapter(binding),
+        phase="start",
+    )
+
+    assert result.passed is False
+    assert result.findings == ("boundary.host-observation-missing",)

--- a/tests/test_appliance_boundary_gate.py
+++ b/tests/test_appliance_boundary_gate.py
@@ -22,7 +22,13 @@ def _payload() -> bytes:
             "schema_version": "aptl.appliance-boundary/v1",
             "policy_id": "default",
             "generation": 1,
+            "workbench_policy_version": "participant-workbench-profile/v1",
             "default_deny": True,
+            "platform_networks": {
+                "participant": "org.aptl.network=participant",
+                "management": "org.aptl.network=management",
+                "egress": "org.aptl.network=egress",
+            },
             "platform_anchors": {
                 "participant": "org.aptl.zone=participant",
                 "management": "org.aptl.zone=management",
@@ -30,6 +36,13 @@ def _payload() -> bytes:
             },
             "fixed_crossings": [],
             "egress_authorities": [],
+            "egress_proxy_limits": {
+                "max_connections": 32,
+                "max_header_bytes": 4096,
+                "header_timeout_seconds": 5,
+                "connect_timeout_seconds": 10,
+                "idle_timeout_seconds": 60,
+            },
             "guest_publications": [
                 {
                     "audience": "participant",
@@ -53,6 +66,9 @@ def _binding(payload: bytes) -> ApplianceBoundaryBinding:
         policy_digest="sha256:" + hashlib.sha256(payload).hexdigest(),
         payload_digest="sha256:" + "b" * 64,
         aces_plan_digest="sha256:" + "d" * 64,
+        aces_boundary_required=False,
+        boundary_helper_image="example.test/aptl-boundary@sha256:" + "e" * 64,
+        egress_proxy_image="example.test/aptl-egress@sha256:" + "f" * 64,
         boot_id="boot-1",
         guest_daemon_id="daemon-1",
         host_observation_id="host-1",
@@ -92,6 +108,7 @@ class _Adapter:
             aces_plan_digest=binding.aces_plan_digest,
             boot_id=binding.boot_id,
             guest_daemon_id=binding.guest_daemon_id,
+            workbench_policy_version="participant-workbench-profile/v1",
             enforcements=(
                 BoundaryEnforcementObservation(
                     authority="platform",
@@ -105,11 +122,21 @@ class _Adapter:
             probes=(
                 BoundaryProbeObservation(
                     identity="declared-crossing",
+                    authority="platform",
+                    source="management",
+                    destination="egress",
+                    protocol="tcp",
+                    port=3128,
                     expectation="reachable",
                     passed=True,
                 ),
                 BoundaryProbeObservation(
                     identity="forbidden-crossing",
+                    authority="platform",
+                    source="participant",
+                    destination="management",
+                    protocol="tcp",
+                    port=443,
                     expectation="blocked",
                     passed=True,
                 ),

--- a/tests/test_appliance_boundary_integration.py
+++ b/tests/test_appliance_boundary_integration.py
@@ -1,0 +1,233 @@
+"""Real-Docker positive/negative proof for the external platform floor."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from aptl.core.deployment._compose_boundary import _helper_command
+from aptl.core.deployment.boundary import (
+    BoundaryNetwork,
+    BoundaryWorkload,
+    PlatformBoundarySpec,
+    PlatformCrossing,
+)
+from aptl.core.deployment.docker_compose import DockerComposeBackend
+
+pytestmark = pytest.mark.integration
+
+_ALPINE = (
+    "alpine:3.22@sha256:"
+    "14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce"
+)
+_SERVER = "aptl-appliance-egress-proxy:1"
+_NETWORK = "aptl-822-boundary-proof"
+_BRIDGE = "ap822proof0"
+_CONTAINERS = (
+    "aptl-822-proof-management",
+    "aptl-822-proof-egress",
+    "aptl-822-proof-participant",
+)
+
+
+def _run(argv: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None and _run(
+        ["docker", "info"]
+    ).returncode == 0
+
+
+def _policy() -> PlatformBoundarySpec:
+    network = BoundaryNetwork(
+        name="transit",
+        bridge=_BRIDGE,
+        ipv4_cidr="10.252.24.0/24",
+    )
+    return PlatformBoundarySpec(
+        owner="aptl-822-boundary-proof",
+        policy_digest="sha256:" + "e" * 64,
+        networks=(network,),
+        anchors=(
+            (
+                "participant",
+                BoundaryWorkload(
+                    identity="participant",
+                    labels=(("org.aptl.zone", "participant"),),
+                    ipv4_by_network=(("transit", "10.252.24.30"),),
+                ),
+            ),
+            (
+                "management",
+                BoundaryWorkload(
+                    identity="management",
+                    labels=(("org.aptl.zone", "management"),),
+                    ipv4_by_network=(("transit", "10.252.24.10"),),
+                ),
+            ),
+            (
+                "egress",
+                BoundaryWorkload(
+                    identity="egress",
+                    labels=(("org.aptl.zone", "egress"),),
+                    ipv4_by_network=(("transit", "10.252.24.20"),),
+                ),
+            ),
+        ),
+        crossings=(
+            PlatformCrossing(
+                source="management",
+                destination="egress",
+                protocol="tcp",
+                ports=(8080,),
+                purpose="live-proof",
+            ),
+        ),
+        egress_ports=(),
+    )
+
+
+def _cleanup(backend: DockerComposeBackend, policy: PlatformBoundarySpec) -> None:
+    backend._run_with_input(
+        _helper_command("cleanup"),
+        policy.canonical_json(),
+        timeout=30,
+    )
+    for container in _CONTAINERS:
+        _run(["docker", "rm", "-f", container])
+    _run(["docker", "network", "rm", _NETWORK])
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker daemon not available")
+def test_platform_floor_allows_declared_crossing_and_blocks_other_source() -> None:
+    project_dir = Path(__file__).parents[1]
+    backend = DockerComposeBackend(project_dir, project_name="aptl-822-proof")
+    policy = _policy()
+    _cleanup(backend, policy)
+    try:
+        build = _run(
+            [
+                "docker",
+                "build",
+                "-q",
+                "-f",
+                str(project_dir / "containers/appliance-egress-proxy/Dockerfile"),
+                "-t",
+                _SERVER,
+                str(project_dir),
+            ],
+            timeout=600,
+        )
+        assert build.returncode == 0
+        created = _run(
+            [
+                "docker",
+                "network",
+                "create",
+                "--driver",
+                "bridge",
+                "--opt",
+                f"com.docker.network.bridge.name={_BRIDGE}",
+                "--subnet",
+                "10.252.24.0/24",
+                _NETWORK,
+            ]
+        )
+        assert created.returncode == 0
+        starts = (
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                _CONTAINERS[0],
+                "--network",
+                _NETWORK,
+                "--ip",
+                "10.252.24.10",
+                _ALPINE,
+                "sleep",
+                "infinity",
+            ],
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                _CONTAINERS[1],
+                "--network",
+                _NETWORK,
+                "--ip",
+                "10.252.24.20",
+                "--entrypoint",
+                "python3",
+                _SERVER,
+                "-m",
+                "http.server",
+                "8080",
+            ],
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                _CONTAINERS[2],
+                "--network",
+                _NETWORK,
+                "--ip",
+                "10.252.24.30",
+                _ALPINE,
+                "sleep",
+                "infinity",
+            ],
+        )
+        assert all(_run(argv).returncode == 0 for argv in starts)
+        time.sleep(1)
+
+        assert backend.realize_boundary(policy).success is True
+        allowed = _run(
+            [
+                "docker",
+                "exec",
+                _CONTAINERS[0],
+                "wget",
+                "-q",
+                "-T",
+                "3",
+                "-O",
+                "-",
+                "http://10.252.24.20:8080/",
+            ],
+            timeout=10,
+        )
+        denied = _run(
+            [
+                "docker",
+                "exec",
+                _CONTAINERS[2],
+                "wget",
+                "-q",
+                "-T",
+                "3",
+                "-O",
+                "-",
+                "http://10.252.24.20:8080/",
+            ],
+            timeout=10,
+        )
+        assert allowed.returncode == 0
+        assert denied.returncode != 0
+    finally:
+        _cleanup(backend, policy)

--- a/tests/test_appliance_boundary_integration.py
+++ b/tests/test_appliance_boundary_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import shutil
 import subprocess
 import time
@@ -11,12 +12,15 @@ import pytest
 
 from aptl.core.deployment._compose_boundary import _helper_command
 from aptl.core.deployment.boundary import (
+    AcesAclOwnerBinding,
+    AcesBoundarySpec,
     BoundaryNetwork,
     BoundaryWorkload,
     PlatformBoundarySpec,
     PlatformCrossing,
 )
 from aptl.core.deployment.docker_compose import DockerComposeBackend
+from aptl.core.deployment.realization import DeploymentAclRealization
 
 pytestmark = pytest.mark.integration
 
@@ -25,13 +29,22 @@ _ALPINE = (
     "14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce"
 )
 _SERVER = "aptl-appliance-egress-proxy:1"
-_NETWORK = "aptl-822-boundary-proof"
-_BRIDGE = "ap822proof0"
+_NETWORKS = (
+    "aptl-822-boundary-participant",
+    "aptl-822-boundary-management",
+    "aptl-822-boundary-egress",
+)
+_BRIDGES = ("ap822part0", "ap822mgmt0", "ap822egress0")
 _CONTAINERS = (
     "aptl-822-proof-management",
     "aptl-822-proof-egress",
     "aptl-822-proof-participant",
 )
+
+
+def _table_name(owner: str, authority: str) -> str:
+    suffix = hashlib.sha256(f"{owner}:{authority}".encode()).hexdigest()[:12]
+    return f"aptl_bnd_{suffix}"
 
 
 def _run(argv: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
@@ -45,28 +58,44 @@ def _run(argv: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
 
 
 def _docker_available() -> bool:
-    return shutil.which("docker") is not None and _run(
-        ["docker", "info"]
-    ).returncode == 0
+    return (
+        shutil.which("docker") is not None and _run(["docker", "info"]).returncode == 0
+    )
 
 
 def _policy() -> PlatformBoundarySpec:
-    network = BoundaryNetwork(
-        name="transit",
-        bridge=_BRIDGE,
-        ipv4_cidr="10.252.24.0/24",
-    )
     return PlatformBoundarySpec(
         owner="aptl-822-boundary-proof",
         policy_digest="sha256:" + "e" * 64,
-        networks=(network,),
+        networks=(
+            BoundaryNetwork(
+                name="participant",
+                bridge=_BRIDGES[0],
+                ipv4_cidr="10.252.24.0/24",
+            ),
+            BoundaryNetwork(
+                name="management",
+                bridge=_BRIDGES[1],
+                ipv4_cidr="10.252.26.0/24",
+            ),
+            BoundaryNetwork(
+                name="egress",
+                bridge=_BRIDGES[2],
+                ipv4_cidr="10.252.27.0/24",
+            ),
+        ),
+        zone_networks=(
+            ("participant", "participant"),
+            ("management", "management"),
+            ("egress", "egress"),
+        ),
         anchors=(
             (
                 "participant",
                 BoundaryWorkload(
                     identity="participant",
                     labels=(("org.aptl.zone", "participant"),),
-                    ipv4_by_network=(("transit", "10.252.24.30"),),
+                    ipv4_by_network=(("participant", "10.252.24.30"),),
                 ),
             ),
             (
@@ -74,7 +103,7 @@ def _policy() -> PlatformBoundarySpec:
                 BoundaryWorkload(
                     identity="management",
                     labels=(("org.aptl.zone", "management"),),
-                    ipv4_by_network=(("transit", "10.252.24.10"),),
+                    ipv4_by_network=(("management", "10.252.26.10"),),
                 ),
             ),
             (
@@ -82,7 +111,10 @@ def _policy() -> PlatformBoundarySpec:
                 BoundaryWorkload(
                     identity="egress",
                     labels=(("org.aptl.zone", "egress"),),
-                    ipv4_by_network=(("transit", "10.252.24.20"),),
+                    ipv4_by_network=(
+                        ("management", "10.252.26.20"),
+                        ("egress", "10.252.27.20"),
+                    ),
                 ),
             ),
         ),
@@ -107,7 +139,8 @@ def _cleanup(backend: DockerComposeBackend, policy: PlatformBoundarySpec) -> Non
     )
     for container in _CONTAINERS:
         _run(["docker", "rm", "-f", container])
-    _run(["docker", "network", "rm", _NETWORK])
+    for network in _NETWORKS:
+        _run(["docker", "network", "rm", network])
 
 
 @pytest.mark.skipif(not _docker_available(), reason="docker daemon not available")
@@ -131,21 +164,29 @@ def test_platform_floor_allows_declared_crossing_and_blocks_other_source() -> No
             timeout=600,
         )
         assert build.returncode == 0
-        created = _run(
-            [
-                "docker",
-                "network",
-                "create",
-                "--driver",
-                "bridge",
-                "--opt",
-                f"com.docker.network.bridge.name={_BRIDGE}",
-                "--subnet",
-                "10.252.24.0/24",
-                _NETWORK,
-            ]
+        creates = tuple(
+            _run(
+                [
+                    "docker",
+                    "network",
+                    "create",
+                    "--driver",
+                    "bridge",
+                    "--opt",
+                    f"com.docker.network.bridge.name={bridge}",
+                    "--subnet",
+                    subnet,
+                    network,
+                ]
+            )
+            for network, bridge, subnet in zip(
+                _NETWORKS,
+                _BRIDGES,
+                ("10.252.24.0/24", "10.252.26.0/24", "10.252.27.0/24"),
+                strict=True,
+            )
         )
-        assert created.returncode == 0
+        assert all(result.returncode == 0 for result in creates)
         starts = (
             [
                 "docker",
@@ -154,9 +195,9 @@ def test_platform_floor_allows_declared_crossing_and_blocks_other_source() -> No
                 "--name",
                 _CONTAINERS[0],
                 "--network",
-                _NETWORK,
+                _NETWORKS[1],
                 "--ip",
-                "10.252.24.10",
+                "10.252.26.10",
                 _ALPINE,
                 "sleep",
                 "infinity",
@@ -168,9 +209,9 @@ def test_platform_floor_allows_declared_crossing_and_blocks_other_source() -> No
                 "--name",
                 _CONTAINERS[1],
                 "--network",
-                _NETWORK,
+                _NETWORKS[2],
                 "--ip",
-                "10.252.24.20",
+                "10.252.27.20",
                 "--entrypoint",
                 "python3",
                 _SERVER,
@@ -185,7 +226,7 @@ def test_platform_floor_allows_declared_crossing_and_blocks_other_source() -> No
                 "--name",
                 _CONTAINERS[2],
                 "--network",
-                _NETWORK,
+                _NETWORKS[0],
                 "--ip",
                 "10.252.24.30",
                 _ALPINE,
@@ -194,6 +235,18 @@ def test_platform_floor_allows_declared_crossing_and_blocks_other_source() -> No
             ],
         )
         assert all(_run(argv).returncode == 0 for argv in starts)
+        attached = _run(
+            [
+                "docker",
+                "network",
+                "connect",
+                "--ip",
+                "10.252.26.20",
+                _NETWORKS[1],
+                _CONTAINERS[1],
+            ]
+        )
+        assert attached.returncode == 0
         time.sleep(1)
 
         assert backend.realize_boundary(policy).success is True
@@ -208,7 +261,7 @@ def test_platform_floor_allows_declared_crossing_and_blocks_other_source() -> No
                 "3",
                 "-O",
                 "-",
-                "http://10.252.24.20:8080/",
+                "http://10.252.26.20:8080/",
             ],
             timeout=10,
         )
@@ -223,11 +276,204 @@ def test_platform_floor_allows_declared_crossing_and_blocks_other_source() -> No
                 "3",
                 "-O",
                 "-",
-                "http://10.252.24.20:8080/",
+                "http://10.252.26.20:8080/",
+            ],
+            timeout=10,
+        )
+        assert allowed.returncode == 0
+        assert denied.returncode != 0
+
+        drift = _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                "host",
+                "--cap-drop=ALL",
+                "--cap-add=NET_ADMIN",
+                "--security-opt=no-new-privileges",
+                "--entrypoint",
+                "nft",
+                "aptl-network-boundary-helper:1",
+                "flush",
+                "chain",
+                "inet",
+                _table_name(policy.owner, policy.authority),
+                "forward",
+            ]
+        )
+        assert drift.returncode == 0
+        observation = backend._run_with_input(
+            _helper_command("observe"),
+            policy.canonical_json(),
+            timeout=30,
+        )
+        assert observation.returncode != 0
+    finally:
+        _cleanup(backend, policy)
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker daemon not available")
+def test_aces_owner_acl_allows_declared_port_and_denies_remainder() -> None:
+    project_dir = Path(__file__).parents[1]
+    backend = DockerComposeBackend(project_dir, project_name="aptl-822-acl-proof")
+    network_name = "aptl-822-acl-proof"
+    bridge = "ap822acl0"
+    source = "aptl-822-acl-source"
+    target = "aptl-822-acl-target"
+    network = BoundaryNetwork(
+        name="transit",
+        bridge=bridge,
+        ipv4_cidr="10.252.25.0/24",
+    )
+    rules = (
+        DeploymentAclRealization(
+            owner_address="provision.node.target",
+            owner_resource_type="node",
+            owner_name="target",
+            name="allow-web",
+            order=0,
+            direction="in",
+            from_network="transit",
+            to_network="transit",
+            protocol="tcp",
+            ports=(8080,),
+            action="allow",
+        ),
+        DeploymentAclRealization(
+            owner_address="provision.node.target",
+            owner_resource_type="node",
+            owner_name="target",
+            name="deny-remainder",
+            order=1,
+            direction="in",
+            from_network="transit",
+            to_network="transit",
+            protocol="any",
+            ports=(),
+            action="deny",
+        ),
+    )
+    policy = AcesBoundarySpec(
+        owner="aptl-822-acl-proof",
+        networks=(network,),
+        owner_bindings=(
+            AcesAclOwnerBinding(
+                owner_address="provision.node.target",
+                owner_resource_type="node",
+                ipv4_by_network=(("transit", "10.252.25.20"),),
+            ),
+        ),
+        rules=rules,
+    )
+    backend._run_with_input(
+        _helper_command("cleanup"),
+        policy.canonical_json(),
+        timeout=30,
+    )
+    for container in (source, target):
+        _run(["docker", "rm", "-f", container])
+    _run(["docker", "network", "rm", network_name])
+    try:
+        created = _run(
+            [
+                "docker",
+                "network",
+                "create",
+                "--driver",
+                "bridge",
+                "--opt",
+                f"com.docker.network.bridge.name={bridge}",
+                "--subnet",
+                "10.252.25.0/24",
+                network_name,
+            ]
+        )
+        assert created.returncode == 0
+        assert (
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "-d",
+                    "--name",
+                    source,
+                    "--network",
+                    network_name,
+                    "--ip",
+                    "10.252.25.10",
+                    _ALPINE,
+                    "sleep",
+                    "infinity",
+                ]
+            ).returncode
+            == 0
+        )
+        assert (
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "-d",
+                    "--name",
+                    target,
+                    "--network",
+                    network_name,
+                    "--ip",
+                    "10.252.25.20",
+                    "--entrypoint",
+                    "sh",
+                    _SERVER,
+                    "-c",
+                    (
+                        "python3 -m http.server 8080 & "
+                        "python3 -m http.server 8081 & wait"
+                    ),
+                ]
+            ).returncode
+            == 0
+        )
+        time.sleep(1)
+        assert backend.realize_boundary(policy).success is True
+        allowed = _run(
+            [
+                "docker",
+                "exec",
+                source,
+                "wget",
+                "-q",
+                "-T",
+                "3",
+                "-O",
+                "-",
+                "http://10.252.25.20:8080/",
+            ],
+            timeout=10,
+        )
+        denied = _run(
+            [
+                "docker",
+                "exec",
+                source,
+                "wget",
+                "-q",
+                "-T",
+                "3",
+                "-O",
+                "-",
+                "http://10.252.25.20:8081/",
             ],
             timeout=10,
         )
         assert allowed.returncode == 0
         assert denied.returncode != 0
     finally:
-        _cleanup(backend, policy)
+        backend._run_with_input(
+            _helper_command("cleanup"),
+            policy.canonical_json(),
+            timeout=30,
+        )
+        for container in (source, target):
+            _run(["docker", "rm", "-f", container])
+        _run(["docker", "network", "rm", network_name])

--- a/tests/test_appliance_boundary_inventory.py
+++ b/tests/test_appliance_boundary_inventory.py
@@ -1,0 +1,187 @@
+"""Fresh desired-versus-observed appliance boundary verdict."""
+
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+)
+from aptl.core.appliance_boundary_inventory import (
+    BoundaryEnforcementObservation,
+    BoundaryEndpoint,
+    BoundaryProbeObservation,
+    DockerAuthorityHolder,
+    GuestBoundaryObservation,
+    HostBoundaryObservation,
+    qualify_appliance_boundary,
+)
+
+
+POLICY_DIGEST = "sha256:" + "1" * 64
+PAYLOAD_DIGEST = "sha256:" + "2" * 64
+
+
+def _binding() -> ApplianceBoundaryBinding:
+    return ApplianceBoundaryBinding(
+        policy_digest=POLICY_DIGEST,
+        payload_digest=PAYLOAD_DIGEST,
+        aces_plan_digest="sha256:" + "4" * 64,
+        boot_id="boot-42",
+        guest_daemon_id="daemon-42",
+        host_observation_id="host-42",
+    )
+
+
+def _policy() -> ApplianceBoundaryPolicy:
+    return ApplianceBoundaryPolicy.model_validate(
+        {
+            "schema_version": "aptl.appliance-boundary/v1",
+            "policy_id": "default",
+            "generation": 1,
+            "default_deny": True,
+            "platform_anchors": {
+                "participant": "org.aptl.appliance.zone=participant",
+                "management": "org.aptl.appliance.zone=management",
+                "egress": "org.aptl.appliance.zone=egress",
+            },
+            "fixed_crossings": [],
+            "egress_authorities": [],
+            "guest_publications": [
+                {
+                    "audience": "participant",
+                    "address": "127.0.0.1",
+                    "port": 443,
+                    "protocol": "tcp",
+                },
+                {
+                    "audience": "recovery",
+                    "address": "127.0.0.1",
+                    "port": 9443,
+                    "protocol": "tcp",
+                },
+            ],
+            "docker_authority": {
+                "allowed_holder_labels": [],
+                "require_guest_daemon": True,
+            },
+        }
+    )
+
+
+def _host() -> HostBoundaryObservation:
+    return HostBoundaryObservation(
+        observation_id="host-42",
+        policy_digest=POLICY_DIGEST,
+        payload_digest=PAYLOAD_DIGEST,
+        boot_id="boot-42",
+        complete=True,
+        listeners=(
+            BoundaryEndpoint(
+                audience="participant",
+                address="127.0.0.1",
+                port=443,
+                protocol="tcp",
+            ),
+            BoundaryEndpoint(
+                audience="recovery",
+                address="127.0.0.1",
+                port=9443,
+                protocol="tcp",
+            ),
+        ),
+        forbidden_reachability_passed=True,
+    )
+
+
+def _guest() -> GuestBoundaryObservation:
+    return GuestBoundaryObservation(
+        policy_digest=POLICY_DIGEST,
+        aces_plan_digest="sha256:" + "4" * 64,
+        boot_id="boot-42",
+        guest_daemon_id="daemon-42",
+        enforcements=(
+            BoundaryEnforcementObservation(
+                authority="platform",
+                source_digest=POLICY_DIGEST,
+                enforcement_digest="sha256:" + "3" * 64,
+                families=("bridge", "inet"),
+                default_deny_observed=True,
+            ),
+        ),
+        observation_complete=True,
+        probes=(
+            BoundaryProbeObservation(
+                identity="management-to-egress",
+                expectation="reachable",
+                passed=True,
+            ),
+            BoundaryProbeObservation(
+                identity="kali-to-metadata",
+                expectation="blocked",
+                passed=True,
+            ),
+        ),
+        docker_authority_holders=(),
+    )
+
+
+def test_fresh_host_and_guest_observations_produce_one_pass_inventory() -> None:
+    result = qualify_appliance_boundary(_policy(), _binding(), _host(), _guest())
+
+    assert result.passed is True
+    assert result.findings == ()
+    assert result.inventory["host"]["observation_id"] == "host-42"
+    assert result.inventory["guest"]["guest_daemon_id"] == "daemon-42"
+
+
+def test_missing_physical_host_observation_is_fatal() -> None:
+    result = qualify_appliance_boundary(_policy(), _binding(), None, _guest())
+
+    assert result.passed is False
+    assert result.findings == ("boundary.host-observation-missing",)
+
+
+def test_unknown_listener_and_stale_identity_fail_closed() -> None:
+    host = _host().model_copy(
+        update={
+            "boot_id": "old-boot",
+            "listeners": (
+                *_host().listeners,
+                BoundaryEndpoint(
+                    audience="participant",
+                    address="127.0.0.1",
+                    port=55000,
+                    protocol="tcp",
+                ),
+            ),
+        }
+    )
+
+    result = qualify_appliance_boundary(_policy(), _binding(), host, _guest())
+
+    assert result.passed is False
+    assert result.findings == (
+        "boundary.host-boot-identity-mismatch",
+        "boundary.host-listener-unapproved",
+    )
+
+
+def test_docker_authority_must_be_guest_scoped_and_least_privileged() -> None:
+    holder = DockerAuthorityHolder(
+        identity="deployment-owner",
+        label_selector="org.aptl.appliance.role=deployment-authority",
+        daemon_id="physical-host-daemon",
+        access="socket",
+        privileged=True,
+        host_pid_namespace=False,
+        host_network_namespace=False,
+        device_count=0,
+    )
+    guest = _guest().model_copy(update={"docker_authority_holders": (holder,)})
+
+    result = qualify_appliance_boundary(_policy(), _binding(), _host(), guest)
+
+    assert result.passed is False
+    assert result.findings == (
+        "boundary.guest-docker-authority-unapproved",
+        "boundary.guest-docker-daemon-mismatch",
+        "boundary.guest-docker-authority-overprivileged",
+    )

--- a/tests/test_appliance_boundary_inventory.py
+++ b/tests/test_appliance_boundary_inventory.py
@@ -24,6 +24,9 @@ def _binding() -> ApplianceBoundaryBinding:
         policy_digest=POLICY_DIGEST,
         payload_digest=PAYLOAD_DIGEST,
         aces_plan_digest="sha256:" + "4" * 64,
+        aces_boundary_required=False,
+        boundary_helper_image="example.test/aptl-boundary@sha256:" + "5" * 64,
+        egress_proxy_image="example.test/aptl-egress@sha256:" + "6" * 64,
         boot_id="boot-42",
         guest_daemon_id="daemon-42",
         host_observation_id="host-42",
@@ -36,7 +39,13 @@ def _policy() -> ApplianceBoundaryPolicy:
             "schema_version": "aptl.appliance-boundary/v1",
             "policy_id": "default",
             "generation": 1,
+            "workbench_policy_version": "participant-workbench-profile/v1",
             "default_deny": True,
+            "platform_networks": {
+                "participant": "org.aptl.network=participant",
+                "management": "org.aptl.network=management",
+                "egress": "org.aptl.network=egress",
+            },
             "platform_anchors": {
                 "participant": "org.aptl.appliance.zone=participant",
                 "management": "org.aptl.appliance.zone=management",
@@ -44,6 +53,13 @@ def _policy() -> ApplianceBoundaryPolicy:
             },
             "fixed_crossings": [],
             "egress_authorities": [],
+            "egress_proxy_limits": {
+                "max_connections": 32,
+                "max_header_bytes": 4096,
+                "header_timeout_seconds": 5,
+                "connect_timeout_seconds": 10,
+                "idle_timeout_seconds": 60,
+            },
             "guest_publications": [
                 {
                     "audience": "participant",
@@ -97,6 +113,7 @@ def _guest() -> GuestBoundaryObservation:
         aces_plan_digest="sha256:" + "4" * 64,
         boot_id="boot-42",
         guest_daemon_id="daemon-42",
+        workbench_policy_version="participant-workbench-profile/v1",
         enforcements=(
             BoundaryEnforcementObservation(
                 authority="platform",
@@ -110,11 +127,21 @@ def _guest() -> GuestBoundaryObservation:
         probes=(
             BoundaryProbeObservation(
                 identity="management-to-egress",
+                authority="platform",
+                source="management",
+                destination="egress",
+                protocol="tcp",
+                port=3128,
                 expectation="reachable",
                 passed=True,
             ),
             BoundaryProbeObservation(
                 identity="kali-to-metadata",
+                authority="platform",
+                source="provision.node.kali",
+                destination="metadata",
+                protocol="tcp",
+                port=80,
                 expectation="blocked",
                 passed=True,
             ),
@@ -137,6 +164,19 @@ def test_missing_physical_host_observation_is_fatal() -> None:
 
     assert result.passed is False
     assert result.findings == ("boundary.host-observation-missing",)
+
+
+def test_required_aces_authority_cannot_be_omitted() -> None:
+    binding = _binding().model_copy(update={"aces_boundary_required": True})
+
+    result = qualify_appliance_boundary(_policy(), binding, _host(), _guest())
+
+    assert result.passed is False
+    assert result.findings == (
+        "boundary.guest-aces-enforcement-missing",
+        "boundary.guest-aces-positive-probe-failed",
+        "boundary.guest-aces-negative-probe-failed",
+    )
 
 
 def test_unknown_listener_and_stale_identity_fail_closed() -> None:

--- a/tests/test_appliance_boundary_inventory.py
+++ b/tests/test_appliance_boundary_inventory.py
@@ -204,6 +204,23 @@ def test_unknown_listener_and_stale_identity_fail_closed() -> None:
     )
 
 
+def test_forbidden_host_reachability_and_policy_digest_mismatch_are_fatal() -> None:
+    host = _host().model_copy(
+        update={
+            "policy_digest": "sha256:" + "9" * 64,
+            "forbidden_reachability_passed": False,
+        }
+    )
+
+    result = qualify_appliance_boundary(_policy(), _binding(), host, _guest())
+
+    assert result.passed is False
+    assert result.findings == (
+        "boundary.host-policy-digest-mismatch",
+        "boundary.host-forbidden-reachability",
+    )
+
+
 def test_docker_authority_must_be_guest_scoped_and_least_privileged() -> None:
     holder = DockerAuthorityHolder(
         identity="deployment-owner",

--- a/tests/test_appliance_boundary_policy.py
+++ b/tests/test_appliance_boundary_policy.py
@@ -80,6 +80,10 @@ def test_policy_is_platform_only_strict_and_default_deny() -> None:
     assert policy.default_deny is True
     assert policy.egress_authorities[0].authority == "api.example.test"
     assert policy.workbench_policy_version == profile_for(ProfileId.RED).policy_version
+    assert (
+        policy.workbench_policy_version
+        == profile_for(ProfileId.GUIDED_BLUE).policy_version
+    )
     assert policy.workbench_policy_version == profile_for(ProfileId.BLUE).policy_version
 
     scenario_copy = _policy()

--- a/tests/test_appliance_boundary_policy.py
+++ b/tests/test_appliance_boundary_policy.py
@@ -1,0 +1,118 @@
+"""Strict platform-only policy contract for issue #822."""
+
+import hashlib
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+    load_boundary_policy,
+)
+
+
+def _policy() -> dict[str, object]:
+    return {
+        "schema_version": "aptl.appliance-boundary/v1",
+        "policy_id": "participant-default",
+        "generation": 4,
+        "default_deny": True,
+        "platform_anchors": {
+            "participant": "org.aptl.appliance.zone=participant",
+            "management": "org.aptl.appliance.zone=management",
+            "egress": "org.aptl.appliance.zone=egress",
+        },
+        "fixed_crossings": [
+            {
+                "source": "management",
+                "destination": "egress",
+                "protocol": "tcp",
+                "ports": [3128],
+                "purpose": "model-provider-proxy",
+            }
+        ],
+        "egress_authorities": [
+            {
+                "authority": "api.example.test",
+                "port": 443,
+                "purpose": "model-provider",
+            }
+        ],
+        "guest_publications": [
+            {
+                "audience": "participant",
+                "address": "127.0.0.1",
+                "port": 443,
+                "protocol": "tcp",
+            }
+        ],
+        "docker_authority": {
+            "allowed_holder_labels": [
+                "org.aptl.appliance.role=deployment-authority"
+            ],
+            "require_guest_daemon": True,
+        },
+    }
+
+
+def test_policy_is_platform_only_strict_and_default_deny() -> None:
+    policy = ApplianceBoundaryPolicy.model_validate(_policy())
+
+    assert policy.default_deny is True
+    assert policy.egress_authorities[0].authority == "api.example.test"
+
+    scenario_copy = _policy()
+    scenario_copy["scenario_networks"] = ["red", "blue"]
+    with pytest.raises(ValidationError):
+        ApplianceBoundaryPolicy.model_validate(scenario_copy)
+
+    fail_open = _policy()
+    fail_open["default_deny"] = False
+    with pytest.raises(ValidationError):
+        ApplianceBoundaryPolicy.model_validate(fail_open)
+
+
+def test_policy_digest_is_bound_by_release_projection(tmp_path) -> None:
+    payload = json.dumps(_policy(), sort_keys=True, separators=(",", ":")).encode()
+    policy_path = tmp_path / "boundary.json"
+    policy_path.write_bytes(payload)
+    digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+    binding = ApplianceBoundaryBinding(
+        policy_digest=digest,
+        payload_digest="sha256:" + "a" * 64,
+        aces_plan_digest="sha256:" + "c" * 64,
+        boot_id="boot-42",
+        guest_daemon_id="daemon-42",
+        host_observation_id="host-42",
+    )
+
+    loaded = load_boundary_policy(policy_path, binding)
+
+    assert loaded.policy_id == "participant-default"
+
+    wrong = binding.model_copy(update={"policy_digest": "sha256:" + "b" * 64})
+    with pytest.raises(ValueError, match="digest"):
+        load_boundary_policy(policy_path, wrong)
+
+
+@pytest.mark.parametrize(
+    "authority",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "169.254.169.254",
+        "[::1]",
+        "https://api.example.test",
+        "*.example.test",
+    ],
+)
+def test_egress_authority_rejects_literal_wildcard_and_url(authority: str) -> None:
+    payload = _policy()
+    payload["egress_authorities"] = [
+        {"authority": authority, "port": 443, "purpose": "model-provider"}
+    ]
+
+    with pytest.raises(ValidationError):
+        ApplianceBoundaryPolicy.model_validate(payload)

--- a/tests/test_appliance_boundary_policy.py
+++ b/tests/test_appliance_boundary_policy.py
@@ -167,3 +167,21 @@ def test_proxy_policy_is_a_narrow_projection_of_signed_authorities() -> None:
             "idle_timeout_seconds": 60,
         },
     }
+
+
+def test_guest_publication_must_remain_loopback_only() -> None:
+    payload = _policy()
+    publication = payload["guest_publications"][0]
+    publication["address"] = "0.0.0.0"
+
+    with pytest.raises(ValidationError, match="loopback"):
+        ApplianceBoundaryPolicy.model_validate(payload)
+
+
+def test_proxy_policy_rejects_an_empty_authority_projection() -> None:
+    payload = _policy()
+    payload["egress_authorities"] = []
+    policy = ApplianceBoundaryPolicy.model_validate(payload)
+
+    with pytest.raises(ValueError, match="at least one"):
+        render_egress_proxy_policy(policy)

--- a/tests/test_appliance_boundary_policy.py
+++ b/tests/test_appliance_boundary_policy.py
@@ -10,7 +10,9 @@ from aptl.core.appliance_boundary import (
     ApplianceBoundaryBinding,
     ApplianceBoundaryPolicy,
     load_boundary_policy,
+    render_egress_proxy_policy,
 )
+from aptl.workbench import ProfileId, profile_for
 
 
 def _policy() -> dict[str, object]:
@@ -18,7 +20,13 @@ def _policy() -> dict[str, object]:
         "schema_version": "aptl.appliance-boundary/v1",
         "policy_id": "participant-default",
         "generation": 4,
+        "workbench_policy_version": "participant-workbench-profile/v1",
         "default_deny": True,
+        "platform_networks": {
+            "participant": "org.aptl.appliance.network=participant",
+            "management": "org.aptl.appliance.network=management",
+            "egress": "org.aptl.appliance.network=egress",
+        },
         "platform_anchors": {
             "participant": "org.aptl.appliance.zone=participant",
             "management": "org.aptl.appliance.zone=management",
@@ -35,11 +43,22 @@ def _policy() -> dict[str, object]:
         ],
         "egress_authorities": [
             {
+                "source": "egress",
                 "authority": "api.example.test",
+                "protocol": "tcp",
                 "port": 443,
                 "purpose": "model-provider",
+                "resolution": "proxy-resolved-all-global",
+                "failure_disposition": "deny",
             }
         ],
+        "egress_proxy_limits": {
+            "max_connections": 32,
+            "max_header_bytes": 4096,
+            "header_timeout_seconds": 5,
+            "connect_timeout_seconds": 10,
+            "idle_timeout_seconds": 60,
+        },
         "guest_publications": [
             {
                 "audience": "participant",
@@ -49,9 +68,7 @@ def _policy() -> dict[str, object]:
             }
         ],
         "docker_authority": {
-            "allowed_holder_labels": [
-                "org.aptl.appliance.role=deployment-authority"
-            ],
+            "allowed_holder_labels": ["org.aptl.appliance.role=deployment-authority"],
             "require_guest_daemon": True,
         },
     }
@@ -62,6 +79,8 @@ def test_policy_is_platform_only_strict_and_default_deny() -> None:
 
     assert policy.default_deny is True
     assert policy.egress_authorities[0].authority == "api.example.test"
+    assert policy.workbench_policy_version == profile_for(ProfileId.RED).policy_version
+    assert policy.workbench_policy_version == profile_for(ProfileId.BLUE).policy_version
 
     scenario_copy = _policy()
     scenario_copy["scenario_networks"] = ["red", "blue"]
@@ -83,6 +102,9 @@ def test_policy_digest_is_bound_by_release_projection(tmp_path) -> None:
         policy_digest=digest,
         payload_digest="sha256:" + "a" * 64,
         aces_plan_digest="sha256:" + "c" * 64,
+        aces_boundary_required=False,
+        boundary_helper_image="example.test/aptl-boundary@sha256:" + "d" * 64,
+        egress_proxy_image="example.test/aptl-egress@sha256:" + "e" * 64,
         boot_id="boot-42",
         guest_daemon_id="daemon-42",
         host_observation_id="host-42",
@@ -111,8 +133,33 @@ def test_policy_digest_is_bound_by_release_projection(tmp_path) -> None:
 def test_egress_authority_rejects_literal_wildcard_and_url(authority: str) -> None:
     payload = _policy()
     payload["egress_authorities"] = [
-        {"authority": authority, "port": 443, "purpose": "model-provider"}
+        {
+            "source": "egress",
+            "authority": authority,
+            "protocol": "tcp",
+            "port": 443,
+            "purpose": "model-provider",
+            "resolution": "proxy-resolved-all-global",
+            "failure_disposition": "deny",
+        }
     ]
 
     with pytest.raises(ValidationError):
         ApplianceBoundaryPolicy.model_validate(payload)
+
+
+def test_proxy_policy_is_a_narrow_projection_of_signed_authorities() -> None:
+    policy = ApplianceBoundaryPolicy.model_validate(_policy())
+
+    assert json.loads(render_egress_proxy_policy(policy)) == {
+        "authorities": [
+            {"authority": "api.example.test", "port": 443},
+        ],
+        "limits": {
+            "max_connections": 32,
+            "max_header_bytes": 4096,
+            "header_timeout_seconds": 5,
+            "connect_timeout_seconds": 10,
+            "idle_timeout_seconds": 60,
+        },
+    }

--- a/tests/test_appliance_egress_proxy.py
+++ b/tests/test_appliance_egress_proxy.py
@@ -1,0 +1,80 @@
+"""Exact-authority CONNECT broker used by the controlled egress crossing."""
+
+import importlib.util
+import ipaddress
+from pathlib import Path
+
+import pytest
+
+
+PROXY = (
+    Path(__file__).parents[1]
+    / "containers"
+    / "appliance-egress-proxy"
+    / "proxy.py"
+)
+
+
+@pytest.fixture(scope="module")
+def proxy():
+    spec = importlib.util.spec_from_file_location("appliance_egress_proxy", PROXY)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_connect_parser_requires_exact_authority_and_port(proxy) -> None:
+    allowed = {("api.example.test", 443)}
+
+    assert proxy.parse_connect(
+        b"CONNECT api.example.test:443 HTTP/1.1\r\nHost: api.example.test:443\r\n\r\n",
+        allowed,
+    ) == ("api.example.test", 443)
+
+    for request in (
+        b"GET https://api.example.test/ HTTP/1.1\r\n\r\n",
+        b"CONNECT api.example.test:8443 HTTP/1.1\r\n\r\n",
+        b"CONNECT 10.0.0.1:443 HTTP/1.1\r\n\r\n",
+        b"CONNECT other.example.test:443 HTTP/1.1\r\n\r\n",
+        b"CONNECT api.example.test:0 HTTP/1.1\r\n\r\n",
+        b"CONNECT api.example.test:65536 HTTP/1.1\r\n\r\n",
+    ):
+        with pytest.raises(ValueError):
+            proxy.parse_connect(request, allowed)
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "169.254.169.254",
+        "::1",
+        "fe80::1",
+        "::ffff:10.0.0.1",
+        "64:ff9b::a00:1",
+    ],
+)
+def test_special_private_metadata_and_nat64_results_are_denied(proxy, address) -> None:
+    assert proxy.is_safe_destination(ipaddress.ip_address(address)) is False
+
+
+def test_global_ipv4_and_ipv6_results_are_allowed(proxy) -> None:
+    assert proxy.is_safe_destination(ipaddress.ip_address("93.184.216.34")) is True
+    assert (
+        proxy.is_safe_destination(
+            ipaddress.ip_address("2606:2800:220:1:248:1893:25c8:1946")
+        )
+        is True
+    )
+
+
+def test_any_unsafe_dns_answer_fails_the_whole_resolution(proxy) -> None:
+    answers = [
+        ("93.184.216.34", 443),
+        ("169.254.169.254", 443),
+    ]
+
+    with pytest.raises(ValueError, match="unsafe"):
+        proxy.validate_resolved_addresses(answers)

--- a/tests/test_appliance_egress_proxy.py
+++ b/tests/test_appliance_egress_proxy.py
@@ -1,9 +1,11 @@
 """Exact-authority CONNECT broker used by the controlled egress crossing."""
 
+import asyncio
 import importlib.util
 import ipaddress
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -121,3 +123,35 @@ def test_out_of_range_proxy_limit_fails_closed(proxy, tmp_path) -> None:
 
     with pytest.raises(ValueError, match="limits"):
         proxy._load_policy(path)
+
+
+def test_handle_returns_403_for_disallowed_connect(proxy) -> None:
+    reader = MagicMock()
+    reader.readuntil = AsyncMock(
+        return_value=b"CONNECT blocked.example.test:443 HTTP/1.1\r\n\r\n"
+    )
+    writer = MagicMock()
+    writer.is_closing.return_value = False
+    writer.drain = AsyncMock()
+    writer.wait_closed = AsyncMock()
+    limits = proxy.ProxyLimits(
+        max_connections=1,
+        max_header_bytes=4096,
+        header_timeout_seconds=1,
+        connect_timeout_seconds=1,
+        idle_timeout_seconds=5,
+    )
+
+    asyncio.run(
+        proxy._handle(
+            reader,
+            writer,
+            {("api.example.test", 443)},
+            limits,
+        )
+    )
+
+    writer.write.assert_called_once_with(
+        b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n"
+    )
+    writer.close.assert_called_once_with()

--- a/tests/test_appliance_egress_proxy.py
+++ b/tests/test_appliance_egress_proxy.py
@@ -2,17 +2,13 @@
 
 import importlib.util
 import ipaddress
+import json
 from pathlib import Path
 
 import pytest
 
 
-PROXY = (
-    Path(__file__).parents[1]
-    / "containers"
-    / "appliance-egress-proxy"
-    / "proxy.py"
-)
+PROXY = Path(__file__).parents[1] / "containers" / "appliance-egress-proxy" / "proxy.py"
 
 
 @pytest.fixture(scope="module")
@@ -78,3 +74,50 @@ def test_any_unsafe_dns_answer_fails_the_whole_resolution(proxy) -> None:
 
     with pytest.raises(ValueError, match="unsafe"):
         proxy.validate_resolved_addresses(answers)
+
+
+def test_signed_resource_limits_are_loaded_with_authorities(proxy, tmp_path) -> None:
+    path = tmp_path / "egress.json"
+    path.write_text(
+        json.dumps(
+            {
+                "authorities": [{"authority": "api.example.test", "port": 443}],
+                "limits": {
+                    "max_connections": 32,
+                    "max_header_bytes": 4096,
+                    "header_timeout_seconds": 5,
+                    "connect_timeout_seconds": 10,
+                    "idle_timeout_seconds": 60,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    allowed, limits = proxy._load_policy(path)
+
+    assert allowed == {("api.example.test", 443)}
+    assert limits.max_connections == 32
+    assert limits.idle_timeout_seconds == 60
+
+
+def test_out_of_range_proxy_limit_fails_closed(proxy, tmp_path) -> None:
+    path = tmp_path / "egress.json"
+    path.write_text(
+        json.dumps(
+            {
+                "authorities": [{"authority": "api.example.test", "port": 443}],
+                "limits": {
+                    "max_connections": 0,
+                    "max_header_bytes": 4096,
+                    "header_timeout_seconds": 5,
+                    "connect_timeout_seconds": 10,
+                    "idle_timeout_seconds": 60,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="limits"):
+        proxy._load_policy(path)

--- a/tests/test_boundary_compiler.py
+++ b/tests/test_boundary_compiler.py
@@ -1,0 +1,202 @@
+"""Binding tests for the separate ACES and platform authorities."""
+
+import pytest
+
+from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
+from aptl.core.deployment.boundary import BoundaryNetwork, BoundaryWorkload
+from aptl.core.deployment.boundary_compiler import (
+    BoundaryCompileError,
+    compile_aces_boundary,
+    compile_platform_boundary,
+)
+from aptl.core.deployment.realization import (
+    DeploymentAclRealization,
+    DeploymentNetworkAttachment,
+    DeploymentNetworkRealization,
+    DeploymentNodeRealization,
+    DeploymentRealizationSpec,
+)
+
+
+def _realization(*, owner_ip: str | None = "10.44.2.10") -> DeploymentRealizationSpec:
+    return DeploymentRealizationSpec(
+        profiles=(),
+        nodes=(
+            DeploymentNodeRealization(
+                address="provision.node.sentinel",
+                name="sentinel",
+                service_name=None,
+                container_name="sentinel",
+                networks=("quartz",),
+                network_attachments=(
+                    DeploymentNetworkAttachment(
+                        network="quartz",
+                        ipv4_address=owner_ip,
+                    ),
+                ),
+            ),
+        ),
+        networks=(
+            DeploymentNetworkRealization(name="orchard"),
+            DeploymentNetworkRealization(name="quartz"),
+        ),
+        acls=(
+            DeploymentAclRealization(
+                owner_address="provision.node.sentinel",
+                owner_resource_type="node",
+                owner_name="sentinel",
+                name="allow-web",
+                order=0,
+                direction="in",
+                from_network="orchard",
+                to_network="quartz",
+                protocol="tcp",
+                ports=(443,),
+                action="allow",
+            ),
+        ),
+    )
+
+
+def _networks() -> tuple[BoundaryNetwork, ...]:
+    return (
+        BoundaryNetwork(
+            name="orchard",
+            bridge="br-orchard",
+            ipv4_cidr="10.44.1.0/24",
+        ),
+        BoundaryNetwork(
+            name="quartz",
+            bridge="br-quartz",
+            ipv4_cidr="10.44.2.0/24",
+        ),
+    )
+
+
+def _policy() -> ApplianceBoundaryPolicy:
+    return ApplianceBoundaryPolicy.model_validate(
+        {
+            "schema_version": "aptl.appliance-boundary/v1",
+            "policy_id": "default",
+            "generation": 1,
+            "default_deny": True,
+            "platform_anchors": {
+                "participant": "org.aptl.zone=participant",
+                "management": "org.aptl.zone=management",
+                "egress": "org.aptl.zone=egress",
+            },
+            "fixed_crossings": [
+                {
+                    "source": "management",
+                    "destination": "egress",
+                    "protocol": "tcp",
+                    "ports": [3128],
+                    "purpose": "model-proxy",
+                }
+            ],
+            "egress_authorities": [],
+            "guest_publications": [],
+            "docker_authority": {
+                "allowed_holder_labels": [],
+                "require_guest_daemon": True,
+            },
+        }
+    )
+
+
+def test_aces_binding_keeps_owner_address_and_platform_data_out() -> None:
+    spec = compile_aces_boundary(_realization(), _networks(), owner="seat-17")
+
+    assert spec.authority == "aces"
+    assert spec.owner_bindings[0].ipv4_by_network == (
+        ("quartz", "10.44.2.10"),
+    )
+    assert "policy_digest" not in spec.details()
+
+
+def test_aces_binding_refuses_to_widen_an_unaddressed_owner() -> None:
+    with pytest.raises(BoundaryCompileError, match="exact admitted addresses"):
+        compile_aces_boundary(_realization(owner_ip=None), _networks(), owner="seat-17")
+
+
+def test_platform_binding_uses_only_exact_labels() -> None:
+    networks = tuple(
+        BoundaryNetwork(
+            name=zone,
+            bridge=f"br-{zone[:7]}",
+        )
+        for zone in ("participant", "management", "egress")
+    )
+    workloads = (
+        BoundaryWorkload(
+            identity="participant-gateway",
+            labels=(("org.aptl.zone", "participant"),),
+            ipv4_by_network=(("participant", "10.50.1.10"),),
+        ),
+        BoundaryWorkload(
+            identity="management-agent",
+            labels=(("org.aptl.zone", "management"),),
+            ipv4_by_network=(
+                ("management", "10.50.2.10"),
+                ("egress", "10.50.3.10"),
+            ),
+        ),
+        BoundaryWorkload(
+            identity="egress-proxy",
+            labels=(("org.aptl.zone", "egress"),),
+            ipv4_by_network=(("egress", "10.50.3.20"),),
+        ),
+    )
+
+    spec = compile_platform_boundary(
+        _policy(),
+        policy_digest="sha256:" + "a" * 64,
+        networks=networks,
+        workloads=workloads,
+        owner="seat-17",
+    )
+
+    assert spec.authority == "platform"
+    assert [zone for zone, _network in spec.anchors] == [
+        "participant",
+        "management",
+        "egress",
+    ]
+    assert "rules" not in spec.details()
+
+
+def test_platform_binding_rejects_ambiguous_anchor() -> None:
+    duplicate = (
+        BoundaryWorkload(
+            identity="participant-a",
+            labels=(("org.aptl.zone", "participant"),),
+            ipv4_by_network=(("participant", "10.50.1.10"),),
+        ),
+        BoundaryWorkload(
+            identity="participant-b",
+            labels=(("org.aptl.zone", "participant"),),
+            ipv4_by_network=(("participant", "10.50.1.11"),),
+        ),
+        BoundaryWorkload(
+            identity="management",
+            labels=(("org.aptl.zone", "management"),),
+            ipv4_by_network=(("management", "10.50.2.10"),),
+        ),
+        BoundaryWorkload(
+            identity="egress",
+            labels=(("org.aptl.zone", "egress"),),
+            ipv4_by_network=(("management", "10.50.2.20"),),
+        ),
+    )
+
+    with pytest.raises(BoundaryCompileError, match="exactly once"):
+        compile_platform_boundary(
+            _policy(),
+            policy_digest="sha256:" + "a" * 64,
+            networks=(
+                BoundaryNetwork(name="participant", bridge="br-part"),
+                BoundaryNetwork(name="management", bridge="br-mgmt"),
+            ),
+            workloads=duplicate,
+            owner="seat-17",
+        )

--- a/tests/test_boundary_compiler.py
+++ b/tests/test_boundary_compiler.py
@@ -122,12 +122,27 @@ def test_aces_binding_keeps_owner_address_and_platform_data_out() -> None:
 
     assert spec.authority == "aces"
     assert spec.owner_bindings[0].ipv4_by_network == (("quartz", "10.44.2.10"),)
-    assert "policy_digest" not in spec.details()
+    assert spec.rules[0].details() == {
+        "owner_address": "provision.node.sentinel",
+        "owner_resource_type": "node",
+        "owner_name": "sentinel",
+        "name": "allow-web",
+        "order": 0,
+        "direction": "in",
+        "from_network": "orchard",
+        "to_network": "quartz",
+        "protocol": "tcp",
+        "ports": [443],
+        "action": "allow",
+    }
 
 
 def test_aces_binding_refuses_to_widen_an_unaddressed_owner() -> None:
+    realization = _realization(owner_ip=None)
+    networks = _networks()
+
     with pytest.raises(BoundaryCompileError, match="exact admitted addresses"):
-        compile_aces_boundary(_realization(owner_ip=None), _networks(), owner="seat-17")
+        compile_aces_boundary(realization, networks, owner="seat-17")
 
 
 def test_aces_binding_rejects_dual_stack_until_acl_rules_are_dual_stack() -> None:
@@ -140,9 +155,10 @@ def test_aces_binding_rejects_dual_stack_until_acl_rules_are_dual_stack() -> Non
             ipv6_cidr="2001:db8:44::/64",
         ),
     )
+    realization = _realization()
 
     with pytest.raises(BoundaryCompileError, match="IPv4-only"):
-        compile_aces_boundary(_realization(), dual_stack, owner="seat-17")
+        compile_aces_boundary(realization, dual_stack, owner="seat-17")
 
 
 def test_platform_binding_uses_only_exact_labels() -> None:
@@ -196,7 +212,14 @@ def test_platform_binding_uses_only_exact_labels() -> None:
         ("management", "10.50.2.10"),
         ("egress", "10.50.3.10"),
     )
-    assert "rules" not in spec.details()
+    assert spec.crossings[0].details() == {
+        "source": "management",
+        "destination": "egress",
+        "protocol": "tcp",
+        "ports": [3128],
+        "purpose": "model-proxy",
+    }
+    assert spec.egress_ports == ()
 
 
 def test_platform_binding_rejects_ambiguous_anchor() -> None:
@@ -226,27 +249,30 @@ def test_platform_binding_rejects_ambiguous_anchor() -> None:
         ),
     )
 
+    policy = _policy()
+    networks = (
+        BoundaryNetwork(
+            name="participant",
+            bridge="br-part",
+            labels=(("org.aptl.network", "participant"),),
+        ),
+        BoundaryNetwork(
+            name="management",
+            bridge="br-mgmt",
+            labels=(("org.aptl.network", "management"),),
+        ),
+        BoundaryNetwork(
+            name="egress",
+            bridge="br-egress",
+            labels=(("org.aptl.network", "egress"),),
+        ),
+    )
+
     with pytest.raises(BoundaryCompileError, match="exactly once"):
         compile_platform_boundary(
-            _policy(),
+            policy,
             policy_digest="sha256:" + "a" * 64,
-            networks=(
-                BoundaryNetwork(
-                    name="participant",
-                    bridge="br-part",
-                    labels=(("org.aptl.network", "participant"),),
-                ),
-                BoundaryNetwork(
-                    name="management",
-                    bridge="br-mgmt",
-                    labels=(("org.aptl.network", "management"),),
-                ),
-                BoundaryNetwork(
-                    name="egress",
-                    bridge="br-egress",
-                    labels=(("org.aptl.network", "egress"),),
-                ),
-            ),
+            networks=networks,
             workloads=duplicate,
             owner="seat-17",
         )
@@ -271,10 +297,11 @@ def test_platform_binding_rejects_ipv6_until_crossings_are_dual_stack() -> None:
             labels=(("org.aptl.network", "egress"),),
         ),
     )
+    policy = _policy()
 
     with pytest.raises(BoundaryCompileError, match="IPv6"):
         compile_platform_boundary(
-            _policy(),
+            policy,
             policy_digest="sha256:" + "a" * 64,
             networks=networks,
             workloads=(),

--- a/tests/test_boundary_compiler.py
+++ b/tests/test_boundary_compiler.py
@@ -79,7 +79,13 @@ def _policy() -> ApplianceBoundaryPolicy:
             "schema_version": "aptl.appliance-boundary/v1",
             "policy_id": "default",
             "generation": 1,
+            "workbench_policy_version": "participant-workbench-profile/v1",
             "default_deny": True,
+            "platform_networks": {
+                "participant": "org.aptl.network=participant",
+                "management": "org.aptl.network=management",
+                "egress": "org.aptl.network=egress",
+            },
             "platform_anchors": {
                 "participant": "org.aptl.zone=participant",
                 "management": "org.aptl.zone=management",
@@ -95,6 +101,13 @@ def _policy() -> ApplianceBoundaryPolicy:
                 }
             ],
             "egress_authorities": [],
+            "egress_proxy_limits": {
+                "max_connections": 32,
+                "max_header_bytes": 4096,
+                "header_timeout_seconds": 5,
+                "connect_timeout_seconds": 10,
+                "idle_timeout_seconds": 60,
+            },
             "guest_publications": [],
             "docker_authority": {
                 "allowed_holder_labels": [],
@@ -108,9 +121,7 @@ def test_aces_binding_keeps_owner_address_and_platform_data_out() -> None:
     spec = compile_aces_boundary(_realization(), _networks(), owner="seat-17")
 
     assert spec.authority == "aces"
-    assert spec.owner_bindings[0].ipv4_by_network == (
-        ("quartz", "10.44.2.10"),
-    )
+    assert spec.owner_bindings[0].ipv4_by_network == (("quartz", "10.44.2.10"),)
     assert "policy_digest" not in spec.details()
 
 
@@ -119,11 +130,27 @@ def test_aces_binding_refuses_to_widen_an_unaddressed_owner() -> None:
         compile_aces_boundary(_realization(owner_ip=None), _networks(), owner="seat-17")
 
 
+def test_aces_binding_rejects_dual_stack_until_acl_rules_are_dual_stack() -> None:
+    dual_stack = (
+        _networks()[0],
+        BoundaryNetwork(
+            name="quartz",
+            bridge="br-quartz",
+            ipv4_cidr="10.44.2.0/24",
+            ipv6_cidr="2001:db8:44::/64",
+        ),
+    )
+
+    with pytest.raises(BoundaryCompileError, match="IPv4-only"):
+        compile_aces_boundary(_realization(), dual_stack, owner="seat-17")
+
+
 def test_platform_binding_uses_only_exact_labels() -> None:
     networks = tuple(
         BoundaryNetwork(
             name=zone,
             bridge=f"br-{zone[:7]}",
+            labels=(("org.aptl.network", zone),),
         )
         for zone in ("participant", "management", "egress")
     )
@@ -144,7 +171,10 @@ def test_platform_binding_uses_only_exact_labels() -> None:
         BoundaryWorkload(
             identity="egress-proxy",
             labels=(("org.aptl.zone", "egress"),),
-            ipv4_by_network=(("egress", "10.50.3.20"),),
+            ipv4_by_network=(
+                ("management", "10.50.2.20"),
+                ("egress", "10.50.3.20"),
+            ),
         ),
     )
 
@@ -162,6 +192,10 @@ def test_platform_binding_uses_only_exact_labels() -> None:
         "management",
         "egress",
     ]
+    assert dict(spec.anchors)["management"].ipv4_by_network == (
+        ("management", "10.50.2.10"),
+        ("egress", "10.50.3.10"),
+    )
     assert "rules" not in spec.details()
 
 
@@ -185,7 +219,10 @@ def test_platform_binding_rejects_ambiguous_anchor() -> None:
         BoundaryWorkload(
             identity="egress",
             labels=(("org.aptl.zone", "egress"),),
-            ipv4_by_network=(("management", "10.50.2.20"),),
+            ipv4_by_network=(
+                ("management", "10.50.2.20"),
+                ("egress", "10.50.3.20"),
+            ),
         ),
     )
 
@@ -194,9 +231,52 @@ def test_platform_binding_rejects_ambiguous_anchor() -> None:
             _policy(),
             policy_digest="sha256:" + "a" * 64,
             networks=(
-                BoundaryNetwork(name="participant", bridge="br-part"),
-                BoundaryNetwork(name="management", bridge="br-mgmt"),
+                BoundaryNetwork(
+                    name="participant",
+                    bridge="br-part",
+                    labels=(("org.aptl.network", "participant"),),
+                ),
+                BoundaryNetwork(
+                    name="management",
+                    bridge="br-mgmt",
+                    labels=(("org.aptl.network", "management"),),
+                ),
+                BoundaryNetwork(
+                    name="egress",
+                    bridge="br-egress",
+                    labels=(("org.aptl.network", "egress"),),
+                ),
             ),
             workloads=duplicate,
+            owner="seat-17",
+        )
+
+
+def test_platform_binding_rejects_ipv6_until_crossings_are_dual_stack() -> None:
+    networks = (
+        BoundaryNetwork(
+            name="participant",
+            bridge="br-part",
+            ipv6_cidr="2001:db8:1::/64",
+            labels=(("org.aptl.network", "participant"),),
+        ),
+        BoundaryNetwork(
+            name="management",
+            bridge="br-mgmt",
+            labels=(("org.aptl.network", "management"),),
+        ),
+        BoundaryNetwork(
+            name="egress",
+            bridge="br-egress",
+            labels=(("org.aptl.network", "egress"),),
+        ),
+    )
+
+    with pytest.raises(BoundaryCompileError, match="IPv6"):
+        compile_platform_boundary(
+            _policy(),
+            policy_digest="sha256:" + "a" * 64,
+            networks=networks,
+            workloads=(),
             owner="seat-17",
         )

--- a/tests/test_compose_base_substrate.py
+++ b/tests/test_compose_base_substrate.py
@@ -208,6 +208,8 @@ def test_declared_network_is_attached_before_image_free_node_starts(tmp_path):
     )
     assert "--network" in create.args[0]
     assert "test-proj_aptl-security" in create.args[0]
+    assert "--ip" in create.args[0]
+    assert "172.31.8.10" in create.args[0]
     assert "none" not in create.args[0]
     assert ["docker", "start", "aptl-kali"] in [
         call.args[0] for call in mock_run.call_args_list

--- a/tests/test_compose_base_substrate.py
+++ b/tests/test_compose_base_substrate.py
@@ -14,13 +14,20 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from aptl.backends.aces_base_substrate import (
     BaseContainerSpec,
     InitRequirements,
     PublishedPort,
     VolumeMount,
 )
-from aptl.core.deployment import DockerComposeBackend
+from aptl.core.deployment import (
+    DeploymentNetworkAttachment,
+    DockerComposeBackend,
+)
+from aptl.core.deployment.errors import BackendSeedError
+from aptl.core.lab_types import LabResult
 
 
 def _backend(tmp_path: Path) -> DockerComposeBackend:
@@ -48,9 +55,16 @@ class TestEnsureGenericBaseImage:
             )
 
         assert failures == []
-        build_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "build"])
+        build_call = next(
+            c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "build"]
+        )
         argv = build_call.args[0]
-        assert argv[:4] == ["docker", "build", "-t", "aptl/generic-systemd-base-debian:latest"]
+        assert argv[:4] == [
+            "docker",
+            "build",
+            "-t",
+            "aptl/generic-systemd-base-debian:latest",
+        ]
         assert argv[4] == str(tmp_path / "containers" / "generic-systemd-base-debian")
 
     def test_no_op_when_the_image_already_exists(self, tmp_path):
@@ -63,7 +77,9 @@ class TestEnsureGenericBaseImage:
             )
 
         assert failures == []
-        assert not any(c.args[0][:2] == ["docker", "build"] for c in mock_run.call_args_list)
+        assert not any(
+            c.args[0][:2] == ["docker", "build"] for c in mock_run.call_args_list
+        )
 
     def test_no_op_for_a_real_registry_image(self, tmp_path):
         # debian:12-slim / rockylinux:9 are real registry references; `docker
@@ -106,7 +122,9 @@ def test_start_base_container_carries_the_compose_project_ownership_label(tmp_pa
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         backend.start_base_container(spec)
 
-    run_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"])
+    run_call = next(
+        c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"]
+    )
     argv = run_call.args[0]
     assert "--label" in argv
     assert "com.docker.compose.project=test-proj" in argv
@@ -128,7 +146,9 @@ def test_start_base_container_keeps_the_aptl_lifecycle_labels(tmp_path):
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         backend.start_base_container(spec)
 
-    run_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"])
+    run_call = next(
+        c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"]
+    )
     argv = run_call.args[0]
     assert "aptl.lifecycle.project=test-proj" in argv
     assert "aptl.node.address=provision.node.victim" in argv
@@ -148,9 +168,68 @@ def test_start_base_container_with_init_still_carries_the_label(tmp_path):
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         backend.start_base_container(spec)
 
-    run_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"])
+    run_call = next(
+        c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"]
+    )
     argv = run_call.args[0]
     assert "com.docker.compose.project=test-proj" in argv
+
+
+def test_declared_network_is_attached_before_image_free_node_starts(tmp_path):
+    backend = _backend(tmp_path)
+    backend._appliance_boundary = (MagicMock(), MagicMock())
+    node = MagicMock(
+        address="provision.node.kali",
+        network_attachments=(
+            DeploymentNetworkAttachment(
+                network="security",
+                ipv4_address="172.31.8.10",
+            ),
+        ),
+    )
+    backend.host_list_lab_networks = MagicMock(return_value=["test-proj_aptl-security"])
+    backend.connect_container_network = MagicMock(return_value=LabResult(success=True))
+    backend.configure_base_container_networks((node,))
+    spec = BaseContainerSpec(
+        node_address=node.address,
+        container_name="aptl-kali",
+        image_ref="debian:12-slim",
+        runs_services=False,
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        backend.start_base_container(spec)
+
+    create = next(
+        call
+        for call in mock_run.call_args_list
+        if call.args[0][:2] == ["docker", "create"]
+    )
+    assert "--network" in create.args[0]
+    assert "test-proj_aptl-security" in create.args[0]
+    assert "none" not in create.args[0]
+    assert ["docker", "start", "aptl-kali"] in [
+        call.args[0] for call in mock_run.call_args_list
+    ]
+    assert not any(
+        call.args[0][:2] == ["docker", "run"] for call in mock_run.call_args_list
+    )
+
+
+def test_appliance_image_free_node_without_network_fails_before_create(
+    tmp_path,
+) -> None:
+    backend = _backend(tmp_path)
+    backend._appliance_boundary = (MagicMock(), MagicMock())
+    node = MagicMock(
+        address="provision.node.unbound",
+        network_attachments=(),
+    )
+    backend.host_list_lab_networks = MagicMock(return_value=[])
+
+    with pytest.raises(BackendSeedError, match="no admitted network"):
+        backend.configure_base_container_networks((node,))
 
 
 class TestStartBaseContainerVolumesAndPorts:
@@ -168,7 +247,9 @@ class TestStartBaseContainerVolumesAndPorts:
             image_ref="debian:12-slim",
             runs_services=False,
             volume_mounts=(
-                VolumeMount(target="/var/lib/suricata/rules/misp", source="suricata_misp_rules"),
+                VolumeMount(
+                    target="/var/lib/suricata/rules/misp", source="suricata_misp_rules"
+                ),
             ),
         )
 
@@ -176,7 +257,9 @@ class TestStartBaseContainerVolumesAndPorts:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             backend.start_base_container(spec)
 
-        run_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"])
+        run_call = next(
+            c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"]
+        )
         argv = run_call.args[0]
         assert "-v" in argv
         assert "test-proj_suricata_misp_rules:/var/lib/suricata/rules/misp" in argv
@@ -190,7 +273,9 @@ class TestStartBaseContainerVolumesAndPorts:
             runs_services=False,
             volume_mounts=(
                 VolumeMount(
-                    target="/var/run/suricata", source="suricata_command_socket", read_only=True
+                    target="/var/run/suricata",
+                    source="suricata_command_socket",
+                    read_only=True,
                 ),
             ),
         )
@@ -199,7 +284,9 @@ class TestStartBaseContainerVolumesAndPorts:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             backend.start_base_container(spec)
 
-        run_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"])
+        run_call = next(
+            c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"]
+        )
         argv = run_call.args[0]
         assert "test-proj_suricata_command_socket:/var/run/suricata:ro" in argv
 
@@ -217,7 +304,9 @@ class TestStartBaseContainerVolumesAndPorts:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             backend.start_base_container(spec)
 
-        run_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"])
+        run_call = next(
+            c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"]
+        )
         argv = run_call.args[0]
         assert "-p" in argv
         assert "8080:8080/tcp" in argv
@@ -231,7 +320,10 @@ class TestStartBaseContainerVolumesAndPorts:
             runs_services=False,
             published_ports=(
                 PublishedPort(
-                    container_port=53, protocol="udp", host_ip="127.0.0.1", host_port=5353
+                    container_port=53,
+                    protocol="udp",
+                    host_ip="127.0.0.1",
+                    host_port=5353,
                 ),
             ),
         )
@@ -240,7 +332,9 @@ class TestStartBaseContainerVolumesAndPorts:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             backend.start_base_container(spec)
 
-        run_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"])
+        run_call = next(
+            c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "run"]
+        )
         argv = run_call.args[0]
         assert "127.0.0.1:5353:53/udp" in argv
 
@@ -267,9 +361,13 @@ class TestRemoveGenericMaterializerContainers:
             failures = backend.remove_generic_materializer_containers()
 
         assert failures == []
-        list_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "ps"])
+        list_call = next(
+            c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "ps"]
+        )
         assert "label=aptl.lifecycle.project=test-proj" in list_call.args[0]
-        rm_call = next(c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "rm"])
+        rm_call = next(
+            c for c in mock_run.call_args_list if c.args[0][:2] == ["docker", "rm"]
+        )
         assert rm_call.args[0] == ["docker", "rm", "-f", "abc123", "def456"]
 
     def test_no_containers_is_a_clean_noop(self, tmp_path):
@@ -281,7 +379,9 @@ class TestRemoveGenericMaterializerContainers:
 
         assert failures == []
         # No `docker rm` call at all when there is nothing to remove.
-        assert not any(c.args[0][:2] == ["docker", "rm"] for c in mock_run.call_args_list)
+        assert not any(
+            c.args[0][:2] == ["docker", "rm"] for c in mock_run.call_args_list
+        )
 
     def test_removal_failure_is_reported_not_raised(self, tmp_path):
         backend = _backend(tmp_path)

--- a/tests/test_compose_boundary_realization.py
+++ b/tests/test_compose_boundary_realization.py
@@ -18,7 +18,13 @@ def _spec() -> PlatformBoundarySpec:
         policy_digest="sha256:" + "a" * 64,
         networks=(
             BoundaryNetwork(name="participant-net", bridge="br-part"),
-            BoundaryNetwork(name="transit", bridge="br-transit"),
+            BoundaryNetwork(name="management-net", bridge="br-mgmt"),
+            BoundaryNetwork(name="egress-net", bridge="br-egress"),
+        ),
+        zone_networks=(
+            ("participant", "participant-net"),
+            ("management", "management-net"),
+            ("egress", "egress-net"),
         ),
         anchors=(
             (
@@ -34,7 +40,7 @@ def _spec() -> PlatformBoundarySpec:
                 BoundaryWorkload(
                     identity="management-agent",
                     labels=(("org.aptl.zone", "management"),),
-                    ipv4_by_network=(("transit", "10.50.2.10"),),
+                    ipv4_by_network=(("management-net", "10.50.2.10"),),
                 ),
             ),
             (
@@ -42,7 +48,10 @@ def _spec() -> PlatformBoundarySpec:
                 BoundaryWorkload(
                     identity="egress-proxy",
                     labels=(("org.aptl.zone", "egress"),),
-                    ipv4_by_network=(("transit", "10.50.2.20"),),
+                    ipv4_by_network=(
+                        ("management-net", "10.50.2.20"),
+                        ("egress-net", "10.50.3.20"),
+                    ),
                 ),
             ),
         ),
@@ -118,3 +127,17 @@ def test_boundary_readback_mismatch_fails_closed(tmp_path) -> None:
 
     assert receipt.success is False
     assert receipt.error == "Boundary policy readback did not match desired state."
+
+
+def test_missing_signed_helper_never_falls_back_to_a_local_build(tmp_path) -> None:
+    backend = DockerComposeBackend(tmp_path, project_name="seat-17")
+    backend._boundary_helper_image = "example.test/aptl-boundary@sha256:" + "f" * 64
+    backend._run = MagicMock(return_value=MagicMock(returncode=1))
+    backend._run_with_input = MagicMock()
+
+    receipt = backend.realize_boundary(_spec())
+
+    assert receipt.success is False
+    assert receipt.error == "Signed boundary enforcement helper was unavailable."
+    backend._run_with_input.assert_not_called()
+    assert backend._run.call_count == 1

--- a/tests/test_compose_boundary_realization.py
+++ b/tests/test_compose_boundary_realization.py
@@ -1,0 +1,120 @@
+"""Authority-preserving external nftables lifecycle for APP-1."""
+
+import json
+from unittest.mock import MagicMock
+
+from aptl.core.deployment.boundary import (
+    BoundaryNetwork,
+    BoundaryWorkload,
+    PlatformBoundarySpec,
+    PlatformCrossing,
+)
+from aptl.core.deployment.docker_compose import DockerComposeBackend
+
+
+def _spec() -> PlatformBoundarySpec:
+    return PlatformBoundarySpec(
+        owner="seat-17",
+        policy_digest="sha256:" + "a" * 64,
+        networks=(
+            BoundaryNetwork(name="participant-net", bridge="br-part"),
+            BoundaryNetwork(name="transit", bridge="br-transit"),
+        ),
+        anchors=(
+            (
+                "participant",
+                BoundaryWorkload(
+                    identity="participant-gateway",
+                    labels=(("org.aptl.zone", "participant"),),
+                    ipv4_by_network=(("participant-net", "10.50.1.10"),),
+                ),
+            ),
+            (
+                "management",
+                BoundaryWorkload(
+                    identity="management-agent",
+                    labels=(("org.aptl.zone", "management"),),
+                    ipv4_by_network=(("transit", "10.50.2.10"),),
+                ),
+            ),
+            (
+                "egress",
+                BoundaryWorkload(
+                    identity="egress-proxy",
+                    labels=(("org.aptl.zone", "egress"),),
+                    ipv4_by_network=(("transit", "10.50.2.20"),),
+                ),
+            ),
+        ),
+        crossings=(
+            PlatformCrossing(
+                source="management",
+                destination="egress",
+                protocol="tcp",
+                ports=(3128,),
+                purpose="model-proxy",
+            ),
+        ),
+        egress_ports=(443,),
+    )
+
+
+def _receipt(spec: PlatformBoundarySpec) -> dict[str, object]:
+    return {
+        "authority": "platform",
+        "owner": "seat-17",
+        "enforcement_digest": spec.digest(),
+        "families": ["bridge", "inet"],
+        "default_deny": True,
+    }
+
+
+def test_boundary_is_applied_on_daemon_host_not_workload_namespace(tmp_path) -> None:
+    backend = DockerComposeBackend(tmp_path, project_name="seat-17")
+    backend._run = MagicMock(return_value=MagicMock(returncode=0))
+    backend._run_with_input = MagicMock()
+    backend._run_with_input.side_effect = [
+        MagicMock(returncode=0, stdout="", stderr=""),
+        MagicMock(returncode=0, stdout=json.dumps(_receipt(_spec())), stderr=""),
+    ]
+
+    receipt = backend.realize_boundary(_spec())
+
+    assert receipt.success is True
+    apply_cmd = backend._run_with_input.call_args_list[0].args[0]
+    assert apply_cmd[:5] == [
+        "docker",
+        "run",
+        "--rm",
+        "--network",
+        "host",
+    ]
+    assert "--cap-add=NET_ADMIN" in apply_cmd
+    assert "--privileged" not in apply_cmd
+    assert "--read-only" in apply_cmd
+    assert "nsenter" not in apply_cmd
+    assert "/var/run/docker.sock" not in apply_cmd
+
+
+def test_boundary_readback_mismatch_fails_closed(tmp_path) -> None:
+    backend = DockerComposeBackend(tmp_path, project_name="seat-17")
+    backend._run = MagicMock(return_value=MagicMock(returncode=0))
+    backend._run_with_input = MagicMock()
+    backend._run_with_input.side_effect = [
+        MagicMock(returncode=0, stdout="", stderr=""),
+        MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    **_receipt(_spec()),
+                    "enforcement_digest": "sha256:" + "0" * 64,
+                }
+            ),
+            stderr="",
+        ),
+    ]
+
+    receipt = backend.realize_boundary(_spec())
+
+    assert receipt.success is False
+    assert receipt.error == "Boundary policy readback did not match desired state."

--- a/tests/test_compose_platform_boundary.py
+++ b/tests/test_compose_platform_boundary.py
@@ -1,0 +1,201 @@
+"""Compose binding of trusted appliance policy to observed workload anchors."""
+
+from unittest.mock import MagicMock
+
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+)
+from aptl.core.deployment.docker_compose import DockerComposeBackend
+from aptl.core.deployment.realization import DeploymentRealizationSpec
+from aptl.core.lab_types import LabResult
+
+
+def _policy() -> ApplianceBoundaryPolicy:
+    return ApplianceBoundaryPolicy.model_validate(
+        {
+            "schema_version": "aptl.appliance-boundary/v1",
+            "policy_id": "default",
+            "generation": 1,
+            "workbench_policy_version": "participant-workbench-profile/v1",
+            "default_deny": True,
+            "platform_networks": {
+                "participant": "org.aptl.network=participant",
+                "management": "org.aptl.network=management",
+                "egress": "org.aptl.network=egress",
+            },
+            "platform_anchors": {
+                "participant": "org.aptl.zone=participant",
+                "management": "org.aptl.zone=management",
+                "egress": "org.aptl.zone=egress",
+            },
+            "fixed_crossings": [
+                {
+                    "source": "management",
+                    "destination": "egress",
+                    "protocol": "tcp",
+                    "ports": [3128],
+                    "purpose": "model-proxy",
+                }
+            ],
+            "egress_authorities": [
+                {
+                    "source": "egress",
+                    "authority": "api.example.test",
+                    "protocol": "tcp",
+                    "port": 443,
+                    "purpose": "model-provider",
+                    "resolution": "proxy-resolved-all-global",
+                    "failure_disposition": "deny",
+                }
+            ],
+            "egress_proxy_limits": {
+                "max_connections": 32,
+                "max_header_bytes": 4096,
+                "header_timeout_seconds": 5,
+                "connect_timeout_seconds": 10,
+                "idle_timeout_seconds": 60,
+            },
+            "guest_publications": [],
+            "docker_authority": {
+                "allowed_holder_labels": [],
+                "require_guest_daemon": True,
+            },
+        }
+    )
+
+
+def _binding() -> ApplianceBoundaryBinding:
+    return ApplianceBoundaryBinding(
+        policy_digest="sha256:" + "a" * 64,
+        payload_digest="sha256:" + "b" * 64,
+        aces_plan_digest="sha256:" + "c" * 64,
+        aces_boundary_required=False,
+        boundary_helper_image="example.test/aptl-boundary@sha256:" + "d" * 64,
+        egress_proxy_image="example.test/aptl-egress@sha256:" + "e" * 64,
+        boot_id="boot-1",
+        guest_daemon_id="daemon-1",
+        host_observation_id="host-1",
+    )
+
+
+def _network(name: str) -> dict[str, object]:
+    zone = name.removeprefix("seat_")
+    index = {"participant": 1, "management": 2, "egress": 3, "scenario": 4}[zone]
+    labels = {"com.docker.compose.project": "seat"}
+    if zone != "scenario":
+        labels["org.aptl.network"] = zone
+    return {
+        "name": name,
+        "bridge": f"br-seat{zone[:6]}",
+        "subnet": f"10.50.{index}.0/24",
+        "subnets": [f"10.50.{index}.0/24"],
+        "labels": labels,
+    }
+
+
+def _inspect(*placements: tuple[str, str]) -> dict[str, object]:
+    return {
+        "NetworkSettings": {
+            "Networks": {
+                f"seat_{zone}": {
+                    "IPAddress": address,
+                    "GlobalIPv6Address": "",
+                }
+                for zone, address in placements
+            }
+        }
+    }
+
+
+def test_platform_policy_binds_exact_labeled_workloads_before_start(tmp_path) -> None:
+    backend = DockerComposeBackend(tmp_path, project_name="seat")
+    backend.configure_appliance_boundary(_policy(), _binding())
+    network_names = [
+        "seat_participant",
+        "seat_management",
+        "seat_egress",
+        "seat_scenario",
+    ]
+    backend.host_list_lab_networks = MagicMock(return_value=network_names)
+    backend.host_inspect_network = MagicMock(side_effect=_network)
+    backend.host_list_lab_containers = MagicMock(
+        return_value=[
+            {"name": "aptl-participant", "labels": {"org.aptl.zone": "participant"}},
+            {"name": "aptl-management", "labels": {"org.aptl.zone": "management"}},
+            {"name": "aptl-egress", "labels": {"org.aptl.zone": "egress"}},
+        ]
+    )
+    placements = {
+        "aptl-participant": (("participant", "10.50.1.10"),),
+        "aptl-management": (("management", "10.50.2.20"),),
+        "aptl-egress": (
+            ("management", "10.50.2.30"),
+            ("egress", "10.50.3.30"),
+        ),
+    }
+    backend.container_inspect = MagicMock(
+        side_effect=lambda name: _inspect(*placements[name]),
+    )
+    backend.realize_boundary = MagicMock(return_value=LabResult(success=True))
+
+    result = backend._realize_platform_boundary()
+
+    assert result is None
+    spec = backend.realize_boundary.call_args.args[0]
+    assert spec.authority == "platform"
+    assert spec.egress_ports == (443,)
+    assert {network.name for network in spec.networks} == {
+        "seat_participant",
+        "seat_management",
+        "seat_egress",
+    }
+    assert [workload.identity for _zone, workload in spec.anchors] == [
+        "aptl-participant",
+        "aptl-management",
+        "aptl-egress",
+    ]
+
+
+def test_ambiguous_platform_anchor_fails_before_mutation(tmp_path) -> None:
+    backend = DockerComposeBackend(tmp_path, project_name="seat")
+    backend.configure_appliance_boundary(_policy(), _binding())
+    network_names = [
+        "seat_participant",
+        "seat_management",
+        "seat_egress",
+    ]
+    backend.host_list_lab_networks = MagicMock(return_value=network_names)
+    backend.host_inspect_network = MagicMock(side_effect=_network)
+    backend.host_list_lab_containers = MagicMock(
+        return_value=[
+            {"name": "aptl-participant", "labels": {"org.aptl.zone": "participant"}},
+            {"name": "aptl-management-a", "labels": {"org.aptl.zone": "management"}},
+            {"name": "aptl-management-b", "labels": {"org.aptl.zone": "management"}},
+            {"name": "aptl-egress", "labels": {"org.aptl.zone": "egress"}},
+        ]
+    )
+    backend.container_inspect = MagicMock(
+        return_value=_inspect(("participant", "10.50.1.10"))
+    )
+    backend.realize_boundary = MagicMock()
+
+    result = backend._realize_platform_boundary()
+
+    assert result is not None and result.success is False
+    backend.realize_boundary.assert_not_called()
+
+
+def test_scenario_without_acls_removes_stale_aces_authority(tmp_path) -> None:
+    backend = DockerComposeBackend(tmp_path, project_name="seat")
+    backend._boundary_receipts["aces"] = {"observed": True}
+    backend.realize_boundary = MagicMock(return_value=LabResult(success=True))
+
+    result = backend._realize_aces_boundary(
+        DeploymentRealizationSpec(profiles=(), nodes=(), networks=())
+    )
+
+    assert result is None
+    cleanup = backend.realize_boundary.call_args.args[0]
+    assert cleanup.authority == "aces"
+    assert cleanup.rules == ()

--- a/tests/test_mixed_realization_integration.py
+++ b/tests/test_mixed_realization_integration.py
@@ -53,7 +53,10 @@ services:
 def _docker_available() -> bool:
     if shutil.which("docker") is None:
         return False
-    return subprocess.run(["docker", "info"], capture_output=True, text=True).returncode == 0
+    return (
+        subprocess.run(["docker", "info"], capture_output=True, text=True).returncode
+        == 0
+    )
 
 
 @pytest.mark.skipif(not _docker_available(), reason="docker daemon not available")
@@ -62,7 +65,9 @@ def test_realize_materializes_runtime_node_and_starts_image_node_together(tmp_pa
     free_container = "aptl-free-box"
     image_container = "aptl-image-box"
     subprocess.run(
-        ["docker", "rm", "-f", free_container, image_container], capture_output=True, text=True
+        ["docker", "rm", "-f", free_container, image_container],
+        capture_output=True,
+        text=True,
     )
 
     backend = DockerComposeBackend(project_dir=tmp_path, project_name="aptl-mixed-test")
@@ -74,7 +79,9 @@ def test_realize_materializes_runtime_node_and_starts_image_node_together(tmp_pa
         container_name=free_container,
         networks=("mixed-net",),
         network_attachments=(
-            DeploymentNetworkAttachment(network="mixed-net", ipv4_address="172.31.0.10"),
+            DeploymentNetworkAttachment(
+                network="mixed-net", ipv4_address="172.31.0.10"
+            ),
         ),
         os="linux",
         os_version="",
@@ -89,7 +96,9 @@ def test_realize_materializes_runtime_node_and_starts_image_node_together(tmp_pa
         container_name=image_container,
         networks=("mixed-net",),
         network_attachments=(
-            DeploymentNetworkAttachment(network="mixed-net", ipv4_address="172.31.0.11"),
+            DeploymentNetworkAttachment(
+                network="mixed-net", ipv4_address="172.31.0.11"
+            ),
         ),
         os="linux",
         os_version="",
@@ -99,7 +108,9 @@ def test_realize_materializes_runtime_node_and_starts_image_node_together(tmp_pa
         profiles=("default",),
         nodes=(free_node, image_node),
         networks=(
-            DeploymentNetworkRealization(name="mixed-net", cidr="172.31.0.0/24", gateway="172.31.0.1"),
+            DeploymentNetworkRealization(
+                name="mixed-net", cidr="172.31.0.0/24", gateway="172.31.0.1"
+            ),
         ),
         images=(
             DeploymentImageRealization(
@@ -125,16 +136,28 @@ def test_realize_materializes_runtime_node_and_starts_image_node_together(tmp_pa
         # scale it to zero, so it never started its own "sleep infinity"
         # placeholder alongside the generic materializer's real container.
         ps = subprocess.run(
-            ["docker", "ps", "-a", "--filter", f"name=^{free_container}$", "--format", "{{.Names}}"],
-            capture_output=True, text=True,
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"name=^{free_container}$",
+                "--format",
+                "{{.Names}}",
+            ],
+            capture_output=True,
+            text=True,
         )
         assert ps.stdout.split() == [free_container]
 
         # The runtime: node was materialized directly (generic materializer),
         # not via Compose - it is not a Compose-managed container.
-        assert "curl" in backend.container_exec(
-            free_container, ["dpkg-query", "-W", "-f=${Package}\n", "curl"]
-        ).stdout
+        assert (
+            "curl"
+            in backend.container_exec(
+                free_container, ["dpkg-query", "-W", "-f=${Package}\n", "curl"]
+            ).stdout
+        )
 
         # The source: node was started via Compose as usual.
         pg_ready = None
@@ -152,16 +175,43 @@ def test_realize_materializes_runtime_node_and_starts_image_node_together(tmp_pa
         # covers both realization styles without any change.
         network = "aptl-mixed-test_aptl-mixed"
         inspect = subprocess.run(
-            ["docker", "inspect", free_container, "--format",
-             f"{{{{(index .NetworkSettings.Networks \"{network}\").IPAddress}}}}"],
-            capture_output=True, text=True,
+            [
+                "docker",
+                "inspect",
+                free_container,
+                "--format",
+                f'{{{{(index .NetworkSettings.Networks "{network}").IPAddress}}}}',
+            ],
+            capture_output=True,
+            text=True,
         )
         assert inspect.stdout.strip() == "172.31.0.10", (inspect.stdout, inspect.stderr)
+        networks = subprocess.run(
+            [
+                "docker",
+                "inspect",
+                free_container,
+                "--format",
+                "{{json .NetworkSettings.Networks}}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert '"bridge"' not in networks.stdout
     finally:
         subprocess.run(
-            ["docker", "rm", "-f", free_container, image_container], capture_output=True, text=True
+            ["docker", "rm", "-f", free_container, image_container],
+            capture_output=True,
+            text=True,
         )
         subprocess.run(
-            ["docker", "network", "rm", "aptl-mixed-test_aptl-mixed", "aptl-mixed-test_default"],
-            capture_output=True, text=True,
+            [
+                "docker",
+                "network",
+                "rm",
+                "aptl-mixed-test_aptl-mixed",
+                "aptl-mixed-test_default",
+            ],
+            capture_output=True,
+            text=True,
         )

--- a/tests/test_network_boundary_helper.py
+++ b/tests/test_network_boundary_helper.py
@@ -1,0 +1,165 @@
+"""Pure rendering checks for the authority-separated nftables helper."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+HELPER = (
+    Path(__file__).parents[1]
+    / "containers"
+    / "network-boundary-helper"
+    / "helper.py"
+)
+
+
+@pytest.fixture(scope="module")
+def helper():
+    spec = importlib.util.spec_from_file_location("network_boundary_helper", HELPER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _network(name: str, bridge: str, cidr: str) -> dict[str, object]:
+    return {
+        "name": name,
+        "bridge": bridge,
+        "ipv4_cidr": cidr,
+        "ipv6_cidr": None,
+        "labels": [],
+    }
+
+
+def _aces_policy() -> dict[str, object]:
+    return {
+        "authority": "aces",
+        "owner": "seat-17",
+        "networks": [
+            _network("orchard", "br-orchard", "10.44.1.0/24"),
+            _network("quartz", "br-quartz", "10.44.2.0/24"),
+        ],
+        "owner_bindings": [
+            {
+                "owner_address": "provision.node.sentinel",
+                "owner_resource_type": "node",
+                "ipv4_by_network": [["quartz", "10.44.2.10"]],
+                "ipv6_by_network": [],
+            }
+        ],
+        "rules": [
+            {
+                "owner_address": "provision.node.sentinel",
+                "owner_resource_type": "node",
+                "owner_name": "sentinel",
+                "name": "allow-web",
+                "order": 0,
+                "direction": "in",
+                "from_network": "orchard",
+                "to_network": "quartz",
+                "protocol": "tcp",
+                "ports": [443],
+                "action": "allow",
+            }
+        ],
+    }
+
+
+def _platform_policy() -> dict[str, object]:
+    return {
+        "authority": "platform",
+        "owner": "seat-17",
+        "policy_digest": "sha256:" + "a" * 64,
+        "networks": [
+            _network("participant-net", "br-part", "10.50.1.0/24"),
+            _network("transit", "br-transit", "10.50.2.0/24"),
+        ],
+        "anchors": [
+            {
+                "zone": "participant",
+                "workload": {
+                    "identity": "participant-gateway",
+                    "labels": [["org.aptl.zone", "participant"]],
+                    "ipv4_by_network": [["participant-net", "10.50.1.10"]],
+                    "ipv6_by_network": [],
+                },
+            },
+            {
+                "zone": "management",
+                "workload": {
+                    "identity": "management-agent",
+                    "labels": [["org.aptl.zone", "management"]],
+                    "ipv4_by_network": [["transit", "10.50.2.10"]],
+                    "ipv6_by_network": [],
+                },
+            },
+            {
+                "zone": "egress",
+                "workload": {
+                    "identity": "egress-proxy",
+                    "labels": [["org.aptl.zone", "egress"]],
+                    "ipv4_by_network": [["transit", "10.50.2.20"]],
+                    "ipv6_by_network": [],
+                },
+            },
+        ],
+        "crossings": [
+            {
+                "source": "management",
+                "destination": "egress",
+                "protocol": "tcp",
+                "ports": [3128],
+                "purpose": "model-proxy",
+            }
+        ],
+        "egress_ports": [443],
+        "default_deny": True,
+    }
+
+
+def test_aces_rules_remain_owner_anchored_and_separate(helper) -> None:
+    rendered = helper.render_ruleset(_aces_policy(), existing_families=())
+
+    assert "authority=aces" in rendered
+    assert "policy-digest=" not in rendered
+    assert "hook forward priority -200" in rendered
+    assert 'iifname "br-orchard" oifname "br-quartz"' in rendered
+    assert "ip daddr 10.44.2.10" in rendered
+    assert "tcp dport 443 return" in rendered
+    assert "ip daddr 10.44.2.10 jump owner_" in rendered
+
+
+def test_platform_floor_covers_forward_and_guest_host_paths(helper) -> None:
+    rendered = helper.render_ruleset(_platform_policy(), existing_families=())
+
+    assert "authority=platform" in rendered
+    assert "hook forward priority -300" in rendered
+    assert "hook input priority -300" in rendered
+    assert "hook output priority -300" in rendered
+    assert 'iifname "br-transit" oifname "br-transit"' in rendered
+    assert "ip saddr 10.50.2.10 ip daddr 10.50.2.20" in rendered
+    assert "tcp dport 3128 accept" in rendered
+    assert "tcp dport 443 accept" in rendered
+    assert "ct state established,related accept" in rendered
+    assert rendered.count("drop") >= 9
+
+
+def test_authorities_get_distinct_owned_tables(helper) -> None:
+    aces = helper.render_ruleset(_aces_policy(), existing_families=())
+    platform = helper.render_ruleset(_platform_policy(), existing_families=())
+
+    aces_table = next(line for line in aces.splitlines() if line.startswith("table inet"))
+    platform_table = next(
+        line for line in platform.splitlines() if line.startswith("table inet")
+    )
+    assert aces_table != platform_table
+
+
+def test_helper_rejects_cross_authority_fields(helper) -> None:
+    policy = _aces_policy()
+    policy["default_deny"] = True
+
+    with pytest.raises(ValueError):
+        helper.validate_policy(policy)

--- a/tests/test_network_boundary_helper.py
+++ b/tests/test_network_boundary_helper.py
@@ -7,10 +7,7 @@ import pytest
 
 
 HELPER = (
-    Path(__file__).parents[1]
-    / "containers"
-    / "network-boundary-helper"
-    / "helper.py"
+    Path(__file__).parents[1] / "containers" / "network-boundary-helper" / "helper.py"
 )
 
 
@@ -74,7 +71,13 @@ def _platform_policy() -> dict[str, object]:
         "policy_digest": "sha256:" + "a" * 64,
         "networks": [
             _network("participant-net", "br-part", "10.50.1.0/24"),
-            _network("transit", "br-transit", "10.50.2.0/24"),
+            _network("management-net", "br-mgmt", "10.50.2.0/24"),
+            _network("egress-net", "br-egress", "10.50.3.0/24"),
+        ],
+        "zone_networks": [
+            {"zone": "participant", "network": "participant-net"},
+            {"zone": "management", "network": "management-net"},
+            {"zone": "egress", "network": "egress-net"},
         ],
         "anchors": [
             {
@@ -91,7 +94,7 @@ def _platform_policy() -> dict[str, object]:
                 "workload": {
                     "identity": "management-agent",
                     "labels": [["org.aptl.zone", "management"]],
-                    "ipv4_by_network": [["transit", "10.50.2.10"]],
+                    "ipv4_by_network": [["management-net", "10.50.2.10"]],
                     "ipv6_by_network": [],
                 },
             },
@@ -100,7 +103,10 @@ def _platform_policy() -> dict[str, object]:
                 "workload": {
                     "identity": "egress-proxy",
                     "labels": [["org.aptl.zone", "egress"]],
-                    "ipv4_by_network": [["transit", "10.50.2.20"]],
+                    "ipv4_by_network": [
+                        ["management-net", "10.50.2.20"],
+                        ["egress-net", "10.50.3.20"],
+                    ],
                     "ipv6_by_network": [],
                 },
             },
@@ -138,11 +144,12 @@ def test_platform_floor_covers_forward_and_guest_host_paths(helper) -> None:
     assert "hook forward priority -300" in rendered
     assert "hook input priority -300" in rendered
     assert "hook output priority -300" in rendered
-    assert 'iifname "br-transit" oifname "br-transit"' in rendered
+    assert 'iifname "br-mgmt" oifname "br-mgmt"' in rendered
     assert "ip saddr 10.50.2.10 ip daddr 10.50.2.20" in rendered
     assert "tcp dport 3128 accept" in rendered
     assert "tcp dport 443 accept" in rendered
     assert "ct state established,related accept" in rendered
+    assert "ip daddr 10.50.3.20 ct state established,related accept" in rendered
     assert rendered.count("drop") >= 9
 
 
@@ -150,7 +157,9 @@ def test_authorities_get_distinct_owned_tables(helper) -> None:
     aces = helper.render_ruleset(_aces_policy(), existing_families=())
     platform = helper.render_ruleset(_platform_policy(), existing_families=())
 
-    aces_table = next(line for line in aces.splitlines() if line.startswith("table inet"))
+    aces_table = next(
+        line for line in aces.splitlines() if line.startswith("table inet")
+    )
     platform_table = next(
         line for line in platform.splitlines() if line.startswith("table inet")
     )
@@ -163,3 +172,98 @@ def test_helper_rejects_cross_authority_fields(helper) -> None:
 
     with pytest.raises(ValueError):
         helper.validate_policy(policy)
+
+
+def test_multiple_acl_owners_remain_independent_intersecting_chains(helper) -> None:
+    policy = _aces_policy()
+    policy["owner_bindings"].append(
+        {
+            "owner_address": "provision.node.gateway",
+            "owner_resource_type": "node",
+            "ipv4_by_network": [["orchard", "10.44.1.10"]],
+            "ipv6_by_network": [],
+        }
+    )
+    policy["rules"].append(
+        {
+            "owner_address": "provision.node.gateway",
+            "owner_resource_type": "node",
+            "owner_name": "gateway",
+            "name": "deny-other",
+            "order": 0,
+            "direction": "out",
+            "from_network": "orchard",
+            "to_network": "quartz",
+            "protocol": "any",
+            "ports": [],
+            "action": "deny",
+        }
+    )
+    policy["owner_bindings"].sort(key=lambda item: item["owner_address"])
+    policy["rules"].sort(
+        key=lambda item: (item["owner_address"], item["order"], item["name"])
+    )
+
+    rendered = helper.render_ruleset(policy, existing_families=())
+
+    assert rendered.count("chain owner_") == 4
+    assert "ip daddr 10.44.2.10 jump owner_" in rendered
+    assert "ip saddr 10.44.1.10 jump owner_" in rendered
+    assert "drop comment" in rendered
+
+
+def test_helper_rejects_malformed_direct_acl_without_native_mutation(helper) -> None:
+    policy = _aces_policy()
+    policy["rules"][0]["from_network"] = ["orchard"]
+
+    with pytest.raises(ValueError, match="endpoint"):
+        helper.validate_policy(policy)
+
+
+def test_authored_wildcard_endpoint_is_scoped_by_acl_owner(helper) -> None:
+    policy = _aces_policy()
+    policy["rules"][0]["from_network"] = None
+
+    rendered = helper.render_ruleset(policy, existing_families=())
+
+    assert "ip daddr 10.44.2.10 tcp dport 443 return" in rendered
+
+
+@pytest.mark.parametrize(
+    ("direction", "protocol", "needle"),
+    [
+        ("out", "udp", "udp dport 443 return"),
+        ("inout", "icmp", "meta l4proto icmp return"),
+        ("in", "any", "ip daddr 10.44.2.10 return"),
+    ],
+)
+def test_supported_acl_direction_and_protocol_subset_is_rendered_exactly(
+    helper,
+    direction: str,
+    protocol: str,
+    needle: str,
+) -> None:
+    policy = _aces_policy()
+    rule = policy["rules"][0]
+    policy["owner_bindings"][0]["ipv4_by_network"].append(["orchard", "10.44.1.20"])
+    rule["direction"] = direction
+    rule["protocol"] = protocol
+    rule["ports"] = [443] if protocol in {"tcp", "udp"} else []
+
+    rendered = helper.render_ruleset(policy, existing_families=())
+
+    assert needle in rendered
+    if direction == "inout":
+        assert rendered.count("meta l4proto icmp return") == 4
+
+
+def test_ruleset_replacement_is_one_atomic_native_transaction(helper) -> None:
+    rendered = helper.render_ruleset(
+        _aces_policy(),
+        existing_families=("bridge", "inet"),
+    )
+
+    assert rendered.startswith("delete table inet ")
+    assert "\ndelete table bridge " in rendered
+    assert rendered.count("table inet ") == 2
+    assert rendered.count("table bridge ") == 2

--- a/tests/test_network_boundary_helper.py
+++ b/tests/test_network_boundary_helper.py
@@ -150,7 +150,15 @@ def test_platform_floor_covers_forward_and_guest_host_paths(helper) -> None:
     assert "tcp dport 443 accept" in rendered
     assert "ct state established,related accept" in rendered
     assert "ip daddr 10.50.3.20 ct state established,related accept" in rendered
-    assert rendered.count("drop") >= 9
+    for bridge in ("br-part", "br-mgmt", "br-egress"):
+        assert f'iifname "{bridge}" drop comment' in rendered
+        assert f'oifname "{bridge}" drop comment' in rendered
+    assert (
+        "ip daddr { 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, "
+        "127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, "
+        "192.0.0.0/24, 192.168.0.0/16, 198.18.0.0/15, "
+        "224.0.0.0/4, 240.0.0.0/4 } drop"
+    ) in rendered
 
 
 def test_authorities_get_distinct_owned_tables(helper) -> None:


### PR DESCRIPTION
## Summary

- materialize admitted ACES ACLs through typed, scenario-independent deployment contracts with external nftables enforcement and exact readback
- enforce a separate signed platform boundary for participant, management, controlled egress, guest publications, and guest Docker authority
- add one fatal, redacted boundary inventory and verdict contract consumed by image qualification (#823) and launch-time host observation (#824)
- add a constrained exact-authority CONNECT broker and digest-pinned boundary helper/proxy images
- preserve developer-local startup while removing the transient default-bridge/package-install window in appliance and ACES-ACL modes

## Verification

- `pytest -q` — 3256 passed, 187 skipped, 42 deselected, 1 xfailed
- `pre-commit run --all-files`
- `mkdocs build --strict`
- built both boundary container images
- clean `aptl lab stop -v && aptl lab start` after merging #820 and #821 — lab ready

## Requirements

- APP-1 — Appliance boundary qualification

Closes #822