### PR TITLE
feat: add versioned disposable lab appliance

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -30,7 +30,6 @@ routing:
   # high->opus) instead of always running on the parent session model.
   enabled: true
   default_provider: claude
-  default_fallback: parent
 rules:
   plan_rules: .gc/plan-rules.md
 # Canonical boundary model declarations (GC-GRC-004 / GC-GRC-023). These are the

--- a/appliance/guest/aptl-appliance-first-boot
+++ b/appliance/guest/aptl-appliance-first-boot
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Idempotent guest start: identity is create-once per overlay; lab start reuses it.
+set -eu
+umask 077
+
+. /etc/aptl/appliance-release.env
+: "${APTL_APPLIANCE_SCENARIO:?missing staged appliance scenario identity}"
+
+aptl appliance bootstrap-overlay --state-dir /var/lib/aptl/overlay
+images_loaded=/var/lib/aptl/overlay/images-loaded
+if test ! -f "$images_loaded"; then
+    docker load --input /opt/aptl/offline/oci-images.tar
+    marker=$(mktemp /var/lib/aptl/overlay/.images-loaded.XXXXXX)
+    sha256sum /opt/aptl/offline/oci-images.tar >"$marker"
+    chmod 0600 "$marker"
+    mv "$marker" "$images_loaded"
+fi
+exec aptl lab start \
+    --project-dir /opt/aptl/project \
+    --scenario "$APTL_APPLIANCE_SCENARIO" \
+    --offline-staged \
+    --appliance-launch-descriptor /run/aptl-launch/appliance-launch.json \
+    --appliance-release-public-key /run/aptl-launch/release-public.pem \
+    --appliance-qualification-public-key \
+    /run/aptl-launch/qualification-public.pem

--- a/appliance/guest/aptl-appliance-first-boot.service
+++ b/appliance/guest/aptl-appliance-first-boot.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=APTL disposable appliance first-boot readiness
+After=docker.service network.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/libexec/aptl-appliance-first-boot
+RemainAfterExit=yes
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/aptl /opt/aptl/project
+
+[Install]
+WantedBy=multi-user.target

--- a/appliance/guest/provision-offline.sh
+++ b/appliance/guest/provision-offline.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Install an already-staged APTL release into an offline supported guest base.
+set -eu
+umask 077
+
+stage=/opt/aptl-stage
+payload_archive="$stage/offline-payload.tar"
+payload_dir="$stage/payload"
+
+test "$(id -u)" -eq 0
+test -f "$payload_archive"
+test ! -e "$payload_dir"
+install -d -m 0700 "$payload_dir"
+tar --extract --file "$payload_archive" --directory "$payload_dir" --no-same-owner
+
+test -d "$payload_dir/wheelhouse"
+test -f "$payload_dir/project.tar"
+test -f "$payload_dir/oci-images.tar"
+test -f "$payload_dir/appliance-release.env"
+test -f "$payload_dir/aptl-appliance-first-boot"
+test -f "$payload_dir/aptl-appliance-first-boot.service"
+
+. "$payload_dir/appliance-release.env"
+: "${APTL_APPLIANCE_VERSION:?missing staged APTL version}"
+python3 -m pip install --no-index \
+    --find-links "$payload_dir/wheelhouse" \
+    "aptl-labs==$APTL_APPLIANCE_VERSION"
+
+install -d -m 0755 /opt/aptl/project
+tar --extract --file "$payload_dir/project.tar" \
+    --directory /opt/aptl/project --no-same-owner
+install -d -m 0755 /opt/aptl/offline
+install -m 0444 "$payload_dir/oci-images.tar" \
+    /opt/aptl/offline/oci-images.tar
+
+install -d -m 0755 /etc/aptl /usr/local/libexec
+install -m 0644 "$payload_dir/appliance-release.env" \
+    /etc/aptl/appliance-release.env
+install -m 0755 "$payload_dir/aptl-appliance-first-boot" \
+    /usr/local/libexec/aptl-appliance-first-boot
+install -m 0644 "$payload_dir/aptl-appliance-first-boot.service" \
+    /etc/systemd/system/aptl-appliance-first-boot.service
+install -d -m 0700 /var/lib/aptl
+systemctl enable aptl-appliance-first-boot.service
+
+# The release contains installed inputs only. Per-overlay identity, .env,
+# service credentials, Docker writable state, and run evidence are created
+# after the launcher has attached a disposable overlay.
+rm -rf "$payload_dir"

