### PR TITLE
ci: add make devmain and gate PR titles on main

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,14 +1,28 @@
 name: PR Title Lint
 
-# Repository-side guard on feature-PR titles: bans agent-branded prefixes
+# Repository-side guard on PR titles: bans agent-branded prefixes
 # (e.g. `[codex] ...`) and requires a Conventional Commit title. Feature PRs are
 # squash-merged, so the title becomes the commit release-please reads on main to
-# compute the version + changelog. Make this a required check on `dev` only.
+# compute the version + changelog.
 #
-# It runs ONLY on PRs targeting `dev`. A `dev`->`main` promotion PR carries a
-# non-conventional (merge/promotion) title and would always fail this check, so
-# `main` is intentionally not gated — release-please reads the underlying feature
-# commits, not the promotion PR title.
+# Runs on PRs targeting BOTH `main` and `dev` (issue #852). `main` was previously
+# exempt on the grounds that a `dev`->`main` promotion PR "carries a
+# non-conventional (merge/promotion) title and would always fail this check".
+# That was never a necessity: `make devmain` opens the promotion with
+# `chore(main): promote dev`, which this guard accepts and which release-please
+# treats as a no-release type. Every title that reaches `main` is now checked —
+# the promotion, and release-please's own `chore(main): release X.Y.Z`.
+# `tests/test_promotion_workflow.py` pins both halves so the exemption cannot
+# quietly return.
+#
+# Note the merge-commit subject GitHub writes for a merged promotion
+# (`Merge pull request #N from ...`) is NOT a PR title and is not checked here;
+# release-please reads the underlying feature commits, not that subject.
+#
+# Running is not blocking. This workflow reports a check; whether the check is
+# required to merge is live branch-protection configuration.
+# `.github/branch-protection-baseline.json` does not currently list
+# `PR title lint` as a required context on either branch.
 #
 # The PR title is untrusted event data, read from $GITHUB_EVENT_PATH by the
 # checker (never shell-interpolated), the token is read-only, and this uses
@@ -17,6 +31,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches:
+      - main
       - dev
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,26 @@
-.PHONY: policy
+.PHONY: policy devmain
 
 policy:
 	bash tools/vale-lint-all.sh
+
+# Open the dev -> main promotion PR with the standardized title (issue #852).
+#
+# The title matters: `chore(main): promote dev` satisfies tools/check_pr_title.py,
+# which is why `pr-title-lint.yml` can gate `main` instead of exempting it, and
+# `chore` is a no-release type so the promotion never computes a bump of its own.
+#
+# The merge method matters more. Release Please derives the version and
+# CHANGELOG.md from the Conventional Commit subjects on `main`; squashing the
+# promotion collapses every feature commit in the batch into one subject and
+# loses the release's changelog entries. This target can state that requirement
+# but cannot enforce it — only a server-side branch rule can.
+#
+# Deliberately thin: no ahead/behind precheck. GitHub already refuses a PR with
+# no commits between the branches, and computing it here would either read stale
+# local refs or add a fetch side effect to a target whose job is to open a PR.
+# `gh` failures propagate as-is. `--head dev` is explicit so the head is never
+# inferred from the current checkout.
+devmain:
+	@gh pr create --base main --head dev \
+	  --title "chore(main): promote dev" \
+	  --body "Promotes \`dev\` to \`main\`. Merge with a merge commit — squashing collapses the Conventional Commit subjects Release Please needs and loses this release's CHANGELOG."

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,6 +156,7 @@ The victim and kali containers publish no host ports; use
 
 ## Preflights
 
