### PR TITLE
chore: configure bounded review caps

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -15,12 +15,16 @@ workflow:
   completion_command: 'uv run pytest -n auto -k "not integration" && uv run pytest -n auto tests/test_techvault_static_gate.py -m integration'
   lint_command: pre-commit run --all-files
   format_command: pre-commit run --all-files
+  codex_review:
+    pre_push_cap: 1
+  test_quality_review:
+    pre_push_cap: 1
   review_disposition:
-    enabled: true
+    enabled: false
     mode: shadow
-    max_auto_overrides: 1
+    max_auto_overrides: 0
     judge:
-      enabled: true
+      enabled: false
 sonarcloud:
   project_key: Brad-Edwards_aptl
   organization: brad-edwards


### PR DESCRIPTION
## Summary
- cap Codex pre-push review at one cycle
- cap test-quality pre-push review at one cycle
- disable automatic review disposition and judge overrides

## Validation
- Ground Control repository config validation: passed
- `git diff --check`: passed

Closes #841