### PR TITLE
docs: sync branch-protection baseline with live required checks

### DIFF
--- a/.github/branch-protection-baseline.json
+++ b/.github/branch-protection-baseline.json
@@ -1,5 +1,5 @@
 {
-  "source": "APTL required merge checks (issue #502); advisory scanners per ADR-026 stay optional",
+  "source": "APTL required merge checks (issues #502, #852); advisory scanners per ADR-026 stay optional",
   "branches": {
     "main": {
       "admin_bypass_allowed": true,
@@ -12,7 +12,8 @@
           "Python tests + coverage",
           "MCP TypeScript tests + coverage",
           "Web frontend tests + coverage",
-          "SonarCloud quality gate"
+          "SonarCloud quality gate",
+          "PR title lint"
         ]
       }
     },
@@ -27,7 +28,8 @@
           "Python tests + coverage",
           "MCP TypeScript tests + coverage",
           "Web frontend tests + coverage",
-          "SonarCloud quality gate"
+          "SonarCloud quality gate",
+          "PR title lint"
         ]
       }
     }


### PR DESCRIPTION
`.github/branch-protection-baseline.json` listed `PR title lint` as a required context on neither branch. Live rules have it on **both**.

- `dev` already required it — the baseline was stale independently of any recent change.
- `main` was added alongside #852, which extended `pr-title-lint.yml` to gate main-targeted PRs.

Verified against the live GitHub API for both branches rather than assumed. Per ADR-026 this file documents required checks; the live rules are authoritative, so this brings the documentation back in line with them — it is not itself an enforcement change.