+- [Issue #852 Dev-To-Main Promotion](issue-852-devmain-promotion-preflight.md)
 - [Issue #847 OpenSSF Scorecard](issue-847-openssf-scorecard-preflight.md)
 - [Issue #820 Resource-Bounded Participant Profile](issue-820-resource-bounded-participant-profile-preflight.md)
 - [DEP-008 Self-Contained Lab Assets](dep-008-self-contained-lab-assets-preflight.md)

--- a/docs/architecture/issue-852-devmain-promotion-preflight.md
+++ b/docs/architecture/issue-852-devmain-promotion-preflight.md
@@ -1,0 +1,127 @@
+# Issue 852 Dev-To-Main Promotion Preflight
+
+This note fixes the design boundaries for standardizing the `dev` to `main`
+promotion. It is architecture guidance, not an implementation plan.
+`docs/releasing.md` remains the operator-facing release contract.
+
+## Architecture Decisions
+
+- Keep promotion as a repository workflow operation. The existing `Makefile`
+  may expose the convenience entry point, but it must delegate PR creation to
+  GitHub CLI with explicit `dev` head and `main` base branches. Do not add an
+  APTL CLI command, Python service, configuration key, or release abstraction.
+- Fix the promotion title and warning text at the entry point:
+  `chore(main): promote dev`, with a PR body that says to use a merge commit and
+  not squash. These values are policy, not user-configurable presentation.
+- Treat the target as a PR creator, not a merge controller. The target cannot
+  guarantee how a maintainer later merges the PR. The documented merge rule and
+  live GitHub branch/ruleset configuration are the enforcement surfaces.
+- Let `gh pr create` and GitHub remain authoritative for repository identity,
+  branch existence, compare state, authentication, duplicate PRs, and whether
+  the branches contain a promotable difference. Propagate failure unchanged.
+  Do not use potentially stale local refs as a second ahead/behind validator or
+  hide an empty-PR error with a successful exit.
+- Extend the existing title workflow to both protected branches without
+  changing its trust boundary: `pull_request`, read-only contents permission,
+  SHA-pinned actions, checkout of the base SHA, and title parsing from
+  `GITHUB_EVENT_PATH`. Never switch this policy job to
+  `pull_request_target` or interpolate the event title into shell.
+- Keep `tools/check_pr_title.py` as the single title-policy implementation.
+  Contract tests should cover the exact promotion, Release Please, and
+  back-merge title shapes. Do not copy its Conventional Commit regex or allowed
+  types into Make, workflow YAML, or release code.
+- Make the operator documentation distinguish feature integration from
+  promotion: feature PRs into `dev` are squash-merged, while the batch
+  promotion from `dev` into `main` requires a merge commit. The merge preserves
+  the individual Conventional Commit subjects that Release Please reads.
+
+No ADR is needed. This change applies the existing release and CI trust
+boundaries and does not introduce a durable product architecture decision.
+
+## Existing Concerns To Reuse
+
+| Concern | Canonical owner and required reuse |
+|---|---|
+| Promotion entry point | `Makefile` owns the repository convenience target. Keep `.PHONY` accurate and use the existing GitHub CLI rather than adding a wrapper package. |
+| Title policy | `tools/check_pr_title.py` owns parsing, allowed types, stable violation IDs, and fail-closed event loading. `tests/test_pr_title_guard.py` owns its executable contract. |
+| Title workflow trust | `.github/workflows/pr-title-lint.yml` owns triggers, least privilege, trusted-base checkout, action pins, concurrency, and safe event ingestion. |
+| Release titles | `release-please-config.json`, the pinned Release Please action in `.github/workflows/release-please.yml`, and observed release commits own the release PR shape. Recent repository history contains `chore(main): release 5.0.0`, `5.1.0`, and `5.1.1`. |
+| Back-merge titles | The `backmerge` job in `.github/workflows/release-please.yml` owns `chore: back-merge <tag> into dev`; do not create a second title formatter. |
+| Release semantics | `docs/releasing.md` is the operator contract; `CONTRIBUTING.md` and `.gc/plan-rules.md` remain the contributor-facing Conventional Commit policy. |
+| Branch governance | Live GitHub branch protection or rulesets are authoritative. `.github/branch-protection-baseline.json` is the checked-in record and must not be mistaken for enforcement. |
+| Main-push consumers | Release Please, OpenSSF Scorecard, and docs deployment retain their existing `push` to `main` triggers. Promotion must not call or duplicate them. |
+| Verification | `pytest`, strict MkDocs, Vale, pre-commit, and GitHub Actions syntax validation remain the existing gates. No issue-specific validation framework is needed. |
+
+## Security And Validation Passage
+
+| Layer | Required behavior |
+|---|---|
+| Developer authentication | Use the operator's existing `gh` authentication. Never embed a PAT, read a secret file, add a repository credential, or pass a token as a command argument. GitHub CLI and the API enforce repository permissions. |
+| Local shell and process surface | Pass only fixed, non-secret branch, title, and body values. Explicit `--head` avoids implicit current-branch push/fork behavior. The PR text may appear in process arguments; no credential or environment dump may. Preserve the CLI's nonzero exit and stderr. |
+| Repository and compare shape | GitHub CLI resolves the repository from its canonical local/`GH_REPO` mechanisms; GitHub validates base/head refs, differences, and duplicate PR state. A future friendly preflight, if justified, must query GitHub's compare API for that same resolved repository rather than inspect stale local tracking refs. |
+| PR title shape | `tools/check_pr_title.py` validates untrusted event JSON, Conventional Commit type/scope/subject shape, lowercase subject, and branded-prefix policy. The three workflow-produced title families must pass this function directly. |
+| Workflow trust | Keep `pull_request`, base-SHA checkout, read-only permissions, pinned actions, and event-file parsing. A PR must not execute a policy checker from its own head or place its title in a `run:` expression. |
+| Release configuration | The existing Release Please JSON schema and action remain unchanged. Promotion preserves commit topology; it does not synthesize changelog data or version state. |
+| Branch rules | Adding `main` to the workflow filter makes a check run; it does not by itself make that check required. If “gate” means merge-blocking, reconcile the live `main` rule and the checked-in baseline with the exact `PR title lint` context. Do not claim enforcement from YAML alone. |
+| Bot-created PRs | Release Please and back-merge PRs use `GITHUB_TOKEN`. GitHub's current event rules can place resulting `pull_request` runs in an approval-required state. Keep the titles valid, but do not replace the token with a PAT merely to avoid approval or admin-bypass workflow. |
+| Persistence and observability | GitHub owns the PR and git history. GitHub CLI stdout/stderr and the Actions check are the operational evidence. Do not add local state, a database record, APTL structured logging, OpenTelemetry, or a second error envelope. |
+| Product validators | `AptlConfig`, environment hydration, API authentication/CSRF, SDL/Pydantic validation, container policy, redaction, and run-store persistence are not traversed because this change adds no product input, runtime, listener, or stored lab state. |
+| Host and runner exposure | The target runs as a short-lived process on the developer host and reaches GitHub over the CLI's normal HTTPS path. The title check runs on a GitHub-hosted Ubuntu runner. No container, port, service, host mount, or lab startup is involved. |
+
+## Extensibility And Whole-Repository Scope
+
+The supported extensibility seam is GitHub CLI's native repository selection
+(`GH_REPO` or its `--repo` equivalent), not configurable promotion branches or
+titles. `dev`, `main`, and the Conventional Commit title are repository policy.
+If another promotion pair is ever accepted, add it against the same GitHub CLI
+and title-validator contracts; introduce a shared helper only after real
+duplication exists.
+
+The repository surfaces in scope are:
+
+- `Makefile`;
+- `.github/workflows/pr-title-lint.yml`;
+- `tools/check_pr_title.py` and `tests/test_pr_title_guard.py`;
+- `.github/workflows/release-please.yml` and `release-please-config.json`;
+- `docs/releasing.md`, `CONTRIBUTING.md`, and `.gc/plan-rules.md`;
+- live GitHub branch rules and `.github/branch-protection-baseline.json`;
+- `.github/workflows/checks.yml`, `scorecard.yml`, and `docs-deploy.yml` as
+  unchanged consumers of PRs or `main` pushes;
+- the developer shell, GitHub CLI/API, Actions runner, and git commit graph.
+
+## Gotchas And Anti-Patterns
+
+- Do not squash the `dev` to `main` PR. A conventional promotion PR title makes
+  the title gate pass; it does not make squash safe. Squash still collapses the
+  batch of feature subjects Release Please needs.
+- Do not conflate feature-PR squash policy with promotion merge policy, or
+  describe all PRs as using one merge method.
+- Do not conflate workflow coverage with required-check enforcement. Verify live
+  branch governance separately and keep the baseline honest.
+- Do not implement another Conventional Commit parser in Make, YAML, a shell
+  script, or release configuration.
+- Do not compute ahead/behind state from an unfetched local `main`, `dev`,
+  `origin/main`, or `origin/dev`. Do not add an implicit fetch or mutate local
+  branches merely to open a remote PR.
+- Do not swallow `gh` failures, turn duplicate/empty/auth/network failures into
+  success, or print authentication/environment details while diagnosing them.
+- Do not derive the promotion head from the current checkout. The command must
+  remain correct when invoked from a feature branch.
+- Do not weaken the title workflow to run head code, expand permissions, use an
+  unpinned action, or adopt `pull_request_target`.
+- Do not assume a bot-created PR's checks are either automatically complete or
+  permanently absent. Approval and branch-bypass behavior is GitHub governance,
+  not title-validation logic.
+- Do not claim the Make target enforces merge commits. Server-side branch rules
+  are the only durable enforcement; the target and docs provide a warning.
+
+## Non-Goals And Boundaries
+
+This issue does not merge the promotion PR, push branches, update `main`, cut a
+release, edit the version or `CHANGELOG.md`, change Release Please behavior,
+replace the automated back-merge, or invoke Scorecard/docs deployment directly.
+It does not add an APTL command, package, schema, DTO, controller, service,
+repository, exception hierarchy, logger, telemetry signal, secret, PAT,
+container, or local persistence. Branch-specific server-side merge-method
+enforcement and redesigning bot-trigger authentication are separate governance
+changes unless explicitly accepted into scope.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,19 +16,52 @@ Nobody runs a script, hand-edits the version, or edits `CHANGELOG.md`.
   Because feature PRs never touch `CHANGELOG.md`, concurrent PRs never conflict
   on it.
 
+## Promoting `dev` to `main`
+
+Feature PRs land on `dev`. Nothing releases until `dev` is promoted to `main`.
+
+Open the promotion PR with:
+
+```bash
+make devmain
+```
+
+That creates a `dev` → `main` PR titled `chore(main): promote dev`. The title is
+fixed rather than free-form for two reasons: it satisfies the PR-title guard (so
+`main` needs no exemption from it), and `chore` is a no-release type, so the
+promotion never computes a version bump of its own.
+
+**Merge the promotion with a merge commit. Do not squash it.** This is the one
+place in the workflow where squashing is wrong. release-please computes the
+version and `CHANGELOG.md` from the Conventional Commit subjects on `main`;
+squashing collapses every feature commit in the batch into a single subject, so
+the release loses its changelog entries and can compute the wrong bump. A merge
+commit preserves each subject underneath.
+
+The merge commit's own subject (`Merge pull request #N from ...`) is not a
+Conventional Commit and does not need to be—release-please reads the feature
+commits it carries, not the merge subject.
+
+Promotion also refreshes repository posture: `.github/workflows/scorecard.yml`
+runs only on pushes to `main`, so the published OpenSSF Scorecard result and the
+README badge do not update until a promotion lands.
+
 ## How a release happens
 
 1. On merges to `main`, release-please keeps a **release PR** open
    (`chore(main): release X.Y.Z`) with the computed version bump in
    `pyproject.toml` and the generated `CHANGELOG.md` section.
-2. **Merge that release PR.** It's opened by `GITHUB_TOKEN`, so the required CI
-   checks don't auto-run on it, so merge it as an admin (or wire a PAT if you want
-   checks enforced on the release PR).
+2. **Merge that release PR.** It's opened by `GITHUB_TOKEN`. Workflow runs
+   triggered that way are restricted: depending on the repository's Actions
+   settings they may not start at all, or may sit awaiting approval. Either way
+   do not expect the required checks to go green on their own—merge it as an
+   admin, or wire a PAT if you want checks genuinely enforced on the release PR.
 3. Merging tags `vX.Y.Z` and cuts the GitHub Release; the `publish` job then
    builds the sdist + wheel, generates an SBOM, and publishes to PyPI via OIDC.
 4. A `main`→`dev` **back-merge PR** is then opened automatically (main now has
-   the version bump + `CHANGELOG.md`). **Admin-merge it** (one click; dev's
-   required checks don't run on a bot-opened PR) to keep `dev` current.
+   the version bump + `CHANGELOG.md`), titled `chore: back-merge <tag> into dev`.
+   **Admin-merge it** (one click) to keep `dev` current—like the release PR it
+   is bot-opened, so its required checks should not be relied on to run.
 
 ## Baseline
 

--- a/tests/test_pr_title_guard.py
+++ b/tests/test_pr_title_guard.py
@@ -72,3 +72,26 @@ def test_rejects_uppercase_subject() -> None:
 def test_rejects_empty() -> None:
     assert any(v.rule_id == check_pr_title.RULE_EMPTY for v in validate_pr_title(""))
     assert any(v.rule_id == check_pr_title.RULE_EMPTY for v in validate_pr_title("   "))
+
+
+@pytest.mark.parametrize(
+    ("title", "origin"),
+    [
+        ("chore(main): promote dev", "make devmain, the dev -> main promotion"),
+        ("chore(main): release 5.1.1", "the release-please release PR"),
+        ("chore: back-merge v5.1.1 into dev", "the automated main -> dev back-merge"),
+    ],
+)
+def test_accepts_every_title_the_release_path_emits(title: str, origin: str) -> None:
+    """Titles produced by automation, not by a human who can react to a rejection.
+
+    Since issue #852 this guard runs on `main` as well as `dev`, so all three of
+    these now pass through it. None has an author watching for a red check: a
+    rejection here would stall the release path rather than prompt a reword.
+
+    This is why the cases are pinned explicitly rather than left to the generic
+    "valid titles" coverage above. Narrowing ``CONVENTIONAL_TYPES``, tightening
+    the optional-scope group, or changing the subject pattern would break the
+    release path, and it should break here first.
+    """
+    assert validate_pr_title(title) == [], f"would block {origin}"

--- a/tests/test_promotion_workflow.py
+++ b/tests/test_promotion_workflow.py
@@ -1,0 +1,144 @@
+"""The `dev` -> `main` promotion path stays standardized and gated (issue #852).
+
+Two halves of one contract:
+
+* `make devmain` opens the promotion PR with a title the PR-title guard accepts.
+* `pr-title-lint.yml` actually runs on `main`, not just `dev`.
+
+They are tested together because each is what justifies the other. The workflow
+previously exempted `main` on the stated grounds that "a `dev`->`main` promotion
+PR carries a non-conventional (merge/promotion) title and would always fail this
+check". Standardizing the title through the Make target removes that premise; if
+the target's title ever drifts away from the guard's policy, the exemption's
+reasoning quietly becomes true again and `main` PRs start failing. So the title
+the target emits is asserted against the *real* validator rather than against a
+copy of its regex.
+
+Note what this does NOT claim: a workflow trigger makes the check run, not merge.
+Whether `PR title lint` blocks a merge is live branch-protection configuration,
+which no test in this repository can observe.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr-title-lint.yml"
+MAKEFILE = REPO_ROOT / "Makefile"
+
+# Reuse the repository's single title validator rather than reimplementing its
+# policy here - two copies of a regex is exactly the drift this guards against.
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import check_pr_title  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def makefile_text() -> str:
+    assert MAKEFILE.is_file(), "Makefile is missing"
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def devmain_recipe(makefile_text: str) -> str:
+    """The body of the `devmain` target, with line continuations joined."""
+    match = re.search(r"^devmain:.*?\n((?:\t.*\n|\n)*)", makefile_text, re.MULTILINE)
+    assert match, "Makefile defines no `devmain` target"
+    return re.sub(r"\\\n\s*", " ", match.group(0))
+
+
+def test_devmain_is_declared_phony(makefile_text: str) -> None:
+    """Without .PHONY, a file named `devmain` would silently disable the target."""
+    phony = re.findall(r"^\.PHONY:(.*(?:\\\n.*)*)", makefile_text, re.MULTILINE)
+    assert phony, "Makefile declares no .PHONY"
+    declared = re.sub(r"\\\n", " ", " ".join(phony)).split()
+    assert "devmain" in declared
+
+
+def test_devmain_promotes_dev_into_main_explicitly(devmain_recipe: str) -> None:
+    """Explicit --base/--head; never infer the head from the current checkout."""
+    assert "gh pr create" in devmain_recipe
+    assert "--base main" in devmain_recipe
+    assert "--head dev" in devmain_recipe
+
+
+def test_devmain_title_satisfies_the_repository_title_guard(devmain_recipe: str) -> None:
+    """The whole point: the promotion title complies, so `main` needs no exemption."""
+    title_match = re.search(r'--title\s+"([^"]+)"', devmain_recipe)
+    assert title_match, "devmain does not pass an explicit --title"
+    title = title_match.group(1)
+
+    violations = check_pr_title.validate_pr_title(title)
+    assert violations == [], (
+        f"devmain's title {title!r} is rejected by tools/check_pr_title.py: "
+        f"{[v.render() for v in violations]}"
+    )
+
+
+def test_devmain_title_does_not_trigger_a_release(devmain_recipe: str) -> None:
+    """A promotion must not itself compute a version bump.
+
+    Release Please bumps on `feat` (minor) and `fix`/`perf` (patch). The
+    promotion carries the underlying feature commits; its own title must be a
+    no-release type or it would double-count.
+    """
+    title = re.search(r'--title\s+"([^"]+)"', devmain_recipe).group(1)
+    release_type = re.match(r"^(feat|fix|perf)(\(|!|:)", title)
+    assert release_type is None, (
+        f"devmain's title {title!r} uses a release-triggering type; promotion "
+        "should be a no-release type such as `chore`"
+    )
+
+
+def test_devmain_warns_against_squashing(devmain_recipe: str) -> None:
+    """The load-bearing part.
+
+    Release Please reads the Conventional Commit subjects on `main`. Squashing a
+    promotion collapses the whole batch into one subject, losing the release's
+    changelog entries. The PR body is where a human sees that warning.
+    """
+    body = re.search(r'--body\s+"(.*?)"\s*$', devmain_recipe, re.DOTALL)
+    assert body, "devmain passes no --body"
+    text = body.group(1).lower()
+    assert "merge commit" in text
+    assert "squash" in text
+
+
+def test_pr_title_lint_gates_main_as_well_as_dev() -> None:
+    """The carve-out this issue closes; this is what stops it coming back."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    # `on:` parses to Python True under YAML 1.1.
+    branches = workflow[True]["pull_request"]["branches"]
+    assert set(branches) == {"main", "dev"}, (
+        f"pr-title-lint must gate both branches, got {branches}. Exempting `main` "
+        "leaves promotion PRs with no title validation at all."
+    )
+
+
+def test_pr_title_lint_reads_the_title_without_shell_interpolation() -> None:
+    """The PR title is untrusted event data; keep it out of the shell.
+
+    Both assertions read parsed structure, not raw text: the workflow's own
+    header comment names `pull_request_target` to say it deliberately avoids it,
+    so a substring scan would fail on prose that proves the opposite point.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    triggers = workflow[True]
+    assert "pull_request_target" not in triggers, (
+        "pull_request_target would run with write scope against fork head code"
+    )
+    assert "pull_request" in triggers
+
+    run_steps = " ".join(
+        step.get("run", "") for job in workflow["jobs"].values() for step in job["steps"]
+    )
+    assert "github.event.pull_request.title" not in run_steps, (
+        "the title must reach the checker via $GITHUB_EVENT_PATH, never a "
+        "workflow expression interpolated into a shell command"
+    )

--- a/web/tests/routes/scenario-workbench.test.ts
+++ b/web/tests/routes/scenario-workbench.test.ts
@@ -1,11 +1,43 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { render, within } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { vi } from 'vitest';
 import type { LabStatus, ScenarioDetail } from '../../src/lib/types';
 
 const labStatus = writable<LabStatus>({ running: false, containers: [], error: null });
 vi.mock('$lib/stores/lab', () => ({ labStatus }));
+
+// Stub the DOM-canvas terminal deps, exactly as tests/components/workbench/blocks.test.ts
+// and tests/routes/terminal-page.test.ts already do. This file renders the whole
+// workbench page, whose fixture includes a `terminal` block, so without these stubs
+// it is the only suite that pulls xterm's lazy dynamic import into a jsdom render.
+// That import resolving after the test had finished is what intermittently left DOM
+// attached and produced "found multiple elements" under CPU contention (issue #852).
+vi.mock('@xterm/xterm', () => ({
+	Terminal: vi.fn(function () {
+		return {
+			loadAddon: vi.fn(),
+			open: vi.fn(),
+			onData: vi.fn(),
+			onResize: vi.fn(),
+			write: vi.fn(),
+			dispose: vi.fn(),
+			cols: 80,
+			rows: 24
+		};
+	})
+}));
+vi.mock('@xterm/addon-fit', () => ({
+	FitAddon: vi.fn(function () {
+		return { fit: vi.fn(), dispose: vi.fn() };
+	})
+}));
+vi.mock('@xterm/addon-web-links', () => ({
+	WebLinksAddon: vi.fn(function () {
+		return { dispose: vi.fn() };
+	})
+}));
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
 
 function detail(overrides: Partial<ScenarioDetail> = {}): ScenarioDetail {
 	return {
@@ -52,7 +84,14 @@ function detail(overrides: Partial<ScenarioDetail> = {}): ScenarioDetail {
 
 async function renderWorkbench(data: { scenario: ScenarioDetail }) {
 	const Page = (await import('../../src/routes/scenarios/[id]/+page.svelte')).default;
-	return render(Page, { props: { data } });
+	const { container } = render(Page, { props: { data } });
+	// Scope queries to THIS render's container rather than the global `screen`
+	// (which searches all of document.body). Under CPU contention these tests
+	// intermittently matched a previous test's still-attached DOM and failed with
+	// "found multiple elements" (issue #852). A scoped query asserts against the
+	// component actually under test, so the assertion is both correct and immune
+	// to a leaked sibling container.
+	return within(container);
 }
 
 describe('Scenario workbench route', () => {
@@ -61,34 +100,34 @@ describe('Scenario workbench route', () => {
 	});
 
 	it('renders every workbench block family from the backend projection', async () => {
-		await renderWorkbench({ scenario: detail() });
+		const view = await renderWorkbench({ scenario: detail() });
 
 		// narrative markdown, section divider, objective, step, siem block.
-		expect(screen.getByText('Heading')).toBeTruthy();
-		expect(screen.getByText('Objectives')).toBeTruthy();
-		expect(screen.getByText('Objective One')).toBeTruthy();
-		expect(screen.getByText('step-one')).toBeTruthy();
-		expect(screen.getByText('wazuh')).toBeTruthy();
+		expect(view.getByText('Heading')).toBeTruthy();
+		expect(view.getByText('Objectives')).toBeTruthy();
+		expect(view.getByText('Objective One')).toBeTruthy();
+		expect(view.getByText('step-one')).toBeTruthy();
+		expect(view.getByText('wazuh')).toBeTruthy();
 	});
 
 	it('keeps the SIEM query block execution disabled (owned by #421)', async () => {
-		await renderWorkbench({ scenario: detail() });
-		const runBtn = screen.getByRole('button', { name: 'Run Query' }) as HTMLButtonElement;
+		const view = await renderWorkbench({ scenario: detail() });
+		const runBtn = view.getByRole('button', { name: 'Run Query' }) as HTMLButtonElement;
 		expect(runBtn.disabled).toBe(true);
 	});
 
 	it('keeps the terminal block lazy — no PTY until an explicit action', async () => {
-		await renderWorkbench({ scenario: detail() });
+		const view = await renderWorkbench({ scenario: detail() });
 		// The lazy affordance is present; the maximize link (only shown once the
 		// embedded terminal mounts) is not.
-		expect(screen.getByRole('button', { name: /Open terminal: host-a/ })).toBeTruthy();
-		expect(screen.queryByText('Maximize')).toBeNull();
+		expect(view.getByRole('button', { name: /Open terminal: host-a/ })).toBeTruthy();
+		expect(view.queryByText('Maximize')).toBeNull();
 	});
 
 	it('surfaces an invalid scenario projection state in the status bar', async () => {
-		await renderWorkbench({
+		const view = await renderWorkbench({
 			scenario: detail({ validation: { valid: false, detail: 'Scenario unavailable' } })
 		});
-		expect(screen.getByText('Scenario unavailable')).toBeTruthy();
+		expect(view.getByText('Scenario unavailable')).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## Summary

Adds `make devmain`, which opens the `dev` → `main` promotion PR with the standardized title `chore(main): promote dev`, and extends `pr-title-lint.yml` to gate `main` as well as `dev`.

Closes #852

## Why the exemption could go

`main` was exempt from the title gate on the stated grounds that a promotion PR "carries a non-conventional (merge/promotion) title and would always fail this check". That was an assumption, not a necessity. Standardizing the title removes it: `chore(main): promote dev` satisfies `tools/check_pr_title.py` and is a no-release type, so the promotion never computes a bump of its own.

Verified against the real validator rather than assumed — every title that now reaches the gate on `main` passes:

| Title | Result |
|---|---|
| `chore(main): promote dev` (new promotion) | PASS |
| `chore(main): release X.Y.Z` (release-please PR) | PASS |
| `chore: back-merge <tag> into dev` (automated back-merge) | PASS |

`Merge pull request #N from ...` rejects, but that is the *merge commit subject*, not a PR title, and only PR titles are gated. That conflation is the likely origin of the original exemption.

## Also

- `docs/releasing.md` never documented the `dev` → `main` promotion at all — it jumped from per-PR merges straight to "On merges to `main`". Now documented, including the merge-commit-not-squash rule that release-please depends on (squashing a promotion collapses the batch into one subject and loses the release's changelog).
- Corrected an over-broad claim in the same file that bot-opened PR checks "don't auto-run"; they may instead sit awaiting approval.
- `web/tests/routes/scenario-workbench.test.ts` now stubs `@xterm/*`, matching `blocks.test.ts` and `terminal-page.test.ts`. That file renders a fixture containing a `terminal` block, so it was the only suite pulling xterm's lazy dynamic import into a jsdom render — the source of intermittent "found multiple elements" failures under CPU load.

## Deliberately not done

The target creates a PR; it cannot enforce how that PR is merged. Only a server-side branch rule can, and documentation is the other surface.

Adding `main` to the trigger makes the check **run**, not **block**. `.github/branch-protection-baseline.json" lists `PR title lint` as a required context on neither branch, so it is advisory today even on `dev`. Making it merge-blocking is a live branch-protection change, which is repo-owner authority. Per ADR-026 the baseline JSON is documentation, not enforcement, so it was not edited to imply otherwise.

No ahead/behind precheck in the target: GitHub already refuses a PR with no commits between the branches, and computing it locally would either read stale refs or add a fetch side effect.

## Test plan

- `tests/test_promotion_workflow.py` (new): the workflow gates both branches; `devmain` targets `--base main --head dev`, its title passes the real validator, its type does not trigger a release, and its body carries the merge-commit warning.
- `tests/test_pr_title_guard.py`: pins the three automation-emitted titles above, so narrowing the allowed types or the scope group breaks here rather than stalling a release.
- Both mutation-tested (five mutations, each caught).
- Local pre-commit was skipped on this push; CI is the validation pass.