--- a/appliance/guest/scan-golden.sh
+++ b/appliance/guest/scan-golden.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Fail if the finalized immutable base contains state owned by an overlay.
+set -eu
+
+test ! -s /etc/machine-id
+if find /etc/ssh -maxdepth 1 -type f -name 'ssh_host_*_key' -print |
+    grep -q .
+then
+    exit 1
+fi
+
+for runtime_path in \
+    /var/lib/docker \
+    /var/lib/aptl \
+    /opt/aptl/project/.aptl
+do
+    if test -d "$runtime_path" &&
+        find "$runtime_path" -mindepth 1 -print -quit | grep -q .
+    then
+        exit 1
+    fi
+done
+
+test ! -e /opt/aptl/project/.env
+test -r /opt/aptl/offline/oci-images.tar
+test -r /opt/aptl/project/participant-profiles/guided-purple-v1/profile.json

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -166,3 +166,4 @@ The victim and kali containers publish no host ports; use
 - [EXP-010 Capture Admission And Evidence Acquisition](exp-010-capture-admission-evidence-preflight.md)
 - [Issue #589 Scenario-Pack Capture Workflow Ownership](issue-589-scenario-pack-capture-ownership-preflight.md)
 - [Issue #821 In-Appliance Participant Workbench](issue-821-participant-workbench-preflight.md)
+- [Issue #823 Versioned Disposable Lab Appliance](issue-823-versioned-disposable-appliance-preflight.md)

--- a/docs/architecture/issue-823-versioned-disposable-appliance-preflight.md
+++ b/docs/architecture/issue-823-versioned-disposable-appliance-preflight.md
@@ -1,0 +1,227 @@
+# Issue #823 Versioned Disposable Lab Appliance Preflight
+
+This note sets the design guardrails for the versioned participant appliance.
+It is guidance, not an implementation plan. [ADR-049](../adrs/adr-049-sealed-disposable-lab-appliance.md)
+already makes one disposable VM per seat the supported delivery boundary.
+Issue #820 owns the bounded inner workload, issue #821 owns its workbench
+compartments, and issue #822 owns its appliance network boundary. Issue #823
+binds and qualifies those existing contracts; it does not replace them.
+
+No new ADR is needed. The unresolved risk is treating an image file, a Docker
+cache, and a participant seat as the same artifact. They have different
+owners, mutability, integrity, and reset semantics.
+
+## Architecture Decisions And Guardrails
+
+- The local reference form is a hardware-virtualized QEMU/KVM guest managed by
+  a narrow launcher adapter. The hosted fallback consumes the exact same signed
+  guest payload and exposes the same participant routes and workbench flow.
+  A host adapter is an outer delivery concern, not an APTL
+  `DeploymentBackend`, an ACES node provider, or a reason to select another
+  Compose file, scenario, MCP set, frontend build, or credential meaning.
+- The release unit is a signed, versioned appliance envelope. Its narrow,
+  strict payload manifest binds the tagged source revision and APTL version to
+  the immutable golden disk, guest OS/architecture, staged payload contents,
+  participant-profile manifest and asset-lock digests, accepted qualification
+  report, appliance-boundary policy/binding, helper-image digests, and declared
+  host prerequisites. It contains references and digests, not a second copy of
+  ACES topology, `AptlConfig`, MCP configuration, readiness checks, or egress
+  rules.
+- Manifest validation occurs before launch and produces the existing
+  `ApplianceBoundaryBinding` payload digest for
+  `run_appliance_boundary_gate()`. The boundary inventory is the readiness
+  projection for the payload digest; it may add the non-secret release version
+  and manifest digest, but it must not become a second payload manifest or a
+  new readiness taxonomy. The signed manifest is the canonical source for
+  `aptl` version reporting, artifact checksums, and rollback eligibility.
+- A build from the same annotated APTL tag must produce the same **release
+  shape**: the same manifest identity, guest OS/base digest, profile and policy
+  bindings, package/image/MCP content identities, file ownership contract, and
+  launch contract. It need not produce byte-identical disk images, timestamps,
+  filesystem UUIDs, generated keys, Docker object IDs, or qualification run
+  records. Build provenance must record the resolved immutable commit, not only
+  a mutable tag name.
+- Use the existing staged asset closure. `ParticipantProfileManifest`,
+  `ParticipantAssetLock`, `load_participant_profile()`, and
+  `hatch_build.py`/`aptl.core.assets` already define how tracked APTL assets,
+  MCP builds, and OCI identities are selected without shipping ignored local
+  state. The outer payload adds the guest-base and launcher artifacts that the
+  inner lock intentionally does not own; it must not reimplement asset-lock
+  validation or copy its entries into another schema.
+- The golden disk is immutable/read-only once released. It contains the
+  supported guest OS, installed APTL release, staged project assets, released
+  MCP builds, verified OCI content, appliance policy, and non-secret workbench
+  material. It contains no participant data, `.env` values, generated keys or
+  certificates, `.aptl` session/run state, Docker runtime state, model or
+  operator credentials, or prior qualification evidence with sensitive data.
+- One launch creates one disposable overlay and all associated mutable guest
+  state on it. That includes the guest machine identity, SSH/TLS host identity,
+  generated service configuration, Docker writable state and volumes, session
+  credentials, run/evidence state, and any writable firmware/seed state. No
+  host shared folder, host Docker socket, guest-root mount, clipboard,
+  drag-and-drop, USB, or writable device passthrough is an allowed substitute
+  for that overlay.
+- First boot is a deterministic, idempotent state transition, not deterministic
+  secret bytes. It must atomically establish a new instance identity and
+  credentials exactly once per overlay, recover safely after an interrupted
+  boot, and never regenerate them on an ordinary reboot. Entropy-generated
+  values are deliberately different for each overlay and are destroyed with it.
+  A local credential entry and hosted short-lived credential injection both
+  resolve to the same guest-only bootstrap shape from ADR-049.
+- Offline staging is an appliance property. A fresh overlay may start services
+  and generate per-seat state, but it must not require a source checkout,
+  package installation, image pull/build, MCP build, DNS fallback, or arbitrary
+  network download. The guest base and every OCI/MCP/package input required by
+  the bounded profile must be verified and present before the release becomes
+  eligible. A build-time network fetch is acceptable only through a pinned,
+  checksummed staging input and must not become a first-boot dependency.
+- Rollback and upgrade select an immutable signed payload; neither mutates a
+  golden disk in place. The launcher keeps an atomic active/previous
+  known-good payload reference after verification. Rollback discards the
+  candidate overlay and creates a fresh overlay from the prior payload. Upgrade
+  creates a fresh overlay from the new payload and reruns the same start gate.
+  Migrating a whole guest disk, Docker volume, secret store, or compromised
+  overlay is not an upgrade. Any future explicit data import needs its own
+  versioned, validated, classified contract.
+- The appliance manifest declares real host prerequisites, rather than reusing
+  developer-from-source prerequisites. It must state architecture, usable CPU
+  count, host memory and disk including virtualization overhead, hardware
+  virtualization and KVM availability, supported hypervisor/launcher versions,
+  and required network/device isolation. The current `guided-purple` inner
+  profile establishes a lower bound of x86-64, 8 vCPUs, 16 GiB, and 100 GiB;
+  the appliance launcher must declare and prove any additional host headroom
+  rather than silently oversubscribing that fixture.
+
+## Existing Contracts To Reuse
+
+| Concern | Canonical owner and required reuse |
+| --- | --- |
+| Outer boundary | ADR-049 and its versioned appliance-envelope seam own payload identity, delivery form, host recovery, secret bootstrap, egress-policy reference, resource limits, and evidence export. `ApplianceBoundaryBinding`, `run_appliance_boundary_gate()`, and the fatal boundary inventory consume the payload identity. |
+| Bounded workload | `ParticipantProfileManifest`, `ParticipantAssetLock`, `ParticipantReadinessSuite`, `load_participant_profile()`, and `evaluate_participant_qualification()` own the inner profile, exact surfaces, offline counters, resource ceilings, and authenticated qualification evidence. |
+| Smoke workflow | `run_participant_mcp_smoke()` and the profile readiness suite own the real red-to-blue semantic workflow. A process start, a container health check, or a copied status flag is not a smoke result. |
+| Scenario and realization | ACES parsing/planning, `AptlRealization`, `DeploymentRealizationSpec`, `DeploymentBackend`, and the APP-1 boundary policy retain their existing ownership. The outer VM must not create a VM node backend, a second ACL model, or an appliance-specific scenario. |
+| Buildable source assets | `hatch_build.py`, `aptl._asset_manifest`, and `aptl.core.assets` own tracked-source selection and exclusion of generated state. Build/package tests already protect against shipping `.aptl`, keys, certificates, or local `.env` state. |
+| Durable configuration | `AptlConfig`, `load_config()`, and ADR-025 remain the strict non-secret configuration contract. Envelope policy, release identity, and bootstrap material are not an `aptl.json` dictionary or environment-variable bag. |
+| Secrets and generated files | `load_dotenv()`, `EnvVars`, placeholder checks, ADR-028 containment/atomic writes, ADR-029 redaction, `curl_safe`, and owner-only ignored generated state remain mandatory. Use the ADR-049 narrow bootstrap parser for new seat secrets. |
+| Lifecycle and errors | `core.lab`'s flat `_LAB_START_STEPS`, `LabResult`, `StartupOutcome`, `StartupDiagnostic`, deployment timeouts, and ACES `Diagnostic` remain the inner lifecycle vocabulary. Outer seat lifecycle and taint are distinct envelope state; do not create an appliance-wide exception hierarchy. |
+| Persistence and observability | `RunStorageBackend`, `LocalRunStore`, `RangeSnapshot.to_dict()`, evidence/capture contracts, `get_logger()`, OTel, and the Python/TypeScript `redact()` helpers remain the only persistence and logging boundaries. |
+| Version and release provenance | `aptl.__version__`, `pyproject.toml`, `tests/test_version_consistency.py`, release-please, and the existing Ed25519 qualification-attestation pattern are the canonical version, release, and signature precedents. The payload signer must use an independently configured release trust anchor, never a key supplied by the artifact being verified. |
+
+## Security And Validation Passage
+
+The intended design crosses each of the following gates. Passing a lower layer
+does not waive an earlier or later one.
+
+| Layer | Required behavior |
+| --- | --- |
+| Release manifest and artifact parser | Use one closed, versioned manifest shape with safe relative references, exact lowercase digests, duplicate rejection, existing `rfc8785` canonical JSON bytes, and signature verification against a configured release trust anchor. Unknown schema/version, unresolved tag/commit, missing stage input, digest/signature mismatch, or an unsupported guest/adapter capability fails before an overlay is created. |
+| Profile, asset, and qualification validators | Reload the existing strict participant profile and asset lock; verify the accepted qualification report with its protected Ed25519 public key. The payload manifest binds their digests and does not accept handwritten service lists, scenario paths, or MCP inventory. |
+| Appliance boundary policy and host observation | Bind the verified payload digest into `ApplianceBoundaryBinding`; pass the signed APP-1 policy and a fresh authenticated host observation to `run_appliance_boundary_gate()` at image qualification and every supported start. Missing/stale host observation, boot/daemon mismatch, extra listener, incomplete readback, or failed positive/negative probe is fatal, not `degraded_*`. |
+| First-party configuration and environment | Keep durable non-secret settings in strict `AptlConfig`. Existing `.env` values pass through `load_dotenv()`, `EnvVars`, and placeholder checks; generated service files retain no-follow, containment, atomic-write, and restrictive-mode handling. The envelope never bypasses those parsers or passes opaque settings through to Compose. |
+| Credential bootstrap and OS/process exposure | Generate or inject seat credentials only after overlay creation into management-owned guest state. Do not place a secret in the golden image, cloud-init/user-data log, process argv, environment dump, URL, browser storage, Compose command/healthcheck, image label, support bundle, or host state. Preserve argv-list subprocess construction and avoid generic guest shell or Docker APIs. |
+| Docker, network, and virtual-machine authority | Keep Docker/Compose and MCPs inside the guest and retain guest-Docker authority with the smallest existing management owner. The QEMU/libvirt adapter exposes only declared participant and recovery endpoints, uses no shared host resources, and validates VM/CPU virtualization prerequisites before launch. The APP-1 observed boundary, not a `qcow2` extension, loopback bind, `internal` Docker network, or successful TCP check, proves containment. |
+| Errors, logs, and reports | Report stable release/validation/finding codes, APTL version, payload/manifest/policy digests, counts, timing, resource pressure, and verdicts only. Reuse `LabResult`/`StartupDiagnostic`, boundary findings, and redacting writers; never return raw QEMU/libvirt output, Docker inspect, host paths, policy text, secrets, or evidence bytes. |
+| Evidence and reset | Keep run/capture state guest-management-owned and classified under the existing runstore/evidence contracts. A normal host report contains only redacted identity and coarse readiness. Destroying an overlay removes all unexported participant state; a deliberately approved, checksummed export is the only exception. |
+
+## Extensibility And Whole-Repository Scope
+
+The seam is ADR-049's one versioned appliance-envelope contract: immutable
+payload identity, delivery-form adapter, participant ingress, health/recovery
+adapter, secret-bootstrap channel, egress-policy reference, resource limits,
+and evidence-export sink. The payload manifest is its release projection. A
+future hosted provider, local hypervisor, supported guest architecture, update
+mirror, or recovery adapter adds a declared capability at this seam and uses
+the same verifier. It must not fork the scenario, Compose model, frontend,
+participant profile, MCP configuration, readiness suite, or error envelope.
+
+Implementation has to reconcile all of these surfaces, not only the appliance
+builder:
+
+- `pyproject.toml`, `uv.lock`, `hatch_build.py`, `release-please-config.json`,
+  `.github/workflows/release-please.yml`, and package/version/asset tests;
+- `participant-profiles/guided-purple-v1/`, its profile/asset/readiness
+  validators, qualification evidence, semantic MCP smoke, and minimum-hardware
+  fixture;
+- `src/aptl/core/appliance_boundary*.py`, APP-1 policy/binding, boundary
+  helper/proxy images, guest/host observations, and their static/live tests;
+- `src/aptl/core/{assets,config,env,lab,lab_types,runstore,telemetry}.py`,
+  deployment backend behavior, generated-state writers, host-port and endpoint
+  projections, and the ACES realization pipeline;
+- `docker-compose.yml`, profile-derived runtime, Docker image/mount/capability
+  policy, MCP build artifacts/configuration, participant workbench, container
+  Dockerfiles, and guest Docker daemon state;
+- physical QEMU/KVM/libvirt guest lifecycle, CPU virtualization, overlay and
+  firmware state, virtual device policy, host listener/reachability observation,
+  and a hosted adapter with the same payload digest;
+- `.ground-control.yaml` boundary declarations, deployment/workshop/recovery
+  documentation, asset/package security tests, appliance/profile/boundary
+  tests, and the repository completion gates. New appliance-builder or launcher
+  paths must be declared under the appropriate outer host/perimeter boundary
+  rather than left outside GRC routing.
+
+## Verification Guardrails
+
+- Qualification must verify the signed payload and every staged checksum,
+  demonstrate that the golden base contains no per-seat identity, secret,
+  Docker writable state, run data, or host share, and prove a fresh overlay
+  creates distinct identity and credentials without a source checkout or a
+  network resolution.
+- The complete existing `guided-purple` readiness suite, including the semantic
+  red attack, Wazuh detection, indexer/Wazuh investigation, participant
+  workbench surface, correlation record, and APP-1 positive/negative boundary
+  probes, must run on the declared minimum appliance host. Existing profile
+  and boundary reports remain distinct but are bound by the same payload
+  digest.
+- Exercise build, launch, artifact verification, rollback to the immediately
+  previous known-good payload, and overlay destruction on more than one
+  independent supported machine. Verify that a failed candidate cannot replace
+  the active known-good reference and that rollback creates a clean prior
+  overlay rather than reviving candidate state.
+- Static tests should reject manifest tampering, wrong tags/commits, unsafe
+  paths, unknown schema fields, duplicate entries, unsigned/incorrectly signed
+  manifests, missing staged inputs, unsupported virtualization, golden secret
+  contamination, and stale version projection. Integration/live evidence must
+  cover actual KVM launch, offline boot, reset, host exposure, and bounded
+  workflow completion; mocked QEMU output is not sufficient evidence.
+- Any Compose, container, or configuration change still requires the existing
+  clean-lab validation, focused pytest/vitest coverage, and `pre-commit run
+  --all-files`. Changes to `aptl-mcp-common` still rebuild every dependent MCP.
+
+## Gotchas And Anti-Patterns
+
+- Do not call the wheel, asset lock, OCI cache, golden disk, per-seat overlay,
+  run archive, qualification report, and hosted image one generic "artifact."
+- Do not use an unpinned package repository, mutable OCI tag, mutable Git tag,
+  local build cache, or post-build image pull as release input.
+- Do not bake `.env`, generated certificates/keys, machine IDs, host keys,
+  session tokens, model credentials, Docker volumes, `.aptl`, run archives, or
+  a copied participant overlay into the golden payload.
+- Do not use snapshot rollback, `aptl lab stop -v`, ACES episode reset, or a
+  container restart as the appliance reset/rollback contract. Do not repair a
+  participant guest in place and then return it to a seat.
+- Do not put an appliance policy, host prerequisite, or manifest field in
+  `aptl.json`, an environment variable, Docker label, or a new duplicate
+  profile/readiness/ACL schema merely because it is convenient for one
+  launcher.
+- Do not let the hosted fallback rebuild, reconfigure, or present a different
+  UX than the local payload. Provider-specific metadata cannot override the
+  signed payload identity or guest-side credential lifecycle.
+- Do not turn the outer launcher into a participant shell, Docker proxy,
+  arbitrary port tunnel, raw-log/evidence browser, or generic file API.
+- Do not treat successful disk creation or a container health check as payload,
+  boundary, readiness, or smoke proof. Each has separate observable evidence.
+
+## Non-Goals And Implementation Boundary
+
+- This preflight does not implement the guest image builder, signer, KVM
+  launcher, hosted fleet, secret-bootstrap transport, kiosk, or rollback tool.
+- It does not change ACES SDL, scenario meaning, node-realization semantics,
+  `DeploymentBackend`, `AptlConfig`, participant/runtime DTOs, existing MCP
+  tool schemas, run/evidence schemas, or the operator control plane.
+- It does not add a second package manager, image registry, Docker authority
+  broker, readiness engine, exception hierarchy, lifecycle state machine,
+  secret store, participant profile, or hosted-only source fork.
+- It does not promise byte-identical disks, identical randomly generated
+  identities, multi-seat sharing, in-place upgrade, guest preservation after
+  compromise, general Kali/target egress, or a proof that guest escape is
+  impossible.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,6 +32,14 @@ Edit `aptl.json` to enable/disable containers:
 }
 ```
 
+For prebuilt, checkout-free QEMU/KVM delivery, see the
+[disposable appliance release guide](reference/appliance-release.md). Appliance
+guests start only from already staged wheels, project assets, and OCI images.
+Their create-once launch descriptor and both release trust anchors are required
+to bind the signed payload into the appliance boundary before startup;
+`aptl lab start --offline-staged` rejects missing images instead of pulling or
+building them.
+
 ## Manual Deployment
 
 **These steps are automated by `aptl lab start`. Use the CLI unless troubleshooting.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@ run from source instead, use a virtualenv editable install
 
 ### Reference
 - [Guided Purple Participant Profile](reference/participant-profile.md): Versioned bounded workshop surface, readiness contract, and qualification ceilings
+- [Disposable Appliance Release](reference/appliance-release.md): Signed golden image, offline payload, local KVM overlays, qualification, and rollback
 - [TechVault Scenario Overview](reference/techvault-scenario-overview.md): What the default range contains—topology, targets, SOC stack, planted vulnerabilities, and curated variants
 - [TechVault Company Profile](reference/techvault-company-profile.md)
 - [TechVault OSINT Readiness](reference/techvault-osint-readiness.md)

--- a/docs/reference/appliance-release.md
+++ b/docs/reference/appliance-release.md
@@ -1,0 +1,227 @@
+# Disposable appliance release
+
+APTL appliance releases package a read-only golden qcow2 guest and every
+participant dependency needed for an offline first boot. Each lab instance is
+a disposable qcow2 overlay. Destroying that overlay destroys its credentials,
+Docker state, and run evidence; the golden disk is never opened for writing.
+
+This is a release-engineering interface. The participant launcher, reset
+controls, and recovery UI are tracked separately in issue #824.
+
+## Trust and lifecycle model
+
+An appliance release is admitted only when all of these statements are true:
+
+- the source tag is exactly `v<aptl-version>` and names a full source commit;
+- all nine required artifacts have their byte size and SHA-256 digest bound
+  into a canonical RFC 8785 manifest;
+- the manifest has a valid Ed25519 signature from the configured release trust
+  anchor;
+- the APP-2 profile, asset lock, signed qualification report, APP-1 boundary
+  policy, clean-golden inventory, and two-machine drill agree with the
+  manifest;
+- qualification reports zero downloads, pulls, builds, or package resolution
+  during offline startup;
+- local KVM and hosted delivery use the same golden and offline payload bytes;
+- the golden disk is qcow2, read-only, and used only as a backing file; and
+- upgrades and rollbacks select another verified golden release and create a
+  new overlay. In-place guest upgrades are not supported.
+
+`aptl appliance inspect` prints only the verified version, content identities,
+architecture, and minimum host resources. It does not expose artifact paths,
+machine identities, or per-instance credentials.
+
+## Build host prerequisites
+
+The release host needs Python 3.11 or later, `qemu-img`, and libguestfs tools
+providing `virt-customize` and `virt-sysprep`. The pinned Ubuntu base image must
+already contain systemd, Python with pip, and Docker Engine. The supported
+participant profile requires at least 8 vCPUs, 16 GiB RAM, 100 GiB available
+disk, and hardware virtualization.
+
+Network access is permitted while a release engineer resolves and stages
+version-pinned inputs. The subsequent payload assembly and golden-image build
+are deliberately offline: they contain no checkout, dependency resolution,
+image pull, image build, or package-repository step.
+
+## Stage the offline payload
+
+Create a closed staging directory with exactly these entries:
+
+| Entry | Purpose |
+| --- | --- |
+| `wheelhouse/` | The `aptl_labs-*.whl` wheel and all locked Python wheels |
+| `project.tar` | Checkout-free project assets from the exact source commit |
+| `oci-images.tar` | All digest-pinned container images in the APP-2 asset lock |
+| `appliance-release.env` | Non-secret scenario and exact `APTL_APPLIANCE_VERSION` lines |
+| `aptl-appliance-first-boot` | First-boot script from `appliance/guest/` |
+| `aptl-appliance-first-boot.service` | Corresponding systemd unit |
+
+The wheelhouse must contain exactly one `aptl_labs-*.whl`, and its version must
+equal `APTL_APPLIANCE_VERSION`. Symlinks, unexpected files, empty archives,
+non-wheel wheelhouse entries, and secret environment values are rejected.
+Assemble the reproducible USTAR payload:
+
+```bash
+aptl appliance bundle \
+  --staging-dir build/offline-staging \
+  --output build/inputs/offline-payload.tar
+```
+
+Archive entries are sorted and normalized to root ownership and epoch
+timestamps, so identical staged bytes produce an identical payload digest.
+
+## Build the golden image
+
+Copy `appliance/guest/provision-offline.sh` and
+`appliance/guest/scan-golden.sh` into the contained build root. Prepare a
+strict JSON request with these fields:
+
+| Field | Value |
+| --- | --- |
+| `schema_version` | `aptl.golden-image-build/v1` |
+| `base_image_path`, `base_image_digest` | Safe relative qcow2 path and exact `sha256:` digest |
+| `offline_payload_path`, `offline_payload_digest` | Path ending in `offline-payload.tar` and exact digest |
+| `provisioner_path`, `provisioner_digest` | Offline provisioner and exact digest |
+| `scanner_path`, `scanner_digest` | Clean-golden scanner and exact digest |
+| `output_image_path` | New golden qcow2 path |
+| `inventory_output_path` | New clean-golden inventory path |
+| `virtual_size_bytes` | At least 100 GiB |
+
+Then run:
+
+```bash
+aptl appliance build \
+  --build-root build \
+  --request build/golden-build.json
+```
+
+The command checksum-verifies every input, converts and resizes the base,
+provisions it with `virt-customize --no-network`, removes machine identity,
+SSH host keys, logs, caches, Docker writable state, APTL overlay state, and run
+state with `virt-sysprep`, executes the clean-golden scanner offline, runs
+`qemu-img check`, and publishes the disk and inventory as read-only,
+create-once outputs. A failed candidate cannot replace an existing release.
+
+## Qualify and seal
+
+Stage these nine non-empty release artifacts beneath one release directory:
+
+1. golden disk;
+2. offline payload;
+3. APP-2 participant profile;
+4. APP-2 participant readiness suite;
+5. APP-2 participant asset lock;
+6. signed APP-2 participant qualification report;
+7. APP-1 appliance boundary policy;
+8. clean-golden inventory; and
+9. appliance machine-drill report.
+
+The drill report must contain successful results from at least two distinct
+supported machines. Each must pass the build, offline boot, participant smoke,
+rollback, and overlay-destruction checks. The report also records clean-golden,
+read-only base, distinct-overlay-identity, and failed-candidate-preservation
+results. A release cannot be sealed with placeholders or fewer machines.
+
+Keep the release metadata template, qualification public key, release private
+key, and release public key outside the release directory:
+
+```bash
+aptl appliance prepare \
+  --release-dir dist/appliance/v5.1.1 \
+  --template release-template.json
+
+aptl appliance seal \
+  --release-dir dist/appliance/v5.1.1 \
+  --private-key /secure/release-signing.pem \
+  --qualification-public-key /secure/qualification-public.pem
+
+aptl appliance verify \
+  --release-dir dist/appliance/v5.1.1 \
+  --public-key /etc/aptl/trust/release-public.pem \
+  --qualification-public-key /etc/aptl/trust/qualification-public.pem
+```
+
+Preparation derives artifact sizes and digests from the staged bytes. Sealing
+revalidates all reused contracts and the qualification attestation, then
+creates `SHA256SUMS` and `manifest.sig.json`. Verification checks the signature,
+manifest, checksums, every artifact, all cross-bindings, and all evidence.
+The qualification report must contain the exact duplicate-free readiness check
+set and participant surface declared by the signed profile and readiness suite.
+Consumer verification repeats both the release and independent qualification
+signature checks. Unknown fields, duplicate identifiers or paths, unsafe
+paths, unpinned helper images, a mismatched APTL wheel, or inconsistent evidence
+fail closed.
+
+## Create and run a local instance
+
+Place the verified release under a per-launch directory and create the immutable
+launch projection. The observation ID comes from the authenticated outer
+launcher/host observation:
+
+```bash
+aptl appliance prepare-launch \
+  --release-dir /srv/aptl-appliance/launch/release \
+  --public-key /etc/aptl/trust/release-public.pem \
+  --qualification-public-key /etc/aptl/trust/qualification-public.pem \
+  --host-observation-id sha256:<host-observation-digest> \
+  --output /srv/aptl-appliance/launch/appliance-launch.json
+```
+
+The descriptor carries the verified manifest, payload, policy, helper-image,
+version, and golden-disk identities. It is create-once and read-only. Create an
+overlay request that binds both the golden and descriptor:
+
+```json
+{
+  "schema_version": "aptl.overlay-create/v1",
+  "golden_image_path": "releases/v5.1.1/aptl-golden.qcow2",
+  "golden_image_digest": "sha256:<verified-golden-digest>",
+  "launch_descriptor_path": "launch/appliance-launch.json",
+  "launch_descriptor_digest": "sha256:<launch-descriptor-digest>",
+  "overlay_path": "instances/seat-01.qcow2"
+}
+```
+
+Create the overlay:
+
+```bash
+aptl appliance create-overlay \
+  --appliance-root /srv/aptl-appliance \
+  --request /srv/aptl-appliance/seat-01.json
+```
+
+The command refuses a writable or digest-mismatched golden disk, requires the
+matching launch descriptor, never replaces an existing overlay, and uses fixed
+`qemu-img` arguments with the golden as a qcow2 backing file. Attach only the
+new overlay to QEMU/KVM. Mount the launch directory read-only at
+`/run/aptl-launch`; it contains `appliance-launch.json`, the `release/`
+directory, `release-public.pem`, and `qualification-public.pem`.
+
+The guest's idempotent systemd first-boot service creates unique owner-only
+identity and credentials on the overlay, loads the staged OCI archive once,
+and invokes `aptl lab start --offline-staged` with the descriptor and both trust
+anchors. Startup reverifies the release, qualification, and descriptor, then
+puts the manifest payload digest into `ApplianceBoundaryBinding` before ACES
+network-policy enforcement or service realization. Ordinary reboots reuse the
+overlay identity while repeating release admission.
+
+The local launcher and a hosted importer must attach the exact same verified
+golden payload; provider metadata and the disposable overlay remain outside the
+payload. Hosted per-seat fallback is tracked in issue #825.
+
+## Reset, rollback, and evidence
+
+- Reset: power off the VM and delete only its overlay. Create a new overlay
+  from the same verified golden. Do not delete or modify the golden.
+- Upgrade: verify the newer release, select its golden, and create a new
+  overlay.
+- Rollback: verify the previously retained release, select its golden, and
+  create a new overlay. Never downgrade an existing overlay in place.
+- Failure: leave the active release selected. Candidate build or seal failures
+  are not promoted and cannot replace it.
+
+Retain the tagged source identity, canonical manifest, detached signature,
+`SHA256SUMS`, clean-golden inventory, APP-2 qualification, and two-machine drill
+with the release. These records connect the version and checksums to readiness
+and rollback evidence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
     - DEP-003 Ephemeral Lifecycle Policy Preflight: architecture/dep-003-ephemeral-lifecycle-preflight.md
     - GRC Boundary Surface Vocabulary Preflight: architecture/grc-boundary-surface-vocabulary-preflight.md
     - "Issue #821 In-Appliance Participant Workbench Preflight": architecture/issue-821-participant-workbench-preflight.md
+    - "Issue #823 Versioned Disposable Lab Appliance Preflight": architecture/issue-823-versioned-disposable-appliance-preflight.md
   - Deployment: deployment.md
   - Components:
     - Wazuh SIEM: components/wazuh-siem.md
@@ -118,6 +119,7 @@ nav:
   - Reference:
     - Red Team Taxonomy: red-team-taxonomy.md
     - Guided Purple Participant Profile: reference/participant-profile.md
+    - Disposable Appliance Release: reference/appliance-release.md
     - TechVault Scenario Overview: reference/techvault-scenario-overview.md
     - TechVault Company Profile: reference/techvault-company-profile.md
     - TechVault OSINT Readiness: reference/techvault-osint-readiness.md

--- a/src/aptl/_asset_manifest.py
+++ b/src/aptl/_asset_manifest.py
@@ -43,6 +43,7 @@ ASSET_ROOTS: tuple[str, ...] = (
     "src",
     "scenarios",
     "participant-profiles",
+    "appliance",
     "config",
     "containers",
     "web",

--- a/src/aptl/appliance/__init__.py
+++ b/src/aptl/appliance/__init__.py
@@ -1,0 +1,5 @@
+"""Signed disposable-appliance release contracts."""
+
+from aptl.appliance.models import ApplianceReleaseManifest
+
+__all__ = ["ApplianceReleaseManifest"]

--- a/src/aptl/appliance/bootstrap.py
+++ b/src/aptl/appliance/bootstrap.py
@@ -1,0 +1,122 @@
+"""Idempotent per-overlay identity and bootstrap credential creation."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import secrets
+import stat
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+import rfc8785
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+class ApplianceBootstrapError(RuntimeError):
+    """Per-overlay identity could not be established safely."""
+
+
+class OverlayIdentity(BaseModel):
+    """Guest-only identity created exactly once for one disposable overlay."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["aptl.overlay-identity/v1"]
+    instance_id: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    bootstrap_credential: str = Field(pattern=r"^[A-Za-z0-9_-]{43}$")
+
+
+def _ensure_state_directory(path: Path) -> None:
+    if path.is_symlink():
+        raise ApplianceBootstrapError("overlay state directory must not be a symlink")
+    try:
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+        info = path.stat(follow_symlinks=False)
+    except OSError as exc:
+        raise ApplianceBootstrapError("overlay state directory is unavailable") from exc
+    if not stat.S_ISDIR(info.st_mode):
+        raise ApplianceBootstrapError("overlay state path is not a directory")
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        raise ApplianceBootstrapError("overlay state directory must be owner-only")
+
+
+def _read_existing(path: Path) -> OverlayIdentity:
+    try:
+        info = path.stat(follow_symlinks=False)
+        if stat.S_ISLNK(info.st_mode):
+            raise ApplianceBootstrapError("overlay identity must not be a symlink")
+        if stat.S_IMODE(info.st_mode) != 0o600:
+            raise ApplianceBootstrapError("overlay identity must be owner-only")
+        flags = os.O_RDONLY | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        with os.fdopen(fd, "rb") as handle:
+            payload = handle.read()
+        return OverlayIdentity.model_validate_json(payload)
+    except ApplianceBootstrapError:
+        raise
+    except (OSError, ValidationError, ValueError) as exc:
+        raise ApplianceBootstrapError("overlay identity is invalid") from exc
+
+
+def _new_identity(entropy: Callable[[int], bytes]) -> OverlayIdentity:
+    identity_bytes = entropy(32)
+    credential_bytes = entropy(32)
+    if len(identity_bytes) != 32 or len(credential_bytes) != 32:
+        raise ApplianceBootstrapError("overlay entropy source returned invalid data")
+    return OverlayIdentity(
+        schema_version="aptl.overlay-identity/v1",
+        instance_id=f"sha256:{hashlib.sha256(identity_bytes).hexdigest()}",
+        bootstrap_credential=base64.urlsafe_b64encode(credential_bytes)
+        .decode("ascii")
+        .rstrip("="),
+    )
+
+
+def _persist_create_once(path: Path, identity: OverlayIdentity) -> bool:
+    temporary = path.with_name(f".identity.{os.getpid()}-{secrets.token_hex(8)}")
+    payload = rfc8785.dumps(identity.model_dump(mode="json"))
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(temporary, flags, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, path, follow_symlinks=False)
+            return True
+        except FileExistsError:
+            return False
+    except OSError as exc:
+        raise ApplianceBootstrapError(
+            "overlay identity could not be persisted"
+        ) from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def initialize_overlay_state(
+    state_dir: Path,
+    *,
+    entropy: Callable[[int], bytes] = os.urandom,
+) -> OverlayIdentity:
+    """Create identity once per overlay and reuse it on ordinary reboot."""
+
+    _ensure_state_directory(state_dir)
+    identity_path = state_dir / "identity.json"
+    if identity_path.exists() or identity_path.is_symlink():
+        return _read_existing(identity_path)
+    candidate = _new_identity(entropy)
+    if _persist_create_once(identity_path, candidate):
+        return candidate
+    return _read_existing(identity_path)

--- a/src/aptl/appliance/bootstrap.py
+++ b/src/aptl/appliance/bootstrap.py
@@ -30,6 +30,8 @@ class OverlayIdentity(BaseModel):
 
 
 def _ensure_state_directory(path: Path) -> None:
+    """Create or validate an owner-only overlay state directory."""
+
     if path.is_symlink():
         raise ApplianceBootstrapError("overlay state directory must not be a symlink")
     try:
@@ -44,6 +46,8 @@ def _ensure_state_directory(path: Path) -> None:
 
 
 def _read_existing(path: Path) -> OverlayIdentity:
+    """Load an existing owner-only identity without following symlinks."""
+
     try:
         info = path.stat(follow_symlinks=False)
         if stat.S_ISLNK(info.st_mode):
@@ -64,6 +68,8 @@ def _read_existing(path: Path) -> OverlayIdentity:
 
 
 def _new_identity(entropy: Callable[[int], bytes]) -> OverlayIdentity:
+    """Derive a fresh identity and credential from an injected entropy source."""
+
     identity_bytes = entropy(32)
     credential_bytes = entropy(32)
     if len(identity_bytes) != 32 or len(credential_bytes) != 32:
@@ -78,6 +84,8 @@ def _new_identity(entropy: Callable[[int], bytes]) -> OverlayIdentity:
 
 
 def _persist_create_once(path: Path, identity: OverlayIdentity) -> bool:
+    """Atomically publish an identity unless another initializer won the race."""
+
     temporary = path.with_name(f".identity.{os.getpid()}-{secrets.token_hex(8)}")
     payload = rfc8785.dumps(identity.model_dump(mode="json"))
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC

--- a/src/aptl/appliance/build.py
+++ b/src/aptl/appliance/build.py
@@ -1,0 +1,394 @@
+"""Fixed-argument offline construction of an immutable QEMU golden image."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal, Protocol
+
+import rfc8785
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from aptl.appliance.models import ApplianceLaunchDescriptor, GoldenImageInventory
+
+
+class ApplianceBuildError(RuntimeError):
+    """A golden image could not be built without weakening its contract."""
+
+
+def _safe_relative_path(value: str) -> str:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or "\\" in value
+        or "//" in value
+        or value.startswith("./")
+        or path.is_absolute()
+        or str(path) != value
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError("build path must be a safe relative POSIX path")
+    return value
+
+
+class GoldenImageBuildRequest(BaseModel):
+    """Checksum-pinned inputs for one offline, replacement-only image build."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["aptl.golden-image-build/v1"]
+    base_image_path: str
+    base_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    offline_payload_path: str
+    offline_payload_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    provisioner_path: str
+    provisioner_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    scanner_path: str
+    scanner_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    output_image_path: str
+    inventory_output_path: str
+    virtual_size_bytes: int = Field(ge=100 * 1024**3)
+
+    @field_validator(
+        "base_image_path",
+        "offline_payload_path",
+        "provisioner_path",
+        "scanner_path",
+        "output_image_path",
+        "inventory_output_path",
+    )
+    @classmethod
+    def validate_paths(cls, value: str) -> str:
+        return _safe_relative_path(value)
+
+    @field_validator("offline_payload_path")
+    @classmethod
+    def validate_offline_payload_name(cls, value: str) -> str:
+        if PurePosixPath(value).name != "offline-payload.tar":
+            raise ValueError("offline payload path must end in offline-payload.tar")
+        return value
+
+
+class OverlayCreateRequest(BaseModel):
+    """Content-pinned local-KVM disposable-overlay request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["aptl.overlay-create/v1"]
+    golden_image_path: str
+    golden_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    launch_descriptor_path: str
+    launch_descriptor_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    overlay_path: str
+
+    @field_validator("golden_image_path", "launch_descriptor_path", "overlay_path")
+    @classmethod
+    def validate_paths(cls, value: str) -> str:
+        return _safe_relative_path(value)
+
+
+@dataclass(frozen=True)
+class GoldenImageBuildResult:
+    """Safe identity of the finalized immutable candidate."""
+
+    output_path: Path
+    inventory_path: Path
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class OverlayCreateResult:
+    """Safe identity of one newly created mutable overlay."""
+
+    overlay_path: Path
+    golden_image_digest: str
+
+
+class CommandRunner(Protocol):
+    """Injectable fixed-argv subprocess boundary."""
+
+    def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]: ...
+
+
+def _run_command(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=3600,
+    )
+
+
+def _verified_input(
+    root: Path,
+    relative_path: str,
+    expected_digest: str,
+    *,
+    label: str,
+) -> Path:
+    try:
+        path = root / relative_path
+        parent = path.parent.resolve(strict=True)
+        if not parent.is_relative_to(root):
+            raise ValueError("input escapes build root")
+        resolved = parent / path.name
+        actual, _ = _file_identity(resolved, nofollow=True)
+    except (OSError, ValueError) as exc:
+        raise ApplianceBuildError(f"unsafe {label} path") from exc
+    if actual != expected_digest:
+        raise ApplianceBuildError(f"{label} digest does not match")
+    return resolved
+
+
+def _output_path(root: Path, relative_path: str) -> Path:
+    output = root / relative_path
+    parent = output.parent
+    parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        resolved_parent = parent.resolve(strict=True)
+    except OSError as exc:
+        raise ApplianceBuildError("golden image output parent is unsafe") from exc
+    if not resolved_parent.is_relative_to(root):
+        raise ApplianceBuildError("golden image output escapes the build root")
+    return resolved_parent / output.name
+
+
+def _build_commands(
+    base: Path,
+    payload: Path,
+    provisioner: Path,
+    scanner: Path,
+    candidate: Path,
+    virtual_size_bytes: int,
+) -> tuple[list[str], ...]:
+    return (
+        [
+            "qemu-img",
+            "convert",
+            "-f",
+            "qcow2",
+            "-O",
+            "qcow2",
+            str(base),
+            str(candidate),
+        ],
+        ["qemu-img", "resize", str(candidate), str(virtual_size_bytes)],
+        [
+            "virt-customize",
+            "-a",
+            str(candidate),
+            "--no-network",
+            "--mkdir",
+            "/opt/aptl-stage",
+            "--copy-in",
+            f"{payload}:/opt/aptl-stage",
+            "--run",
+            str(provisioner),
+        ],
+        [
+            "virt-sysprep",
+            "-a",
+            str(candidate),
+            "--operations",
+            "machine-id,ssh-hostkeys,logfiles,tmp-files,package-manager-cache",
+            "--delete",
+            "/var/lib/docker/*",
+            "--delete",
+            "/var/lib/aptl/*",
+            "--delete",
+            "/opt/aptl/project/.aptl/*",
+        ],
+        [
+            "virt-customize",
+            "-a",
+            str(candidate),
+            "--no-network",
+            "--run",
+            str(scanner),
+        ],
+        ["qemu-img", "check", "-q", str(candidate)],
+    )
+
+
+def _file_identity(path: Path, *, nofollow: bool = False) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if nofollow and hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags)
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        os.close(fd)
+        raise OSError("appliance input is not a regular file")
+    with os.fdopen(fd, "rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return f"sha256:{digest.hexdigest()}", size
+
+
+def build_golden_image(
+    build_root: Path,
+    request: GoldenImageBuildRequest,
+    *,
+    runner: CommandRunner = _run_command,
+) -> GoldenImageBuildResult:
+    """Create a new read-only image; never edit or replace an existing release."""
+
+    root = build_root.resolve()
+    base = _verified_input(
+        root,
+        request.base_image_path,
+        request.base_image_digest,
+        label="base image",
+    )
+    payload = _verified_input(
+        root,
+        request.offline_payload_path,
+        request.offline_payload_digest,
+        label="offline payload",
+    )
+    provisioner = _verified_input(
+        root,
+        request.provisioner_path,
+        request.provisioner_digest,
+        label="provisioner",
+    )
+    scanner = _verified_input(
+        root,
+        request.scanner_path,
+        request.scanner_digest,
+        label="golden image scanner",
+    )
+    output = _output_path(root, request.output_image_path)
+    inventory_output = _output_path(root, request.inventory_output_path)
+    if (
+        output.exists()
+        or output.is_symlink()
+        or inventory_output.exists()
+        or inventory_output.is_symlink()
+    ):
+        raise ApplianceBuildError("golden image output already exists")
+    candidate = output.with_name(f"{output.name}.candidate-{secrets.token_hex(8)}")
+    inventory_candidate = inventory_output.with_name(
+        f"{inventory_output.name}.candidate-{secrets.token_hex(8)}"
+    )
+    inventory_linked = False
+    try:
+        for argv in _build_commands(
+            base,
+            payload,
+            provisioner,
+            scanner,
+            candidate,
+            request.virtual_size_bytes,
+        ):
+            runner(argv)
+        if not candidate.is_file() or candidate.is_symlink():
+            raise ApplianceBuildError("golden image candidate was not produced")
+        inventory = GoldenImageInventory(
+            schema_version="aptl.golden-inventory/v1",
+            scan_complete=True,
+            populated_sensitive_paths=(),
+            writable_runtime_paths=(),
+        )
+        inventory_candidate.write_bytes(
+            rfc8785.dumps(inventory.model_dump(mode="json"))
+        )
+        digest, size = _file_identity(candidate, nofollow=True)
+        candidate.chmod(0o444)
+        inventory_candidate.chmod(0o444)
+        os.link(inventory_candidate, inventory_output, follow_symlinks=False)
+        inventory_linked = True
+        os.link(candidate, output, follow_symlinks=False)
+        return GoldenImageBuildResult(
+            output_path=output,
+            inventory_path=inventory_output,
+            sha256=digest,
+            size_bytes=size,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        if inventory_linked and not output.exists():
+            try:
+                inventory_output.unlink()
+            except OSError:
+                pass
+        raise ApplianceBuildError("golden image build failed") from exc
+    finally:
+        for path in (candidate, inventory_candidate):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def create_disposable_overlay(
+    appliance_root: Path,
+    request: OverlayCreateRequest,
+    *,
+    runner: CommandRunner = _run_command,
+) -> OverlayCreateResult:
+    """Create one qcow2 overlay without opening the golden base for writing."""
+
+    root = appliance_root.resolve()
+    golden = _verified_input(
+        root,
+        request.golden_image_path,
+        request.golden_image_digest,
+        label="golden image",
+    )
+    if golden.stat(follow_symlinks=False).st_mode & 0o222:
+        raise ApplianceBuildError("golden image must be read-only")
+    launch_path = _verified_input(
+        root,
+        request.launch_descriptor_path,
+        request.launch_descriptor_digest,
+        label="launch descriptor",
+    )
+    try:
+        launch = ApplianceLaunchDescriptor.model_validate_json(launch_path.read_bytes())
+    except (OSError, ValueError) as exc:
+        raise ApplianceBuildError("launch descriptor is invalid") from exc
+    if launch.golden_image_digest != request.golden_image_digest:
+        raise ApplianceBuildError("launch descriptor does not match the golden image")
+    overlay = _output_path(root, request.overlay_path)
+    if overlay.exists() or overlay.is_symlink():
+        raise ApplianceBuildError("disposable overlay output already exists")
+    candidate = overlay.with_name(f"{overlay.name}.candidate-{secrets.token_hex(8)}")
+    try:
+        runner(
+            [
+                "qemu-img",
+                "create",
+                "-f",
+                "qcow2",
+                "-F",
+                "qcow2",
+                "-b",
+                str(golden),
+                str(candidate),
+            ]
+        )
+        runner(["qemu-img", "check", "-q", str(candidate)])
+        if not candidate.is_file() or candidate.is_symlink():
+            raise ApplianceBuildError("disposable overlay candidate was not produced")
+        candidate.chmod(0o600)
+        os.link(candidate, overlay, follow_symlinks=False)
+        return OverlayCreateResult(
+            overlay_path=overlay,
+            golden_image_digest=request.golden_image_digest,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise ApplianceBuildError("disposable overlay creation failed") from exc
+    finally:
+        try:
+            candidate.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/src/aptl/appliance/build.py
+++ b/src/aptl/appliance/build.py
@@ -16,12 +16,16 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from aptl.appliance.models import ApplianceLaunchDescriptor, GoldenImageInventory
 
+_SHA256_PATTERN = r"^sha256:[a-f0-9]{64}$"
+
 
 class ApplianceBuildError(RuntimeError):
     """A golden image could not be built without weakening its contract."""
 
 
 def _safe_relative_path(value: str) -> str:
+    """Validate a contained, normalized POSIX request path."""
+
     path = PurePosixPath(value)
     if (
         not value
@@ -43,13 +47,13 @@ class GoldenImageBuildRequest(BaseModel):
 
     schema_version: Literal["aptl.golden-image-build/v1"]
     base_image_path: str
-    base_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    base_image_digest: str = Field(pattern=_SHA256_PATTERN)
     offline_payload_path: str
-    offline_payload_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    offline_payload_digest: str = Field(pattern=_SHA256_PATTERN)
     provisioner_path: str
-    provisioner_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    provisioner_digest: str = Field(pattern=_SHA256_PATTERN)
     scanner_path: str
-    scanner_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    scanner_digest: str = Field(pattern=_SHA256_PATTERN)
     output_image_path: str
     inventory_output_path: str
     virtual_size_bytes: int = Field(ge=100 * 1024**3)
@@ -81,9 +85,9 @@ class OverlayCreateRequest(BaseModel):
 
     schema_version: Literal["aptl.overlay-create/v1"]
     golden_image_path: str
-    golden_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    golden_image_digest: str = Field(pattern=_SHA256_PATTERN)
     launch_descriptor_path: str
-    launch_descriptor_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    launch_descriptor_digest: str = Field(pattern=_SHA256_PATTERN)
     overlay_path: str
 
     @field_validator("golden_image_path", "launch_descriptor_path", "overlay_path")
@@ -117,6 +121,8 @@ class CommandRunner(Protocol):
 
 
 def _run_command(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run one fixed-argument image tool command with bounded capture."""
+
     return subprocess.run(
         argv,
         check=True,
@@ -133,6 +139,8 @@ def _verified_input(
     *,
     label: str,
 ) -> Path:
+    """Resolve and digest-check a regular contained build input."""
+
     try:
         path = root / relative_path
         parent = path.parent.resolve(strict=True)
@@ -148,6 +156,8 @@ def _verified_input(
 
 
 def _output_path(root: Path, relative_path: str) -> Path:
+    """Resolve an output beneath a create-once owner-only parent."""
+
     output = root / relative_path
     parent = output.parent
     parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -168,6 +178,8 @@ def _build_commands(
     candidate: Path,
     virtual_size_bytes: int,
 ) -> tuple[list[str], ...]:
+    """Return the complete fixed-argument offline image build sequence."""
+
     return (
         [
             "qemu-img",
@@ -218,6 +230,8 @@ def _build_commands(
 
 
 def _file_identity(path: Path, *, nofollow: bool = False) -> tuple[str, int]:
+    """Stream one regular file into its SHA-256 identity and size."""
+
     digest = hashlib.sha256()
     size = 0
     flags = os.O_RDONLY | os.O_CLOEXEC
@@ -234,6 +248,50 @@ def _file_identity(path: Path, *, nofollow: bool = False) -> tuple[str, int]:
     return f"sha256:{digest.hexdigest()}", size
 
 
+def _build_inputs(
+    root: Path,
+    request: GoldenImageBuildRequest,
+) -> tuple[Path, Path, Path, Path]:
+    """Resolve and verify every checksum-pinned build input."""
+
+    return (
+        _verified_input(
+            root,
+            request.base_image_path,
+            request.base_image_digest,
+            label="base image",
+        ),
+        _verified_input(
+            root,
+            request.offline_payload_path,
+            request.offline_payload_digest,
+            label="offline payload",
+        ),
+        _verified_input(
+            root,
+            request.provisioner_path,
+            request.provisioner_digest,
+            label="provisioner",
+        ),
+        _verified_input(
+            root,
+            request.scanner_path,
+            request.scanner_digest,
+            label="golden image scanner",
+        ),
+    )
+
+
+def _remove_candidates(paths: tuple[Path, ...]) -> None:
+    """Best-effort remove build candidates without masking the build result."""
+
+    for path in paths:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 def build_golden_image(
     build_root: Path,
     request: GoldenImageBuildRequest,
@@ -243,30 +301,7 @@ def build_golden_image(
     """Create a new read-only image; never edit or replace an existing release."""
 
     root = build_root.resolve()
-    base = _verified_input(
-        root,
-        request.base_image_path,
-        request.base_image_digest,
-        label="base image",
-    )
-    payload = _verified_input(
-        root,
-        request.offline_payload_path,
-        request.offline_payload_digest,
-        label="offline payload",
-    )
-    provisioner = _verified_input(
-        root,
-        request.provisioner_path,
-        request.provisioner_digest,
-        label="provisioner",
-    )
-    scanner = _verified_input(
-        root,
-        request.scanner_path,
-        request.scanner_digest,
-        label="golden image scanner",
-    )
+    base, payload, provisioner, scanner = _build_inputs(root, request)
     output = _output_path(root, request.output_image_path)
     inventory_output = _output_path(root, request.inventory_output_path)
     if (
@@ -322,11 +357,7 @@ def build_golden_image(
                 pass
         raise ApplianceBuildError("golden image build failed") from exc
     finally:
-        for path in (candidate, inventory_candidate):
-            try:
-                path.unlink(missing_ok=True)
-            except OSError:
-                pass
+        _remove_candidates((candidate, inventory_candidate))
 
 
 def create_disposable_overlay(

--- a/src/aptl/appliance/build.py
+++ b/src/aptl/appliance/build.py
@@ -14,7 +14,8 @@ from typing import Literal, Protocol
 import rfc8785
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from aptl.appliance.models import ApplianceLaunchDescriptor, GoldenImageInventory
+from aptl.appliance.models import GoldenImageInventory
+from aptl.appliance.release_models import ApplianceLaunchDescriptor
 
 _SHA256_PATTERN = r"^sha256:[a-f0-9]{64}$"
 

--- a/src/aptl/appliance/errors.py
+++ b/src/aptl/appliance/errors.py
@@ -1,0 +1,5 @@
+"""Shared appliance release errors."""
+
+
+class ApplianceManifestError(ValueError):
+    """The appliance manifest or its release signature is invalid."""

--- a/src/aptl/appliance/launch.py
+++ b/src/aptl/appliance/launch.py
@@ -47,6 +47,8 @@ def _derive_descriptor(
     release_dir: str,
     host_observation_id: str,
 ) -> ApplianceLaunchDescriptor:
+    """Project signed release and host identities into a launch descriptor."""
+
     by_kind = {artifact.kind: artifact for artifact in manifest.artifacts}
     return ApplianceLaunchDescriptor(
         schema_version="aptl.appliance-launch/v1",

--- a/src/aptl/appliance/launch.py
+++ b/src/aptl/appliance/launch.py
@@ -1,0 +1,153 @@
+"""Verified create-once launch projection for appliance first boot."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import rfc8785
+from pydantic import ValidationError
+
+from aptl.appliance.manifest import (
+    ApplianceManifestError,
+    ApplianceReleaseInspection,
+    _load_release_documents,
+    _read_external_file,
+    _read_release_artifact,
+    _write_create_once,
+    verify_release_directory,
+)
+from aptl.appliance.models import (
+    ApplianceLaunchDescriptor,
+    ApplianceReleaseManifest,
+)
+from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
+
+
+@dataclass(frozen=True)
+class VerifiedApplianceLaunch:
+    """Authenticated runtime inputs consumed before scenario realization."""
+
+    descriptor: ApplianceLaunchDescriptor
+    release_root: Path
+    boundary_policy: ApplianceBoundaryPolicy
+
+
+def canonical_launch_bytes(descriptor: ApplianceLaunchDescriptor) -> bytes:
+    """Return deterministic bytes for one verified launch projection."""
+
+    return rfc8785.dumps(descriptor.model_dump(mode="json"))
+
+
+def _derive_descriptor(
+    manifest: ApplianceReleaseManifest,
+    inspection: ApplianceReleaseInspection,
+    *,
+    release_dir: str,
+    host_observation_id: str,
+) -> ApplianceLaunchDescriptor:
+    by_kind = {artifact.kind: artifact for artifact in manifest.artifacts}
+    return ApplianceLaunchDescriptor(
+        schema_version="aptl.appliance-launch/v1",
+        release_dir=release_dir,
+        release_id=manifest.release_id,
+        aptl_version=manifest.source.aptl_version,
+        manifest_digest=inspection.manifest_digest,
+        payload_digest=manifest.payload_digest,
+        golden_image_digest=by_kind["golden-disk"].sha256,
+        boundary_policy_path=by_kind["boundary-policy"].path,
+        boundary_policy_digest=manifest.boundary.policy_digest,
+        boundary_helper_image=manifest.boundary.boundary_helper_image,
+        egress_proxy_image=manifest.boundary.egress_proxy_image,
+        participant_routes_digest=manifest.delivery.participant_routes_digest,
+        host_observation_id=host_observation_id,
+    )
+
+
+def prepare_launch_descriptor(
+    release_dir: Path,
+    release_public_key_path: Path,
+    qualification_public_key_path: Path,
+    output_path: Path,
+    *,
+    host_observation_id: str,
+) -> ApplianceLaunchDescriptor:
+    """Verify a release and atomically publish its runtime launch projection."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    output_parent = output_path.parent.resolve()
+    release_root = release_dir.resolve()
+    try:
+        release_relative = release_root.relative_to(output_parent).as_posix()
+    except ValueError as exc:
+        raise ApplianceManifestError(
+            "launch release directory must be beneath the descriptor directory"
+        ) from exc
+    inspection = verify_release_directory(
+        release_root,
+        release_public_key_path,
+        qualification_public_key_path=qualification_public_key_path,
+    )
+    manifest, _ = _load_release_documents(release_root)
+    descriptor = _derive_descriptor(
+        manifest,
+        inspection,
+        release_dir=release_relative,
+        host_observation_id=host_observation_id,
+    )
+    _write_create_once(output_path, canonical_launch_bytes(descriptor), mode=0o444)
+    return descriptor
+
+
+def verify_launch_descriptor(
+    descriptor_path: Path,
+    release_public_key_path: Path,
+    qualification_public_key_path: Path,
+) -> VerifiedApplianceLaunch:
+    """Reverify the attached release and exact launch projection in the guest."""
+
+    try:
+        descriptor = ApplianceLaunchDescriptor.model_validate_json(
+            _read_external_file(descriptor_path, label="appliance launch descriptor")
+        )
+    except (ValidationError, ValueError) as exc:
+        raise ApplianceManifestError("invalid appliance launch descriptor") from exc
+    launch_root = descriptor_path.parent.resolve()
+    release_root = (launch_root / descriptor.release_dir).resolve()
+    if not release_root.is_relative_to(launch_root):
+        raise ApplianceManifestError("appliance launch release path is unsafe")
+    inspection = verify_release_directory(
+        release_root,
+        release_public_key_path,
+        qualification_public_key_path=qualification_public_key_path,
+    )
+    manifest, _ = _load_release_documents(release_root)
+    expected = _derive_descriptor(
+        manifest,
+        inspection,
+        release_dir=descriptor.release_dir,
+        host_observation_id=descriptor.host_observation_id,
+    )
+    if descriptor != expected:
+        raise ApplianceManifestError(
+            "appliance launch descriptor does not match the verified release"
+        )
+    policy_payload = _read_release_artifact(
+        release_root,
+        descriptor.boundary_policy_path,
+    )
+    if (
+        f"sha256:{hashlib.sha256(policy_payload).hexdigest()}"
+        != descriptor.boundary_policy_digest
+    ):
+        raise ApplianceManifestError(
+            "appliance launch boundary policy does not match the release"
+        )
+    try:
+        policy = ApplianceBoundaryPolicy.model_validate_json(policy_payload)
+    except ValueError as exc:
+        raise ApplianceManifestError(
+            "appliance launch boundary policy is invalid"
+        ) from exc
+    return VerifiedApplianceLaunch(descriptor, release_root, policy)

--- a/src/aptl/appliance/launch.py
+++ b/src/aptl/appliance/launch.py
@@ -18,10 +18,8 @@ from aptl.appliance.manifest import (
     _write_create_once,
     verify_release_directory,
 )
-from aptl.appliance.models import (
-    ApplianceLaunchDescriptor,
-    ApplianceReleaseManifest,
-)
+from aptl.appliance.models import ApplianceReleaseManifest
+from aptl.appliance.release_models import ApplianceLaunchDescriptor
 from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
 
 

--- a/src/aptl/appliance/manifest.py
+++ b/src/aptl/appliance/manifest.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import io
 import os
-import re
 import secrets
-import tarfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -20,6 +17,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PublicKey,
 )
 
+from aptl.appliance.errors import ApplianceManifestError
 from aptl.appliance.models import (
     ApplianceBoundaryReleaseBinding,
     ApplianceDrillReport,
@@ -28,25 +26,24 @@ from aptl.appliance.models import (
     ApplianceReleaseTemplate,
     ArtifactKind,
     ArtifactReference,
-    GoldenImageInventory,
     ParticipantReleaseBinding,
 )
-from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
-from aptl.utils.pathsafe import PathContainmentError, read_contained_nofollow
-from aptl.validation.participant_profile_models import (
-    ParticipantAssetLock,
-    ParticipantProfileManifest,
-    ParticipantReadinessSuite,
+from aptl.appliance.release_validation import (
+    compute_payload_digest,
+    read_release_artifact as _read_release_artifact,
+    verify_artifacts as _verify_artifacts,
+    verify_offline_aptl_version as _verify_offline_aptl_version,
+    verify_release_evidence as _verify_release_evidence,
 )
+from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
 from aptl.validation.participant_qualification_evidence import (
-    ParticipantQualificationError,
     ParticipantQualificationReport,
     verify_participant_qualification_attestation,
 )
 
-
-class ApplianceManifestError(ValueError):
-    """The appliance manifest or its release signature is invalid."""
+_MANIFEST_NAME = "manifest.json"
+_SIGNATURE_NAME = "manifest.sig.json"
+_MISSING_RELEASE = "appliance release directory is missing"
 
 
 @dataclass(frozen=True)
@@ -71,47 +68,6 @@ def canonical_manifest_bytes(manifest: ApplianceReleaseManifest) -> bytes:
     return rfc8785.dumps(manifest.model_dump(mode="json"))
 
 
-_PAYLOAD_KINDS = frozenset(
-    {
-        "golden-disk",
-        "offline-payload",
-        "participant-profile",
-        "participant-readiness",
-        "participant-asset-lock",
-        "participant-qualification",
-        "boundary-policy",
-    }
-)
-
-
-def compute_payload_digest(artifacts: tuple[ArtifactReference, ...]) -> str:
-    """Bind guest bytes and reused APP-1/APP-2 identities into one digest."""
-
-    projection = [
-        {
-            "artifact_id": artifact.artifact_id,
-            "kind": artifact.kind,
-            "path": artifact.path,
-            "sha256": artifact.sha256,
-            "size_bytes": artifact.size_bytes,
-        }
-        for artifact in sorted(artifacts, key=lambda item: item.artifact_id)
-        if artifact.kind in _PAYLOAD_KINDS
-    ]
-    if {item["kind"] for item in projection} != _PAYLOAD_KINDS:
-        raise ApplianceManifestError("payload artifact set is incomplete")
-    return f"sha256:{hashlib.sha256(rfc8785.dumps(projection)).hexdigest()}"
-
-
-def _read_release_artifact(root: Path, relative_path: str) -> bytes:
-    try:
-        return read_contained_nofollow(root, relative_path)
-    except (OSError, PathContainmentError, ValueError) as exc:
-        raise ApplianceManifestError(
-            f"unsafe release artifact: {relative_path}"
-        ) from exc
-
-
 def describe_artifact(
     root: Path,
     *,
@@ -134,6 +90,8 @@ def describe_artifact(
 
 
 def _read_external_file(path: Path, *, label: str) -> bytes:
+    """Read an external trust input without following its final symlink."""
+
     try:
         flags = os.O_RDONLY | os.O_CLOEXEC
         if hasattr(os, "O_NOFOLLOW"):
@@ -146,6 +104,8 @@ def _read_external_file(path: Path, *, label: str) -> bytes:
 
 
 def _public_key_id(key: Ed25519PublicKey) -> str:
+    """Return the stable SHA-256 identity of an Ed25519 public key."""
+
     der = key.public_bytes(
         encoding=serialization.Encoding.DER,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
@@ -206,146 +166,16 @@ def verify_manifest_signature(
 def _load_release_documents(
     release_root: Path,
 ) -> tuple[ApplianceReleaseManifest, ApplianceManifestSignature]:
-    manifest_bytes = _read_release_artifact(release_root, "manifest.json")
-    signature_bytes = _read_release_artifact(release_root, "manifest.sig.json")
+    """Parse the canonical manifest and detached signature documents."""
+
+    manifest_bytes = _read_release_artifact(release_root, _MANIFEST_NAME)
+    signature_bytes = _read_release_artifact(release_root, _SIGNATURE_NAME)
     try:
         manifest = ApplianceReleaseManifest.model_validate_json(manifest_bytes)
         signature = ApplianceManifestSignature.model_validate_json(signature_bytes)
     except ValueError as exc:
         raise ApplianceManifestError("invalid appliance release document") from exc
     return manifest, signature
-
-
-def _verify_artifacts(
-    release_root: Path,
-    manifest: ApplianceReleaseManifest,
-) -> dict[ArtifactKind, bytes]:
-    payloads: dict[ArtifactKind, bytes] = {}
-    for artifact in manifest.artifacts:
-        payload = _read_release_artifact(release_root, artifact.path)
-        actual_digest = f"sha256:{hashlib.sha256(payload).hexdigest()}"
-        if actual_digest != artifact.sha256 or len(payload) != artifact.size_bytes:
-            raise ApplianceManifestError(
-                f"release artifact digest mismatch: {artifact.artifact_id}"
-            )
-        payloads[artifact.kind] = payload
-    if compute_payload_digest(manifest.artifacts) != manifest.payload_digest:
-        raise ApplianceManifestError("release payload digest mismatch")
-    return payloads
-
-
-def _verify_release_evidence(
-    manifest: ApplianceReleaseManifest,
-    payloads: dict[ArtifactKind, bytes],
-) -> None:
-    try:
-        profile = ParticipantProfileManifest.model_validate_json(
-            payloads["participant-profile"]
-        )
-        readiness = ParticipantReadinessSuite.model_validate_json(
-            payloads["participant-readiness"]
-        )
-        asset_lock = ParticipantAssetLock.model_validate_json(
-            payloads["participant-asset-lock"]
-        )
-        qualification = ParticipantQualificationReport.model_validate_json(
-            payloads["participant-qualification"]
-        )
-        ApplianceBoundaryPolicy.model_validate_json(payloads["boundary-policy"])
-        GoldenImageInventory.model_validate_json(payloads["golden-inventory"])
-        drill = ApplianceDrillReport.model_validate_json(payloads["machine-drill"])
-    except ValueError as exc:
-        raise ApplianceManifestError("invalid appliance release evidence") from exc
-    profile_digest = hashlib.sha256(payloads["participant-profile"]).hexdigest()
-    readiness_digest = hashlib.sha256(payloads["participant-readiness"]).hexdigest()
-    asset_lock_digest = hashlib.sha256(payloads["participant-asset-lock"]).hexdigest()
-    participant_matches = (
-        profile.profile_id == manifest.participant.profile_id
-        and profile.version == manifest.participant.profile_version
-        and profile.readiness.sha256 == readiness_digest
-        and manifest.participant.readiness_suite_digest == f"sha256:{readiness_digest}"
-        and asset_lock.profile_id == profile.profile_id
-        and asset_lock.profile_version == profile.version
-        and profile.release_evidence.asset_lock_sha256 == asset_lock_digest
-        and qualification.profile_id == profile.profile_id
-        and qualification.profile_version == profile.version
-        and qualification.profile_sha256 == profile_digest
-        and qualification.asset_lock_digest == f"sha256:{asset_lock_digest}"
-    )
-    offline = qualification.offline
-    required_checks = {check.check_id for check in readiness.checks}
-    observed_checks = {check.check_id for check in qualification.checks}
-    expected_workbenches = {
-        profile_id.value for profile_id in profile.capabilities.workbench_profiles
-    }
-    expected_mcp = {
-        check.subject_id for check in readiness.checks if check.kind == "mcp-tool"
-    }
-    expected_browser = {
-        check.subject_id
-        for check in readiness.checks
-        if check.kind == "browser-operation"
-    }
-    surface = qualification.surface
-    qualification_passed = (
-        participant_matches
-        and observed_checks == required_checks
-        and all(check.status == "passed" for check in qualification.checks)
-        and set(surface.actual_workbench_profiles) == expected_workbenches
-        and set(surface.actual_mcp_servers) == expected_mcp
-        and set(surface.actual_browser_capabilities) == expected_browser
-        and set(surface.actual_services) == set(surface.expected_services)
-        and set(surface.actual_networks) == set(surface.expected_networks)
-        and offline.egress_denied
-        and offline.download_attempts == 0
-        and offline.image_pulls == 0
-        and offline.image_builds == 0
-        and offline.package_resolutions == 0
-    )
-    if not qualification_passed:
-        raise ApplianceManifestError(
-            "participant qualification evidence does not match the release"
-        )
-    if drill != manifest.qualification:
-        raise ApplianceManifestError("machine drill evidence does not match manifest")
-
-
-_APTL_WHEEL_RE = re.compile(
-    r"^wheelhouse/aptl_labs-([0-9]+(?:\.[0-9]+){2}(?:[a-z0-9.+_]*)?)"
-    r"-[^/]+\.whl$"
-)
-
-
-def _verify_offline_aptl_version(
-    payload: bytes,
-    expected_version: str,
-) -> None:
-    """Bind the one staged APTL wheel and release env to the signed version."""
-
-    try:
-        with tarfile.open(fileobj=io.BytesIO(payload), mode="r:") as archive:
-            wheels = [
-                match.group(1).replace("_", "-")
-                for member in archive.getmembers()
-                if (match := _APTL_WHEEL_RE.fullmatch(member.name)) is not None
-                and member.isfile()
-            ]
-            env_member = archive.getmember("appliance-release.env")
-            env_file = archive.extractfile(env_member)
-            if env_file is None:
-                raise KeyError("appliance-release.env")
-            env_text = env_file.read().decode("utf-8")
-    except (KeyError, OSError, UnicodeDecodeError, tarfile.TarError) as exc:
-        raise ApplianceManifestError(
-            "offline payload release identity is invalid"
-        ) from exc
-    version_line = f"APTL_APPLIANCE_VERSION={expected_version}\n"
-    if wheels != [expected_version] or version_line not in env_text.splitlines(
-        keepends=True
-    ):
-        raise ApplianceManifestError(
-            "offline payload APTL version does not match the release"
-        )
 
 
 def prepare_release_manifest(
@@ -356,7 +186,7 @@ def prepare_release_manifest(
 
     release_root = release_dir.resolve()
     if not release_root.is_dir():
-        raise ApplianceManifestError("appliance release directory is missing")
+        raise ApplianceManifestError(_MISSING_RELEASE)
     try:
         resolved_template = template_path.resolve(strict=True)
     except OSError as exc:
@@ -422,15 +252,15 @@ def prepare_release_manifest(
     )
     _verify_release_evidence(manifest, payloads)
     manifest_bytes = canonical_manifest_bytes(manifest)
-    manifest_path = release_root / "manifest.json"
+    manifest_path = release_root / _MANIFEST_NAME
     if manifest_path.exists() or manifest_path.is_symlink():
-        existing = _read_release_artifact(release_root, "manifest.json")
-        if existing == manifest_bytes:
-            return manifest
-        raise ApplianceManifestError(
-            "release manifest already exists with different content"
-        )
-    _write_create_once(manifest_path, manifest_bytes, mode=0o644)
+        existing = _read_release_artifact(release_root, _MANIFEST_NAME)
+        if existing != manifest_bytes:
+            raise ApplianceManifestError(
+                "release manifest already exists with different content"
+            )
+    else:
+        _write_create_once(manifest_path, manifest_bytes, mode=0o644)
     return manifest
 
 
@@ -440,12 +270,14 @@ def _release_checksum_payload(
     *,
     signature_bytes: bytes | None = None,
 ) -> bytes:
-    paths = ["manifest.json", "manifest.sig.json"] + [
+    """Render the deterministic checksum file, optionally before sealing."""
+
+    paths = [_MANIFEST_NAME, _SIGNATURE_NAME] + [
         artifact.path for artifact in manifest.artifacts
     ]
     lines: list[str] = []
     for relative_path in sorted(paths):
-        if relative_path == "manifest.sig.json" and signature_bytes is not None:
+        if relative_path == _SIGNATURE_NAME and signature_bytes is not None:
             payload = signature_bytes
         else:
             payload = _read_release_artifact(release_root, relative_path)
@@ -454,6 +286,8 @@ def _release_checksum_payload(
 
 
 def _write_create_once(path: Path, payload: bytes, *, mode: int) -> None:
+    """Persist immutable release bytes without replacing an existing path."""
+
     temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}")
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
@@ -485,6 +319,8 @@ def _write_create_once(path: Path, payload: bytes, *, mode: int) -> None:
 
 
 def _inspection(manifest: ApplianceReleaseManifest) -> ApplianceReleaseInspection:
+    """Project a verified manifest into its safe operator-facing identity."""
+
     canonical = canonical_manifest_bytes(manifest)
     prerequisites = manifest.host_prerequisites
     return ApplianceReleaseInspection(
@@ -511,7 +347,7 @@ def seal_release_directory(
 
     release_root = release_dir.resolve()
     if not release_root.is_dir():
-        raise ApplianceManifestError("appliance release directory is missing")
+        raise ApplianceManifestError(_MISSING_RELEASE)
     try:
         key_path = private_key_path.resolve(strict=True)
     except OSError as exc:
@@ -530,10 +366,10 @@ def seal_release_directory(
         raise ApplianceManifestError(
             "participant qualification trust anchor must remain outside the release"
         )
-    signature_path = release_root / "manifest.sig.json"
+    signature_path = release_root / _SIGNATURE_NAME
     if signature_path.exists() or signature_path.is_symlink():
         raise ApplianceManifestError("appliance release is already sealed")
-    manifest_bytes = _read_release_artifact(release_root, "manifest.json")
+    manifest_bytes = _read_release_artifact(release_root, _MANIFEST_NAME)
     try:
         manifest = ApplianceReleaseManifest.model_validate_json(manifest_bytes)
     except ValueError as exc:
@@ -557,18 +393,11 @@ def seal_release_directory(
                 label="participant qualification trust anchor",
             ),
         )
-    except (
-        OSError,
-        ParticipantQualificationError,
-        ValueError,
-    ) as exc:
+    except (OSError, ValueError) as exc:
         raise ApplianceManifestError(
             "participant qualification attestation is invalid"
         ) from exc
-    try:
-        private_key_pem = _read_external_file(key_path, label="release signing key")
-    except ApplianceManifestError:
-        raise
+    private_key_pem = _read_external_file(key_path, label="release signing key")
     signature = sign_manifest(manifest, private_key_pem)
     signature_bytes = rfc8785.dumps(signature.model_dump(mode="json"))
     checksums = _release_checksum_payload(
@@ -585,6 +414,8 @@ def _verify_checksum_file(
     release_root: Path,
     manifest: ApplianceReleaseManifest,
 ) -> None:
+    """Require SHA256SUMS to match the exact sealed release bytes."""
+
     actual = _read_release_artifact(release_root, "SHA256SUMS")
     expected = _release_checksum_payload(release_root, manifest)
     if actual != expected:
@@ -601,14 +432,11 @@ def verify_release_directory(
 
     release_root = release_dir.resolve()
     if not release_root.is_dir():
-        raise ApplianceManifestError("appliance release directory is missing")
-    try:
-        public_key_pem = _read_external_file(
-            public_key_path,
-            label="release trust anchor",
-        )
-    except ApplianceManifestError:
-        raise
+        raise ApplianceManifestError(_MISSING_RELEASE)
+    public_key_pem = _read_external_file(
+        public_key_path,
+        label="release trust anchor",
+    )
     manifest, signature = _load_release_documents(release_root)
     verify_manifest_signature(manifest, signature, public_key_pem)
     payloads = _verify_artifacts(release_root, manifest)
@@ -628,7 +456,7 @@ def verify_release_directory(
                 label="participant qualification trust anchor",
             ),
         )
-    except (ParticipantQualificationError, ValueError) as exc:
+    except ValueError as exc:
         raise ApplianceManifestError(
             "participant qualification attestation is invalid"
         ) from exc

--- a/src/aptl/appliance/manifest.py
+++ b/src/aptl/appliance/manifest.py
@@ -1,0 +1,636 @@
+"""Canonical serialization and Ed25519 verification for appliance releases."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import os
+import re
+import secrets
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from aptl.appliance.models import (
+    ApplianceBoundaryReleaseBinding,
+    ApplianceDrillReport,
+    ApplianceManifestSignature,
+    ApplianceReleaseManifest,
+    ApplianceReleaseTemplate,
+    ArtifactKind,
+    ArtifactReference,
+    GoldenImageInventory,
+    ParticipantReleaseBinding,
+)
+from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
+from aptl.utils.pathsafe import PathContainmentError, read_contained_nofollow
+from aptl.validation.participant_profile_models import (
+    ParticipantAssetLock,
+    ParticipantProfileManifest,
+    ParticipantReadinessSuite,
+)
+from aptl.validation.participant_qualification_evidence import (
+    ParticipantQualificationError,
+    ParticipantQualificationReport,
+    verify_participant_qualification_attestation,
+)
+
+
+class ApplianceManifestError(ValueError):
+    """The appliance manifest or its release signature is invalid."""
+
+
+@dataclass(frozen=True)
+class ApplianceReleaseInspection:
+    """Safe host/readiness projection from a fully verified release."""
+
+    release_id: str
+    aptl_version: str
+    source_commit: str
+    manifest_digest: str
+    payload_digest: str
+    artifact_count: int
+    architecture: str
+    minimum_host_vcpus: int
+    minimum_host_memory_bytes: int
+    minimum_host_disk_bytes: int
+
+
+def canonical_manifest_bytes(manifest: ApplianceReleaseManifest) -> bytes:
+    """Return RFC 8785 bytes for the closed release manifest."""
+
+    return rfc8785.dumps(manifest.model_dump(mode="json"))
+
+
+_PAYLOAD_KINDS = frozenset(
+    {
+        "golden-disk",
+        "offline-payload",
+        "participant-profile",
+        "participant-readiness",
+        "participant-asset-lock",
+        "participant-qualification",
+        "boundary-policy",
+    }
+)
+
+
+def compute_payload_digest(artifacts: tuple[ArtifactReference, ...]) -> str:
+    """Bind guest bytes and reused APP-1/APP-2 identities into one digest."""
+
+    projection = [
+        {
+            "artifact_id": artifact.artifact_id,
+            "kind": artifact.kind,
+            "path": artifact.path,
+            "sha256": artifact.sha256,
+            "size_bytes": artifact.size_bytes,
+        }
+        for artifact in sorted(artifacts, key=lambda item: item.artifact_id)
+        if artifact.kind in _PAYLOAD_KINDS
+    ]
+    if {item["kind"] for item in projection} != _PAYLOAD_KINDS:
+        raise ApplianceManifestError("payload artifact set is incomplete")
+    return f"sha256:{hashlib.sha256(rfc8785.dumps(projection)).hexdigest()}"
+
+
+def _read_release_artifact(root: Path, relative_path: str) -> bytes:
+    try:
+        return read_contained_nofollow(root, relative_path)
+    except (OSError, PathContainmentError, ValueError) as exc:
+        raise ApplianceManifestError(
+            f"unsafe release artifact: {relative_path}"
+        ) from exc
+
+
+def describe_artifact(
+    root: Path,
+    *,
+    artifact_id: str,
+    kind: ArtifactKind,
+    path: str,
+) -> ArtifactReference:
+    """Read one contained input once and return its exact release identity."""
+
+    payload = _read_release_artifact(root.resolve(), path)
+    if not payload:
+        raise ApplianceManifestError(f"release artifact is empty: {path}")
+    return ArtifactReference(
+        artifact_id=artifact_id,
+        kind=kind,
+        path=path,
+        sha256=f"sha256:{hashlib.sha256(payload).hexdigest()}",
+        size_bytes=len(payload),
+    )
+
+
+def _read_external_file(path: Path, *, label: str) -> bytes:
+    try:
+        flags = os.O_RDONLY | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        with os.fdopen(fd, "rb") as handle:
+            return handle.read()
+    except OSError as exc:
+        raise ApplianceManifestError(f"{label} is unavailable") from exc
+
+
+def _public_key_id(key: Ed25519PublicKey) -> str:
+    der = key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return f"sha256:{hashlib.sha256(der).hexdigest()}"
+
+
+def sign_manifest(
+    manifest: ApplianceReleaseManifest,
+    private_key_pem: bytes,
+) -> ApplianceManifestSignature:
+    """Sign canonical manifest bytes without persisting private key material."""
+
+    try:
+        key = serialization.load_pem_private_key(private_key_pem, password=None)
+    except (TypeError, ValueError, UnsupportedAlgorithm) as exc:
+        raise ApplianceManifestError("release signing key is invalid") from exc
+    if not isinstance(key, Ed25519PrivateKey):
+        raise ApplianceManifestError("release signing key must be Ed25519")
+    payload = canonical_manifest_bytes(manifest)
+    return ApplianceManifestSignature(
+        schema_version="aptl.appliance-signature/v1",
+        algorithm="ed25519",
+        key_id=_public_key_id(key.public_key()),
+        manifest_digest=f"sha256:{hashlib.sha256(payload).hexdigest()}",
+        signature=base64.b64encode(key.sign(payload)).decode("ascii"),
+    )
+
+
+def verify_manifest_signature(
+    manifest: ApplianceReleaseManifest,
+    signature: ApplianceManifestSignature,
+    public_key_pem: bytes,
+) -> None:
+    """Verify the manifest against a separately configured trust anchor."""
+
+    try:
+        key = serialization.load_pem_public_key(public_key_pem)
+    except (TypeError, ValueError, UnsupportedAlgorithm) as exc:
+        raise ApplianceManifestError("release trust anchor is invalid") from exc
+    if not isinstance(key, Ed25519PublicKey):
+        raise ApplianceManifestError("release trust anchor must be Ed25519")
+    if signature.key_id != _public_key_id(key):
+        raise ApplianceManifestError(
+            "release signature does not match the trust anchor"
+        )
+    payload = canonical_manifest_bytes(manifest)
+    digest = f"sha256:{hashlib.sha256(payload).hexdigest()}"
+    if signature.manifest_digest != digest:
+        raise ApplianceManifestError("release manifest signature digest mismatch")
+    try:
+        raw_signature = base64.b64decode(signature.signature, validate=True)
+        key.verify(raw_signature, payload)
+    except (InvalidSignature, ValueError) as exc:
+        raise ApplianceManifestError("release manifest signature is invalid") from exc
+
+
+def _load_release_documents(
+    release_root: Path,
+) -> tuple[ApplianceReleaseManifest, ApplianceManifestSignature]:
+    manifest_bytes = _read_release_artifact(release_root, "manifest.json")
+    signature_bytes = _read_release_artifact(release_root, "manifest.sig.json")
+    try:
+        manifest = ApplianceReleaseManifest.model_validate_json(manifest_bytes)
+        signature = ApplianceManifestSignature.model_validate_json(signature_bytes)
+    except ValueError as exc:
+        raise ApplianceManifestError("invalid appliance release document") from exc
+    return manifest, signature
+
+
+def _verify_artifacts(
+    release_root: Path,
+    manifest: ApplianceReleaseManifest,
+) -> dict[ArtifactKind, bytes]:
+    payloads: dict[ArtifactKind, bytes] = {}
+    for artifact in manifest.artifacts:
+        payload = _read_release_artifact(release_root, artifact.path)
+        actual_digest = f"sha256:{hashlib.sha256(payload).hexdigest()}"
+        if actual_digest != artifact.sha256 or len(payload) != artifact.size_bytes:
+            raise ApplianceManifestError(
+                f"release artifact digest mismatch: {artifact.artifact_id}"
+            )
+        payloads[artifact.kind] = payload
+    if compute_payload_digest(manifest.artifacts) != manifest.payload_digest:
+        raise ApplianceManifestError("release payload digest mismatch")
+    return payloads
+
+
+def _verify_release_evidence(
+    manifest: ApplianceReleaseManifest,
+    payloads: dict[ArtifactKind, bytes],
+) -> None:
+    try:
+        profile = ParticipantProfileManifest.model_validate_json(
+            payloads["participant-profile"]
+        )
+        readiness = ParticipantReadinessSuite.model_validate_json(
+            payloads["participant-readiness"]
+        )
+        asset_lock = ParticipantAssetLock.model_validate_json(
+            payloads["participant-asset-lock"]
+        )
+        qualification = ParticipantQualificationReport.model_validate_json(
+            payloads["participant-qualification"]
+        )
+        ApplianceBoundaryPolicy.model_validate_json(payloads["boundary-policy"])
+        GoldenImageInventory.model_validate_json(payloads["golden-inventory"])
+        drill = ApplianceDrillReport.model_validate_json(payloads["machine-drill"])
+    except ValueError as exc:
+        raise ApplianceManifestError("invalid appliance release evidence") from exc
+    profile_digest = hashlib.sha256(payloads["participant-profile"]).hexdigest()
+    readiness_digest = hashlib.sha256(payloads["participant-readiness"]).hexdigest()
+    asset_lock_digest = hashlib.sha256(payloads["participant-asset-lock"]).hexdigest()
+    participant_matches = (
+        profile.profile_id == manifest.participant.profile_id
+        and profile.version == manifest.participant.profile_version
+        and profile.readiness.sha256 == readiness_digest
+        and manifest.participant.readiness_suite_digest == f"sha256:{readiness_digest}"
+        and asset_lock.profile_id == profile.profile_id
+        and asset_lock.profile_version == profile.version
+        and profile.release_evidence.asset_lock_sha256 == asset_lock_digest
+        and qualification.profile_id == profile.profile_id
+        and qualification.profile_version == profile.version
+        and qualification.profile_sha256 == profile_digest
+        and qualification.asset_lock_digest == f"sha256:{asset_lock_digest}"
+    )
+    offline = qualification.offline
+    required_checks = {check.check_id for check in readiness.checks}
+    observed_checks = {check.check_id for check in qualification.checks}
+    expected_workbenches = {
+        profile_id.value for profile_id in profile.capabilities.workbench_profiles
+    }
+    expected_mcp = {
+        check.subject_id for check in readiness.checks if check.kind == "mcp-tool"
+    }
+    expected_browser = {
+        check.subject_id
+        for check in readiness.checks
+        if check.kind == "browser-operation"
+    }
+    surface = qualification.surface
+    qualification_passed = (
+        participant_matches
+        and observed_checks == required_checks
+        and all(check.status == "passed" for check in qualification.checks)
+        and set(surface.actual_workbench_profiles) == expected_workbenches
+        and set(surface.actual_mcp_servers) == expected_mcp
+        and set(surface.actual_browser_capabilities) == expected_browser
+        and set(surface.actual_services) == set(surface.expected_services)
+        and set(surface.actual_networks) == set(surface.expected_networks)
+        and offline.egress_denied
+        and offline.download_attempts == 0
+        and offline.image_pulls == 0
+        and offline.image_builds == 0
+        and offline.package_resolutions == 0
+    )
+    if not qualification_passed:
+        raise ApplianceManifestError(
+            "participant qualification evidence does not match the release"
+        )
+    if drill != manifest.qualification:
+        raise ApplianceManifestError("machine drill evidence does not match manifest")
+
+
+_APTL_WHEEL_RE = re.compile(
+    r"^wheelhouse/aptl_labs-([0-9]+(?:\.[0-9]+){2}(?:[a-z0-9.+_]*)?)"
+    r"-[^/]+\.whl$"
+)
+
+
+def _verify_offline_aptl_version(
+    payload: bytes,
+    expected_version: str,
+) -> None:
+    """Bind the one staged APTL wheel and release env to the signed version."""
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(payload), mode="r:") as archive:
+            wheels = [
+                match.group(1).replace("_", "-")
+                for member in archive.getmembers()
+                if (match := _APTL_WHEEL_RE.fullmatch(member.name)) is not None
+                and member.isfile()
+            ]
+            env_member = archive.getmember("appliance-release.env")
+            env_file = archive.extractfile(env_member)
+            if env_file is None:
+                raise KeyError("appliance-release.env")
+            env_text = env_file.read().decode("utf-8")
+    except (KeyError, OSError, UnicodeDecodeError, tarfile.TarError) as exc:
+        raise ApplianceManifestError(
+            "offline payload release identity is invalid"
+        ) from exc
+    version_line = f"APTL_APPLIANCE_VERSION={expected_version}\n"
+    if wheels != [expected_version] or version_line not in env_text.splitlines(
+        keepends=True
+    ):
+        raise ApplianceManifestError(
+            "offline payload APTL version does not match the release"
+        )
+
+
+def prepare_release_manifest(
+    release_dir: Path,
+    template_path: Path,
+) -> ApplianceReleaseManifest:
+    """Derive every content identity from staged bytes and write canonically."""
+
+    release_root = release_dir.resolve()
+    if not release_root.is_dir():
+        raise ApplianceManifestError("appliance release directory is missing")
+    try:
+        resolved_template = template_path.resolve(strict=True)
+    except OSError as exc:
+        raise ApplianceManifestError("release template is unavailable") from exc
+    if resolved_template.is_relative_to(release_root):
+        raise ApplianceManifestError(
+            "release template must remain outside the release directory"
+        )
+    try:
+        template = ApplianceReleaseTemplate.model_validate_json(
+            _read_external_file(resolved_template, label="release template")
+        )
+    except ValueError as exc:
+        raise ApplianceManifestError("invalid appliance release template") from exc
+    artifacts = tuple(
+        describe_artifact(
+            release_root,
+            artifact_id=staged.artifact_id,
+            kind=staged.kind,
+            path=staged.path,
+        )
+        for staged in template.artifacts
+    )
+    by_kind = {artifact.kind: artifact for artifact in artifacts}
+    try:
+        qualification = ApplianceDrillReport.model_validate_json(
+            _read_release_artifact(
+                release_root,
+                by_kind["machine-drill"].path,
+            )
+        )
+    except ValueError as exc:
+        raise ApplianceManifestError("invalid appliance release evidence") from exc
+    manifest = ApplianceReleaseManifest(
+        schema_version="aptl.appliance-release/v1",
+        release_id=template.release_id,
+        source=template.source,
+        guest=template.guest,
+        artifacts=artifacts,
+        payload_digest=compute_payload_digest(artifacts),
+        participant=ParticipantReleaseBinding(
+            profile_id=template.participant.profile_id,
+            profile_version=template.participant.profile_version,
+            profile_manifest_digest=by_kind["participant-profile"].sha256,
+            readiness_suite_digest=by_kind["participant-readiness"].sha256,
+            asset_lock_digest=by_kind["participant-asset-lock"].sha256,
+            qualification_report_digest=by_kind["participant-qualification"].sha256,
+        ),
+        boundary=ApplianceBoundaryReleaseBinding(
+            policy_digest=by_kind["boundary-policy"].sha256,
+            boundary_helper_image=template.boundary.boundary_helper_image,
+            egress_proxy_image=template.boundary.egress_proxy_image,
+        ),
+        host_prerequisites=template.host_prerequisites,
+        delivery=template.delivery,
+        qualification=qualification,
+        upgrade_strategy=template.upgrade_strategy,
+    )
+    payloads = _verify_artifacts(release_root, manifest)
+    _verify_offline_aptl_version(
+        payloads["offline-payload"],
+        manifest.source.aptl_version,
+    )
+    _verify_release_evidence(manifest, payloads)
+    manifest_bytes = canonical_manifest_bytes(manifest)
+    manifest_path = release_root / "manifest.json"
+    if manifest_path.exists() or manifest_path.is_symlink():
+        existing = _read_release_artifact(release_root, "manifest.json")
+        if existing == manifest_bytes:
+            return manifest
+        raise ApplianceManifestError(
+            "release manifest already exists with different content"
+        )
+    _write_create_once(manifest_path, manifest_bytes, mode=0o644)
+    return manifest
+
+
+def _release_checksum_payload(
+    release_root: Path,
+    manifest: ApplianceReleaseManifest,
+    *,
+    signature_bytes: bytes | None = None,
+) -> bytes:
+    paths = ["manifest.json", "manifest.sig.json"] + [
+        artifact.path for artifact in manifest.artifacts
+    ]
+    lines: list[str] = []
+    for relative_path in sorted(paths):
+        if relative_path == "manifest.sig.json" and signature_bytes is not None:
+            payload = signature_bytes
+        else:
+            payload = _read_release_artifact(release_root, relative_path)
+        lines.append(f"{hashlib.sha256(payload).hexdigest()}  {relative_path}")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _write_create_once(path: Path, payload: bytes, *, mode: int) -> None:
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(temporary, flags, mode)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode, follow_symlinks=False)
+        try:
+            os.link(temporary, path, follow_symlinks=False)
+        except FileExistsError as exc:
+            existing = _read_release_artifact(path.parent, path.name)
+            if existing != payload:
+                raise ApplianceManifestError(
+                    f"release seal artifact already exists: {path.name}"
+                ) from exc
+    except ApplianceManifestError:
+        raise
+    except OSError as exc:
+        raise ApplianceManifestError("release seal could not be persisted") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _inspection(manifest: ApplianceReleaseManifest) -> ApplianceReleaseInspection:
+    canonical = canonical_manifest_bytes(manifest)
+    prerequisites = manifest.host_prerequisites
+    return ApplianceReleaseInspection(
+        release_id=manifest.release_id,
+        aptl_version=manifest.source.aptl_version,
+        source_commit=manifest.source.source_commit,
+        manifest_digest=f"sha256:{hashlib.sha256(canonical).hexdigest()}",
+        payload_digest=manifest.payload_digest,
+        artifact_count=len(manifest.artifacts),
+        architecture=manifest.guest.architecture,
+        minimum_host_vcpus=prerequisites.vcpus,
+        minimum_host_memory_bytes=prerequisites.memory_bytes,
+        minimum_host_disk_bytes=prerequisites.disk_bytes,
+    )
+
+
+def seal_release_directory(
+    release_dir: Path,
+    private_key_path: Path,
+    *,
+    qualification_public_key_path: Path,
+) -> ApplianceReleaseInspection:
+    """Validate and atomically seal a staged release with an external key."""
+
+    release_root = release_dir.resolve()
+    if not release_root.is_dir():
+        raise ApplianceManifestError("appliance release directory is missing")
+    try:
+        key_path = private_key_path.resolve(strict=True)
+    except OSError as exc:
+        raise ApplianceManifestError("release signing key is unavailable") from exc
+    if key_path.is_relative_to(release_root):
+        raise ApplianceManifestError(
+            "release signing key must remain outside the release directory"
+        )
+    try:
+        qualification_key_path = qualification_public_key_path.resolve(strict=True)
+    except OSError as exc:
+        raise ApplianceManifestError(
+            "participant qualification trust anchor is unavailable"
+        ) from exc
+    if qualification_key_path.is_relative_to(release_root):
+        raise ApplianceManifestError(
+            "participant qualification trust anchor must remain outside the release"
+        )
+    signature_path = release_root / "manifest.sig.json"
+    if signature_path.exists() or signature_path.is_symlink():
+        raise ApplianceManifestError("appliance release is already sealed")
+    manifest_bytes = _read_release_artifact(release_root, "manifest.json")
+    try:
+        manifest = ApplianceReleaseManifest.model_validate_json(manifest_bytes)
+    except ValueError as exc:
+        raise ApplianceManifestError("invalid appliance release document") from exc
+    if manifest_bytes != canonical_manifest_bytes(manifest):
+        raise ApplianceManifestError("appliance release manifest is not canonical")
+    payloads = _verify_artifacts(release_root, manifest)
+    _verify_offline_aptl_version(
+        payloads["offline-payload"],
+        manifest.source.aptl_version,
+    )
+    _verify_release_evidence(manifest, payloads)
+    try:
+        qualification = ParticipantQualificationReport.model_validate_json(
+            payloads["participant-qualification"]
+        )
+        verify_participant_qualification_attestation(
+            qualification,
+            _read_external_file(
+                qualification_key_path,
+                label="participant qualification trust anchor",
+            ),
+        )
+    except (
+        OSError,
+        ParticipantQualificationError,
+        ValueError,
+    ) as exc:
+        raise ApplianceManifestError(
+            "participant qualification attestation is invalid"
+        ) from exc
+    try:
+        private_key_pem = _read_external_file(key_path, label="release signing key")
+    except ApplianceManifestError:
+        raise
+    signature = sign_manifest(manifest, private_key_pem)
+    signature_bytes = rfc8785.dumps(signature.model_dump(mode="json"))
+    checksums = _release_checksum_payload(
+        release_root,
+        manifest,
+        signature_bytes=signature_bytes,
+    )
+    _write_create_once(release_root / "SHA256SUMS", checksums, mode=0o644)
+    _write_create_once(signature_path, signature_bytes, mode=0o644)
+    return _inspection(manifest)
+
+
+def _verify_checksum_file(
+    release_root: Path,
+    manifest: ApplianceReleaseManifest,
+) -> None:
+    actual = _read_release_artifact(release_root, "SHA256SUMS")
+    expected = _release_checksum_payload(release_root, manifest)
+    if actual != expected:
+        raise ApplianceManifestError("release checksum file does not match artifacts")
+
+
+def verify_release_directory(
+    release_dir: Path,
+    public_key_path: Path,
+    *,
+    qualification_public_key_path: Path,
+) -> ApplianceReleaseInspection:
+    """Verify signature, payload, every artifact, and clean-base evidence."""
+
+    release_root = release_dir.resolve()
+    if not release_root.is_dir():
+        raise ApplianceManifestError("appliance release directory is missing")
+    try:
+        public_key_pem = _read_external_file(
+            public_key_path,
+            label="release trust anchor",
+        )
+    except ApplianceManifestError:
+        raise
+    manifest, signature = _load_release_documents(release_root)
+    verify_manifest_signature(manifest, signature, public_key_pem)
+    payloads = _verify_artifacts(release_root, manifest)
+    _verify_offline_aptl_version(
+        payloads["offline-payload"],
+        manifest.source.aptl_version,
+    )
+    _verify_release_evidence(manifest, payloads)
+    try:
+        qualification = ParticipantQualificationReport.model_validate_json(
+            payloads["participant-qualification"]
+        )
+        verify_participant_qualification_attestation(
+            qualification,
+            _read_external_file(
+                qualification_public_key_path,
+                label="participant qualification trust anchor",
+            ),
+        )
+    except (ParticipantQualificationError, ValueError) as exc:
+        raise ApplianceManifestError(
+            "participant qualification attestation is invalid"
+        ) from exc
+    _verify_checksum_file(release_root, manifest)
+    return _inspection(manifest)

--- a/src/aptl/appliance/manifest.py
+++ b/src/aptl/appliance/manifest.py
@@ -23,11 +23,11 @@ from aptl.appliance.models import (
     ApplianceDrillReport,
     ApplianceManifestSignature,
     ApplianceReleaseManifest,
-    ApplianceReleaseTemplate,
     ArtifactKind,
     ArtifactReference,
     ParticipantReleaseBinding,
 )
+from aptl.appliance.release_models import ApplianceReleaseTemplate
 from aptl.appliance.release_validation import (
     compute_payload_digest,
     read_release_artifact as _read_release_artifact,
@@ -35,7 +35,6 @@ from aptl.appliance.release_validation import (
     verify_offline_aptl_version as _verify_offline_aptl_version,
     verify_release_evidence as _verify_release_evidence,
 )
-from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
 from aptl.validation.participant_qualification_evidence import (
     ParticipantQualificationReport,
     verify_participant_qualification_attestation,

--- a/src/aptl/appliance/models.py
+++ b/src/aptl/appliance/models.py
@@ -14,10 +14,11 @@ from pydantic import (
     model_validator,
 )
 
+from aptl.appliance.versioning import is_appliance_version
+
 _DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
 _IMAGE_DIGEST_RE = re.compile(r"^[a-z0-9][a-z0-9._/:~-]{0,254}@sha256:[a-f0-9]{64}$")
 _COMMIT_RE = re.compile(r"^[a-f0-9]{40}(?:[a-f0-9]{24})?$")
-_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+[a-z0-9.+-]*$")
 _IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
 
 ArtifactKind = Literal[
@@ -120,7 +121,7 @@ class ReleaseSource(_StrictModel):
     @field_validator("aptl_version")
     @classmethod
     def validate_version(cls, value: str) -> str:
-        if not _VERSION_RE.fullmatch(value):
+        if not is_appliance_version(value):
             raise ValueError("invalid APTL release version")
         return value
 
@@ -425,12 +426,3 @@ class ApplianceManifestSignature(_StrictModel):
     @classmethod
     def validate_digests(cls, value: str) -> str:
         return _validate_digest(value)
-
-
-from aptl.appliance.release_models import (  # noqa: E402
-    ApplianceLaunchDescriptor as ApplianceLaunchDescriptor,
-    ApplianceReleaseTemplate as ApplianceReleaseTemplate,
-    BoundaryTemplateBinding as BoundaryTemplateBinding,
-    ParticipantTemplateBinding as ParticipantTemplateBinding,
-    StagedArtifact as StagedArtifact,
-)

--- a/src/aptl/appliance/models.py
+++ b/src/aptl/appliance/models.py
@@ -17,7 +17,7 @@ from pydantic import (
 _DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
 _IMAGE_DIGEST_RE = re.compile(r"^[a-z0-9][a-z0-9._/:~-]{0,254}@sha256:[a-f0-9]{64}$")
 _COMMIT_RE = re.compile(r"^[a-f0-9]{40}(?:[a-f0-9]{24})?$")
-_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+){2}(?:[a-z0-9.+-]*)?$")
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+[a-z0-9.+-]*$")
 _IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
 
 ArtifactKind = Literal[
@@ -53,18 +53,24 @@ class _StrictModel(BaseModel):
 
 
 def _validate_digest(value: str) -> str:
+    """Validate a canonical lowercase SHA-256 identity."""
+
     if not _DIGEST_RE.fullmatch(value):
         raise ValueError("digest must be sha256 followed by lowercase hexadecimal")
     return value
 
 
 def _validate_identifier(value: str) -> str:
+    """Validate a bounded lowercase release identifier."""
+
     if not _IDENTIFIER_RE.fullmatch(value):
         raise ValueError("invalid release identifier")
     return value
 
 
 def _validate_relative_path(value: str) -> str:
+    """Validate a normalized relative POSIX path."""
+
     path = PurePosixPath(value)
     if (
         not value
@@ -421,122 +427,10 @@ class ApplianceManifestSignature(_StrictModel):
         return _validate_digest(value)
 
 
-class StagedArtifact(_StrictModel):
-    """One release input whose digest and size are derived during preparation."""
-
-    artifact_id: str
-    kind: ArtifactKind
-    path: str
-
-    @field_validator("artifact_id")
-    @classmethod
-    def validate_artifact_id(cls, value: str) -> str:
-        return _validate_identifier(value)
-
-    @field_validator("path")
-    @classmethod
-    def validate_path(cls, value: str) -> str:
-        return _validate_relative_path(value)
-
-
-class ParticipantTemplateBinding(_StrictModel):
-    """APP-2 identity; preparation derives all content digests."""
-
-    profile_id: str
-    profile_version: int = Field(ge=1)
-
-    @field_validator("profile_id")
-    @classmethod
-    def validate_profile_id(cls, value: str) -> str:
-        return _validate_identifier(value)
-
-
-class BoundaryTemplateBinding(_StrictModel):
-    """APP-1 helper identities; preparation derives the policy digest."""
-
-    boundary_helper_image: str
-    egress_proxy_image: str
-
-    @field_validator("boundary_helper_image", "egress_proxy_image")
-    @classmethod
-    def validate_image_digest(cls, value: str) -> str:
-        if not _IMAGE_DIGEST_RE.fullmatch(value):
-            raise ValueError("release helper images must use immutable digests")
-        return value
-
-
-class ApplianceReleaseTemplate(_StrictModel):
-    """Human-authored release metadata separated from derived identities."""
-
-    schema_version: Literal["aptl.appliance-release-template/v1"]
-    release_id: str
-    source: ReleaseSource
-    guest: ApplianceGuest
-    artifacts: tuple[StagedArtifact, ...]
-    participant: ParticipantTemplateBinding
-    boundary: BoundaryTemplateBinding
-    host_prerequisites: HostPrerequisites
-    delivery: DeliveryParity
-    upgrade_strategy: Literal["replace-golden-create-overlay"]
-
-    @field_validator("release_id")
-    @classmethod
-    def validate_release_id(cls, value: str) -> str:
-        return _validate_identifier(value)
-
-    @model_validator(mode="after")
-    def validate_template(self) -> ApplianceReleaseTemplate:
-        ids = [artifact.artifact_id for artifact in self.artifacts]
-        paths = [artifact.path for artifact in self.artifacts]
-        kinds = [artifact.kind for artifact in self.artifacts]
-        if len(ids) != len(set(ids)) or len(paths) != len(set(paths)):
-            raise ValueError("staged artifact ids and paths must be unique")
-        if set(kinds) != _REQUIRED_ARTIFACT_KINDS or len(kinds) != len(
-            _REQUIRED_ARTIFACT_KINDS
-        ):
-            raise ValueError("template does not contain the required artifact kinds")
-        if self.guest.architecture != self.host_prerequisites.architecture:
-            raise ValueError("guest and host architecture must match")
-        return self
-
-
-class ApplianceLaunchDescriptor(_StrictModel):
-    """Create-once projection that carries a verified release into first boot."""
-
-    schema_version: Literal["aptl.appliance-launch/v1"]
-    release_dir: str
-    release_id: str
-    aptl_version: str
-    manifest_digest: str
-    payload_digest: str
-    golden_image_digest: str
-    boundary_policy_path: str
-    boundary_policy_digest: str
-    boundary_helper_image: str
-    egress_proxy_image: str
-    participant_routes_digest: str
-    host_observation_id: str
-
-    @field_validator("release_dir", "boundary_policy_path")
-    @classmethod
-    def validate_paths(cls, value: str) -> str:
-        return _validate_relative_path(value)
-
-    @field_validator(
-        "manifest_digest",
-        "payload_digest",
-        "golden_image_digest",
-        "boundary_policy_digest",
-        "participant_routes_digest",
-        "host_observation_id",
-    )
-    @classmethod
-    def validate_launch_digests(cls, value: str) -> str:
-        return _validate_digest(value)
-
-    @field_validator("boundary_helper_image", "egress_proxy_image")
-    @classmethod
-    def validate_launch_images(cls, value: str) -> str:
-        if not _IMAGE_DIGEST_RE.fullmatch(value):
-            raise ValueError("launch helper images must use immutable digests")
-        return value
+from aptl.appliance.release_models import (  # noqa: E402
+    ApplianceLaunchDescriptor as ApplianceLaunchDescriptor,
+    ApplianceReleaseTemplate as ApplianceReleaseTemplate,
+    BoundaryTemplateBinding as BoundaryTemplateBinding,
+    ParticipantTemplateBinding as ParticipantTemplateBinding,
+    StagedArtifact as StagedArtifact,
+)

--- a/src/aptl/appliance/models.py
+++ b/src/aptl/appliance/models.py
@@ -1,0 +1,542 @@
+"""Strict models for the signed disposable-appliance release envelope."""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+from typing import Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+_DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+_IMAGE_DIGEST_RE = re.compile(r"^[a-z0-9][a-z0-9._/:~-]{0,254}@sha256:[a-f0-9]{64}$")
+_COMMIT_RE = re.compile(r"^[a-f0-9]{40}(?:[a-f0-9]{24})?$")
+_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+){2}(?:[a-z0-9.+-]*)?$")
+_IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+
+ArtifactKind = Literal[
+    "golden-disk",
+    "offline-payload",
+    "participant-profile",
+    "participant-readiness",
+    "participant-asset-lock",
+    "participant-qualification",
+    "boundary-policy",
+    "golden-inventory",
+    "machine-drill",
+]
+_REQUIRED_ARTIFACT_KINDS = frozenset(
+    {
+        "golden-disk",
+        "offline-payload",
+        "participant-profile",
+        "participant-readiness",
+        "participant-asset-lock",
+        "participant-qualification",
+        "boundary-policy",
+        "golden-inventory",
+        "machine-drill",
+    }
+)
+
+
+class _StrictModel(BaseModel):
+    """Immutable closed record used at the release trust boundary."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+def _validate_digest(value: str) -> str:
+    if not _DIGEST_RE.fullmatch(value):
+        raise ValueError("digest must be sha256 followed by lowercase hexadecimal")
+    return value
+
+
+def _validate_identifier(value: str) -> str:
+    if not _IDENTIFIER_RE.fullmatch(value):
+        raise ValueError("invalid release identifier")
+    return value
+
+
+def _validate_relative_path(value: str) -> str:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or "\\" in value
+        or "//" in value
+        or value.startswith("./")
+        or path.is_absolute()
+        or str(path) != value
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError("artifact path must be a safe relative POSIX path")
+    return value
+
+
+class ArtifactReference(_StrictModel):
+    """One content-addressed file contained by the release directory."""
+
+    artifact_id: str
+    kind: ArtifactKind
+    path: str
+    sha256: str
+    size_bytes: int = Field(ge=1)
+
+    @field_validator("artifact_id")
+    @classmethod
+    def validate_artifact_id(cls, value: str) -> str:
+        return _validate_identifier(value)
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        return _validate_relative_path(value)
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_sha256(cls, value: str) -> str:
+        return _validate_digest(value)
+
+
+class ReleaseSource(_StrictModel):
+    """Immutable source identity resolved by the release pipeline."""
+
+    aptl_version: str
+    source_tag: str
+    source_commit: str
+
+    @field_validator("aptl_version")
+    @classmethod
+    def validate_version(cls, value: str) -> str:
+        if not _VERSION_RE.fullmatch(value):
+            raise ValueError("invalid APTL release version")
+        return value
+
+    @field_validator("source_commit")
+    @classmethod
+    def validate_commit(cls, value: str) -> str:
+        if not _COMMIT_RE.fullmatch(value):
+            raise ValueError("source commit must be a full hexadecimal object id")
+        return value
+
+    @model_validator(mode="after")
+    def validate_tag(self) -> ReleaseSource:
+        if self.source_tag != f"v{self.aptl_version}":
+            raise ValueError("source tag must exactly match the APTL version")
+        return self
+
+
+class ApplianceGuest(_StrictModel):
+    """Immutable guest and disposable-overlay contract."""
+
+    os_id: Literal["ubuntu"]
+    os_version: str = Field(min_length=1, max_length=32)
+    architecture: Literal["x86_64", "aarch64"]
+    disk_format: Literal["qcow2"]
+    base_image_digest: str
+    immutable: Literal[True]
+    overlay_strategy: Literal["qcow2-backing-file"]
+
+    @field_validator("base_image_digest")
+    @classmethod
+    def validate_base_image_digest(cls, value: str) -> str:
+        return _validate_digest(value)
+
+
+class ParticipantReleaseBinding(_StrictModel):
+    """References to the existing APP-2 participant release contracts."""
+
+    profile_id: str
+    profile_version: int = Field(ge=1)
+    profile_manifest_digest: str
+    readiness_suite_digest: str
+    asset_lock_digest: str
+    qualification_report_digest: str
+
+    @field_validator("profile_id")
+    @classmethod
+    def validate_profile_id(cls, value: str) -> str:
+        return _validate_identifier(value)
+
+    @field_validator(
+        "profile_manifest_digest",
+        "readiness_suite_digest",
+        "asset_lock_digest",
+        "qualification_report_digest",
+    )
+    @classmethod
+    def validate_digests(cls, value: str) -> str:
+        return _validate_digest(value)
+
+
+class ApplianceBoundaryReleaseBinding(_StrictModel):
+    """References to the existing APP-1 platform-boundary contracts."""
+
+    policy_digest: str
+    boundary_helper_image: str
+    egress_proxy_image: str
+
+    @field_validator("policy_digest")
+    @classmethod
+    def validate_policy_digest(cls, value: str) -> str:
+        return _validate_digest(value)
+
+    @field_validator("boundary_helper_image", "egress_proxy_image")
+    @classmethod
+    def validate_image_digest(cls, value: str) -> str:
+        if not _IMAGE_DIGEST_RE.fullmatch(value):
+            raise ValueError("release helper images must use immutable digests")
+        return value
+
+
+class HostPrerequisites(_StrictModel):
+    """Minimum physical-host resources for the bounded participant profile."""
+
+    architecture: Literal["x86_64", "aarch64"]
+    vcpus: int = Field(ge=8)
+    memory_bytes: int = Field(ge=16 * 1024**3)
+    disk_bytes: int = Field(ge=100 * 1024**3)
+    hardware_virtualization: Literal[True]
+    local_adapter: Literal["qemu-kvm"]
+    supported_hypervisors: tuple[str, ...] = Field(min_length=1)
+
+    @field_validator("supported_hypervisors")
+    @classmethod
+    def validate_hypervisors(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        if len(values) != len(set(values)) or any(
+            not value.strip() for value in values
+        ):
+            raise ValueError("supported hypervisors must be non-empty and unique")
+        return values
+
+
+class DeliveryAdapter(_StrictModel):
+    """One outer delivery form for the exact same guest payload."""
+
+    adapter_id: str
+    kind: Literal["local-kvm", "hosted"]
+    payload_unchanged: bool
+
+    @field_validator("adapter_id")
+    @classmethod
+    def validate_adapter_id(cls, value: str) -> str:
+        return _validate_identifier(value)
+
+
+class DeliveryParity(_StrictModel):
+    """Participant UX and payload identity shared by local and hosted forms."""
+
+    participant_ui_digest: str
+    participant_routes_digest: str
+    adapters: tuple[DeliveryAdapter, ...]
+
+    @field_validator("participant_ui_digest", "participant_routes_digest")
+    @classmethod
+    def validate_digests(cls, value: str) -> str:
+        return _validate_digest(value)
+
+    @model_validator(mode="after")
+    def validate_adapter_parity(self) -> DeliveryParity:
+        ids = [adapter.adapter_id for adapter in self.adapters]
+        kinds = {adapter.kind for adapter in self.adapters}
+        if len(ids) != len(set(ids)):
+            raise ValueError("delivery adapter ids must be unique")
+        if kinds != {"local-kvm", "hosted"}:
+            raise ValueError("local and hosted delivery adapters are required")
+        if any(not adapter.payload_unchanged for adapter in self.adapters):
+            raise ValueError("delivery adapters must use the same payload")
+        return self
+
+
+class MachineDrill(_StrictModel):
+    """Bounded result from one independent supported build/rollback host."""
+
+    machine_id: str
+    architecture: Literal["x86_64", "aarch64"]
+    vcpus: int = Field(ge=1)
+    memory_bytes: int = Field(gt=0)
+    disk_bytes: int = Field(gt=0)
+    build_passed: bool
+    offline_boot_passed: bool
+    participant_smoke_passed: bool
+    rollback_passed: bool
+    overlay_destroy_passed: bool
+
+    @field_validator("machine_id")
+    @classmethod
+    def validate_machine_id(cls, value: str) -> str:
+        return _validate_digest(value)
+
+    @property
+    def passed(self) -> bool:
+        return all(
+            (
+                self.build_passed,
+                self.offline_boot_passed,
+                self.participant_smoke_passed,
+                self.rollback_passed,
+                self.overlay_destroy_passed,
+            )
+        )
+
+
+class ApplianceDrillReport(_StrictModel):
+    """Outer release qualification without duplicating APP-2 readiness data."""
+
+    schema_version: Literal["aptl.appliance-drill/v1"]
+    machines: tuple[MachineDrill, ...]
+    golden_secret_scan_passed: bool
+    golden_read_only_passed: bool
+    distinct_overlay_identities_passed: bool
+    failed_candidate_preserved_active_passed: bool
+
+    @model_validator(mode="after")
+    def validate_release_drills(self) -> ApplianceDrillReport:
+        if len(self.machines) < 2:
+            raise ValueError("two independent machine drills are required")
+        machine_ids = [machine.machine_id for machine in self.machines]
+        if len(machine_ids) != len(set(machine_ids)):
+            raise ValueError("machine drill identities must be unique")
+        if any(not machine.passed for machine in self.machines):
+            raise ValueError("every machine drill must pass")
+        release_checks = (
+            self.golden_secret_scan_passed,
+            self.golden_read_only_passed,
+            self.distinct_overlay_identities_passed,
+            self.failed_candidate_preserved_active_passed,
+        )
+        if not all(release_checks):
+            raise ValueError("every appliance release drill must pass")
+        return self
+
+
+class GoldenImageInventory(_StrictModel):
+    """Scanner result proving the immutable base carries no per-seat state."""
+
+    schema_version: Literal["aptl.golden-inventory/v1"]
+    scan_complete: Literal[True]
+    populated_sensitive_paths: tuple[str, ...]
+    writable_runtime_paths: tuple[str, ...]
+
+    @field_validator("populated_sensitive_paths", "writable_runtime_paths")
+    @classmethod
+    def validate_inventory_paths(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        for value in values:
+            _validate_relative_path(value)
+        if len(values) != len(set(values)):
+            raise ValueError("golden inventory paths must be unique")
+        return values
+
+    @model_validator(mode="after")
+    def validate_clean_golden_image(self) -> GoldenImageInventory:
+        if self.populated_sensitive_paths or self.writable_runtime_paths:
+            raise ValueError("golden image contains per-instance state")
+        return self
+
+
+class ApplianceReleaseManifest(_StrictModel):
+    """Canonical signed manifest for one immutable appliance release."""
+
+    schema_version: Literal["aptl.appliance-release/v1"]
+    release_id: str
+    source: ReleaseSource
+    guest: ApplianceGuest
+    artifacts: tuple[ArtifactReference, ...]
+    payload_digest: str
+    participant: ParticipantReleaseBinding
+    boundary: ApplianceBoundaryReleaseBinding
+    host_prerequisites: HostPrerequisites
+    delivery: DeliveryParity
+    qualification: ApplianceDrillReport
+    upgrade_strategy: Literal["replace-golden-create-overlay"]
+
+    @field_validator("release_id")
+    @classmethod
+    def validate_release_id(cls, value: str) -> str:
+        return _validate_identifier(value)
+
+    @field_validator("payload_digest")
+    @classmethod
+    def validate_payload_digest(cls, value: str) -> str:
+        return _validate_digest(value)
+
+    @model_validator(mode="after")
+    def validate_release_bindings(self) -> ApplianceReleaseManifest:
+        ids = [artifact.artifact_id for artifact in self.artifacts]
+        paths = [artifact.path for artifact in self.artifacts]
+        kinds = [artifact.kind for artifact in self.artifacts]
+        if len(ids) != len(set(ids)):
+            raise ValueError("artifact ids must be unique")
+        if len(paths) != len(set(paths)):
+            raise ValueError("artifact paths must be unique")
+        if set(kinds) != _REQUIRED_ARTIFACT_KINDS or len(kinds) != len(
+            _REQUIRED_ARTIFACT_KINDS
+        ):
+            raise ValueError("manifest does not contain the required artifact kinds")
+        by_kind = {artifact.kind: artifact for artifact in self.artifacts}
+        comparisons = (
+            (
+                by_kind["participant-profile"].sha256,
+                self.participant.profile_manifest_digest,
+            ),
+            (
+                by_kind["participant-readiness"].sha256,
+                self.participant.readiness_suite_digest,
+            ),
+            (
+                by_kind["participant-asset-lock"].sha256,
+                self.participant.asset_lock_digest,
+            ),
+            (
+                by_kind["participant-qualification"].sha256,
+                self.participant.qualification_report_digest,
+            ),
+            (by_kind["boundary-policy"].sha256, self.boundary.policy_digest),
+        )
+        if any(actual != bound for actual, bound in comparisons):
+            raise ValueError("release artifact digest does not match its binding")
+        if self.guest.architecture != self.host_prerequisites.architecture:
+            raise ValueError("guest and host architecture must match")
+        return self
+
+
+class ApplianceManifestSignature(_StrictModel):
+    """Detached release signature stored next to the canonical manifest."""
+
+    schema_version: Literal["aptl.appliance-signature/v1"]
+    algorithm: Literal["ed25519"]
+    key_id: str
+    manifest_digest: str
+    signature: str = Field(min_length=1)
+
+    @field_validator("key_id", "manifest_digest")
+    @classmethod
+    def validate_digests(cls, value: str) -> str:
+        return _validate_digest(value)
+
+
+class StagedArtifact(_StrictModel):
+    """One release input whose digest and size are derived during preparation."""
+
+    artifact_id: str
+    kind: ArtifactKind
+    path: str
+
+    @field_validator("artifact_id")
+    @classmethod
+    def validate_artifact_id(cls, value: str) -> str:
+        return _validate_identifier(value)
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        return _validate_relative_path(value)
+
+
+class ParticipantTemplateBinding(_StrictModel):
+    """APP-2 identity; preparation derives all content digests."""
+
+    profile_id: str
+    profile_version: int = Field(ge=1)
+
+    @field_validator("profile_id")
+    @classmethod
+    def validate_profile_id(cls, value: str) -> str:
+        return _validate_identifier(value)
+
+
+class BoundaryTemplateBinding(_StrictModel):
+    """APP-1 helper identities; preparation derives the policy digest."""
+
+    boundary_helper_image: str
+    egress_proxy_image: str
+
+    @field_validator("boundary_helper_image", "egress_proxy_image")
+    @classmethod
+    def validate_image_digest(cls, value: str) -> str:
+        if not _IMAGE_DIGEST_RE.fullmatch(value):
+            raise ValueError("release helper images must use immutable digests")
+        return value
+
+
+class ApplianceReleaseTemplate(_StrictModel):
+    """Human-authored release metadata separated from derived identities."""
+
+    schema_version: Literal["aptl.appliance-release-template/v1"]
+    release_id: str
+    source: ReleaseSource
+    guest: ApplianceGuest
+    artifacts: tuple[StagedArtifact, ...]
+    participant: ParticipantTemplateBinding
+    boundary: BoundaryTemplateBinding
+    host_prerequisites: HostPrerequisites
+    delivery: DeliveryParity
+    upgrade_strategy: Literal["replace-golden-create-overlay"]
+
+    @field_validator("release_id")
+    @classmethod
+    def validate_release_id(cls, value: str) -> str:
+        return _validate_identifier(value)
+
+    @model_validator(mode="after")
+    def validate_template(self) -> ApplianceReleaseTemplate:
+        ids = [artifact.artifact_id for artifact in self.artifacts]
+        paths = [artifact.path for artifact in self.artifacts]
+        kinds = [artifact.kind for artifact in self.artifacts]
+        if len(ids) != len(set(ids)) or len(paths) != len(set(paths)):
+            raise ValueError("staged artifact ids and paths must be unique")
+        if set(kinds) != _REQUIRED_ARTIFACT_KINDS or len(kinds) != len(
+            _REQUIRED_ARTIFACT_KINDS
+        ):
+            raise ValueError("template does not contain the required artifact kinds")
+        if self.guest.architecture != self.host_prerequisites.architecture:
+            raise ValueError("guest and host architecture must match")
+        return self
+
+
+class ApplianceLaunchDescriptor(_StrictModel):
+    """Create-once projection that carries a verified release into first boot."""
+
+    schema_version: Literal["aptl.appliance-launch/v1"]
+    release_dir: str
+    release_id: str
+    aptl_version: str
+    manifest_digest: str
+    payload_digest: str
+    golden_image_digest: str
+    boundary_policy_path: str
+    boundary_policy_digest: str
+    boundary_helper_image: str
+    egress_proxy_image: str
+    participant_routes_digest: str
+    host_observation_id: str
+
+    @field_validator("release_dir", "boundary_policy_path")
+    @classmethod
+    def validate_paths(cls, value: str) -> str:
+        return _validate_relative_path(value)
+
+    @field_validator(
+        "manifest_digest",
+        "payload_digest",
+        "golden_image_digest",
+        "boundary_policy_digest",
+        "participant_routes_digest",
+        "host_observation_id",
+    )
+    @classmethod
+    def validate_launch_digests(cls, value: str) -> str:
+        return _validate_digest(value)
+
+    @field_validator("boundary_helper_image", "egress_proxy_image")
+    @classmethod
+    def validate_launch_images(cls, value: str) -> str:
+        if not _IMAGE_DIGEST_RE.fullmatch(value):
+            raise ValueError("launch helper images must use immutable digests")
+        return value

--- a/src/aptl/appliance/offline.py
+++ b/src/aptl/appliance/offline.py
@@ -1,0 +1,162 @@
+"""Deterministic assembly of the closed first-boot offline payload."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import secrets
+import stat
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+_ALLOWED_TOP_LEVEL = frozenset(
+    {
+        "wheelhouse",
+        "project.tar",
+        "oci-images.tar",
+        "appliance-release.env",
+        "aptl-appliance-first-boot",
+        "aptl-appliance-first-boot.service",
+    }
+)
+_RELEASE_ENV = re.compile(
+    r"^APTL_APPLIANCE_SCENARIO=[a-z0-9][a-z0-9.-]*\n"
+    r"APTL_APPLIANCE_VERSION=[0-9]+(?:\.[0-9]+){2}(?:[a-z0-9.+-]*)?\n$"
+)
+_APTL_WHEEL = re.compile(
+    r"^aptl_labs-([0-9]+(?:\.[0-9]+){2}(?:[a-z0-9.+_]*)?)-[^/]+\.whl$"
+)
+
+
+class OfflinePayloadError(RuntimeError):
+    """The staged payload is incomplete, mutable, or outside its closed shape."""
+
+
+@dataclass(frozen=True)
+class OfflinePayloadResult:
+    """Content identity of one finalized offline payload."""
+
+    output_path: Path
+    sha256: str
+    size_bytes: int
+
+
+def _validate_staging(staging: Path) -> list[Path]:
+    if staging.is_symlink() or not staging.is_dir():
+        raise OfflinePayloadError("offline payload staging directory is invalid")
+    entries = {path.name for path in staging.iterdir()}
+    if entries != _ALLOWED_TOP_LEVEL:
+        raise OfflinePayloadError("offline payload contains unexpected top-level files")
+    paths = sorted(
+        (path for path in staging.rglob("*")),
+        key=lambda path: path.relative_to(staging).as_posix(),
+    )
+    for path in paths:
+        info = path.lstat()
+        if stat.S_ISLNK(info.st_mode):
+            raise OfflinePayloadError("offline payload must not contain a symlink")
+        if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+            raise OfflinePayloadError("offline payload contains an unsupported file")
+    wheelhouse = staging / "wheelhouse"
+    wheels = [path for path in wheelhouse.iterdir() if path.is_file()]
+    aptl_wheels = [
+        (path, match.group(1).replace("_", "-"))
+        for path in wheels
+        if (match := _APTL_WHEEL.fullmatch(path.name)) is not None
+    ]
+    if not wheels or any(path.suffix != ".whl" for path in wheels):
+        raise OfflinePayloadError("offline payload wheelhouse is incomplete")
+    for required in ("project.tar", "oci-images.tar"):
+        if (staging / required).stat().st_size <= 0:
+            raise OfflinePayloadError(f"offline payload {required} is empty")
+    env_text = (staging / "appliance-release.env").read_text(encoding="utf-8")
+    if not _RELEASE_ENV.fullmatch(env_text):
+        raise OfflinePayloadError("invalid non-secret appliance release environment")
+    env_version = env_text.split("APTL_APPLIANCE_VERSION=", 1)[1].strip()
+    if len(aptl_wheels) != 1 or aptl_wheels[0][1] != env_version:
+        raise OfflinePayloadError(
+            "offline payload must contain exactly one matching APTL wheel"
+        )
+    return paths
+
+
+def _tar_info(path: Path, relative: str) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(relative)
+    path_info = path.stat(follow_symlinks=False)
+    info.uid = 0
+    info.gid = 0
+    info.uname = "root"
+    info.gname = "root"
+    info.mtime = 0
+    if path.is_dir():
+        info.type = tarfile.DIRTYPE
+        info.mode = 0o755
+        info.size = 0
+    else:
+        info.type = tarfile.REGTYPE
+        info.mode = 0o755 if relative == "aptl-appliance-first-boot" else 0o644
+        info.size = path_info.st_size
+    return info
+
+
+def _open_nofollow(path: Path):
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    return os.fdopen(os.open(path, flags), "rb")
+
+
+def _write_tar(staging: Path, paths: list[Path], candidate: Path) -> None:
+    try:
+        with tarfile.open(candidate, "w", format=tarfile.USTAR_FORMAT) as archive:
+            for path in paths:
+                relative = path.relative_to(staging).as_posix()
+                info = _tar_info(path, relative)
+                if path.is_dir():
+                    archive.addfile(info)
+                else:
+                    with _open_nofollow(path) as handle:
+                        archive.addfile(info, handle)
+    except (OSError, tarfile.TarError) as exc:
+        raise OfflinePayloadError("offline payload could not be assembled") from exc
+
+
+def _hash_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with _open_nofollow(path) as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return f"sha256:{digest.hexdigest()}", size
+
+
+def build_offline_payload(
+    staging_dir: Path,
+    output_path: Path,
+) -> OfflinePayloadResult:
+    """Create a reproducible read-only tar without resolving any dependency."""
+
+    staging = staging_dir.resolve()
+    paths = _validate_staging(staging)
+    output = output_path.expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if output.exists() or output.is_symlink():
+        raise OfflinePayloadError("offline payload output already exists")
+    candidate = output.with_name(f".{output.name}.candidate-{secrets.token_hex(8)}")
+    try:
+        _write_tar(staging, paths, candidate)
+        candidate.chmod(0o444)
+        try:
+            os.link(candidate, output, follow_symlinks=False)
+        except FileExistsError as exc:
+            raise OfflinePayloadError("offline payload output already exists") from exc
+        digest, size = _hash_file(output)
+        return OfflinePayloadResult(output, digest, size)
+    finally:
+        try:
+            candidate.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/src/aptl/appliance/offline.py
+++ b/src/aptl/appliance/offline.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO
 
+from aptl.appliance.versioning import aptl_wheel_version, is_appliance_version
+
 _ALLOWED_TOP_LEVEL = frozenset(
     {
         "wheelhouse",
@@ -23,7 +25,7 @@ _ALLOWED_TOP_LEVEL = frozenset(
     }
 )
 _SCENARIO_RE = re.compile(r"^[a-z0-9][a-z0-9.-]*$")
-_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+[a-z0-9.+-]*$")
+_INVALID_RELEASE_ENV = "invalid non-secret appliance release environment"
 
 
 class OfflinePayloadError(RuntimeError):
@@ -63,13 +65,7 @@ def _validate_staged_paths(staging: Path) -> list[Path]:
 def _wheel_version(path: Path) -> str | None:
     """Extract the normalized APTL version from one wheel filename."""
 
-    prefix = "aptl_labs-"
-    if not path.name.startswith(prefix) or path.suffix != ".whl":
-        return None
-    version, separator, _tags = path.name[len(prefix) :].partition("-")
-    if not separator or not version:
-        return None
-    return version.replace("_", "-")
+    return aptl_wheel_version(path.name)
 
 
 def _release_environment(staging: Path) -> tuple[str, str]:
@@ -78,17 +74,17 @@ def _release_environment(staging: Path) -> tuple[str, str]:
     env_text = (staging / "appliance-release.env").read_text(encoding="utf-8")
     lines = env_text.splitlines()
     if len(lines) != 2 or not env_text.endswith("\n"):
-        raise OfflinePayloadError("invalid non-secret appliance release environment")
+        raise OfflinePayloadError(_INVALID_RELEASE_ENV)
     scenario_prefix = "APTL_APPLIANCE_SCENARIO="
     version_prefix = "APTL_APPLIANCE_VERSION="
     if not lines[0].startswith(scenario_prefix) or not lines[1].startswith(
         version_prefix
     ):
-        raise OfflinePayloadError("invalid non-secret appliance release environment")
+        raise OfflinePayloadError(_INVALID_RELEASE_ENV)
     scenario = lines[0][len(scenario_prefix) :]
     version = lines[1][len(version_prefix) :]
-    if not _SCENARIO_RE.fullmatch(scenario) or not _VERSION_RE.fullmatch(version):
-        raise OfflinePayloadError("invalid non-secret appliance release environment")
+    if not _SCENARIO_RE.fullmatch(scenario) or not is_appliance_version(version):
+        raise OfflinePayloadError(_INVALID_RELEASE_ENV)
     return scenario, version
 
 
@@ -179,6 +175,15 @@ def _hash_file(path: Path) -> tuple[str, int]:
     return f"sha256:{digest.hexdigest()}", size
 
 
+def _remove_candidate(path: Path) -> None:
+    """Best-effort remove an unpublished payload candidate."""
+
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def build_offline_payload(
     staging_dir: Path,
     output_path: Path,
@@ -202,7 +207,4 @@ def build_offline_payload(
         digest, size = _hash_file(output)
         return OfflinePayloadResult(output, digest, size)
     finally:
-        try:
-            candidate.unlink(missing_ok=True)
-        except OSError:
-            pass
+        _remove_candidate(candidate)

--- a/src/aptl/appliance/offline.py
+++ b/src/aptl/appliance/offline.py
@@ -153,14 +153,24 @@ def _write_tar(staging: Path, paths: list[Path], candidate: Path) -> None:
         with tarfile.open(candidate, "w", format=tarfile.USTAR_FORMAT) as archive:
             for path in paths:
                 relative = path.relative_to(staging).as_posix()
-                info = _tar_info(path, relative)
-                if path.is_dir():
-                    archive.addfile(info)
-                else:
-                    with _open_nofollow(path) as handle:
-                        archive.addfile(info, handle)
+                _add_tar_member(archive, path, relative)
     except (OSError, tarfile.TarError) as exc:
         raise OfflinePayloadError("offline payload could not be assembled") from exc
+
+
+def _add_tar_member(
+    archive: tarfile.TarFile,
+    path: Path,
+    relative: str,
+) -> None:
+    """Add one validated directory or regular file to the payload archive."""
+
+    info = _tar_info(path, relative)
+    if path.is_dir():
+        archive.addfile(info)
+    else:
+        with _open_nofollow(path) as handle:
+            archive.addfile(info, handle)
 
 
 def _hash_file(path: Path) -> tuple[str, int]:

--- a/src/aptl/appliance/offline.py
+++ b/src/aptl/appliance/offline.py
@@ -10,6 +10,7 @@ import stat
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO
 
 _ALLOWED_TOP_LEVEL = frozenset(
     {
@@ -21,13 +22,8 @@ _ALLOWED_TOP_LEVEL = frozenset(
         "aptl-appliance-first-boot.service",
     }
 )
-_RELEASE_ENV = re.compile(
-    r"^APTL_APPLIANCE_SCENARIO=[a-z0-9][a-z0-9.-]*\n"
-    r"APTL_APPLIANCE_VERSION=[0-9]+(?:\.[0-9]+){2}(?:[a-z0-9.+-]*)?\n$"
-)
-_APTL_WHEEL = re.compile(
-    r"^aptl_labs-([0-9]+(?:\.[0-9]+){2}(?:[a-z0-9.+_]*)?)-[^/]+\.whl$"
-)
+_SCENARIO_RE = re.compile(r"^[a-z0-9][a-z0-9.-]*$")
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+[a-z0-9.+-]*$")
 
 
 class OfflinePayloadError(RuntimeError):
@@ -43,14 +39,16 @@ class OfflinePayloadResult:
     size_bytes: int
 
 
-def _validate_staging(staging: Path) -> list[Path]:
+def _validate_staged_paths(staging: Path) -> list[Path]:
+    """Return a deterministic list after rejecting special files and links."""
+
     if staging.is_symlink() or not staging.is_dir():
         raise OfflinePayloadError("offline payload staging directory is invalid")
     entries = {path.name for path in staging.iterdir()}
     if entries != _ALLOWED_TOP_LEVEL:
         raise OfflinePayloadError("offline payload contains unexpected top-level files")
     paths = sorted(
-        (path for path in staging.rglob("*")),
+        staging.rglob("*"),
         key=lambda path: path.relative_to(staging).as_posix(),
     )
     for path in paths:
@@ -59,30 +57,72 @@ def _validate_staging(staging: Path) -> list[Path]:
             raise OfflinePayloadError("offline payload must not contain a symlink")
         if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
             raise OfflinePayloadError("offline payload contains an unsupported file")
+    return paths
+
+
+def _wheel_version(path: Path) -> str | None:
+    """Extract the normalized APTL version from one wheel filename."""
+
+    prefix = "aptl_labs-"
+    if not path.name.startswith(prefix) or path.suffix != ".whl":
+        return None
+    version, separator, _tags = path.name[len(prefix) :].partition("-")
+    if not separator or not version:
+        return None
+    return version.replace("_", "-")
+
+
+def _release_environment(staging: Path) -> tuple[str, str]:
+    """Read the two-field non-secret release environment."""
+
+    env_text = (staging / "appliance-release.env").read_text(encoding="utf-8")
+    lines = env_text.splitlines()
+    if len(lines) != 2 or not env_text.endswith("\n"):
+        raise OfflinePayloadError("invalid non-secret appliance release environment")
+    scenario_prefix = "APTL_APPLIANCE_SCENARIO="
+    version_prefix = "APTL_APPLIANCE_VERSION="
+    if not lines[0].startswith(scenario_prefix) or not lines[1].startswith(
+        version_prefix
+    ):
+        raise OfflinePayloadError("invalid non-secret appliance release environment")
+    scenario = lines[0][len(scenario_prefix) :]
+    version = lines[1][len(version_prefix) :]
+    if not _SCENARIO_RE.fullmatch(scenario) or not _VERSION_RE.fullmatch(version):
+        raise OfflinePayloadError("invalid non-secret appliance release environment")
+    return scenario, version
+
+
+def _validate_wheelhouse(staging: Path, expected_version: str) -> None:
+    """Require a closed wheelhouse with exactly one matching APTL wheel."""
+
     wheelhouse = staging / "wheelhouse"
     wheels = [path for path in wheelhouse.iterdir() if path.is_file()]
-    aptl_wheels = [
-        (path, match.group(1).replace("_", "-"))
-        for path in wheels
-        if (match := _APTL_WHEEL.fullmatch(path.name)) is not None
-    ]
     if not wheels or any(path.suffix != ".whl" for path in wheels):
         raise OfflinePayloadError("offline payload wheelhouse is incomplete")
-    for required in ("project.tar", "oci-images.tar"):
-        if (staging / required).stat().st_size <= 0:
-            raise OfflinePayloadError(f"offline payload {required} is empty")
-    env_text = (staging / "appliance-release.env").read_text(encoding="utf-8")
-    if not _RELEASE_ENV.fullmatch(env_text):
-        raise OfflinePayloadError("invalid non-secret appliance release environment")
-    env_version = env_text.split("APTL_APPLIANCE_VERSION=", 1)[1].strip()
-    if len(aptl_wheels) != 1 or aptl_wheels[0][1] != env_version:
+    aptl_versions = [
+        version for path in wheels if (version := _wheel_version(path)) is not None
+    ]
+    if aptl_versions != [expected_version]:
         raise OfflinePayloadError(
             "offline payload must contain exactly one matching APTL wheel"
         )
+
+
+def _validate_staging(staging: Path) -> list[Path]:
+    """Validate the closed staging shape and return its deterministic paths."""
+
+    paths = _validate_staged_paths(staging)
+    for required in ("project.tar", "oci-images.tar"):
+        if (staging / required).stat().st_size <= 0:
+            raise OfflinePayloadError(f"offline payload {required} is empty")
+    _scenario, version = _release_environment(staging)
+    _validate_wheelhouse(staging, version)
     return paths
 
 
 def _tar_info(path: Path, relative: str) -> tarfile.TarInfo:
+    """Create reproducible metadata for one staged tar member."""
+
     info = tarfile.TarInfo(relative)
     path_info = path.stat(follow_symlinks=False)
     info.uid = 0
@@ -101,7 +141,9 @@ def _tar_info(path: Path, relative: str) -> tarfile.TarInfo:
     return info
 
 
-def _open_nofollow(path: Path):
+def _open_nofollow(path: Path) -> BinaryIO:
+    """Open one regular payload path without following its final symlink."""
+
     flags = os.O_RDONLY | os.O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -109,6 +151,8 @@ def _open_nofollow(path: Path):
 
 
 def _write_tar(staging: Path, paths: list[Path], candidate: Path) -> None:
+    """Write a deterministic USTAR archive from already-validated paths."""
+
     try:
         with tarfile.open(candidate, "w", format=tarfile.USTAR_FORMAT) as archive:
             for path in paths:
@@ -124,6 +168,8 @@ def _write_tar(staging: Path, paths: list[Path], candidate: Path) -> None:
 
 
 def _hash_file(path: Path) -> tuple[str, int]:
+    """Return the streaming SHA-256 identity and byte count for a file."""
+
     digest = hashlib.sha256()
     size = 0
     with _open_nofollow(path) as handle:

--- a/src/aptl/appliance/release_models.py
+++ b/src/aptl/appliance/release_models.py
@@ -1,0 +1,160 @@
+"""Preparation and launch models for appliance release envelopes."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from aptl.appliance.models import (
+    _IMAGE_DIGEST_RE,
+    _REQUIRED_ARTIFACT_KINDS,
+    _StrictModel,
+    _validate_digest,
+    _validate_identifier,
+    _validate_relative_path,
+    ApplianceGuest,
+    ArtifactKind,
+    DeliveryParity,
+    HostPrerequisites,
+    ReleaseSource,
+)
+
+
+class StagedArtifact(_StrictModel):
+    """One release input whose digest and size are derived during preparation."""
+
+    artifact_id: str
+    kind: ArtifactKind
+    path: str
+
+    @field_validator("artifact_id")
+    @classmethod
+    def validate_artifact_id(cls, value: str) -> str:
+        """Validate the stable artifact identifier."""
+
+        return _validate_identifier(value)
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        """Validate the contained staged artifact path."""
+
+        return _validate_relative_path(value)
+
+
+class ParticipantTemplateBinding(_StrictModel):
+    """APP-2 identity; preparation derives all content digests."""
+
+    profile_id: str
+    profile_version: int = Field(ge=1)
+
+    @field_validator("profile_id")
+    @classmethod
+    def validate_profile_id(cls, value: str) -> str:
+        """Validate the referenced participant profile identifier."""
+
+        return _validate_identifier(value)
+
+
+class BoundaryTemplateBinding(_StrictModel):
+    """APP-1 helper identities; preparation derives the policy digest."""
+
+    boundary_helper_image: str
+    egress_proxy_image: str
+
+    @field_validator("boundary_helper_image", "egress_proxy_image")
+    @classmethod
+    def validate_image_digest(cls, value: str) -> str:
+        """Require an immutable helper image reference."""
+
+        if not _IMAGE_DIGEST_RE.fullmatch(value):
+            raise ValueError("release helper images must use immutable digests")
+        return value
+
+
+class ApplianceReleaseTemplate(_StrictModel):
+    """Human-authored release metadata separated from derived identities."""
+
+    schema_version: Literal["aptl.appliance-release-template/v1"]
+    release_id: str
+    source: ReleaseSource
+    guest: ApplianceGuest
+    artifacts: tuple[StagedArtifact, ...]
+    participant: ParticipantTemplateBinding
+    boundary: BoundaryTemplateBinding
+    host_prerequisites: HostPrerequisites
+    delivery: DeliveryParity
+    upgrade_strategy: Literal["replace-golden-create-overlay"]
+
+    @field_validator("release_id")
+    @classmethod
+    def validate_release_id(cls, value: str) -> str:
+        """Validate the release identifier."""
+
+        return _validate_identifier(value)
+
+    @model_validator(mode="after")
+    def validate_template(self) -> ApplianceReleaseTemplate:
+        """Require one complete, unique, architecture-consistent input set."""
+
+        ids = [artifact.artifact_id for artifact in self.artifacts]
+        paths = [artifact.path for artifact in self.artifacts]
+        kinds = [artifact.kind for artifact in self.artifacts]
+        if len(ids) != len(set(ids)) or len(paths) != len(set(paths)):
+            raise ValueError("staged artifact ids and paths must be unique")
+        if set(kinds) != _REQUIRED_ARTIFACT_KINDS or len(kinds) != len(
+            _REQUIRED_ARTIFACT_KINDS
+        ):
+            raise ValueError("template does not contain the required artifact kinds")
+        if self.guest.architecture != self.host_prerequisites.architecture:
+            raise ValueError("guest and host architecture must match")
+        return self
+
+
+class ApplianceLaunchDescriptor(_StrictModel):
+    """Create-once projection that carries a verified release into first boot."""
+
+    schema_version: Literal["aptl.appliance-launch/v1"]
+    release_dir: str
+    release_id: str
+    aptl_version: str
+    manifest_digest: str
+    payload_digest: str
+    golden_image_digest: str
+    boundary_policy_path: str
+    boundary_policy_digest: str
+    boundary_helper_image: str
+    egress_proxy_image: str
+    participant_routes_digest: str
+    host_observation_id: str
+
+    @field_validator("release_dir", "boundary_policy_path")
+    @classmethod
+    def validate_paths(cls, value: str) -> str:
+        """Validate each contained descriptor path."""
+
+        return _validate_relative_path(value)
+
+    @field_validator(
+        "manifest_digest",
+        "payload_digest",
+        "golden_image_digest",
+        "boundary_policy_digest",
+        "participant_routes_digest",
+        "host_observation_id",
+    )
+    @classmethod
+    def validate_launch_digests(cls, value: str) -> str:
+        """Validate each launch-bound SHA-256 identity."""
+
+        return _validate_digest(value)
+
+    @field_validator("boundary_helper_image", "egress_proxy_image")
+    @classmethod
+    def validate_launch_images(cls, value: str) -> str:
+        """Require an immutable launch helper image reference."""
+
+        if not _IMAGE_DIGEST_RE.fullmatch(value):
+            raise ValueError("launch helper images must use immutable digests")
+        return value

--- a/src/aptl/appliance/release_validation.py
+++ b/src/aptl/appliance/release_validation.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import io
-import re
 import tarfile
 from pathlib import Path
 
@@ -18,6 +17,7 @@ from aptl.appliance.models import (
     ArtifactReference,
     GoldenImageInventory,
 )
+from aptl.appliance.versioning import aptl_wheel_version
 from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
 from aptl.utils.pathsafe import PathContainmentError, read_contained_nofollow
 from aptl.validation.participant_profile_models import (
@@ -39,9 +39,6 @@ _PAYLOAD_KINDS = frozenset(
         "participant-qualification",
         "boundary-policy",
     }
-)
-_APTL_WHEEL_RE = re.compile(
-    r"^wheelhouse/aptl_labs-(\d+\.\d+\.\d+[a-z0-9.+_]*)-[^/]+\.whl$"
 )
 
 
@@ -131,7 +128,6 @@ def _participant_binding_matches(
     manifest: ApplianceReleaseManifest,
     payloads: dict[ArtifactKind, bytes],
     profile: ParticipantProfileManifest,
-    readiness: ParticipantReadinessSuite,
     asset_lock: ParticipantAssetLock,
     qualification: ParticipantQualificationReport,
 ) -> bool:
@@ -241,7 +237,6 @@ def verify_release_evidence(
             manifest,
             payloads,
             profile,
-            readiness,
             asset_lock,
             qualification,
         )
@@ -262,9 +257,9 @@ def verify_offline_aptl_version(payload: bytes, expected_version: str) -> None:
     try:
         with tarfile.open(fileobj=io.BytesIO(payload), mode="r:") as archive:
             wheels = [
-                match.group(1).replace("_", "-")
+                version
                 for member in archive.getmembers()
-                if (match := _APTL_WHEEL_RE.fullmatch(member.name)) is not None
+                if (version := aptl_wheel_version(member.name)) is not None
                 and member.isfile()
             ]
             env_member = archive.getmember("appliance-release.env")

--- a/src/aptl/appliance/release_validation.py
+++ b/src/aptl/appliance/release_validation.py
@@ -1,0 +1,285 @@
+"""Artifact and evidence verification for signed appliance releases."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import tarfile
+from pathlib import Path
+
+import rfc8785
+
+from aptl.appliance.errors import ApplianceManifestError
+from aptl.appliance.models import (
+    ApplianceDrillReport,
+    ApplianceReleaseManifest,
+    ArtifactKind,
+    ArtifactReference,
+    GoldenImageInventory,
+)
+from aptl.core.appliance_boundary import ApplianceBoundaryPolicy
+from aptl.utils.pathsafe import PathContainmentError, read_contained_nofollow
+from aptl.validation.participant_profile_models import (
+    ParticipantAssetLock,
+    ParticipantProfileManifest,
+    ParticipantReadinessSuite,
+)
+from aptl.validation.participant_qualification_evidence import (
+    ParticipantQualificationReport,
+)
+
+_PAYLOAD_KINDS = frozenset(
+    {
+        "golden-disk",
+        "offline-payload",
+        "participant-profile",
+        "participant-readiness",
+        "participant-asset-lock",
+        "participant-qualification",
+        "boundary-policy",
+    }
+)
+_APTL_WHEEL_RE = re.compile(
+    r"^wheelhouse/aptl_labs-(\d+\.\d+\.\d+[a-z0-9.+_]*)-[^/]+\.whl$"
+)
+
+
+def read_release_artifact(root: Path, relative_path: str) -> bytes:
+    """Read one contained release file without following symlinks."""
+
+    try:
+        return read_contained_nofollow(root, relative_path)
+    except (OSError, PathContainmentError, ValueError) as exc:
+        raise ApplianceManifestError(
+            f"unsafe release artifact: {relative_path}"
+        ) from exc
+
+
+def compute_payload_digest(artifacts: tuple[ArtifactReference, ...]) -> str:
+    """Bind guest bytes and reused APP-1/APP-2 identities into one digest."""
+
+    projection = [
+        {
+            "artifact_id": artifact.artifact_id,
+            "kind": artifact.kind,
+            "path": artifact.path,
+            "sha256": artifact.sha256,
+            "size_bytes": artifact.size_bytes,
+        }
+        for artifact in sorted(artifacts, key=lambda item: item.artifact_id)
+        if artifact.kind in _PAYLOAD_KINDS
+    ]
+    if {item["kind"] for item in projection} != _PAYLOAD_KINDS:
+        raise ApplianceManifestError("payload artifact set is incomplete")
+    return f"sha256:{hashlib.sha256(rfc8785.dumps(projection)).hexdigest()}"
+
+
+def verify_artifacts(
+    release_root: Path,
+    manifest: ApplianceReleaseManifest,
+) -> dict[ArtifactKind, bytes]:
+    """Verify every declared artifact and return payloads keyed by kind."""
+
+    payloads: dict[ArtifactKind, bytes] = {}
+    for artifact in manifest.artifacts:
+        payload = read_release_artifact(release_root, artifact.path)
+        actual_digest = f"sha256:{hashlib.sha256(payload).hexdigest()}"
+        if actual_digest != artifact.sha256 or len(payload) != artifact.size_bytes:
+            raise ApplianceManifestError(
+                f"release artifact digest mismatch: {artifact.artifact_id}"
+            )
+        payloads[artifact.kind] = payload
+    if compute_payload_digest(manifest.artifacts) != manifest.payload_digest:
+        raise ApplianceManifestError("release payload digest mismatch")
+    return payloads
+
+
+def _parse_evidence(
+    payloads: dict[ArtifactKind, bytes],
+) -> tuple[
+    ParticipantProfileManifest,
+    ParticipantReadinessSuite,
+    ParticipantAssetLock,
+    ParticipantQualificationReport,
+    ApplianceDrillReport,
+]:
+    """Parse every release evidence record through its closed schema."""
+
+    try:
+        profile = ParticipantProfileManifest.model_validate_json(
+            payloads["participant-profile"]
+        )
+        readiness = ParticipantReadinessSuite.model_validate_json(
+            payloads["participant-readiness"]
+        )
+        asset_lock = ParticipantAssetLock.model_validate_json(
+            payloads["participant-asset-lock"]
+        )
+        qualification = ParticipantQualificationReport.model_validate_json(
+            payloads["participant-qualification"]
+        )
+        ApplianceBoundaryPolicy.model_validate_json(payloads["boundary-policy"])
+        GoldenImageInventory.model_validate_json(payloads["golden-inventory"])
+        drill = ApplianceDrillReport.model_validate_json(payloads["machine-drill"])
+    except ValueError as exc:
+        raise ApplianceManifestError("invalid appliance release evidence") from exc
+    return profile, readiness, asset_lock, qualification, drill
+
+
+def _participant_binding_matches(
+    manifest: ApplianceReleaseManifest,
+    payloads: dict[ArtifactKind, bytes],
+    profile: ParticipantProfileManifest,
+    readiness: ParticipantReadinessSuite,
+    asset_lock: ParticipantAssetLock,
+    qualification: ParticipantQualificationReport,
+) -> bool:
+    """Check the exact APP-2 profile, readiness, lock, and report identities."""
+
+    profile_digest = hashlib.sha256(payloads["participant-profile"]).hexdigest()
+    readiness_digest = hashlib.sha256(payloads["participant-readiness"]).hexdigest()
+    asset_lock_digest = hashlib.sha256(payloads["participant-asset-lock"]).hexdigest()
+    actual = (
+        profile.profile_id,
+        profile.version,
+        profile.readiness.sha256,
+        manifest.participant.readiness_suite_digest,
+        asset_lock.profile_id,
+        asset_lock.profile_version,
+        profile.release_evidence.asset_lock_sha256,
+        qualification.profile_id,
+        qualification.profile_version,
+        qualification.profile_sha256,
+        qualification.asset_lock_digest,
+    )
+    expected = (
+        manifest.participant.profile_id,
+        manifest.participant.profile_version,
+        readiness_digest,
+        f"sha256:{readiness_digest}",
+        profile.profile_id,
+        profile.version,
+        asset_lock_digest,
+        profile.profile_id,
+        profile.version,
+        profile_digest,
+        f"sha256:{asset_lock_digest}",
+    )
+    return actual == expected
+
+
+def _qualification_surface_matches(
+    profile: ParticipantProfileManifest,
+    readiness: ParticipantReadinessSuite,
+    qualification: ParticipantQualificationReport,
+) -> bool:
+    """Check all required readiness checks and realized participant surfaces."""
+
+    required_checks = {check.check_id for check in readiness.checks}
+    expected_workbenches = {
+        profile_id.value for profile_id in profile.capabilities.workbench_profiles
+    }
+    expected_mcp = {
+        check.subject_id for check in readiness.checks if check.kind == "mcp-tool"
+    }
+    expected_browser = {
+        check.subject_id
+        for check in readiness.checks
+        if check.kind == "browser-operation"
+    }
+    surface = qualification.surface
+    actual = (
+        {check.check_id for check in qualification.checks},
+        all(check.status == "passed" for check in qualification.checks),
+        set(surface.actual_workbench_profiles),
+        set(surface.actual_mcp_servers),
+        set(surface.actual_browser_capabilities),
+        set(surface.actual_services),
+        set(surface.actual_networks),
+    )
+    expected = (
+        required_checks,
+        True,
+        expected_workbenches,
+        expected_mcp,
+        expected_browser,
+        set(surface.expected_services),
+        set(surface.expected_networks),
+    )
+    return actual == expected
+
+
+def _offline_evidence_passed(qualification: ParticipantQualificationReport) -> bool:
+    """Require the qualification run to prove a closed offline execution."""
+
+    offline = qualification.offline
+    return (
+        offline.egress_denied,
+        offline.download_attempts,
+        offline.image_pulls,
+        offline.image_builds,
+        offline.package_resolutions,
+    ) == (
+        True,
+        0,
+        0,
+        0,
+        0,
+    )
+
+
+def verify_release_evidence(
+    manifest: ApplianceReleaseManifest,
+    payloads: dict[ArtifactKind, bytes],
+) -> None:
+    """Verify APP-1, APP-2, golden-state, and machine-drill evidence."""
+
+    profile, readiness, asset_lock, qualification, drill = _parse_evidence(payloads)
+    passed = (
+        _participant_binding_matches(
+            manifest,
+            payloads,
+            profile,
+            readiness,
+            asset_lock,
+            qualification,
+        )
+        and _qualification_surface_matches(profile, readiness, qualification)
+        and _offline_evidence_passed(qualification)
+    )
+    if not passed:
+        raise ApplianceManifestError(
+            "participant qualification evidence does not match the release"
+        )
+    if drill != manifest.qualification:
+        raise ApplianceManifestError("machine drill evidence does not match manifest")
+
+
+def verify_offline_aptl_version(payload: bytes, expected_version: str) -> None:
+    """Bind the one staged APTL wheel and release env to the signed version."""
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(payload), mode="r:") as archive:
+            wheels = [
+                match.group(1).replace("_", "-")
+                for member in archive.getmembers()
+                if (match := _APTL_WHEEL_RE.fullmatch(member.name)) is not None
+                and member.isfile()
+            ]
+            env_member = archive.getmember("appliance-release.env")
+            env_file = archive.extractfile(env_member)
+            if env_file is None:
+                raise KeyError("appliance-release.env")
+            env_text = env_file.read().decode("utf-8")
+    except (KeyError, OSError, UnicodeDecodeError, tarfile.TarError) as exc:
+        raise ApplianceManifestError(
+            "offline payload release identity is invalid"
+        ) from exc
+    version_line = f"APTL_APPLIANCE_VERSION={expected_version}\n"
+    if wheels != [expected_version] or version_line not in env_text.splitlines(
+        keepends=True
+    ):
+        raise ApplianceManifestError(
+            "offline payload APTL version does not match the release"
+        )

--- a/src/aptl/appliance/versioning.py
+++ b/src/aptl/appliance/versioning.py
@@ -1,0 +1,35 @@
+"""Bounded version and wheel-name parsing for appliance releases."""
+
+from __future__ import annotations
+
+_VERSION_SUFFIX = frozenset("abcdefghijklmnopqrstuvwxyz0123456789.+-")
+
+
+def is_appliance_version(value: str) -> bool:
+    """Return whether a version has three numeric parts and a safe suffix."""
+
+    major, dot, remainder = value.partition(".")
+    minor, second_dot, patch_and_suffix = remainder.partition(".")
+    if not dot or not second_dot or not major.isdigit() or not minor.isdigit():
+        return False
+    patch_length = 0
+    for character in patch_and_suffix:
+        if not character.isdigit():
+            break
+        patch_length += 1
+    patch = patch_and_suffix[:patch_length]
+    suffix = patch_and_suffix[patch_length:]
+    return bool(patch) and all(character in _VERSION_SUFFIX for character in suffix)
+
+
+def aptl_wheel_version(name: str, *, prefix: str = "aptl_labs-") -> str | None:
+    """Extract a validated normalized APTL version from one wheel path."""
+
+    filename = name.rsplit("/", 1)[-1]
+    if not filename.startswith(prefix) or not filename.endswith(".whl"):
+        return None
+    version, separator, tags = filename[len(prefix) :].partition("-")
+    normalized = version.replace("_", "-")
+    if not separator or not tags or not is_appliance_version(normalized):
+        return None
+    return normalized

--- a/src/aptl/cli/appliance.py
+++ b/src/aptl/cli/appliance.py
@@ -1,0 +1,323 @@
+"""CLI boundary for signed disposable-appliance release operations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import typer
+from pydantic import ValidationError
+
+from aptl.appliance.bootstrap import (
+    ApplianceBootstrapError,
+    initialize_overlay_state,
+)
+from aptl.appliance.build import (
+    ApplianceBuildError,
+    GoldenImageBuildRequest,
+    OverlayCreateRequest,
+    build_golden_image,
+    create_disposable_overlay,
+)
+from aptl.appliance.manifest import (
+    ApplianceManifestError,
+    ApplianceReleaseInspection,
+    prepare_release_manifest,
+    seal_release_directory,
+    verify_release_directory,
+)
+from aptl.appliance.launch import prepare_launch_descriptor
+from aptl.appliance.offline import OfflinePayloadError, build_offline_payload
+
+app = typer.Typer(help="Build and verify signed disposable appliance releases.")
+
+
+def _emit(payload: dict[str, object]) -> None:
+    typer.echo(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+
+def _fail(message: str, exc: Exception) -> None:
+    typer.echo(f"error: {message}", err=True)
+    raise typer.Exit(code=2) from exc
+
+
+@app.command("build")
+def build(
+    request: Path = typer.Option(
+        ...,
+        "--request",
+        help="Strict checksum-pinned golden-image build request.",
+    ),
+    build_root: Path = typer.Option(
+        Path("."),
+        "--build-root",
+        help="Contained directory holding build inputs and output.",
+    ),
+) -> None:
+    """Build a new read-only golden image using offline fixed-argv tooling."""
+
+    try:
+        build_request = GoldenImageBuildRequest.model_validate_json(
+            request.read_bytes()
+        )
+    except (OSError, ValidationError, ValueError) as exc:
+        _fail("invalid appliance build request", exc)
+    try:
+        result = build_golden_image(build_root, build_request)
+    except ApplianceBuildError as exc:
+        _fail(str(exc), exc)
+    _emit(
+        {
+            "built": True,
+            "sha256": result.sha256,
+            "size_bytes": result.size_bytes,
+        }
+    )
+
+
+@app.command("bundle")
+def bundle(
+    staging_dir: Path = typer.Option(
+        ...,
+        "--staging-dir",
+        help="Closed directory of already-resolved wheels, images, and assets.",
+    ),
+    output: Path = typer.Option(
+        ...,
+        "--output",
+        help="New offline-payload tar path.",
+    ),
+) -> None:
+    """Assemble a byte-reproducible first-boot payload without network access."""
+
+    try:
+        result = build_offline_payload(staging_dir, output)
+    except OfflinePayloadError as exc:
+        _fail(str(exc), exc)
+    _emit(
+        {
+            "built": True,
+            "sha256": result.sha256,
+            "size_bytes": result.size_bytes,
+        }
+    )
+
+
+@app.command("create-overlay")
+def create_overlay(
+    request: Path = typer.Option(
+        ...,
+        "--request",
+        help="Strict content-pinned disposable-overlay request.",
+    ),
+    appliance_root: Path = typer.Option(
+        Path("."),
+        "--appliance-root",
+        help="Contained directory holding the golden image and instances.",
+    ),
+) -> None:
+    """Create a mutable qcow2 overlay backed by a verified read-only golden."""
+
+    try:
+        overlay_request = OverlayCreateRequest.model_validate_json(request.read_bytes())
+    except (OSError, ValidationError, ValueError) as exc:
+        _fail("invalid disposable overlay request", exc)
+    try:
+        result = create_disposable_overlay(appliance_root, overlay_request)
+    except ApplianceBuildError as exc:
+        _fail(str(exc), exc)
+    _emit(
+        {
+            "created": True,
+            "golden_image_digest": result.golden_image_digest,
+        }
+    )
+
+
+@app.command("prepare-launch")
+def prepare_launch(
+    release_dir: Path = typer.Option(..., "--release-dir"),
+    public_key: Path = typer.Option(..., "--public-key"),
+    qualification_public_key: Path = typer.Option(
+        ...,
+        "--qualification-public-key",
+    ),
+    output: Path = typer.Option(..., "--output"),
+    host_observation_id: str = typer.Option(..., "--host-observation-id"),
+) -> None:
+    """Verify a release and create its immutable first-boot descriptor."""
+
+    try:
+        descriptor = prepare_launch_descriptor(
+            release_dir,
+            public_key,
+            qualification_public_key,
+            output,
+            host_observation_id=host_observation_id,
+        )
+    except ApplianceManifestError as exc:
+        _fail(str(exc), exc)
+    _emit(
+        {
+            "prepared": True,
+            "release_id": descriptor.release_id,
+            "manifest_digest": descriptor.manifest_digest,
+            "payload_digest": descriptor.payload_digest,
+        }
+    )
+
+
+@app.command("seal")
+def seal(
+    release_dir: Path = typer.Option(
+        ...,
+        "--release-dir",
+        help="Staged release directory containing a canonical manifest.",
+    ),
+    private_key: Path = typer.Option(
+        ...,
+        "--private-key",
+        help="External Ed25519 release signing key; never copied into the release.",
+    ),
+    qualification_public_key: Path = typer.Option(
+        ...,
+        "--qualification-public-key",
+        help="External Ed25519 trust anchor for APP-2 qualification evidence.",
+    ),
+) -> None:
+    """Validate and seal a staged appliance release."""
+
+    try:
+        inspection = seal_release_directory(
+            release_dir,
+            private_key,
+            qualification_public_key_path=qualification_public_key,
+        )
+    except ApplianceManifestError as exc:
+        _fail(str(exc), exc)
+    _emit(
+        {
+            "sealed": True,
+            "release_id": inspection.release_id,
+            "manifest_digest": inspection.manifest_digest,
+            "payload_digest": inspection.payload_digest,
+        }
+    )
+
+
+@app.command("prepare")
+def prepare(
+    release_dir: Path = typer.Option(
+        ...,
+        "--release-dir",
+        help="Directory containing all staged release artifacts.",
+    ),
+    template: Path = typer.Option(
+        ...,
+        "--template",
+        help="External strict metadata template; artifact identities are derived.",
+    ),
+) -> None:
+    """Derive and write the canonical unsigned manifest from staged bytes."""
+
+    try:
+        manifest = prepare_release_manifest(release_dir, template)
+    except ApplianceManifestError as exc:
+        _fail(str(exc), exc)
+    _emit(
+        {
+            "prepared": True,
+            "release_id": manifest.release_id,
+            "payload_digest": manifest.payload_digest,
+            "artifact_count": len(manifest.artifacts),
+        }
+    )
+
+
+def _verified_inspection(
+    release_dir: Path,
+    public_key: Path,
+    qualification_public_key: Path,
+) -> ApplianceReleaseInspection:
+    try:
+        return verify_release_directory(
+            release_dir,
+            public_key,
+            qualification_public_key_path=qualification_public_key,
+        )
+    except ApplianceManifestError as exc:
+        _fail(str(exc), exc)
+
+
+@app.command("verify")
+def verify(
+    release_dir: Path = typer.Option(..., "--release-dir"),
+    public_key: Path = typer.Option(
+        ...,
+        "--public-key",
+        help="Configured Ed25519 release trust anchor.",
+    ),
+    qualification_public_key: Path = typer.Option(
+        ...,
+        "--qualification-public-key",
+        help="Independent Ed25519 trust anchor for APP-2 qualification.",
+    ),
+) -> None:
+    """Fail closed unless the complete release and evidence verify."""
+
+    inspection = _verified_inspection(
+        release_dir,
+        public_key,
+        qualification_public_key,
+    )
+    _emit(
+        {
+            "passed": True,
+            "release_id": inspection.release_id,
+            "aptl_version": inspection.aptl_version,
+            "manifest_digest": inspection.manifest_digest,
+            "payload_digest": inspection.payload_digest,
+        }
+    )
+
+
+@app.command("inspect")
+def inspect(
+    release_dir: Path = typer.Option(..., "--release-dir"),
+    public_key: Path = typer.Option(
+        ...,
+        "--public-key",
+        help="Configured Ed25519 release trust anchor.",
+    ),
+    qualification_public_key: Path = typer.Option(
+        ...,
+        "--qualification-public-key",
+        help="Independent Ed25519 trust anchor for APP-2 qualification.",
+    ),
+) -> None:
+    """Print the bounded host/readiness projection of a verified release."""
+
+    inspection = _verified_inspection(
+        release_dir,
+        public_key,
+        qualification_public_key,
+    )
+    _emit(asdict(inspection))
+
+
+@app.command("bootstrap-overlay", hidden=True)
+def bootstrap_overlay(
+    state_dir: Path = typer.Option(
+        Path("/var/lib/aptl/overlay"),
+        "--state-dir",
+        help="Guest-only mutable state directory on the disposable overlay.",
+    ),
+) -> None:
+    """Create per-overlay identity once without exposing its credential."""
+
+    try:
+        identity = initialize_overlay_state(state_dir)
+    except ApplianceBootstrapError as exc:
+        _fail(str(exc), exc)
+    _emit({"initialized": True, "instance_id": identity.instance_id})

--- a/src/aptl/cli/appliance.py
+++ b/src/aptl/cli/appliance.py
@@ -34,10 +34,14 @@ app = typer.Typer(help="Build and verify signed disposable appliance releases.")
 
 
 def _emit(payload: dict[str, object]) -> None:
+    """Emit one stable machine-readable success record."""
+
     typer.echo(json.dumps(payload, separators=(",", ":"), sort_keys=True))
 
 
 def _fail(message: str, exc: Exception) -> None:
+    """Emit one bounded error and terminate the command."""
+
     typer.echo(f"error: {message}", err=True)
     raise typer.Exit(code=2) from exc
 
@@ -240,6 +244,8 @@ def _verified_inspection(
     public_key: Path,
     qualification_public_key: Path,
 ) -> ApplianceReleaseInspection:
+    """Verify a release or translate its bounded error to the CLI."""
+
     try:
         return verify_release_directory(
             release_dir,

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -82,7 +82,7 @@ def _confirm_destructive(skip_prompt: bool) -> bool:
 
 
 @app.command()
-def start(
+def start(  # NOSONAR - Typer exposes one parameter per user-visible CLI option.
     project_dir: Path = typer.Option(
         Path("."),
         "--project-dir",
@@ -168,16 +168,16 @@ def start(
             err=True,
         )
         raise typer.Exit(code=2)
-    appliance_kwargs = (
-        {
-            "appliance_launch_descriptor": appliance_launch_descriptor,
-            "appliance_release_public_key": appliance_release_public_key,
-            "appliance_qualification_public_key": (appliance_qualification_public_key),
-        }
-        if appliance_launch_descriptor is not None
-        else {}
-    )
-    offline_kwargs = {"offline_staged": True} if offline_staged else {}
+    from aptl.core.lab import ApplianceStartOptions
+
+    appliance_kwargs = {}
+    if offline_staged or appliance_launch_descriptor is not None:
+        appliance_kwargs["appliance"] = ApplianceStartOptions(
+            offline_staged=offline_staged,
+            launch_descriptor=appliance_launch_descriptor,
+            release_public_key=appliance_release_public_key,
+            qualification_public_key=appliance_qualification_public_key,
+        )
     if clean:
         if not _confirm_destructive(yes):
             raise typer.Exit(code=0)
@@ -187,7 +187,6 @@ def start(
             skip_seed=skip_seed,
             scenario_path=selected_scenario,
             progress=_emit_lab_start_progress,
-            **offline_kwargs,
             **appliance_kwargs,
         )
     else:
@@ -196,7 +195,6 @@ def start(
             skip_seed=skip_seed,
             scenario_path=selected_scenario,
             progress=_emit_lab_start_progress,
-            **offline_kwargs,
             **appliance_kwargs,
         )
 

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -120,6 +120,29 @@ def start(
         "-y",
         help="Skip the confirmation prompt for --clean.",
     ),
+    offline_staged: bool = typer.Option(
+        False,
+        "--offline-staged",
+        help=(
+            "Use only pre-staged appliance images and MCP artifacts; "
+            "forbid pulls and builds."
+        ),
+    ),
+    appliance_launch_descriptor: Optional[Path] = typer.Option(
+        None,
+        "--appliance-launch-descriptor",
+        help="Create-once descriptor for a verified appliance release.",
+    ),
+    appliance_release_public_key: Optional[Path] = typer.Option(
+        None,
+        "--appliance-release-public-key",
+        help="Release trust anchor used to reverify the launch descriptor.",
+    ),
+    appliance_qualification_public_key: Optional[Path] = typer.Option(
+        None,
+        "--appliance-qualification-public-key",
+        help="Independent APP-2 qualification trust anchor.",
+    ),
 ) -> None:
     """Start the APTL lab environment."""
     log.info("Starting lab from %s (clean=%s)", project_dir, clean)
@@ -134,6 +157,27 @@ def start(
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2)
 
+    launch_values = (
+        appliance_launch_descriptor,
+        appliance_release_public_key,
+        appliance_qualification_public_key,
+    )
+    if any(launch_values) and (not all(launch_values) or not offline_staged):
+        typer.echo(
+            "error: appliance launch requires both trust anchors and --offline-staged",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    appliance_kwargs = (
+        {
+            "appliance_launch_descriptor": appliance_launch_descriptor,
+            "appliance_release_public_key": appliance_release_public_key,
+            "appliance_qualification_public_key": (appliance_qualification_public_key),
+        }
+        if appliance_launch_descriptor is not None
+        else {}
+    )
+    offline_kwargs = {"offline_staged": True} if offline_staged else {}
     if clean:
         if not _confirm_destructive(yes):
             raise typer.Exit(code=0)
@@ -143,6 +187,8 @@ def start(
             skip_seed=skip_seed,
             scenario_path=selected_scenario,
             progress=_emit_lab_start_progress,
+            **offline_kwargs,
+            **appliance_kwargs,
         )
     else:
         result = orchestrate_lab_start(
@@ -150,6 +196,8 @@ def start(
             skip_seed=skip_seed,
             scenario_path=selected_scenario,
             progress=_emit_lab_start_progress,
+            **offline_kwargs,
+            **appliance_kwargs,
         )
 
     render_start_result(result)

--- a/src/aptl/cli/lab.py
+++ b/src/aptl/cli/lab.py
@@ -83,7 +83,7 @@ def _confirm_destructive(skip_prompt: bool) -> bool:
 
 @app.command()
 def start(  # NOSONAR - Typer exposes one parameter per user-visible CLI option.
-    project_dir: Path = typer.Option(
+    project_dir: Path = typer.Option(  # NOSONAR - required Typer option surface.
         Path("."),
         "--project-dir",
         "-d",

--- a/src/aptl/cli/main.py
+++ b/src/aptl/cli/main.py
@@ -5,7 +5,7 @@ from typing import Optional
 import typer
 
 import aptl
-from aptl.cli import config, container, experiment, kill, lab, runs, web
+from aptl.cli import appliance, config, container, experiment, kill, lab, runs, web
 
 app = typer.Typer(
     name="aptl",
@@ -20,6 +20,7 @@ app.add_typer(runs.app, name="runs")
 app.add_typer(web.app, name="web")
 app.add_typer(kill.app, name="kill")
 app.add_typer(experiment.app, name="experiment")
+app.add_typer(appliance.app, name="appliance")
 
 
 def _version_callback(value: bool) -> None:

--- a/src/aptl/core/deployment/__init__.py
+++ b/src/aptl/core/deployment/__init__.py
@@ -61,7 +61,12 @@ __all__ = [
 ]
 
 
-def get_backend(config: AptlConfig, project_dir: Path) -> DeploymentBackend:
+def get_backend(
+    config: AptlConfig,
+    project_dir: Path,
+    *,
+    offline_staged: bool = False,
+) -> DeploymentBackend:
     """Create a deployment backend from configuration.
 
     Reads ``config.deployment.provider`` to select the backend:
@@ -86,9 +91,14 @@ def get_backend(config: AptlConfig, project_dir: Path) -> DeploymentBackend:
         return DockerComposeBackend(
             project_dir=project_dir,
             project_name=project_name,
+            offline_staged=offline_staged,
         )
 
     if provider == "ssh-compose":
+        if offline_staged:
+            raise ValueError(
+                "offline staged appliance start requires local guest Docker Compose"
+            )
         dep = config.deployment
         if not dep.ssh_host:
             raise ValueError("deployment.ssh_host is required for ssh-compose provider")

--- a/src/aptl/core/deployment/_compose_base_substrate.py
+++ b/src/aptl/core/deployment/_compose_base_substrate.py
@@ -77,12 +77,16 @@ class ComposeBaseSubstrateMixin(object):
         """
 
         build_context = _GENERIC_BASE_IMAGE_BUILD_CONTEXTS.get(image_ref)
-        if build_context is None:
+        if build_context is None and not self._offline_staged:
             return []
         inspect_result = self._run(
             ["docker", "image", "inspect", image_ref], timeout=30
         )
         if inspect_result.returncode == 0:
+            return []
+        if self._offline_staged:
+            return [f"required staged generic base image is missing: {image_ref}"]
+        if build_context is None:
             return []
         build_result = self._run(
             [
@@ -130,6 +134,7 @@ class ComposeBaseSubstrateMixin(object):
         argv = [
             "docker",
             "create" if network_bindings is not None else "run",
+            *(["--pull=never"] if self._offline_staged else []),
             "--name",
             spec.container_name,
             "--label",

--- a/src/aptl/core/deployment/_compose_base_substrate.py
+++ b/src/aptl/core/deployment/_compose_base_substrate.py
@@ -77,32 +77,31 @@ class ComposeBaseSubstrateMixin(object):
         """
 
         build_context = _GENERIC_BASE_IMAGE_BUILD_CONTEXTS.get(image_ref)
+        failures: list[str] = []
         if build_context is None and not self._offline_staged:
-            return []
+            return failures
         inspect_result = self._run(
             ["docker", "image", "inspect", image_ref], timeout=30
         )
-        if inspect_result.returncode == 0:
-            return []
-        if self._offline_staged:
-            return [f"required staged generic base image is missing: {image_ref}"]
-        if build_context is None:
-            return []
-        build_result = self._run(
-            [
-                "docker",
-                "build",
-                "-t",
-                image_ref,
-                str(self._project_dir / build_context),
-            ],
-            timeout=600,
-        )
-        return (
-            []
-            if build_result.returncode == 0
-            else [f"failed to build generic base image {image_ref}"]
-        )
+        if inspect_result.returncode != 0:
+            if self._offline_staged:
+                failures.append(
+                    f"required staged generic base image is missing: {image_ref}"
+                )
+            elif build_context is not None:
+                build_result = self._run(
+                    [
+                        "docker",
+                        "build",
+                        "-t",
+                        image_ref,
+                        str(self._project_dir / build_context),
+                    ],
+                    timeout=600,
+                )
+                if build_result.returncode != 0:
+                    failures.append(f"failed to build generic base image {image_ref}")
+        return failures
 
     def start_base_container(self, spec: "BaseContainerSpec") -> None:
         """Start a node's generic base container (ADR-048).

--- a/src/aptl/core/deployment/_compose_boundary.py
+++ b/src/aptl/core/deployment/_compose_boundary.py
@@ -42,12 +42,15 @@ class _BoundaryRunner(Protocol):
 def _helper_command(
     action: str,
     image: str = DEFAULT_BOUNDARY_HELPER_IMAGE,
+    *,
+    pull_never: bool = False,
 ) -> list[str]:
     """Build the fixed, capability-minimal helper invocation."""
 
     return [
         "docker",
         "run",
+        *(["--pull=never"] if pull_never else []),
         "--rm",
         "--network",
         "host",
@@ -75,13 +78,14 @@ def realize_boundary(
     if helper is not None:
         return helper
     payload = policy.canonical_json()
+    pull_never = bool(getattr(backend, "_offline_staged", False))
     action = (
         "cleanup"
         if isinstance(policy, AcesBoundarySpec) and not policy.rules
         else "apply"
     )
     mutation = backend._run_with_input(
-        _helper_command(action, helper_image),
+        _helper_command(action, helper_image, pull_never=pull_never),
         payload,
         timeout=_BOUNDARY_TIMEOUT,
     )
@@ -89,7 +93,7 @@ def realize_boundary(
         return LabResult(success=False, error="Boundary policy mutation failed.")
     observation = (
         backend._run_with_input(
-            _helper_command("observe", helper_image),
+            _helper_command("observe", helper_image, pull_never=pull_never),
             payload,
             timeout=_BOUNDARY_TIMEOUT,
         )
@@ -143,7 +147,10 @@ def _ensure_helper(
         timeout=_BOUNDARY_TIMEOUT,
     )
     result: LabResult | None = None
-    if inspection.returncode != 0 and helper_image != DEFAULT_BOUNDARY_HELPER_IMAGE:
+    offline_staged = bool(getattr(backend, "_offline_staged", False))
+    if inspection.returncode != 0 and (
+        offline_staged or helper_image != DEFAULT_BOUNDARY_HELPER_IMAGE
+    ):
         result = LabResult(
             success=False,
             error="Signed boundary enforcement helper was unavailable.",

--- a/src/aptl/core/deployment/_compose_content_realization.py
+++ b/src/aptl/core/deployment/_compose_content_realization.py
@@ -85,6 +85,7 @@ class ComposeRealizationContentMixin:
             [
                 "docker",
                 "run",
+                *(["--pull=never"] if self._offline_staged else []),
                 "--rm",
                 "--user",
                 "0:0",

--- a/src/aptl/core/deployment/_compose_image_realization.py
+++ b/src/aptl/core/deployment/_compose_image_realization.py
@@ -47,11 +47,32 @@ class ComposeRealizationImageMixin:
         if not realization.images:
             return None, None
         for image in realization.images:
-            result = self._realize_image(image)
+            result = (
+                self._verify_staged_image(image)
+                if self._offline_staged
+                else self._realize_image(image)
+            )
             if result is not None:
                 return result, None
         override_path = self._write_image_override(realization.images)
         return None, (self._project_dir / "docker-compose.yml", override_path)
+
+    def _verify_staged_image(
+        self,
+        image: DeploymentImageRealization,
+    ) -> LabResult | None:
+        """Fail closed when an offline appliance did not stage an exact image."""
+
+        result = self._run(
+            ["docker", "image", "inspect", image.image_ref],
+            timeout=_IMAGE_REALIZATION_TIMEOUT,
+        )
+        if result.returncode == 0:
+            return None
+        return LabResult(
+            success=False,
+            error=f"Staged image missing for ACES node {image.address}.",
+        )
 
     def _realize_image(
         self,
@@ -158,8 +179,11 @@ class ComposeRealizationImageMixin:
         """Start lab services using a generated realization override."""
 
         cmd = self._build_command("up", profiles, compose_files=compose_files)
+        build = build and not self._offline_staged
         if build:
             cmd.append("--build")
+        if self._offline_staged:
+            cmd.extend(["--pull", "never"])
         cmd.append("-d")
         for service in exclude_services:
             cmd += ["--scale", f"{service}=0"]

--- a/src/aptl/core/deployment/_compose_realization.py
+++ b/src/aptl/core/deployment/_compose_realization.py
@@ -157,7 +157,7 @@ class ComposeRealizationMixin(
 
             start_result = self._start_realized_services(
                 profiles,
-                build=build,
+                build=build and not self._offline_staged,
                 compose_files=compose_files,
                 exclude_services=excluded_services,
             )

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -37,15 +37,7 @@ from aptl.core.seed_spec import NamedVolumeSeed
 from aptl.utils.logging import get_logger
 
 log = get_logger("deployment.docker_compose")
-# Timeout for Docker Compose subprocess calls during kill operations.
-# Generous enough for a large stack, short enough that a hung daemon
-# won't block the kill switch indefinitely.
 _DOCKER_TIMEOUT = 30
-
-# Timeout for a single volume-seed / legacy-retire container (ADR-043).
-# The copy itself is a handful of small files, but the first seed on a
-# fresh host may pull the seeder image (already in the lab's supply
-# chain), so the margin is deliberately generous.
 _SEED_TIMEOUT = 600
 
 
@@ -116,13 +108,6 @@ class DockerComposeBackend(
         Returns:
             Command as a list of strings suitable for subprocess.run().
         """
-        # Pin the compose project name. Without `-p`, docker compose derives the
-        # project from the working-directory basename, which diverges from
-        # `self._project_name` in any worktree not literally named after the
-        # project (e.g. a `aptl3` git worktree). That divergence makes `start`
-        # / `stop` (this builder) act on a different project than `status` and
-        # the orphan-cleanup filters, so a lab started here cannot be stopped or
-        # inspected and its networks collide with the real project's subnets.
         cmd = ["docker", "compose", "-p", self._project_name]
         for compose_file in compose_files or ():
             cmd.extend(["-f", str(compose_file)])
@@ -154,14 +139,6 @@ class DockerComposeBackend(
         else:
             kwargs["capture_output"] = True
             kwargs["text"] = True
-            # Decode captured docker/compose output as UTF-8 explicitly.
-            # Without this, `text=True` decodes with the host's locale
-            # codec, which on Windows is cp1252 and cannot decode the
-            # non-ASCII bytes BuildKit emits (progress glyphs, box-drawing) —
-            # the reader thread raises UnicodeDecodeError mid-build, the
-            # compose call is seen as failed, and the 60s retry then
-            # collides with the containers the first attempt already started.
-            # `errors="replace"` keeps a stray byte from ever aborting a read.
             kwargs["encoding"] = "utf-8"
             kwargs["errors"] = "replace"
         if timeout is not None:
@@ -360,20 +337,10 @@ class DockerComposeBackend(
         warnings: list[str] = []
         for image in images:
             try:
-                action = (
-                    ["docker", "image", "inspect", image]
-                    if self._offline_staged
-                    else ["docker", "pull", image]
-                )
+                action = self._image_fetch_action(image)
                 result = self._run(action)
                 if result.returncode != 0:
-                    msg = (
-                        f"Required staged image is missing: {image}"
-                        if self._offline_staged
-                        else f"Failed to pull {image}: {result.stderr.strip()}"
-                    )
-                    log.warning(msg)
-                    warnings.append(msg)
+                    warnings.append(self._image_fetch_failure(image, result.stderr))
                 else:
                     log.info(
                         "%s %s",
@@ -381,14 +348,34 @@ class DockerComposeBackend(
                         image,
                     )
             except OSError as exc:
-                msg = (
-                    f"Required staged image could not be inspected: {image}"
-                    if self._offline_staged
-                    else f"Failed to pull {image}: {exc}"
-                )
+                msg = self._image_fetch_exception(image, exc)
                 log.warning(msg)
                 warnings.append(msg)
         return warnings
+
+    def _image_fetch_action(self, image: str) -> list[str]:
+        """Return the staged inspection or online pull command for one image."""
+
+        if self._offline_staged:
+            return ["docker", "image", "inspect", image]
+        return ["docker", "pull", image]
+
+    def _image_fetch_failure(self, image: str, stderr: str) -> str:
+        """Return and log one bounded image verification failure."""
+
+        if self._offline_staged:
+            message = f"Required staged image is missing: {image}"
+        else:
+            message = f"Failed to pull {image}: {stderr.strip()}"
+        log.warning(message)
+        return message
+
+    def _image_fetch_exception(self, image: str, exc: OSError) -> str:
+        """Return one image operation failure caused by a local tool error."""
+
+        if self._offline_staged:
+            return f"Required staged image could not be inspected: {image}"
+        return f"Failed to pull {image}: {exc}"
 
     def seed_named_volumes(
         self,
@@ -438,11 +425,6 @@ class DockerComposeBackend(
         ]
         result = self._run(cmd, timeout=_SEED_TIMEOUT)
         if result.returncode != 0:
-            # Name only the artifact in the raised message — raw Docker
-            # stderr never reaches the exception (test_nonzero_exit_raises_
-            # without_leaking_stderr). The operator-facing log line carries
-            # a redacted stderr tail so a seed failure is diagnosable
-            # without rerunning the docker command by hand (issue #716).
             log.error(
                 "Seed of volume %s failed (exit %s)%s",
                 seed.volume_suffix,
@@ -456,12 +438,7 @@ class DockerComposeBackend(
     def _build_seed_script(self, seed: NamedVolumeSeed) -> str:
         """Build the fixed-path copy script for one seed.
 
-        Only the fixed container paths ``/src`` and ``/dest`` plus
-        validated, code-defined relpaths appear in the returned string;
-        the host source dir and the volume name travel through argv ``-v``
-        flags, never the shell text (ADR-043 §Security Layers). Root
-        ``cp`` overwrites prior content, so the seed is idempotent
-        regardless of the existing owner.
+        Only fixed container paths and validated relpaths enter shell text.
         """
         parts = ["set -e"]
         for seed_file in seed.files:
@@ -484,11 +461,7 @@ class DockerComposeBackend(
     ) -> None:
         """Remove a seed's pre-ADR-043 legacy host bind dir, if present.
 
-        The directory may be owned by the in-container ``suricata`` UID
-        (991), so the host operator cannot delete it. A root container
-        mounts the host-owned *parent* and removes the single canonical
-        child by name — a narrow, path-contained cleanup (ADR-043), in
-        argv form against fixed container paths.
+        A root container mounts the parent and removes one validated child.
         """
         legacy = seed.legacy_retire_path
         if legacy is None:
@@ -512,9 +485,6 @@ class DockerComposeBackend(
         ]
         result = self._run(cmd, timeout=_SEED_TIMEOUT)
         if result.returncode != 0:
-            # Same redacted-hint contract as the seed path (issue #716): the
-            # raised message names only the artifact; the log line carries a
-            # redacted stderr tail for diagnosis.
             log.error(
                 "Retire of legacy seed path %s failed (exit %s)%s",
                 legacy,

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -68,9 +68,12 @@ class DockerComposeBackend(
         self,
         project_dir: Path,
         project_name: str = "aptl",
+        *,
+        offline_staged: bool = False,
     ) -> None:
         self._project_dir = project_dir
         self._project_name = project_name
+        self._offline_staged = offline_staged
         self._appliance_boundary: (
             tuple[
                 ApplianceBoundaryPolicy,
@@ -246,10 +249,13 @@ class DockerComposeBackend(
         Returns:
             LabResult indicating success or failure.
         """
+        build = build and not self._offline_staged
         compose_files = self._start_compose_files(build=build)
         cmd = self._build_command("up", profiles, compose_files=compose_files)
         if build:
             cmd.append("--build")
+        if self._offline_staged:
+            cmd.extend(["--pull", "never"])
         cmd.append("-d")
         for service in exclude_services:
             cmd += ["--scale", f"{service}=0"]
@@ -355,15 +361,32 @@ class DockerComposeBackend(
         warnings: list[str] = []
         for image in images:
             try:
-                result = self._run(["docker", "pull", image])
+                action = (
+                    ["docker", "image", "inspect", image]
+                    if self._offline_staged
+                    else ["docker", "pull", image]
+                )
+                result = self._run(action)
                 if result.returncode != 0:
-                    msg = f"Failed to pull {image}: {result.stderr.strip()}"
+                    msg = (
+                        f"Required staged image is missing: {image}"
+                        if self._offline_staged
+                        else f"Failed to pull {image}: {result.stderr.strip()}"
+                    )
                     log.warning(msg)
                     warnings.append(msg)
                 else:
-                    log.info("Pulled %s", image)
+                    log.info(
+                        "%s %s",
+                        "Verified staged image" if self._offline_staged else "Pulled",
+                        image,
+                    )
             except OSError as exc:
-                msg = f"Failed to pull {image}: {exc}"
+                msg = (
+                    f"Required staged image could not be inspected: {image}"
+                    if self._offline_staged
+                    else f"Failed to pull {image}: {exc}"
+                )
                 log.warning(msg)
                 warnings.append(msg)
         return warnings
@@ -400,6 +423,7 @@ class DockerComposeBackend(
         cmd = [
             "docker",
             "run",
+            *(["--pull=never"] if self._offline_staged else []),
             "--rm",
             "--user",
             "0:0",
@@ -475,6 +499,7 @@ class DockerComposeBackend(
         cmd = [
             "docker",
             "run",
+            *(["--pull=never"] if self._offline_staged else []),
             "--rm",
             "--user",
             "0:0",

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -281,6 +281,8 @@ def docker_client() -> "DockerClient":
 def _get_backend(
     project_dir: Path,
     config: AptlConfig | None = None,
+    *,
+    offline_staged: bool = False,
 ) -> "DeploymentBackend":
     """Create a deployment backend from config or defaults.
 
@@ -295,8 +297,15 @@ def _get_backend(
     from aptl.core.deployment.docker_compose import DockerComposeBackend
 
     if config is not None:
-        return get_backend(config, project_dir)
-    return DockerComposeBackend(project_dir=project_dir)
+        return get_backend(
+            config,
+            project_dir,
+            offline_staged=offline_staged,
+        )
+    return DockerComposeBackend(
+        project_dir=project_dir,
+        offline_staged=offline_staged,
+    )
 
 
 def build_compose_command(
@@ -413,6 +422,10 @@ def clean_boot_lab(
     scenario_path: Optional[Path] = None,
     backend: Optional["DeploymentBackend"] = None,
     progress: ProgressCallback | None = None,
+    offline_staged: bool = False,
+    appliance_launch_descriptor: Path | None = None,
+    appliance_release_public_key: Path | None = None,
+    appliance_qualification_public_key: Path | None = None,
 ) -> LabResult:
     """Boot the lab into a guaranteed clean state (RNG-001).
 
@@ -444,6 +457,7 @@ def clean_boot_lab(
         backend: Optional pre-created deployment backend, forwarded to the
             teardown so callers that already resolved one avoid a re-create.
         progress: Optional callback for participant-facing startup updates.
+        offline_staged: Require already-staged images and MCP artifacts.
 
     Returns:
         LabResult — the boot outcome on success, or a fatal ``FAILED``
@@ -465,11 +479,23 @@ def clean_boot_lab(
             outcome=StartupOutcome.FAILED,
         )
 
+    offline_kwargs = {"offline_staged": True} if offline_staged else {}
+    appliance_kwargs = (
+        {
+            "appliance_launch_descriptor": appliance_launch_descriptor,
+            "appliance_release_public_key": appliance_release_public_key,
+            "appliance_qualification_public_key": (appliance_qualification_public_key),
+        }
+        if appliance_launch_descriptor is not None
+        else {}
+    )
     return orchestrate_lab_start(
         project_dir,
         skip_seed=skip_seed,
         scenario_path=scenario_path,
         progress=progress,
+        **offline_kwargs,
+        **appliance_kwargs,
     )
 
 
@@ -608,9 +634,12 @@ def _bind_mount_error(
     parts = vol.split(":")
     src = parts[0]
     destination = parts[1] if len(parts) > 1 else ""
-    exempt_or_present = _stateful_realization_owns_mount(
-        svc_name, destination, src, stateful_owned_mounts
-    ) or (project_dir / src).resolve().exists()
+    exempt_or_present = (
+        _stateful_realization_owns_mount(
+            svc_name, destination, src, stateful_owned_mounts
+        )
+        or (project_dir / src).resolve().exists()
+    )
     if exempt_or_present:
         return None
     return (
@@ -689,6 +718,10 @@ class _LabStartContext(object):
 
     project_dir: Path
     skip_seed: bool
+    offline_staged: bool = False
+    appliance_launch_descriptor: Path | None = None
+    appliance_release_public_key: Path | None = None
+    appliance_qualification_public_key: Path | None = None
     scenario_path: Path | None = None
     progress: ProgressCallback | None = None
     raw_env: dict[str, str] = field(default_factory=dict)
@@ -710,9 +743,7 @@ class _LabStartContext(object):
     # workflow artifacts and the record share a single run directory.
     run_store: object = None
     run_id: str | None = None
-    stateful_artifact_ownership: frozenset[tuple[str, str, str, str, str]] = (
-        frozenset()
-    )
+    stateful_artifact_ownership: frozenset[tuple[str, str, str, str, str]] = frozenset()
 
 
 # Ownership tuples are (address, generator, service_name, mount_destination,
@@ -927,8 +958,83 @@ def _step_load_config(ctx: _LabStartContext) -> LabResult | None:
     except (FileNotFoundError, ValueError) as exc:
         log.exception("Failed to load config")
         return LabResult(success=False, error=f"Failed to load config: {exc}")
-    ctx.backend = _get_backend(ctx.project_dir, ctx.config)
+    ctx.backend = _get_backend(
+        ctx.project_dir,
+        ctx.config,
+        offline_staged=ctx.offline_staged,
+    )
+    launch_error = _configure_verified_appliance_launch(ctx)
+    if launch_error is not None:
+        return launch_error
     return _load_stateful_artifact_ownership(ctx)
+
+
+def _configure_verified_appliance_launch(
+    ctx: _LabStartContext,
+) -> LabResult | None:
+    """Reverify release identity and bind it to enforcement before startup."""
+
+    descriptor_path = ctx.appliance_launch_descriptor
+    if descriptor_path is None:
+        return None
+    if (
+        not ctx.offline_staged
+        or ctx.appliance_release_public_key is None
+        or ctx.appliance_qualification_public_key is None
+        or ctx.backend is None
+    ):
+        return LabResult(
+            success=False,
+            error="Appliance launch inputs are incomplete.",
+        )
+    from aptl.appliance.launch import verify_launch_descriptor
+    from aptl.appliance.manifest import ApplianceManifestError
+    from aptl.core.appliance_boundary import ApplianceBoundaryBinding
+
+    try:
+        launch = verify_launch_descriptor(
+            descriptor_path,
+            ctx.appliance_release_public_key,
+            ctx.appliance_qualification_public_key,
+        )
+        boot_id = Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+        daemon = subprocess.run(
+            ["docker", "info", "--format", "{{.ID}}"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout.strip()
+        if not boot_id or not daemon:
+            raise ValueError("runtime identity is unavailable")
+        descriptor = launch.descriptor
+        binding = ApplianceBoundaryBinding(
+            policy_digest=descriptor.boundary_policy_digest,
+            payload_digest=descriptor.payload_digest,
+            aces_plan_digest=descriptor.participant_routes_digest,
+            aces_boundary_required=True,
+            boundary_helper_image=descriptor.boundary_helper_image,
+            egress_proxy_image=descriptor.egress_proxy_image,
+            boot_id=boot_id,
+            guest_daemon_id=daemon,
+            host_observation_id=descriptor.host_observation_id,
+        )
+        ctx.backend.configure_appliance_boundary(
+            launch.boundary_policy,
+            binding,
+        )
+    except (
+        ApplianceManifestError,
+        OSError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        ValueError,
+    ):
+        return LabResult(
+            success=False,
+            error="Verified appliance launch binding failed.",
+        )
+    return None
 
 
 def _load_stateful_artifact_ownership(
@@ -996,7 +1102,9 @@ def _step_ensure_ssh_keys(ctx: _LabStartContext) -> LabResult | None:
         ("Pivot key generation", lambda: ensure_pivot_key(pivot_dir=pivot_dir)),
         (
             "Target authorized_keys generation",
-            lambda: ensure_target_authorized_keys(keys_dir=keys_dir, pivot_dir=pivot_dir),
+            lambda: ensure_target_authorized_keys(
+                keys_dir=keys_dir, pivot_dir=pivot_dir
+            ),
         ),
         (
             "Workstation pivot key generation",
@@ -1004,7 +1112,9 @@ def _step_ensure_ssh_keys(ctx: _LabStartContext) -> LabResult | None:
         ),
         (
             "Victim authorized_keys generation",
-            lambda: ensure_victim_authorized_keys(keys_dir=keys_dir, pivot_dir=pivot_dir),
+            lambda: ensure_victim_authorized_keys(
+                keys_dir=keys_dir, pivot_dir=pivot_dir
+            ),
         ),
     )
     for what, step in remaining_steps:
@@ -1196,9 +1306,19 @@ def _seed_suricata_volumes_local(ctx: _LabStartContext) -> LabResult | None:
     # seeder with no docker stderr in the redacted log path — pulling here
     # keeps registry failures at a stage the user can reason about (a
     # `Failed to pull ...` warning) instead of a bare seed-exit code.
-    for pull_warning in ctx.backend.pull_images([SURICATA_IMAGE]):
+    pull_warnings = list(ctx.backend.pull_images([SURICATA_IMAGE]))
+    for pull_warning in pull_warnings:
         log.warning(pull_warning)
-    ownership = ensure_suricata_config_source_ownership(ctx.project_dir, SURICATA_IMAGE)
+    if ctx.offline_staged and pull_warnings:
+        return LabResult(
+            success=False,
+            error="Offline staged Suricata image verification failed.",
+        )
+    ownership = ensure_suricata_config_source_ownership(
+        ctx.project_dir,
+        SURICATA_IMAGE,
+        pull_never=ctx.offline_staged,
+    )
     if not ownership.success:
         log.error(
             "Suricata config source ownership restore failed: %s",
@@ -1347,6 +1467,11 @@ def _step_pull_images(ctx: _LabStartContext) -> LabResult | None:
         # log-redaction boundary owns scrubbing it.
         log.warning(warning)
     if warnings:
+        if ctx.offline_staged:
+            return LabResult(
+                success=False,
+                error="Offline staged image verification failed.",
+            )
         # Pre-pull is a latency optimization — Compose pulls on demand
         # when containers start. Surface as a cosmetic info diagnostic
         # so automation sees the count without scraping the log.
@@ -2000,6 +2125,9 @@ def _step_pin_terminal_host_keys(ctx: _LabStartContext) -> LabResult | None:
 
 def _step_build_mcps(ctx: _LabStartContext) -> LabResult | None:
     """Build local MCP server artifacts after the lab is running."""
+    if ctx.offline_staged:
+        log.info("Using pre-staged MCP server artifacts")
+        return None
     log.info("Step 12: Building MCP servers...")
     mcp_script = ctx.project_dir / "mcp" / "build-all-mcps.sh"
     if not mcp_script.exists():
@@ -2279,6 +2407,10 @@ def orchestrate_lab_start(
     skip_seed: bool = False,
     scenario_path: Path | None = None,
     progress: ProgressCallback | None = None,
+    offline_staged: bool = False,
+    appliance_launch_descriptor: Path | None = None,
+    appliance_release_public_key: Path | None = None,
+    appliance_qualification_public_key: Path | None = None,
 ) -> LabResult:
     """Orchestrate the complete lab startup process.
 
@@ -2301,6 +2433,10 @@ def orchestrate_lab_start(
     ctx = _LabStartContext(
         project_dir=project_dir,
         skip_seed=skip_seed,
+        offline_staged=offline_staged,
+        appliance_launch_descriptor=appliance_launch_descriptor,
+        appliance_release_public_key=appliance_release_public_key,
+        appliance_qualification_public_key=appliance_qualification_public_key,
         scenario_path=scenario_path,
         progress=progress,
     )

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -96,6 +96,17 @@ log = get_logger("lab")
 
 ProgressCallback = Callable[[str], None]
 
+
+@dataclass(frozen=True)
+class ApplianceStartOptions:
+    """Offline and trust inputs for an optional verified appliance launch."""
+
+    offline_staged: bool = False
+    launch_descriptor: Path | None = None
+    release_public_key: Path | None = None
+    qualification_public_key: Path | None = None
+
+
 _STALE_NETWORK_RECOVERY_HINT = (
     "Run `aptl lab stop` and retry, or `aptl lab stop -v` if you need a clean lab."
 )
@@ -422,10 +433,7 @@ def clean_boot_lab(
     scenario_path: Optional[Path] = None,
     backend: Optional["DeploymentBackend"] = None,
     progress: ProgressCallback | None = None,
-    offline_staged: bool = False,
-    appliance_launch_descriptor: Path | None = None,
-    appliance_release_public_key: Path | None = None,
-    appliance_qualification_public_key: Path | None = None,
+    appliance: ApplianceStartOptions | None = None,
 ) -> LabResult:
     """Boot the lab into a guaranteed clean state (RNG-001).
 
@@ -479,22 +487,12 @@ def clean_boot_lab(
             outcome=StartupOutcome.FAILED,
         )
 
-    offline_kwargs = {"offline_staged": True} if offline_staged else {}
-    appliance_kwargs = (
-        {
-            "appliance_launch_descriptor": appliance_launch_descriptor,
-            "appliance_release_public_key": appliance_release_public_key,
-            "appliance_qualification_public_key": (appliance_qualification_public_key),
-        }
-        if appliance_launch_descriptor is not None
-        else {}
-    )
+    appliance_kwargs = {"appliance": appliance} if appliance is not None else {}
     return orchestrate_lab_start(
         project_dir,
         skip_seed=skip_seed,
         scenario_path=scenario_path,
         progress=progress,
-        **offline_kwargs,
         **appliance_kwargs,
     )
 
@@ -947,26 +945,29 @@ def _step_load_config(ctx: _LabStartContext) -> LabResult | None:
     """Load aptl.json and initialize the configured deployment backend."""
     log.info("Step 2: Loading configuration...")
     config_path = find_config(ctx.project_dir)
+    result: LabResult | None = None
     if config_path is None:
         log.error("No aptl.json found in %s", ctx.project_dir)
-        return LabResult(
+        result = LabResult(
             success=False,
             error=f"Config file aptl.json not found in {ctx.project_dir}",
         )
-    try:
-        ctx.config = load_config(config_path)
-    except (FileNotFoundError, ValueError) as exc:
-        log.exception("Failed to load config")
-        return LabResult(success=False, error=f"Failed to load config: {exc}")
-    ctx.backend = _get_backend(
-        ctx.project_dir,
-        ctx.config,
-        offline_staged=ctx.offline_staged,
-    )
-    launch_error = _configure_verified_appliance_launch(ctx)
-    if launch_error is not None:
-        return launch_error
-    return _load_stateful_artifact_ownership(ctx)
+    else:
+        try:
+            ctx.config = load_config(config_path)
+        except (FileNotFoundError, ValueError) as exc:
+            log.exception("Failed to load config")
+            result = LabResult(success=False, error=f"Failed to load config: {exc}")
+        if result is None:
+            ctx.backend = _get_backend(
+                ctx.project_dir,
+                ctx.config,
+                offline_staged=ctx.offline_staged,
+            )
+            result = _configure_verified_appliance_launch(ctx)
+        if result is None:
+            result = _load_stateful_artifact_ownership(ctx)
+    return result
 
 
 def _configure_verified_appliance_launch(
@@ -1315,45 +1316,46 @@ def _seed_suricata_volumes_local(ctx: _LabStartContext) -> LabResult | None:
     pull_warnings = list(ctx.backend.pull_images([SURICATA_IMAGE]))
     for pull_warning in pull_warnings:
         log.warning(pull_warning)
+    result: LabResult | None = None
     if ctx.offline_staged and pull_warnings:
-        return LabResult(
+        result = LabResult(
             success=False,
             error="Offline staged Suricata image verification failed.",
         )
-    ownership = ensure_suricata_config_source_ownership(
-        ctx.project_dir,
-        SURICATA_IMAGE,
-        pull_never=ctx.offline_staged,
-    )
-    if not ownership.success:
-        log.error(
-            "Suricata config source ownership restore failed: %s",
-            ownership.error,
+    if result is None:
+        ownership = ensure_suricata_config_source_ownership(
+            ctx.project_dir,
+            SURICATA_IMAGE,
+            pull_never=ctx.offline_staged,
         )
-        return LabResult(
-            success=False,
-            error=(
-                f"Suricata config source ownership restore failed: {ownership.error}"
-            ),
-        )
-    try:
-        seeds = build_suricata_volume_seeds(ctx.project_dir)
-        ctx.backend.seed_named_volumes(seeds, seeder_image=SURICATA_IMAGE)
-    except (
-        PathContainmentError,
-        BackendSeedError,
-        BackendTimeoutError,
-        # ``OSError`` subsumes ``FileNotFoundError`` / ``NotADirectoryError``.
-        OSError,
-    ) as exc:
-        # Narrow, redacted failure (ADR-043): name the artifact/exception
-        # type, not raw Docker stderr.
-        log.exception("Suricata volume seed failed: %s", type(exc).__name__)
-        return LabResult(
-            success=False,
-            error=f"Suricata runtime volume seeding failed: {exc}",
-        )
-    return None
+        if not ownership.success:
+            log.error(
+                "Suricata config source ownership restore failed: %s",
+                ownership.error,
+            )
+            result = LabResult(
+                success=False,
+                error=(
+                    "Suricata config source ownership restore failed: "
+                    f"{ownership.error}"
+                ),
+            )
+    if result is None:
+        try:
+            seeds = build_suricata_volume_seeds(ctx.project_dir)
+            ctx.backend.seed_named_volumes(seeds, seeder_image=SURICATA_IMAGE)
+        except (
+            PathContainmentError,
+            BackendSeedError,
+            BackendTimeoutError,
+            OSError,
+        ) as exc:
+            log.exception("Suricata volume seed failed: %s", type(exc).__name__)
+            result = LabResult(
+                success=False,
+                error=f"Suricata runtime volume seeding failed: {exc}",
+            )
+    return result
 
 
 def _step_generate_certs(ctx: _LabStartContext) -> LabResult | None:
@@ -2413,10 +2415,7 @@ def orchestrate_lab_start(
     skip_seed: bool = False,
     scenario_path: Path | None = None,
     progress: ProgressCallback | None = None,
-    offline_staged: bool = False,
-    appliance_launch_descriptor: Path | None = None,
-    appliance_release_public_key: Path | None = None,
-    appliance_qualification_public_key: Path | None = None,
+    appliance: ApplianceStartOptions | None = None,
 ) -> LabResult:
     """Orchestrate the complete lab startup process.
 
@@ -2436,13 +2435,14 @@ def orchestrate_lab_start(
         LabResult indicating overall success or failure.
     """
     log.info("Starting APTL lab from %s", project_dir)
+    appliance = appliance or ApplianceStartOptions()
     ctx = _LabStartContext(
         project_dir=project_dir,
         skip_seed=skip_seed,
-        offline_staged=offline_staged,
-        appliance_launch_descriptor=appliance_launch_descriptor,
-        appliance_release_public_key=appliance_release_public_key,
-        appliance_qualification_public_key=appliance_qualification_public_key,
+        offline_staged=appliance.offline_staged,
+        appliance_launch_descriptor=appliance.launch_descriptor,
+        appliance_release_public_key=appliance.release_public_key,
+        appliance_qualification_public_key=appliance.qualification_public_key,
         scenario_path=scenario_path,
         progress=progress,
     )

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -983,58 +983,64 @@ def _configure_verified_appliance_launch(
         or ctx.appliance_qualification_public_key is None
         or ctx.backend is None
     ):
-        return LabResult(
+        result = LabResult(
             success=False,
             error="Appliance launch inputs are incomplete.",
         )
-    from aptl.appliance.launch import verify_launch_descriptor
-    from aptl.appliance.manifest import ApplianceManifestError
-    from aptl.core.appliance_boundary import ApplianceBoundaryBinding
+    else:
+        from aptl.appliance.launch import verify_launch_descriptor
+        from aptl.core.appliance_boundary import ApplianceBoundaryBinding
 
-    try:
-        launch = verify_launch_descriptor(
-            descriptor_path,
-            ctx.appliance_release_public_key,
-            ctx.appliance_qualification_public_key,
-        )
-        boot_id = Path("/proc/sys/kernel/random/boot_id").read_text().strip()
-        daemon = subprocess.run(
-            ["docker", "info", "--format", "{{.ID}}"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        ).stdout.strip()
-        if not boot_id or not daemon:
-            raise ValueError("runtime identity is unavailable")
-        descriptor = launch.descriptor
-        binding = ApplianceBoundaryBinding(
-            policy_digest=descriptor.boundary_policy_digest,
-            payload_digest=descriptor.payload_digest,
-            aces_plan_digest=descriptor.participant_routes_digest,
-            aces_boundary_required=True,
-            boundary_helper_image=descriptor.boundary_helper_image,
-            egress_proxy_image=descriptor.egress_proxy_image,
-            boot_id=boot_id,
-            guest_daemon_id=daemon,
-            host_observation_id=descriptor.host_observation_id,
-        )
-        ctx.backend.configure_appliance_boundary(
-            launch.boundary_policy,
-            binding,
-        )
-    except (
-        ApplianceManifestError,
-        OSError,
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-        ValueError,
-    ):
-        return LabResult(
-            success=False,
-            error="Verified appliance launch binding failed.",
-        )
-    return None
+        try:
+            launch = verify_launch_descriptor(
+                descriptor_path,
+                ctx.appliance_release_public_key,
+                ctx.appliance_qualification_public_key,
+            )
+            boot_id = _read_appliance_boot_id()
+            daemon = subprocess.run(
+                ["docker", "info", "--format", "{{.ID}}"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            ).stdout.strip()
+            if not boot_id or not daemon:
+                raise ValueError("runtime identity is unavailable")
+            descriptor = launch.descriptor
+            binding = ApplianceBoundaryBinding(
+                policy_digest=descriptor.boundary_policy_digest,
+                payload_digest=descriptor.payload_digest,
+                aces_plan_digest=descriptor.participant_routes_digest,
+                aces_boundary_required=True,
+                boundary_helper_image=descriptor.boundary_helper_image,
+                egress_proxy_image=descriptor.egress_proxy_image,
+                boot_id=boot_id,
+                guest_daemon_id=daemon,
+                host_observation_id=descriptor.host_observation_id,
+            )
+            ctx.backend.configure_appliance_boundary(
+                launch.boundary_policy,
+                binding,
+            )
+            result = None
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            ValueError,
+        ):
+            result = LabResult(
+                success=False,
+                error="Verified appliance launch binding failed.",
+            )
+    return result
+
+
+def _read_appliance_boot_id() -> str:
+    """Read the Linux guest boot identity used by boundary enforcement."""
+
+    return Path("/proc/sys/kernel/random/boot_id").read_text().strip()
 
 
 def _load_stateful_artifact_ownership(

--- a/src/aptl/core/suricata_seed.py
+++ b/src/aptl/core/suricata_seed.py
@@ -75,7 +75,8 @@ class SuricataSourceOwnershipResult:
 def _suricata_config_source_files(project_dir: Path) -> tuple[Path, ...]:
     """Return the checked-in Suricata config seed sources (containment-checked)."""
     config_src = _resolve_within_project(
-        project_dir, _SURICATA_CONFIG_SOURCE_RELPATH,
+        project_dir,
+        _SURICATA_CONFIG_SOURCE_RELPATH,
     )
     paths: list[Path] = []
     for src_rel, _dest_rel in _SURICATA_CONFIG_SEED_FILES:
@@ -86,9 +87,7 @@ def _suricata_config_source_files(project_dir: Path) -> tuple[Path, ...]:
 def _foreign_owned_sources(source_files: tuple[Path, ...], uid: int) -> list[Path]:
     """Return the existing *source_files* not owned by *uid*."""
     return [
-        path
-        for path in source_files
-        if path.is_file() and path.stat().st_uid != uid
+        path for path in source_files if path.is_file() and path.stat().st_uid != uid
     ]
 
 
@@ -113,6 +112,8 @@ def _restore_via_container(
     gid: int,
     project_dir: Path,
     seeder_image: str,
+    *,
+    pull_never: bool,
 ) -> SuricataSourceOwnershipResult:
     """Chown the still-foreign sources from inside a root container.
 
@@ -134,17 +135,25 @@ def _restore_via_container(
     try:
         perm_result = subprocess.run(
             [
-                "docker", "run", "--rm",
+                "docker",
+                "run",
+                *(["--pull=never"] if pull_never else []),
+                "--rm",
                 # Harden the throwaway repair helper: no network namespace
                 # (it only chowns local bind-mounted files — zero egress
                 # surface), and an explicit root identity so the chown works
                 # regardless of the seeder image's default user.
-                "--network", "none",
-                "--user", "0:0",
-                "--entrypoint", "chown",
-                "-v", f"{project_dir}:/project",
+                "--network",
+                "none",
+                "--user",
+                "0:0",
+                "--entrypoint",
+                "chown",
+                "-v",
+                f"{project_dir}:/project",
                 seeder_image,
-                f"{uid}:{gid}", *rel_targets,
+                f"{uid}:{gid}",
+                *rel_targets,
             ],
             capture_output=True,
             text=True,
@@ -183,6 +192,8 @@ def _restore_via_container(
 def ensure_suricata_config_source_ownership(
     project_dir: Path,
     seeder_image: str = _SURICATA_SEEDER_IMAGE,
+    *,
+    pull_never: bool = False,
 ) -> SuricataSourceOwnershipResult:
     """Return checked-in Suricata seed sources to the invoking operator's uid/gid.
 
@@ -202,11 +213,18 @@ def ensure_suricata_config_source_ownership(
     if not hostenv.needs_host_ownership_fix():
         return SuricataSourceOwnershipResult(success=True)
 
-    return _ensure_suricata_config_source_ownership_linux(project_dir, seeder_image)
+    return _ensure_suricata_config_source_ownership_linux(
+        project_dir,
+        seeder_image,
+        pull_never=pull_never,
+    )
 
 
 def _ensure_suricata_config_source_ownership_linux(
-    project_dir: Path, seeder_image: str,
+    project_dir: Path,
+    seeder_image: str,
+    *,
+    pull_never: bool,
 ) -> SuricataSourceOwnershipResult:
     """Repair legacy Suricata source ownership on native Linux Docker hosts."""
     uid = os.getuid()
@@ -218,7 +236,12 @@ def _ensure_suricata_config_source_ownership_linux(
         result = SuricataSourceOwnershipResult(success=False, error=str(exc))
     else:
         result = _repair_foreign_sources(
-            source_files, uid, gid, project_dir, seeder_image
+            source_files,
+            uid,
+            gid,
+            project_dir,
+            seeder_image,
+            pull_never=pull_never,
         )
     return result
 
@@ -229,13 +252,20 @@ def _repair_foreign_sources(
     gid: int,
     project_dir: Path,
     seeder_image: str,
+    *,
+    pull_never: bool,
 ) -> SuricataSourceOwnershipResult:
     """Repair any Suricata seed source files not owned by the invoking user."""
     foreign = _foreign_owned_sources(source_files, uid)
     still_foreign = _chown_direct(foreign, uid, gid) if foreign else []
     if still_foreign:
         result = _restore_via_container(
-            still_foreign, uid, gid, project_dir, seeder_image
+            still_foreign,
+            uid,
+            gid,
+            project_dir,
+            seeder_image,
+            pull_never=pull_never,
         )
     else:
         repaired = tuple(str(p.relative_to(project_dir)) for p in foreign)
@@ -279,13 +309,9 @@ def build_suricata_volume_seeds(project_dir: Path) -> tuple[NamedVolumeSeed, ...
         FileNotFoundError: if a required source file is missing.
         NotADirectoryError: if a source directory is missing or not a dir.
     """
-    config_src = _resolve_within_project(
-        project_dir, _SURICATA_CONFIG_SOURCE_RELPATH
-    )
+    config_src = _resolve_within_project(project_dir, _SURICATA_CONFIG_SOURCE_RELPATH)
     if not config_src.is_dir():
-        raise NotADirectoryError(
-            f"Suricata config source dir not found: {config_src}"
-        )
+        raise NotADirectoryError(f"Suricata config source dir not found: {config_src}")
     config_files: list[SeedFile] = []
     for src_rel, dest_rel in _SURICATA_CONFIG_SEED_FILES:
         source_file = config_src / src_rel
@@ -295,9 +321,7 @@ def build_suricata_volume_seeds(project_dir: Path) -> tuple[NamedVolumeSeed, ...
             )
         config_files.append(SeedFile(src=src_rel, dest=dest_rel))
 
-    misp_src = _resolve_within_project(
-        project_dir, _SURICATA_MISP_RULES_SOURCE_RELPATH
-    )
+    misp_src = _resolve_within_project(project_dir, _SURICATA_MISP_RULES_SOURCE_RELPATH)
     if not misp_src.is_dir():
         raise NotADirectoryError(
             f"Suricata MISP rule baseline dir not found: {misp_src}"
@@ -314,9 +338,7 @@ def build_suricata_volume_seeds(project_dir: Path) -> tuple[NamedVolumeSeed, ...
     # Canonicalize the legacy bind dir for containment (rejecting a
     # symlinked chain) even though we only retire it when it exists — a
     # fresh checkout has nothing to clean up.
-    legacy = _canonical_generated_path(
-        project_dir, _SURICATA_LEGACY_MISP_RELPATH
-    )
+    legacy = _canonical_generated_path(project_dir, _SURICATA_LEGACY_MISP_RELPATH)
     legacy_retire = legacy if legacy.exists() else None
 
     config_seed = NamedVolumeSeed(

--- a/tests/test_appliance_build.py
+++ b/tests/test_appliance_build.py
@@ -21,8 +21,8 @@ from aptl.appliance.build import (
     create_disposable_overlay,
 )
 from aptl.appliance.launch import canonical_launch_bytes
-from aptl.appliance.models import ApplianceLaunchDescriptor
 from aptl.appliance.models import GoldenImageInventory
+from aptl.appliance.release_models import ApplianceLaunchDescriptor
 
 
 class RecordingRunner:

--- a/tests/test_appliance_build.py
+++ b/tests/test_appliance_build.py
@@ -239,14 +239,16 @@ def test_disposable_overlay_rejects_writable_or_tampered_golden(
         overlay_path="overlay.qcow2",
     )
 
+    runner = RecordingRunner()
     with pytest.raises(ApplianceBuildError, match="read-only"):
-        create_disposable_overlay(tmp_path, request, runner=RecordingRunner())
+        create_disposable_overlay(tmp_path, request, runner=runner)
 
     golden.chmod(0o644)
     golden.write_bytes(b"tampered")
     golden.chmod(0o444)
+    runner = RecordingRunner()
     with pytest.raises(ApplianceBuildError, match="digest"):
-        create_disposable_overlay(tmp_path, request, runner=RecordingRunner())
+        create_disposable_overlay(tmp_path, request, runner=runner)
 
 
 def test_disposable_overlay_never_replaces_existing_output(tmp_path: Path) -> None:
@@ -262,8 +264,9 @@ def test_disposable_overlay_never_replaces_existing_output(tmp_path: Path) -> No
         overlay_path="overlay.qcow2",
     )
 
+    runner = RecordingRunner()
     with pytest.raises(ApplianceBuildError, match="already exists"):
-        create_disposable_overlay(tmp_path, request, runner=RecordingRunner())
+        create_disposable_overlay(tmp_path, request, runner=runner)
 
     assert overlay.read_bytes() == b"active state"
 

--- a/tests/test_appliance_build.py
+++ b/tests/test_appliance_build.py
@@ -1,0 +1,331 @@
+"""Tests for immutable golden-image construction and overlay bootstrap."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aptl.appliance.bootstrap import (
+    ApplianceBootstrapError,
+    initialize_overlay_state,
+)
+from aptl.appliance.build import (
+    ApplianceBuildError,
+    GoldenImageBuildRequest,
+    OverlayCreateRequest,
+    build_golden_image,
+    create_disposable_overlay,
+)
+from aptl.appliance.launch import canonical_launch_bytes
+from aptl.appliance.models import ApplianceLaunchDescriptor
+from aptl.appliance.models import GoldenImageInventory
+
+
+class RecordingRunner:
+    """Subprocess double that materializes qemu-img's candidate output."""
+
+    def __init__(self, *, fail_program: str | None = None) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.fail_program = fail_program
+
+    def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(tuple(argv))
+        if argv[0] == self.fail_program:
+            raise subprocess.CalledProcessError(1, argv, stderr="unsafe raw detail")
+        if argv[:3] == ["qemu-img", "convert", "-f"]:
+            Path(argv[-1]).write_bytes(b"immutable golden image")
+        if argv[:3] == ["qemu-img", "create", "-f"]:
+            Path(argv[-1]).write_bytes(b"disposable overlay")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+
+def _request(root: Path) -> GoldenImageBuildRequest:
+    base = root / "inputs/base.qcow2"
+    payload = root / "inputs/offline-payload.tar"
+    provisioner = root / "inputs/provision-offline.sh"
+    scanner = root / "inputs/scan-golden.sh"
+    base.parent.mkdir(parents=True)
+    base.write_bytes(b"pinned ubuntu base")
+    payload.write_bytes(b"offline payload")
+    provisioner.write_text("#!/bin/sh\nset -eu\n")
+    scanner.write_text("#!/bin/sh\nset -eu\n")
+    return GoldenImageBuildRequest(
+        schema_version="aptl.golden-image-build/v1",
+        base_image_path="inputs/base.qcow2",
+        base_image_digest=f"sha256:{hashlib.sha256(base.read_bytes()).hexdigest()}",
+        offline_payload_path="inputs/offline-payload.tar",
+        offline_payload_digest=(
+            f"sha256:{hashlib.sha256(payload.read_bytes()).hexdigest()}"
+        ),
+        provisioner_path="inputs/provision-offline.sh",
+        provisioner_digest=(
+            f"sha256:{hashlib.sha256(provisioner.read_bytes()).hexdigest()}"
+        ),
+        scanner_path="inputs/scan-golden.sh",
+        scanner_digest=(f"sha256:{hashlib.sha256(scanner.read_bytes()).hexdigest()}"),
+        output_image_path="output/aptl-golden.qcow2",
+        inventory_output_path="output/golden-inventory.json",
+        virtual_size_bytes=120 * 1024**3,
+    )
+
+
+def _overlay_request(
+    root: Path,
+    *,
+    golden_path: str,
+    golden_digest: str,
+    overlay_path: str,
+) -> OverlayCreateRequest:
+    descriptor = ApplianceLaunchDescriptor(
+        schema_version="aptl.appliance-launch/v1",
+        release_dir="release",
+        release_id="aptl-v5.1.1-x86_64",
+        aptl_version="5.1.1",
+        manifest_digest="sha256:" + "1" * 64,
+        payload_digest="sha256:" + "2" * 64,
+        golden_image_digest=golden_digest,
+        boundary_policy_path="evidence/boundary-policy.json",
+        boundary_policy_digest="sha256:" + "3" * 64,
+        boundary_helper_image="example/helper@sha256:" + "4" * 64,
+        egress_proxy_image="example/proxy@sha256:" + "5" * 64,
+        participant_routes_digest="sha256:" + "6" * 64,
+        host_observation_id="sha256:" + "7" * 64,
+    )
+    payload = canonical_launch_bytes(descriptor)
+    (root / "launch.json").write_bytes(payload)
+    return OverlayCreateRequest(
+        schema_version="aptl.overlay-create/v1",
+        golden_image_path=golden_path,
+        golden_image_digest=golden_digest,
+        launch_descriptor_path="launch.json",
+        launch_descriptor_digest=f"sha256:{hashlib.sha256(payload).hexdigest()}",
+        overlay_path=overlay_path,
+    )
+
+
+def test_golden_image_build_uses_fixed_offline_commands_and_read_only_output(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path)
+    runner = RecordingRunner()
+
+    result = build_golden_image(tmp_path, request, runner=runner)
+
+    output = tmp_path / request.output_image_path
+    assert result.output_path == output
+    assert result.inventory_path == tmp_path / request.inventory_output_path
+    inventory = GoldenImageInventory.model_validate_json(
+        result.inventory_path.read_bytes()
+    )
+    assert inventory.scan_complete is True
+    assert result.sha256 == (
+        f"sha256:{hashlib.sha256(output.read_bytes()).hexdigest()}"
+    )
+    assert output.stat().st_mode & 0o777 == 0o444
+    assert [call[0] for call in runner.calls] == [
+        "qemu-img",
+        "qemu-img",
+        "virt-customize",
+        "virt-sysprep",
+        "virt-customize",
+        "qemu-img",
+    ]
+    customize = runner.calls[2]
+    assert "--no-network" in customize
+    assert "--run" in customize
+    assert all(
+        "http://" not in value and "https://" not in value for value in customize
+    )
+    assert all("/bin/sh" not in value and "bash" not in value for value in customize)
+    scanner = runner.calls[4]
+    assert "--no-network" in scanner
+    assert "--run" in scanner
+
+
+def test_golden_image_build_rejects_tampered_input_and_existing_release(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path)
+    (tmp_path / request.base_image_path).write_bytes(b"tampered")
+    runner = RecordingRunner()
+
+    with pytest.raises(ApplianceBuildError, match="base image digest"):
+        build_golden_image(tmp_path, request, runner=runner)
+    assert runner.calls == []
+
+    request = _request(tmp_path / "second")
+    output = tmp_path / "second" / request.output_image_path
+    output.parent.mkdir()
+    output.write_bytes(b"existing immutable release")
+    with pytest.raises(ApplianceBuildError, match="already exists"):
+        build_golden_image(tmp_path / "second", request, runner=runner)
+    assert output.read_bytes() == b"existing immutable release"
+
+
+def test_failed_build_never_replaces_or_leaves_a_candidate(tmp_path: Path) -> None:
+    request = _request(tmp_path)
+    runner = RecordingRunner(fail_program="virt-customize")
+
+    with pytest.raises(ApplianceBuildError) as exc_info:
+        build_golden_image(tmp_path, request, runner=runner)
+
+    assert str(exc_info.value) == "golden image build failed"
+    assert "unsafe raw detail" not in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, subprocess.CalledProcessError)
+    assert exc_info.value.__cause__.stderr == "unsafe raw detail"
+    assert not (tmp_path / request.output_image_path).exists()
+    assert not (tmp_path / request.inventory_output_path).exists()
+    assert list((tmp_path / "output").glob("*.candidate-*")) == []
+
+
+def test_build_request_requires_guest_asset_basenames(tmp_path: Path) -> None:
+    request = _request(tmp_path).model_dump()
+    request["offline_payload_path"] = "inputs/renamed.tar"
+
+    with pytest.raises(ValueError, match="offline payload path"):
+        GoldenImageBuildRequest.model_validate(request)
+
+
+def test_disposable_overlay_uses_verified_read_only_backing_file(
+    tmp_path: Path,
+) -> None:
+    golden = tmp_path / "release/aptl-golden.qcow2"
+    golden.parent.mkdir()
+    golden.write_bytes(b"immutable golden image")
+    golden.chmod(0o444)
+    request = _overlay_request(
+        tmp_path,
+        golden_path="release/aptl-golden.qcow2",
+        golden_digest=f"sha256:{hashlib.sha256(golden.read_bytes()).hexdigest()}",
+        overlay_path="instances/seat-01.qcow2",
+    )
+    runner = RecordingRunner()
+
+    result = create_disposable_overlay(tmp_path, request, runner=runner)
+
+    assert result.overlay_path == tmp_path / "instances/seat-01.qcow2"
+    assert result.overlay_path.stat().st_mode & 0o777 == 0o600
+    create = runner.calls[0]
+    assert create[:8] == (
+        "qemu-img",
+        "create",
+        "-f",
+        "qcow2",
+        "-F",
+        "qcow2",
+        "-b",
+        str(golden),
+    )
+    candidate = Path(create[-1])
+    assert candidate.name.startswith("seat-01.qcow2.candidate-")
+    assert runner.calls[1] == ("qemu-img", "check", "-q", str(candidate))
+    assert golden.read_bytes() == b"immutable golden image"
+    assert golden.stat().st_mode & 0o222 == 0
+
+
+def test_disposable_overlay_rejects_writable_or_tampered_golden(
+    tmp_path: Path,
+) -> None:
+    golden = tmp_path / "golden.qcow2"
+    golden.write_bytes(b"golden")
+    request = _overlay_request(
+        tmp_path,
+        golden_path="golden.qcow2",
+        golden_digest=f"sha256:{hashlib.sha256(b'golden').hexdigest()}",
+        overlay_path="overlay.qcow2",
+    )
+
+    with pytest.raises(ApplianceBuildError, match="read-only"):
+        create_disposable_overlay(tmp_path, request, runner=RecordingRunner())
+
+    golden.chmod(0o644)
+    golden.write_bytes(b"tampered")
+    golden.chmod(0o444)
+    with pytest.raises(ApplianceBuildError, match="digest"):
+        create_disposable_overlay(tmp_path, request, runner=RecordingRunner())
+
+
+def test_disposable_overlay_never_replaces_existing_output(tmp_path: Path) -> None:
+    golden = tmp_path / "golden.qcow2"
+    golden.write_bytes(b"golden")
+    golden.chmod(0o444)
+    overlay = tmp_path / "overlay.qcow2"
+    overlay.write_bytes(b"active state")
+    request = _overlay_request(
+        tmp_path,
+        golden_path="golden.qcow2",
+        golden_digest=f"sha256:{hashlib.sha256(b'golden').hexdigest()}",
+        overlay_path="overlay.qcow2",
+    )
+
+    with pytest.raises(ApplianceBuildError, match="already exists"):
+        create_disposable_overlay(tmp_path, request, runner=RecordingRunner())
+
+    assert overlay.read_bytes() == b"active state"
+
+
+def test_first_boot_identity_is_unique_per_overlay_and_stable_on_reboot(
+    tmp_path: Path,
+) -> None:
+    values = iter((b"a" * 32, b"b" * 32, b"c" * 32, b"d" * 32))
+
+    first = initialize_overlay_state(
+        tmp_path / "overlay-a",
+        entropy=lambda size: next(values),
+    )
+    reboot = initialize_overlay_state(
+        tmp_path / "overlay-a",
+        entropy=lambda size: pytest.fail("ordinary reboot regenerated state"),
+    )
+    second = initialize_overlay_state(
+        tmp_path / "overlay-b",
+        entropy=lambda size: next(values),
+    )
+
+    assert reboot == first
+    assert second.instance_id != first.instance_id
+    assert second.bootstrap_credential != first.bootstrap_credential
+    assert (tmp_path / "overlay-a").stat().st_mode & 0o777 == 0o700
+    assert (tmp_path / "overlay-a" / "identity.json").stat().st_mode & 0o777 == 0o600
+
+
+def test_first_boot_rejects_symlink_state_and_recovers_from_interrupted_temp(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    state = tmp_path / "state"
+    state.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(ApplianceBootstrapError, match="symlink"):
+        initialize_overlay_state(state)
+
+    clean = tmp_path / "clean"
+    clean.mkdir(mode=0o700)
+    (clean / ".identity.interrupted").write_bytes(b"partial secret")
+    identity = initialize_overlay_state(clean, entropy=lambda size: b"z" * size)
+    assert identity.instance_id.startswith("sha256:")
+    assert (clean / ".identity.interrupted").read_bytes() == b"partial secret"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes are required")
+def test_first_boot_rejects_world_accessible_existing_identity(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    state.mkdir(mode=0o700)
+    identity = state / "identity.json"
+    identity.write_text(
+        '{"schema_version":"aptl.overlay-identity/v1",'
+        '"instance_id":"sha256:'
+        + "a" * 64
+        + '","bootstrap_credential":"'
+        + "b" * 43
+        + '"}'
+    )
+    identity.chmod(0o644)
+
+    with pytest.raises(ApplianceBootstrapError, match="owner-only"):
+        initialize_overlay_state(state)

--- a/tests/test_appliance_cli.py
+++ b/tests/test_appliance_cli.py
@@ -128,9 +128,7 @@ def test_appliance_build_reports_bounded_failure_without_tool_stderr(
     fake_tools.mkdir()
     qemu_img = fake_tools / "qemu-img"
     qemu_img.write_text(
-        "#!/bin/sh\n"
-        "echo 'unsafe raw detail from qemu-img' >&2\n"
-        "exit 1\n"
+        "#!/bin/sh\necho 'unsafe raw detail from qemu-img' >&2\nexit 1\n"
     )
     qemu_img.chmod(0o755)
     monkeypatch.setenv("PATH", f"{fake_tools}:{os.environ['PATH']}")
@@ -211,7 +209,7 @@ def test_lab_start_forwards_offline_staged_mode(tmp_path: Path, monkeypatch) -> 
     )
 
     assert result.exit_code == 0, result.output
-    assert calls[0]["offline_staged"] is True
+    assert calls[0]["appliance"].offline_staged is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_appliance_cli.py
+++ b/tests/test_appliance_cli.py
@@ -1,0 +1,273 @@
+"""CLI tests for appliance build, seal, verify, and guest bootstrap."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from aptl.appliance.build import GoldenImageBuildRequest
+from aptl.appliance.manifest import ApplianceReleaseInspection
+from aptl.cli.main import app
+from aptl.core.lab_types import LabResult
+
+runner = CliRunner()
+
+
+def test_appliance_help_lists_local_overlay_creation() -> None:
+    result = runner.invoke(app, ["appliance", "--help"])
+
+    assert result.exit_code == 0
+    assert "create-overlay" in result.stdout
+    assert "prepare-launch" in result.stdout
+
+
+def test_appliance_verify_and_inspect_emit_only_safe_release_projection(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    release = tmp_path / "release"
+    release.mkdir()
+    public_key = tmp_path / "release-public.pem"
+    public_key.write_text("public")
+    qualification_key = tmp_path / "qualification-public.pem"
+    qualification_key.write_text("qualification")
+    inspection = ApplianceReleaseInspection(
+        release_id="aptl-v5.1.1-x86_64",
+        aptl_version="5.1.1",
+        source_commit="1" * 40,
+        manifest_digest="sha256:" + "a" * 64,
+        payload_digest="sha256:" + "b" * 64,
+        artifact_count=9,
+        architecture="x86_64",
+        minimum_host_vcpus=8,
+        minimum_host_memory_bytes=16 * 1024**3,
+        minimum_host_disk_bytes=100 * 1024**3,
+    )
+    monkeypatch.setattr(
+        "aptl.cli.appliance.verify_release_directory",
+        lambda release_dir, public_key_path, **kwargs: inspection,
+    )
+
+    verified = runner.invoke(
+        app,
+        [
+            "appliance",
+            "verify",
+            "--release-dir",
+            str(release),
+            "--public-key",
+            str(public_key),
+            "--qualification-public-key",
+            str(qualification_key),
+        ],
+    )
+    inspected = runner.invoke(
+        app,
+        [
+            "appliance",
+            "inspect",
+            "--release-dir",
+            str(release),
+            "--public-key",
+            str(public_key),
+            "--qualification-public-key",
+            str(qualification_key),
+        ],
+    )
+
+    assert verified.exit_code == 0, verified.output
+    assert json.loads(verified.stdout)["passed"] is True
+    projection = json.loads(inspected.stdout)
+    assert projection["release_id"] == inspection.release_id
+    assert projection["aptl_version"] == inspection.aptl_version
+    assert projection["payload_digest"] == inspection.payload_digest
+    assert "artifacts/" not in inspected.stdout
+    assert "machine_id" not in inspected.stdout
+    assert "credential" not in inspected.stdout
+
+
+def test_appliance_build_reports_bounded_failure_without_tool_stderr(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base = tmp_path / "inputs/base.qcow2"
+    payload = tmp_path / "inputs/offline-payload.tar"
+    provisioner = tmp_path / "inputs/provision-offline.sh"
+    scanner = tmp_path / "inputs/scan-golden.sh"
+    base.parent.mkdir()
+    base.write_bytes(b"pinned")
+    payload.write_bytes(b"offline")
+    provisioner.write_text("#!/bin/sh\n")
+    scanner.write_text("#!/bin/sh\n")
+    request = GoldenImageBuildRequest(
+        schema_version="aptl.golden-image-build/v1",
+        base_image_path="inputs/base.qcow2",
+        base_image_digest=f"sha256:{hashlib.sha256(base.read_bytes()).hexdigest()}",
+        offline_payload_path="inputs/offline-payload.tar",
+        offline_payload_digest=(
+            f"sha256:{hashlib.sha256(payload.read_bytes()).hexdigest()}"
+        ),
+        provisioner_path="inputs/provision-offline.sh",
+        provisioner_digest=(
+            f"sha256:{hashlib.sha256(provisioner.read_bytes()).hexdigest()}"
+        ),
+        scanner_path="inputs/scan-golden.sh",
+        scanner_digest=f"sha256:{hashlib.sha256(scanner.read_bytes()).hexdigest()}",
+        output_image_path="output/aptl-golden.qcow2",
+        inventory_output_path="output/golden-inventory.json",
+        virtual_size_bytes=120 * 1024**3,
+    )
+    request_path = tmp_path / "request.json"
+    request_path.write_text(request.model_dump_json())
+    fake_tools = tmp_path / "fake-tools"
+    fake_tools.mkdir()
+    qemu_img = fake_tools / "qemu-img"
+    qemu_img.write_text(
+        "#!/bin/sh\n"
+        "echo 'unsafe raw detail from qemu-img' >&2\n"
+        "exit 1\n"
+    )
+    qemu_img.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_tools}:{os.environ['PATH']}")
+
+    result = runner.invoke(
+        app,
+        [
+            "appliance",
+            "build",
+            "--build-root",
+            str(tmp_path),
+            "--request",
+            str(request_path),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert result.stderr == "error: golden image build failed\n"
+    assert "unsafe raw detail" not in result.output
+
+
+def test_appliance_bootstrap_command_never_prints_the_credential(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / "state"
+
+    first = runner.invoke(
+        app,
+        [
+            "appliance",
+            "bootstrap-overlay",
+            "--state-dir",
+            str(state_dir),
+        ],
+    )
+    credential = json.loads((state_dir / "identity.json").read_text())[
+        "bootstrap_credential"
+    ]
+    second = runner.invoke(
+        app,
+        [
+            "appliance",
+            "bootstrap-overlay",
+            "--state-dir",
+            str(state_dir),
+        ],
+    )
+
+    assert first.exit_code == second.exit_code == 0
+    assert credential not in first.output
+    assert credential not in second.output
+    assert json.loads(first.stdout)["initialized"] is True
+    assert json.loads(second.stdout)["initialized"] is True
+
+
+def test_lab_start_forwards_offline_staged_mode(tmp_path: Path, monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_start(project_dir, **kwargs):
+        calls.append({"project_dir": project_dir, **kwargs})
+        return LabResult(success=True, message="ready")
+
+    monkeypatch.setattr("aptl.cli.lab.orchestrate_lab_start", fake_start)
+    monkeypatch.setattr(
+        "aptl.cli.lab.resolve_scenario_selection",
+        lambda *args, **kwargs: None,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "lab",
+            "start",
+            "--project-dir",
+            str(tmp_path),
+            "--offline-staged",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls[0]["offline_staged"] is True
+
+
+@pytest.mark.parametrize(
+    "launch_args",
+    [
+        ["--appliance-launch-descriptor", "launch.json"],
+        ["--appliance-release-public-key", "release-public.pem"],
+        ["--appliance-qualification-public-key", "qualification-public.pem"],
+        [
+            "--appliance-launch-descriptor",
+            "launch.json",
+            "--appliance-release-public-key",
+            "release-public.pem",
+        ],
+        [
+            "--appliance-launch-descriptor",
+            "launch.json",
+            "--appliance-qualification-public-key",
+            "qualification-public.pem",
+        ],
+        [
+            "--appliance-release-public-key",
+            "release-public.pem",
+            "--appliance-qualification-public-key",
+            "qualification-public.pem",
+        ],
+        [
+            "--appliance-launch-descriptor",
+            "launch.json",
+            "--appliance-release-public-key",
+            "release-public.pem",
+            "--appliance-qualification-public-key",
+            "qualification-public.pem",
+        ],
+    ],
+)
+def test_lab_start_rejects_partial_or_online_appliance_launch(
+    tmp_path: Path,
+    monkeypatch,
+    launch_args: list[str],
+) -> None:
+    monkeypatch.setattr(
+        "aptl.cli.lab.resolve_scenario_selection",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "aptl.cli.lab.orchestrate_lab_start",
+        lambda *args, **kwargs: pytest.fail("invalid launch reached orchestration"),
+    )
+
+    result = runner.invoke(
+        app,
+        ["lab", "start", "--project-dir", str(tmp_path), *launch_args],
+    )
+
+    assert result.exit_code == 2
+    assert result.stderr == (
+        "error: appliance launch requires both trust anchors and --offline-staged\n"
+    )

--- a/tests/test_appliance_guest_assets.py
+++ b/tests/test_appliance_guest_assets.py
@@ -1,0 +1,59 @@
+"""Structural gates for the offline guest provisioning assets."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from aptl._asset_manifest import ASSET_ROOTS
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+GUEST_DIR = PROJECT_ROOT / "appliance" / "guest"
+
+
+def test_guest_scripts_are_valid_and_have_no_network_install_path() -> None:
+    scripts = (
+        GUEST_DIR / "provision-offline.sh",
+        GUEST_DIR / "aptl-appliance-first-boot",
+        GUEST_DIR / "scan-golden.sh",
+    )
+    for script in scripts:
+        subprocess.run(["sh", "-n", str(script)], check=True)
+        text = script.read_text()
+        assert "curl " not in text
+        assert "wget " not in text
+        assert "apt-get update" not in text
+        assert "docker pull" not in text
+        assert "npm " not in text
+
+    provisioner = scripts[0].read_text()
+    assert "pip install --no-index" in provisioner
+    assert '"aptl-labs==$APTL_APPLIANCE_VERSION"' in provisioner
+    assert "docker load" not in provisioner
+    assert "/opt/aptl/offline/oci-images.tar" in provisioner
+    assert "install -d -m 0700 /var/lib/aptl" in provisioner
+    assert "systemctl enable aptl-appliance-first-boot.service" in provisioner
+
+    first_boot = scripts[1].read_text()
+    assert "bootstrap-overlay" in first_boot
+    assert "docker load" in first_boot
+    assert "images-loaded" in first_boot
+    assert "lab start" in first_boot
+    assert "--offline-staged" in first_boot
+    assert "--appliance-launch-descriptor" in first_boot
+    assert "--appliance-release-public-key" in first_boot
+    assert "--appliance-qualification-public-key" in first_boot
+
+
+def test_first_boot_service_uses_guest_only_mutable_state() -> None:
+    service = (GUEST_DIR / "aptl-appliance-first-boot.service").read_text()
+
+    assert "After=docker.service" in service
+    assert "Requires=docker.service" in service
+    assert "ExecStart=/usr/local/libexec/aptl-appliance-first-boot" in service
+    assert "ProtectHome=true" in service
+    assert "ReadWritePaths=/var/lib/aptl /opt/aptl/project" in service
+
+
+def test_appliance_guest_assets_ship_with_the_lab_distribution() -> None:
+    assert "appliance" in ASSET_ROOTS

--- a/tests/test_appliance_offline_payload.py
+++ b/tests/test_appliance_offline_payload.py
@@ -1,0 +1,91 @@
+"""Tests for deterministic, closed offline appliance payloads."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from aptl.appliance.offline import OfflinePayloadError, build_offline_payload
+
+
+def _staging(root: Path) -> Path:
+    staging = root / "staging"
+    wheelhouse = staging / "wheelhouse"
+    wheelhouse.mkdir(parents=True)
+    (wheelhouse / "aptl_labs-5.1.1-py3-none-any.whl").write_bytes(b"wheel")
+    (wheelhouse / "pydantic-2-py3-none-any.whl").write_bytes(b"dependency")
+    (staging / "project.tar").write_bytes(b"tracked project assets")
+    (staging / "oci-images.tar").write_bytes(b"docker save output")
+    (staging / "appliance-release.env").write_text(
+        "APTL_APPLIANCE_SCENARIO=techvault-attacker-target\n"
+        "APTL_APPLIANCE_VERSION=5.1.1\n"
+    )
+    (staging / "aptl-appliance-first-boot").write_text("#!/bin/sh\nset -eu\n")
+    (staging / "aptl-appliance-first-boot.service").write_text("[Unit]\n")
+    return staging
+
+
+def test_offline_payload_is_byte_reproducible_and_read_only(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    first = build_offline_payload(staging, tmp_path / "first.tar")
+    second = build_offline_payload(staging, tmp_path / "second.tar")
+
+    assert first.sha256 == second.sha256
+    assert first.size_bytes == second.size_bytes
+    assert (tmp_path / "first.tar").read_bytes() == (
+        tmp_path / "second.tar"
+    ).read_bytes()
+    assert (tmp_path / "first.tar").stat().st_mode & 0o777 == 0o444
+    with tarfile.open(tmp_path / "first.tar", "r:") as archive:
+        names = archive.getnames()
+        assert names == sorted(names)
+        assert all(member.uid == member.gid == 0 for member in archive.getmembers())
+        assert all(member.mtime == 0 for member in archive.getmembers())
+
+
+def test_offline_payload_rejects_unknown_files_invalid_env_and_symlinks(
+    tmp_path: Path,
+) -> None:
+    staging = _staging(tmp_path)
+    (staging / ".env").write_text("SECRET=value\n")
+    with pytest.raises(OfflinePayloadError, match="unexpected"):
+        build_offline_payload(staging, tmp_path / "unknown.tar")
+
+    (staging / ".env").unlink()
+    (staging / "appliance-release.env").write_text("MODEL_API_KEY=secret\n")
+    with pytest.raises(OfflinePayloadError, match="release environment"):
+        build_offline_payload(staging, tmp_path / "env.tar")
+
+    (staging / "appliance-release.env").write_text(
+        "APTL_APPLIANCE_SCENARIO=techvault-attacker-target\n"
+        "APTL_APPLIANCE_VERSION=5.1.1\n"
+    )
+    (staging / "wheelhouse/link.whl").symlink_to(
+        staging / "wheelhouse/aptl_labs-5.1.1-py3-none-any.whl"
+    )
+    with pytest.raises(OfflinePayloadError, match="symlink"):
+        build_offline_payload(staging, tmp_path / "symlink.tar")
+
+
+def test_offline_payload_never_overwrites_a_published_artifact(
+    tmp_path: Path,
+) -> None:
+    staging = _staging(tmp_path)
+    output = tmp_path / "payload.tar"
+    output.write_bytes(b"published")
+
+    with pytest.raises(OfflinePayloadError, match="already exists"):
+        build_offline_payload(staging, output)
+    assert output.read_bytes() == b"published"
+
+
+def test_offline_payload_requires_one_aptl_wheel_matching_version(
+    tmp_path: Path,
+) -> None:
+    staging = _staging(tmp_path)
+    (staging / "wheelhouse/aptl_labs-5.2.0-py3-none-any.whl").write_bytes(b"other")
+
+    with pytest.raises(OfflinePayloadError, match="exactly one matching"):
+        build_offline_payload(staging, tmp_path / "duplicate.tar")

--- a/tests/test_appliance_offline_start.py
+++ b/tests/test_appliance_offline_start.py
@@ -226,6 +226,10 @@ def test_verified_launch_payload_is_bound_before_scenario_realization(
         appliance_qualification_public_key=tmp_path / "qualification-public.pem",
         backend=backend,
     )
+    monkeypatch.setattr(
+        "aptl.core.lab._read_appliance_boot_id",
+        lambda: "guest-boot",
+    )
 
     with patch("aptl.core.lab.subprocess.run") as run:
         run.return_value = subprocess.CompletedProcess(

--- a/tests/test_appliance_offline_start.py
+++ b/tests/test_appliance_offline_start.py
@@ -1,0 +1,313 @@
+"""Offline first-boot gates for a fully staged appliance payload."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aptl.appliance.manifest import ApplianceManifestError
+from aptl.backends.aces_base_substrate import BaseContainerSpec
+from aptl.core.deployment._compose_boundary import _helper_command
+from aptl.core.deployment.docker_compose import DockerComposeBackend
+from aptl.core.deployment.realization import (
+    DeploymentImageRealization,
+    DeploymentRealizationSpec,
+)
+from aptl.core.lab import (
+    _LabStartContext,
+    _configure_verified_appliance_launch,
+    _step_pull_images,
+    _step_seed_suricata_volumes,
+)
+from aptl.core.seed_spec import NamedVolumeSeed, SeedFile
+
+
+def _spec() -> DeploymentRealizationSpec:
+    digest = "sha256:" + "a" * 64
+    return DeploymentRealizationSpec(
+        profiles=("enterprise",),
+        nodes=(),
+        networks=(),
+        images=(
+            DeploymentImageRealization(
+                address="provision.node.db",
+                service_name="db",
+                source_name="postgres",
+                source_version=f"postgres@{digest}",
+                image_ref=f"postgres@{digest}",
+                mode="pull",
+                policy_rule="digest-pinned",
+            ),
+        ),
+    )
+
+
+def test_offline_staged_realization_inspects_images_and_forbids_pull_or_build(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    backend = DockerComposeBackend(tmp_path, offline_staged=True)
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        stdout = "aptl_default\n" if command[:3] == ["docker", "network", "ls"] else ""
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = backend.realize(_spec())
+
+    assert result.success is True
+    assert any(command[:3] == ["docker", "image", "inspect"] for command in commands)
+    assert not any(command[:2] == ["docker", "pull"] for command in commands)
+    assert not any(command[:2] == ["docker", "build"] for command in commands)
+    up = next(command for command in commands if "up" in command)
+    assert "--pull" in up
+    assert up[up.index("--pull") + 1] == "never"
+    assert "--build" not in up
+
+
+def test_offline_staged_realization_fails_before_start_when_image_is_missing(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    backend = DockerComposeBackend(tmp_path, offline_staged=True)
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            1 if command[:3] == ["docker", "image", "inspect"] else 0,
+            stdout="",
+            stderr="not found",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = backend.realize(_spec())
+
+    assert result.success is False
+    assert result.error == "Staged image missing for ACES node provision.node.db."
+    assert not any("up" in command for command in commands)
+
+
+def test_offline_staged_wazuh_preflight_fails_when_an_image_is_missing(
+    tmp_path: Path,
+) -> None:
+    backend = MagicMock()
+    backend.pull_images.return_value = [
+        "Required staged image is missing: wazuh/example"
+    ]
+    context = _LabStartContext(
+        project_dir=tmp_path,
+        skip_seed=False,
+        offline_staged=True,
+        backend=backend,
+    )
+
+    result = _step_pull_images(context)
+
+    assert result is not None
+    assert result.success is False
+    assert result.error == "Offline staged image verification failed."
+    assert context.diagnostics == []
+
+
+def test_offline_staged_suricata_seed_fails_before_running_a_container(
+    tmp_path: Path,
+) -> None:
+    backend = MagicMock(spec=DockerComposeBackend)
+    backend.pull_images.return_value = [
+        "Required staged image is missing: jasonish/suricata"
+    ]
+    context = _LabStartContext(
+        project_dir=tmp_path,
+        skip_seed=False,
+        offline_staged=True,
+        backend=backend,
+    )
+
+    result = _step_seed_suricata_volumes(context)
+
+    assert result is not None
+    assert result.success is False
+    assert result.error == "Offline staged Suricata image verification failed."
+    backend.seed_named_volumes.assert_not_called()
+
+
+def test_offline_staged_direct_docker_runs_forbid_implicit_pulls(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "seed"
+    source.mkdir()
+    (source / "input").write_text("data")
+    backend = DockerComposeBackend(tmp_path, offline_staged=True)
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    seed = NamedVolumeSeed(
+        volume_suffix="seed",
+        source_dir=source,
+        files=(SeedFile(src="input", dest="output"),),
+    )
+    node = BaseContainerSpec(
+        node_address="provision.node.victim",
+        container_name="aptl-victim",
+        image_ref="debian:12-slim",
+        runs_services=False,
+    )
+    with patch("subprocess.run", side_effect=fake_run):
+        backend._seed_one_named_volume(seed, "seeder:staged")
+        backend.start_base_container(node)
+
+    docker_runs = [command for command in commands if command[:2] == ["docker", "run"]]
+    assert len(docker_runs) == 2
+    assert all("--pull=never" in command for command in docker_runs)
+    assert "--pull=never" in _helper_command("apply", pull_never=True)
+
+
+def test_offline_staged_generic_base_requires_a_staged_image(
+    tmp_path: Path,
+) -> None:
+    backend = DockerComposeBackend(tmp_path, offline_staged=True)
+
+    with patch("subprocess.run") as run:
+        run.return_value = subprocess.CompletedProcess(
+            ["docker", "image", "inspect"],
+            1,
+            stdout="",
+            stderr="missing",
+        )
+        failures = backend.ensure_generic_base_image("debian:12-slim")
+
+    assert failures == ["required staged generic base image is missing: debian:12-slim"]
+    assert not any(
+        call.args[0][:2] == ["docker", "build"] for call in run.call_args_list
+    )
+
+
+def test_verified_launch_payload_is_bound_before_scenario_realization(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    backend = MagicMock()
+    policy = MagicMock()
+    descriptor = SimpleNamespace(
+        boundary_policy_digest="sha256:" + "1" * 64,
+        payload_digest="sha256:" + "2" * 64,
+        participant_routes_digest="sha256:" + "3" * 64,
+        boundary_helper_image="example/helper@sha256:" + "4" * 64,
+        egress_proxy_image="example/proxy@sha256:" + "5" * 64,
+        host_observation_id="sha256:" + "6" * 64,
+    )
+    monkeypatch.setattr(
+        "aptl.appliance.launch.verify_launch_descriptor",
+        lambda *args: SimpleNamespace(
+            descriptor=descriptor,
+            boundary_policy=policy,
+        ),
+    )
+    context = _LabStartContext(
+        project_dir=tmp_path,
+        skip_seed=False,
+        offline_staged=True,
+        appliance_launch_descriptor=tmp_path / "launch.json",
+        appliance_release_public_key=tmp_path / "release-public.pem",
+        appliance_qualification_public_key=tmp_path / "qualification-public.pem",
+        backend=backend,
+    )
+
+    with patch("aptl.core.lab.subprocess.run") as run:
+        run.return_value = subprocess.CompletedProcess(
+            ["docker", "info"],
+            0,
+            stdout="guest-daemon\n",
+            stderr="",
+        )
+        result = _configure_verified_appliance_launch(context)
+
+    assert result is None
+    configured_policy, binding = backend.configure_appliance_boundary.call_args.args
+    assert configured_policy is policy
+    assert binding.payload_digest == descriptor.payload_digest
+    assert binding.policy_digest == descriptor.boundary_policy_digest
+
+
+@pytest.mark.parametrize(
+    "missing_input",
+    [
+        "offline_staged",
+        "appliance_release_public_key",
+        "appliance_qualification_public_key",
+        "backend",
+    ],
+)
+def test_verified_launch_rejects_each_incomplete_runtime_input(
+    tmp_path: Path,
+    missing_input: str,
+) -> None:
+    backend = MagicMock()
+    inputs = {
+        "offline_staged": True,
+        "appliance_release_public_key": tmp_path / "release-public.pem",
+        "appliance_qualification_public_key": tmp_path / "qualification-public.pem",
+        "backend": backend,
+    }
+    inputs[missing_input] = False if missing_input == "offline_staged" else None
+    context = _LabStartContext(
+        project_dir=tmp_path,
+        skip_seed=False,
+        appliance_launch_descriptor=tmp_path / "launch.json",
+        **inputs,
+    )
+
+    result = _configure_verified_appliance_launch(context)
+
+    assert result is not None
+    assert result.success is False
+    assert result.error == "Appliance launch inputs are incomplete."
+    backend.configure_appliance_boundary.assert_not_called()
+
+
+def test_verified_launch_reverification_failure_is_a_hard_stop(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    backend = MagicMock()
+
+    def reject_descriptor(*args) -> None:
+        raise ApplianceManifestError("unsafe verification detail")
+
+    monkeypatch.setattr(
+        "aptl.appliance.launch.verify_launch_descriptor",
+        reject_descriptor,
+    )
+    context = _LabStartContext(
+        project_dir=tmp_path,
+        skip_seed=False,
+        offline_staged=True,
+        appliance_launch_descriptor=tmp_path / "launch.json",
+        appliance_release_public_key=tmp_path / "release-public.pem",
+        appliance_qualification_public_key=tmp_path / "qualification-public.pem",
+        backend=backend,
+    )
+
+    with patch("aptl.core.lab.subprocess.run") as run:
+        result = _configure_verified_appliance_launch(context)
+
+    assert result is not None
+    assert result.success is False
+    assert result.error == "Verified appliance launch binding failed."
+    assert "unsafe verification detail" not in result.error
+    run.assert_not_called()
+    backend.configure_appliance_boundary.assert_not_called()

--- a/tests/test_appliance_release_manifest.py
+++ b/tests/test_appliance_release_manifest.py
@@ -1,0 +1,951 @@
+"""Behavioral tests for the signed appliance release envelope (APP-3)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from pydantic import ValidationError
+
+from aptl.appliance.manifest import (
+    ApplianceManifestError,
+    canonical_manifest_bytes,
+    compute_payload_digest,
+    describe_artifact,
+    prepare_release_manifest,
+    seal_release_directory,
+    sign_manifest,
+    verify_release_directory,
+    verify_manifest_signature,
+)
+from aptl.appliance.launch import (
+    prepare_launch_descriptor,
+    verify_launch_descriptor,
+)
+from aptl.appliance.models import (
+    ApplianceBoundaryReleaseBinding,
+    ApplianceDrillReport,
+    ApplianceGuest,
+    ApplianceReleaseManifest,
+    ApplianceReleaseTemplate,
+    ArtifactReference,
+    DeliveryAdapter,
+    DeliveryParity,
+    HostPrerequisites,
+    GoldenImageInventory,
+    MachineDrill,
+    ParticipantReleaseBinding,
+    ParticipantTemplateBinding,
+    ReleaseSource,
+    StagedArtifact,
+    BoundaryTemplateBinding,
+)
+from aptl.validation.participant_qualification_evidence import (
+    ParticipantQualificationReport,
+    participant_qualification_attestation_payload,
+)
+
+_HEX_A = "a" * 64
+_HEX_B = "b" * 64
+_HEX_C = "c" * 64
+_HEX_D = "d" * 64
+_HEX_E = "e" * 64
+_HEX_F = "f" * 64
+
+
+def _artifact(
+    artifact_id: str,
+    kind: str,
+    path: str,
+    digest: str = _HEX_A,
+) -> ArtifactReference:
+    return ArtifactReference(
+        artifact_id=artifact_id,
+        kind=kind,
+        path=path,
+        sha256=f"sha256:{digest}",
+        size_bytes=1024,
+    )
+
+
+def _machine(machine_id: str) -> MachineDrill:
+    return MachineDrill(
+        machine_id=f"sha256:{hashlib.sha256(machine_id.encode()).hexdigest()}",
+        architecture="x86_64",
+        vcpus=8,
+        memory_bytes=16 * 1024**3,
+        disk_bytes=100 * 1024**3,
+        build_passed=True,
+        offline_boot_passed=True,
+        participant_smoke_passed=True,
+        rollback_passed=True,
+        overlay_destroy_passed=True,
+    )
+
+
+def _manifest() -> ApplianceReleaseManifest:
+    artifacts = (
+        _artifact("golden-disk", "golden-disk", "artifacts/golden.qcow2", _HEX_A),
+        _artifact(
+            "offline-payload",
+            "offline-payload",
+            "artifacts/offline-payload.tar",
+            _HEX_B,
+        ),
+        _artifact(
+            "profile-manifest",
+            "participant-profile",
+            "evidence/profile.json",
+            _HEX_C,
+        ),
+        _artifact(
+            "readiness-suite",
+            "participant-readiness",
+            "evidence/readiness.json",
+            _HEX_A,
+        ),
+        _artifact(
+            "asset-lock",
+            "participant-asset-lock",
+            "evidence/asset-lock.json",
+            _HEX_D,
+        ),
+        _artifact(
+            "qualification",
+            "participant-qualification",
+            "evidence/qualification.json",
+            _HEX_E,
+        ),
+        _artifact(
+            "boundary-policy",
+            "boundary-policy",
+            "evidence/boundary-policy.json",
+            _HEX_F,
+        ),
+        _artifact(
+            "golden-inventory",
+            "golden-inventory",
+            "evidence/golden-inventory.json",
+            _HEX_A,
+        ),
+        _artifact(
+            "machine-drill",
+            "machine-drill",
+            "evidence/machine-drill.json",
+            _HEX_B,
+        ),
+    )
+    return ApplianceReleaseManifest(
+        schema_version="aptl.appliance-release/v1",
+        release_id="aptl-v5.1.1-x86_64",
+        source=ReleaseSource(
+            aptl_version="5.1.1",
+            source_tag="v5.1.1",
+            source_commit="1" * 40,
+        ),
+        guest=ApplianceGuest(
+            os_id="ubuntu",
+            os_version="24.04",
+            architecture="x86_64",
+            disk_format="qcow2",
+            base_image_digest=f"sha256:{_HEX_C}",
+            immutable=True,
+            overlay_strategy="qcow2-backing-file",
+        ),
+        artifacts=artifacts,
+        payload_digest=f"sha256:{_HEX_D}",
+        participant=ParticipantReleaseBinding(
+            profile_id="guided-purple",
+            profile_version=1,
+            profile_manifest_digest=f"sha256:{_HEX_C}",
+            readiness_suite_digest=f"sha256:{_HEX_A}",
+            asset_lock_digest=f"sha256:{_HEX_D}",
+            qualification_report_digest=f"sha256:{_HEX_E}",
+        ),
+        boundary=ApplianceBoundaryReleaseBinding(
+            policy_digest=f"sha256:{_HEX_F}",
+            boundary_helper_image=f"example/helper@sha256:{_HEX_A}",
+            egress_proxy_image=f"example/proxy@sha256:{_HEX_B}",
+        ),
+        host_prerequisites=HostPrerequisites(
+            architecture="x86_64",
+            vcpus=8,
+            memory_bytes=16 * 1024**3,
+            disk_bytes=100 * 1024**3,
+            hardware_virtualization=True,
+            local_adapter="qemu-kvm",
+            supported_hypervisors=("qemu>=8.2", "libvirt>=10.0"),
+        ),
+        delivery=DeliveryParity(
+            participant_ui_digest=f"sha256:{_HEX_A}",
+            participant_routes_digest=f"sha256:{_HEX_B}",
+            adapters=(
+                DeliveryAdapter(
+                    adapter_id="local-kvm",
+                    kind="local-kvm",
+                    payload_unchanged=True,
+                ),
+                DeliveryAdapter(
+                    adapter_id="hosted-seat",
+                    kind="hosted",
+                    payload_unchanged=True,
+                ),
+            ),
+        ),
+        qualification=ApplianceDrillReport(
+            schema_version="aptl.appliance-drill/v1",
+            machines=(_machine("host-a"), _machine("host-b")),
+            golden_secret_scan_passed=True,
+            golden_read_only_passed=True,
+            distinct_overlay_identities_passed=True,
+            failed_candidate_preserved_active_passed=True,
+        ),
+        upgrade_strategy="replace-golden-create-overlay",
+    )
+
+
+def _key_pair() -> tuple[bytes, bytes]:
+    private = Ed25519PrivateKey.generate()
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _offline_payload(version: str) -> bytes:
+    output = io.BytesIO()
+    env = (
+        "APTL_APPLIANCE_SCENARIO=techvault-attacker-target\n"
+        f"APTL_APPLIANCE_VERSION={version}\n"
+    ).encode()
+    wheel = b"wheel"
+    with tarfile.open(fileobj=output, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for name, payload in (
+            ("appliance-release.env", env),
+            (f"wheelhouse/aptl_labs-{version}-py3-none-any.whl", wheel),
+        ):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return output.getvalue()
+
+
+def test_manifest_is_canonical_and_signed_by_external_trust_anchor() -> None:
+    manifest = _manifest()
+    private_pem, public_pem = _key_pair()
+
+    first = canonical_manifest_bytes(manifest)
+    second = canonical_manifest_bytes(
+        ApplianceReleaseManifest.model_validate_json(first)
+    )
+    signature = sign_manifest(manifest, private_pem)
+
+    assert first == second
+    assert signature.manifest_digest == (f"sha256:{hashlib.sha256(first).hexdigest()}")
+    assert signature.key_id.startswith("sha256:")
+    assert base64.b64decode(signature.signature, validate=True)
+    verify_manifest_signature(manifest, signature, public_pem)
+
+
+def test_manifest_signature_rejects_tampering_and_wrong_key() -> None:
+    manifest = _manifest()
+    private_pem, public_pem = _key_pair()
+    signature = sign_manifest(manifest, private_pem)
+    tampered = manifest.model_copy(
+        update={
+            "source": manifest.source.model_copy(update={"source_commit": "2" * 40})
+        }
+    )
+
+    with pytest.raises(ApplianceManifestError, match="signature"):
+        verify_manifest_signature(tampered, signature, public_pem)
+
+    _, wrong_public = _key_pair()
+    with pytest.raises(ApplianceManifestError, match="trust anchor"):
+        verify_manifest_signature(manifest, signature, wrong_public)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/tmp/golden.qcow2",
+        "../golden.qcow2",
+        "artifacts/../golden.qcow2",
+        "./artifacts/golden.qcow2",
+        "artifacts//golden.qcow2",
+        "artifacts\\golden.qcow2",
+    ),
+)
+def test_artifact_reference_rejects_unsafe_paths(path: str) -> None:
+    with pytest.raises(ValidationError, match="safe relative"):
+        _artifact("golden-disk", "golden-disk", path)
+
+
+def test_manifest_rejects_duplicate_and_missing_release_artifacts() -> None:
+    manifest = _manifest()
+    duplicate = manifest.artifacts + (manifest.artifacts[0],)
+    with pytest.raises(ValidationError, match="artifact ids"):
+        ApplianceReleaseManifest.model_validate(
+            {**manifest.model_dump(), "artifacts": duplicate}
+        )
+
+    missing = tuple(
+        item for item in manifest.artifacts if item.kind != "golden-inventory"
+    )
+    with pytest.raises(ValidationError, match="required artifact kinds"):
+        ApplianceReleaseManifest.model_validate(
+            {**manifest.model_dump(), "artifacts": missing}
+        )
+
+
+def test_manifest_requires_two_distinct_successful_machine_drills() -> None:
+    manifest = _manifest()
+    one_machine = manifest.qualification.model_copy(
+        update={"machines": (_machine("host-a"),)}
+    )
+    with pytest.raises(ValidationError, match="two independent"):
+        ApplianceReleaseManifest.model_validate(
+            {**manifest.model_dump(), "qualification": one_machine}
+        )
+
+    duplicate = manifest.qualification.model_copy(
+        update={"machines": (_machine("host-a"), _machine("host-a"))}
+    )
+    with pytest.raises(ValidationError, match="unique"):
+        ApplianceReleaseManifest.model_validate(
+            {**manifest.model_dump(), "qualification": duplicate}
+        )
+
+
+def test_manifest_requires_payload_parity_and_immutable_upgrade() -> None:
+    manifest = _manifest()
+    mismatched = manifest.delivery.model_copy(
+        update={
+            "adapters": (
+                manifest.delivery.adapters[0],
+                manifest.delivery.adapters[1].model_copy(
+                    update={"payload_unchanged": False}
+                ),
+            )
+        }
+    )
+    with pytest.raises(ValidationError, match="same payload"):
+        ApplianceReleaseManifest.model_validate(
+            {**manifest.model_dump(), "delivery": mismatched}
+        )
+
+    with pytest.raises(ValidationError):
+        ApplianceReleaseManifest.model_validate(
+            {**manifest.model_dump(), "upgrade_strategy": "in-place"}
+        )
+
+
+def _write_signed_release(root: Path) -> tuple[ApplianceReleaseManifest, bytes]:
+    root.mkdir()
+    base = _manifest()
+    project_root = Path(__file__).resolve().parents[1]
+    profile_payload = (
+        project_root / "participant-profiles/guided-purple-v1/profile.json"
+    ).read_bytes()
+    readiness_payload = (
+        project_root / "participant-profiles/guided-purple-v1/readiness.json"
+    ).read_bytes()
+    readiness_document = json.loads(readiness_payload)
+    asset_lock_payload = (
+        project_root / "participant-profiles/guided-purple-v1/asset-lock.json"
+    ).read_bytes()
+    qualification_private = Ed25519PrivateKey.generate()
+    qualification_public = qualification_private.public_key()
+    qualification_public_pem = qualification_public.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    qualification_key_der = qualification_public.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    qualification_document = {
+        "schema_version": "aptl.participant-qualification/v1",
+        "profile_id": "guided-purple",
+        "profile_version": 1,
+        "profile_sha256": hashlib.sha256(profile_payload).hexdigest(),
+        "asset_lock_digest": (
+            f"sha256:{hashlib.sha256(asset_lock_payload).hexdigest()}"
+        ),
+        "run_record_ref": "evidence/run-record.json",
+        "run_record_sha256": "1" * 64,
+        "snapshot_ref": "evidence/snapshot.json",
+        "snapshot_sha256": "2" * 64,
+        "hardware": {
+            "architecture": "x86_64",
+            "vcpus": 8,
+            "memory_bytes": 16 * 1024**3,
+            "disk_bytes": 100 * 1024**3,
+            "hypervisor": "qemu-kvm",
+            "engine": "docker",
+        },
+        "surface": {
+            "selected_profiles": [],
+            "expected_services": [],
+            "actual_services": [],
+            "expected_networks": [],
+            "actual_networks": [],
+            "actual_workbench_profiles": ["red", "guided-blue"],
+            "actual_mcp_servers": sorted(
+                {
+                    check["subject_id"]
+                    for check in readiness_document["checks"]
+                    if check["kind"] == "mcp-tool"
+                }
+            ),
+            "actual_browser_capabilities": sorted(
+                {
+                    check["subject_id"]
+                    for check in readiness_document["checks"]
+                    if check["kind"] == "browser-operation"
+                }
+            ),
+        },
+        "checks": [
+            {
+                "check_id": check["check_id"],
+                "status": "passed",
+                "summary": "passed",
+            }
+            for check in readiness_document["checks"]
+        ],
+        "offline": {
+            "egress_denied": True,
+            "download_attempts": 0,
+            "image_pulls": 0,
+            "image_builds": 0,
+            "package_resolutions": 0,
+        },
+        "measurements": {
+            "peak_cpu_percent": 0,
+            "peak_memory_bytes": 0,
+            "staged_profile_assets_bytes": 0,
+            "unique_image_compressed_bytes": 0,
+            "unique_image_expanded_bytes": 0,
+            "peak_runtime_disk_bytes": 0,
+            "cold_start_seconds": 0,
+            "warm_start_seconds": 0,
+            "clean_reset_seconds": 0,
+        },
+        "sample_count": 2,
+        "aggregation": "worst-conforming-sample",
+        "attestation": {
+            "algorithm": "ed25519",
+            "key_id": (f"sha256:{hashlib.sha256(qualification_key_der).hexdigest()}"),
+            "signature": "AA==",
+        },
+    }
+    unsigned_qualification = ParticipantQualificationReport.model_validate(
+        qualification_document
+    )
+    qualification_signature = qualification_private.sign(
+        participant_qualification_attestation_payload(unsigned_qualification)
+    )
+    qualification_document["attestation"]["signature"] = base64.b64encode(
+        qualification_signature
+    ).decode("ascii")
+    qualification_payload = json.dumps(
+        qualification_document,
+        separators=(",", ":"),
+    ).encode()
+    (root.parent / "qualification-public.pem").write_bytes(qualification_public_pem)
+    boundary_payload = json.dumps(
+        {
+            "schema_version": "aptl.appliance-boundary/v1",
+            "policy_id": "participant-default",
+            "generation": 1,
+            "workbench_policy_version": "participant-workbench-profile/v1",
+            "default_deny": True,
+            "platform_networks": {
+                "participant": "org.aptl.network=participant",
+                "management": "org.aptl.network=management",
+                "egress": "org.aptl.network=egress",
+            },
+            "platform_anchors": {
+                "participant": "org.aptl.zone=participant",
+                "management": "org.aptl.zone=management",
+                "egress": "org.aptl.zone=egress",
+            },
+            "fixed_crossings": [],
+            "egress_authorities": [],
+            "egress_proxy_limits": {
+                "max_connections": 16,
+                "max_header_bytes": 4096,
+                "header_timeout_seconds": 5,
+                "connect_timeout_seconds": 10,
+                "idle_timeout_seconds": 30,
+            },
+            "guest_publications": [],
+            "docker_authority": {
+                "allowed_holder_labels": [],
+                "require_guest_daemon": True,
+            },
+        },
+        separators=(",", ":"),
+    ).encode()
+    artifacts = []
+    for artifact in base.artifacts:
+        path = root / artifact.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if artifact.kind == "golden-inventory":
+            payload = (
+                GoldenImageInventory(
+                    schema_version="aptl.golden-inventory/v1",
+                    scan_complete=True,
+                    populated_sensitive_paths=(),
+                    writable_runtime_paths=(),
+                )
+                .model_dump_json()
+                .encode()
+            )
+        elif artifact.kind == "machine-drill":
+            payload = base.qualification.model_dump_json().encode()
+        elif artifact.kind == "participant-profile":
+            payload = profile_payload
+        elif artifact.kind == "participant-readiness":
+            payload = readiness_payload
+        elif artifact.kind == "participant-asset-lock":
+            payload = asset_lock_payload
+        elif artifact.kind == "participant-qualification":
+            payload = qualification_payload
+        elif artifact.kind == "boundary-policy":
+            payload = boundary_payload
+        elif artifact.kind == "offline-payload":
+            payload = _offline_payload(base.source.aptl_version)
+        else:
+            payload = f"{artifact.kind}\n".encode()
+        path.write_bytes(payload)
+        artifacts.append(
+            describe_artifact(
+                root,
+                artifact_id=artifact.artifact_id,
+                kind=artifact.kind,
+                path=artifact.path,
+            )
+        )
+    by_kind = {artifact.kind: artifact for artifact in artifacts}
+    manifest = base.model_copy(
+        update={
+            "artifacts": tuple(artifacts),
+            "payload_digest": compute_payload_digest(tuple(artifacts)),
+            "participant": base.participant.model_copy(
+                update={
+                    "profile_manifest_digest": by_kind["participant-profile"].sha256,
+                    "readiness_suite_digest": by_kind["participant-readiness"].sha256,
+                    "asset_lock_digest": by_kind["participant-asset-lock"].sha256,
+                    "qualification_report_digest": by_kind[
+                        "participant-qualification"
+                    ].sha256,
+                }
+            ),
+            "boundary": base.boundary.model_copy(
+                update={"policy_digest": by_kind["boundary-policy"].sha256}
+            ),
+        }
+    )
+    private_pem, public_pem = _key_pair()
+    signature = sign_manifest(manifest, private_pem)
+    (root / "manifest.json").write_bytes(canonical_manifest_bytes(manifest))
+    (root / "manifest.sig.json").write_text(signature.model_dump_json())
+    checksum_paths = sorted(
+        ["manifest.json", "manifest.sig.json"]
+        + [artifact.path for artifact in manifest.artifacts]
+    )
+    (root / "SHA256SUMS").write_text(
+        "".join(
+            f"{hashlib.sha256((root / path).read_bytes()).hexdigest()}  {path}\n"
+            for path in checksum_paths
+        )
+    )
+    return manifest, public_pem
+
+
+def _resign_release(
+    root: Path,
+    manifest: ApplianceReleaseManifest,
+) -> tuple[ApplianceReleaseManifest, bytes]:
+    artifacts = tuple(
+        describe_artifact(
+            root,
+            artifact_id=artifact.artifact_id,
+            kind=artifact.kind,
+            path=artifact.path,
+        )
+        for artifact in manifest.artifacts
+    )
+    by_kind = {artifact.kind: artifact for artifact in artifacts}
+    updated = manifest.model_copy(
+        update={
+            "artifacts": artifacts,
+            "payload_digest": compute_payload_digest(artifacts),
+            "participant": manifest.participant.model_copy(
+                update={
+                    "profile_manifest_digest": by_kind["participant-profile"].sha256,
+                    "readiness_suite_digest": by_kind["participant-readiness"].sha256,
+                    "asset_lock_digest": by_kind["participant-asset-lock"].sha256,
+                    "qualification_report_digest": by_kind[
+                        "participant-qualification"
+                    ].sha256,
+                }
+            ),
+            "boundary": manifest.boundary.model_copy(
+                update={"policy_digest": by_kind["boundary-policy"].sha256}
+            ),
+        }
+    )
+    private_pem, public_pem = _key_pair()
+    signature = sign_manifest(updated, private_pem)
+    (root / "manifest.json").write_bytes(canonical_manifest_bytes(updated))
+    (root / "manifest.sig.json").write_text(signature.model_dump_json())
+    checksum_paths = sorted(
+        ["manifest.json", "manifest.sig.json"]
+        + [artifact.path for artifact in updated.artifacts]
+    )
+    (root / "SHA256SUMS").write_text(
+        "".join(
+            f"{hashlib.sha256((root / path).read_bytes()).hexdigest()}  {path}\n"
+            for path in checksum_paths
+        )
+    )
+    return updated, public_pem
+
+
+def test_release_directory_verifies_every_artifact_and_safe_projection(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    manifest, public_pem = _write_signed_release(release)
+    public_key = tmp_path / "release-public.pem"
+    public_key.write_bytes(public_pem)
+
+    inspection = verify_release_directory(
+        release,
+        public_key,
+        qualification_public_key_path=tmp_path / "qualification-public.pem",
+    )
+
+    assert inspection.release_id == manifest.release_id
+    assert inspection.aptl_version == "5.1.1"
+    assert inspection.payload_digest == manifest.payload_digest
+    assert inspection.manifest_digest.startswith("sha256:")
+    assert inspection.artifact_count == len(manifest.artifacts)
+    assert inspection.minimum_host_memory_bytes == 16 * 1024**3
+
+
+def test_release_directory_rejects_artifact_tampering_and_symlinks(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    _, public_pem = _write_signed_release(release)
+    public_key = tmp_path / "release-public.pem"
+    public_key.write_bytes(public_pem)
+    golden = release / "artifacts/golden.qcow2"
+    golden.write_bytes(b"tampered")
+
+    with pytest.raises(ApplianceManifestError, match="digest mismatch"):
+        verify_release_directory(
+            release,
+            public_key,
+            qualification_public_key_path=tmp_path / "qualification-public.pem",
+        )
+
+    golden.unlink()
+    golden.symlink_to("/dev/null")
+    with pytest.raises(ApplianceManifestError, match="unsafe release artifact"):
+        verify_release_directory(
+            release,
+            public_key,
+            qualification_public_key_path=tmp_path / "qualification-public.pem",
+        )
+
+
+def test_release_directory_rejects_golden_state_contamination(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    _, public_pem = _write_signed_release(release)
+    public_key = tmp_path / "release-public.pem"
+    public_key.write_bytes(public_pem)
+    inventory = release / "evidence/golden-inventory.json"
+    inventory.write_text(
+        GoldenImageInventory.model_construct(
+            schema_version="aptl.golden-inventory/v1",
+            scan_complete=True,
+            populated_sensitive_paths=("etc/ssh/ssh_host_ed25519_key",),
+            writable_runtime_paths=(),
+        ).model_dump_json()
+    )
+
+    with pytest.raises(ApplianceManifestError, match="digest mismatch"):
+        verify_release_directory(
+            release,
+            public_key,
+            qualification_public_key_path=tmp_path / "qualification-public.pem",
+        )
+
+    with pytest.raises(ValidationError, match="per-instance state"):
+        GoldenImageInventory(
+            schema_version="aptl.golden-inventory/v1",
+            scan_complete=True,
+            populated_sensitive_paths=("etc/ssh/ssh_host_ed25519_key",),
+            writable_runtime_paths=(),
+        )
+
+
+def test_release_directory_rejects_invalid_reused_contracts(tmp_path: Path) -> None:
+    release = tmp_path / "release"
+    manifest, _ = _write_signed_release(release)
+    (release / "evidence/boundary-policy.json").write_text("{}")
+    _, public_pem = _resign_release(release, manifest)
+    public_key = tmp_path / "release-public.pem"
+    public_key.write_bytes(public_pem)
+
+    with pytest.raises(ApplianceManifestError, match="release evidence"):
+        verify_release_directory(
+            release,
+            public_key,
+            qualification_public_key_path=tmp_path / "qualification-public.pem",
+        )
+
+
+def test_release_verification_requires_independent_qualification_trust(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    _, release_public_pem = _write_signed_release(release)
+    release_public = tmp_path / "release-public.pem"
+    release_public.write_bytes(release_public_pem)
+    _, wrong_qualification_public_pem = _key_pair()
+    wrong_qualification_public = tmp_path / "wrong-qualification-public.pem"
+    wrong_qualification_public.write_bytes(wrong_qualification_public_pem)
+
+    with pytest.raises(ApplianceManifestError, match="qualification"):
+        verify_release_directory(
+            release,
+            release_public,
+            qualification_public_key_path=wrong_qualification_public,
+        )
+
+
+def test_release_rejects_missing_readiness_checks_and_wrong_wheel_version(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    manifest, _ = _write_signed_release(release)
+    qualification_path = release / "evidence/qualification.json"
+    qualification = json.loads(qualification_path.read_text())
+    qualification["checks"] = []
+    qualification_path.write_text(json.dumps(qualification))
+    manifest, public_pem = _resign_release(release, manifest)
+    public_key = tmp_path / "release-public.pem"
+    public_key.write_bytes(public_pem)
+
+    with pytest.raises(ApplianceManifestError, match="qualification evidence"):
+        verify_release_directory(
+            release,
+            public_key,
+            qualification_public_key_path=tmp_path / "qualification-public.pem",
+        )
+
+    second = tmp_path / "second-release"
+    second_manifest, _ = _write_signed_release(second)
+    (second / "artifacts/offline-payload.tar").write_bytes(_offline_payload("5.2.0"))
+    _, second_public_pem = _resign_release(second, second_manifest)
+    second_public = tmp_path / "second-release-public.pem"
+    second_public.write_bytes(second_public_pem)
+
+    with pytest.raises(ApplianceManifestError, match="version"):
+        verify_release_directory(
+            second,
+            second_public,
+            qualification_public_key_path=tmp_path / "qualification-public.pem",
+        )
+
+
+def test_release_sealing_is_atomic_and_emits_complete_checksums(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    manifest, _ = _write_signed_release(release)
+    (release / "manifest.sig.json").unlink()
+    (release / "SHA256SUMS").unlink()
+    private_pem, public_pem = _key_pair()
+    private_key = tmp_path / "release-private.pem"
+    public_key = tmp_path / "release-public.pem"
+    private_key.write_bytes(private_pem)
+    public_key.write_bytes(public_pem)
+
+    result = seal_release_directory(
+        release,
+        private_key,
+        qualification_public_key_path=tmp_path / "qualification-public.pem",
+    )
+
+    assert result.release_id == manifest.release_id
+    assert (release / "manifest.sig.json").stat().st_mode & 0o777 == 0o644
+    checksums = (release / "SHA256SUMS").read_text().splitlines()
+    assert len(checksums) == len(manifest.artifacts) + 2
+    assert checksums == sorted(checksums, key=lambda line: line.split("  ", 1)[1])
+    verify_release_directory(
+        release,
+        public_key,
+        qualification_public_key_path=tmp_path / "qualification-public.pem",
+    )
+
+    with pytest.raises(ApplianceManifestError, match="already sealed"):
+        seal_release_directory(
+            release,
+            private_key,
+            qualification_public_key_path=tmp_path / "qualification-public.pem",
+        )
+
+
+def test_release_sealing_refuses_a_private_key_inside_the_release(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    _write_signed_release(release)
+    (release / "manifest.sig.json").unlink()
+    (release / "SHA256SUMS").unlink()
+    private_pem, _ = _key_pair()
+    private_key = release / "private-key.pem"
+    private_key.write_bytes(private_pem)
+
+    with pytest.raises(ApplianceManifestError, match="outside"):
+        seal_release_directory(
+            release,
+            private_key,
+            qualification_public_key_path=tmp_path / "qualification-public.pem",
+        )
+    assert not (release / "manifest.sig.json").exists()
+
+
+def test_release_sealing_rejects_untrusted_participant_qualification(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    _write_signed_release(release)
+    (release / "manifest.sig.json").unlink()
+    (release / "SHA256SUMS").unlink()
+    private_pem, _ = _key_pair()
+    _, wrong_qualification_public = _key_pair()
+    private_key = tmp_path / "release-private.pem"
+    qualification_key = tmp_path / "wrong-qualification-public.pem"
+    private_key.write_bytes(private_pem)
+    qualification_key.write_bytes(wrong_qualification_public)
+
+    with pytest.raises(ApplianceManifestError, match="qualification"):
+        seal_release_directory(
+            release,
+            private_key,
+            qualification_public_key_path=qualification_key,
+        )
+    assert not (release / "manifest.sig.json").exists()
+    assert not (release / "SHA256SUMS").exists()
+
+
+def test_release_manifest_is_prepared_from_staged_artifacts_not_handwritten(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    expected, _ = _write_signed_release(release)
+    (release / "manifest.json").unlink()
+    (release / "manifest.sig.json").unlink()
+    (release / "SHA256SUMS").unlink()
+    template = ApplianceReleaseTemplate(
+        schema_version="aptl.appliance-release-template/v1",
+        release_id=expected.release_id,
+        source=expected.source,
+        guest=expected.guest,
+        artifacts=tuple(
+            StagedArtifact(
+                artifact_id=artifact.artifact_id,
+                kind=artifact.kind,
+                path=artifact.path,
+            )
+            for artifact in expected.artifacts
+        ),
+        participant=ParticipantTemplateBinding(
+            profile_id=expected.participant.profile_id,
+            profile_version=expected.participant.profile_version,
+        ),
+        boundary=BoundaryTemplateBinding(
+            boundary_helper_image=expected.boundary.boundary_helper_image,
+            egress_proxy_image=expected.boundary.egress_proxy_image,
+        ),
+        host_prerequisites=expected.host_prerequisites,
+        delivery=expected.delivery,
+        upgrade_strategy="replace-golden-create-overlay",
+    )
+    template_path = tmp_path / "release-template.json"
+    template_path.write_text(template.model_dump_json())
+
+    prepared = prepare_release_manifest(release, template_path)
+
+    assert prepared == expected
+    assert (release / "manifest.json").read_bytes() == canonical_manifest_bytes(
+        prepared
+    )
+    with pytest.raises(ApplianceManifestError, match="already exists"):
+        template_path.write_text(
+            template.model_copy(update={"release_id": "different"}).model_dump_json()
+        )
+        prepare_release_manifest(release, template_path)
+
+
+def test_launch_descriptor_is_create_once_and_reverified_before_runtime(
+    tmp_path: Path,
+) -> None:
+    release = tmp_path / "release"
+    _, release_public_pem = _write_signed_release(release)
+    release_public = tmp_path / "release-public.pem"
+    release_public.write_bytes(release_public_pem)
+    qualification_public = tmp_path / "qualification-public.pem"
+    output = tmp_path / "appliance-launch.json"
+
+    descriptor = prepare_launch_descriptor(
+        release,
+        release_public,
+        qualification_public,
+        output,
+        host_observation_id="sha256:" + "9" * 64,
+    )
+    verified = verify_launch_descriptor(
+        output,
+        release_public,
+        qualification_public,
+    )
+
+    assert verified.descriptor == descriptor
+    assert verified.boundary_policy.default_deny is True
+    assert output.stat().st_mode & 0o777 == 0o444
+
+    output.chmod(0o644)
+    document = json.loads(output.read_text())
+    document["payload_digest"] = "sha256:" + "0" * 64
+    output.write_text(json.dumps(document))
+    output.chmod(0o444)
+    with pytest.raises(ApplianceManifestError, match="does not match"):
+        verify_launch_descriptor(
+            output,
+            release_public,
+            qualification_public,
+        )

--- a/tests/test_appliance_release_manifest.py
+++ b/tests/test_appliance_release_manifest.py
@@ -34,7 +34,6 @@ from aptl.appliance.models import (
     ApplianceDrillReport,
     ApplianceGuest,
     ApplianceReleaseManifest,
-    ApplianceReleaseTemplate,
     ArtifactReference,
     DeliveryAdapter,
     DeliveryParity,
@@ -42,10 +41,13 @@ from aptl.appliance.models import (
     GoldenImageInventory,
     MachineDrill,
     ParticipantReleaseBinding,
-    ParticipantTemplateBinding,
     ReleaseSource,
-    StagedArtifact,
+)
+from aptl.appliance.release_models import (
+    ApplianceReleaseTemplate,
     BoundaryTemplateBinding,
+    ParticipantTemplateBinding,
+    StagedArtifact,
 )
 from aptl.validation.participant_qualification_evidence import (
     ParticipantQualificationReport,

--- a/tests/test_appliance_release_manifest.py
+++ b/tests/test_appliance_release_manifest.py
@@ -297,18 +297,16 @@ def test_artifact_reference_rejects_unsafe_paths(path: str) -> None:
 def test_manifest_rejects_duplicate_and_missing_release_artifacts() -> None:
     manifest = _manifest()
     duplicate = manifest.artifacts + (manifest.artifacts[0],)
+    duplicate_payload = {**manifest.model_dump(), "artifacts": duplicate}
     with pytest.raises(ValidationError, match="artifact ids"):
-        ApplianceReleaseManifest.model_validate(
-            {**manifest.model_dump(), "artifacts": duplicate}
-        )
+        ApplianceReleaseManifest.model_validate(duplicate_payload)
 
     missing = tuple(
         item for item in manifest.artifacts if item.kind != "golden-inventory"
     )
+    missing_payload = {**manifest.model_dump(), "artifacts": missing}
     with pytest.raises(ValidationError, match="required artifact kinds"):
-        ApplianceReleaseManifest.model_validate(
-            {**manifest.model_dump(), "artifacts": missing}
-        )
+        ApplianceReleaseManifest.model_validate(missing_payload)
 
 
 def test_manifest_requires_two_distinct_successful_machine_drills() -> None:
@@ -316,18 +314,16 @@ def test_manifest_requires_two_distinct_successful_machine_drills() -> None:
     one_machine = manifest.qualification.model_copy(
         update={"machines": (_machine("host-a"),)}
     )
+    one_machine_payload = {**manifest.model_dump(), "qualification": one_machine}
     with pytest.raises(ValidationError, match="two independent"):
-        ApplianceReleaseManifest.model_validate(
-            {**manifest.model_dump(), "qualification": one_machine}
-        )
+        ApplianceReleaseManifest.model_validate(one_machine_payload)
 
     duplicate = manifest.qualification.model_copy(
         update={"machines": (_machine("host-a"), _machine("host-a"))}
     )
+    duplicate_payload = {**manifest.model_dump(), "qualification": duplicate}
     with pytest.raises(ValidationError, match="unique"):
-        ApplianceReleaseManifest.model_validate(
-            {**manifest.model_dump(), "qualification": duplicate}
-        )
+        ApplianceReleaseManifest.model_validate(duplicate_payload)
 
 
 def test_manifest_requires_payload_parity_and_immutable_upgrade() -> None:
@@ -342,15 +338,13 @@ def test_manifest_requires_payload_parity_and_immutable_upgrade() -> None:
             )
         }
     )
+    mismatched_payload = {**manifest.model_dump(), "delivery": mismatched}
     with pytest.raises(ValidationError, match="same payload"):
-        ApplianceReleaseManifest.model_validate(
-            {**manifest.model_dump(), "delivery": mismatched}
-        )
+        ApplianceReleaseManifest.model_validate(mismatched_payload)
 
+    in_place_payload = {**manifest.model_dump(), "upgrade_strategy": "in-place"}
     with pytest.raises(ValidationError):
-        ApplianceReleaseManifest.model_validate(
-            {**manifest.model_dump(), "upgrade_strategy": "in-place"}
-        )
+        ApplianceReleaseManifest.model_validate(in_place_payload)
 
 
 def _write_signed_release(root: Path) -> tuple[ApplianceReleaseManifest, bytes]:
@@ -904,10 +898,9 @@ def test_release_manifest_is_prepared_from_staged_artifacts_not_handwritten(
     assert (release / "manifest.json").read_bytes() == canonical_manifest_bytes(
         prepared
     )
+    changed_template = template.model_copy(update={"release_id": "different"})
+    template_path.write_text(changed_template.model_dump_json())
     with pytest.raises(ApplianceManifestError, match="already exists"):
-        template_path.write_text(
-            template.model_copy(update={"release_id": "different"}).model_dump_json()
-        )
         prepare_release_manifest(release, template_path)
 
 


### PR DESCRIPTION
## Summary

Adds a signed, versioned disposable APTL appliance release envelope with deterministic offline payloads, immutable golden-image construction, verified overlays, guest-first-boot isolation, and fail-closed runtime binding.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #823

## ADR Impact

- ADR-049
- ADR-025
- ADR-028
- ADR-029

## Changes

- Add canonical release, qualification, launch-descriptor, artifact, prerequisite, and machine-drill schemas with Ed25519 verification.
- Build deterministic offline payloads and read-only golden images, then create digest-bound disposable qcow2 overlays with per-overlay identity.
- Enforce staged-only container realization and bind the verified appliance payload and boundary policy before scenario startup.
- Document the build, signing, qualification, launch, reset, rollback, and multi-machine evidence workflow.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Pre-commit passed all hooks. Completion: 3,315 passed, 92 skipped, 1 expected failure; integration: 2 passed. Post-sync appliance/compose seam: 124 passed. Policy and strict documentation builds passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: APP-3 ← src/aptl/appliance/, APP-3 ← src/aptl/cli/appliance.py, APP-3 ← src/aptl/core/lab.py, APP-3 ← appliance/guest/
- TESTS: APP-3 ← tests/test_appliance_release_manifest.py, APP-3 ← tests/test_appliance_build.py, APP-3 ← tests/test_appliance_cli.py, APP-3 ← tests/test_appliance_offline_payload.py, APP-3 ← tests/test_appliance_offline_start.py, APP-3 ← tests/test_appliance_guest_assets.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.