### PR TITLE
feat: add host-side appliance seat launcher for kiosk lifecycle

### DIFF
--- a/changelog.d/824.added.md
+++ b/changelog.d/824.added.md
@@ -1,0 +1,1 @@
+Host-side seat launcher with stage, start, reset, recover, reboot reconcile, coarse status, and participant kiosk presentation for signed disposable appliance releases.

--- a/changelog.d/824.fixed.md
+++ b/changelog.d/824.fixed.md
@@ -1,0 +1,1 @@
+Scope seat host-exposure share audits to QEMU `-fsdev` options so writable overlay drives no longer fail `aptl seat start` on real KVM hosts.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -170,3 +170,4 @@ The victim and kali containers publish no host ports; use
 - [Issue #589 Scenario-Pack Capture Workflow Ownership](issue-589-scenario-pack-capture-ownership-preflight.md)
 - [Issue #821 In-Appliance Participant Workbench](issue-821-participant-workbench-preflight.md)
 - [Issue #823 Versioned Disposable Lab Appliance](issue-823-versioned-disposable-appliance-preflight.md)
+- [Issue #824 Kiosk Launcher, Reset, And Recovery](issue-824-kiosk-launcher-reset-recovery-preflight.md)

--- a/docs/architecture/issue-824-kiosk-launcher-reset-recovery-preflight.md
+++ b/docs/architecture/issue-824-kiosk-launcher-reset-recovery-preflight.md
@@ -1,0 +1,148 @@
+# Issue #824 Kiosk Launcher, Reset, And Recovery Preflight
+
+This note sets the design guardrails for the host-side appliance seat launcher.
+It is guidance, not an implementation plan. [ADR-049](../adrs/adr-049-sealed-disposable-lab-appliance.md),
+[Issue #823](issue-823-versioned-disposable-appliance-preflight.md), and the
+[appliance boundary contract](../components/appliance-boundary.md) already own
+the signed payload, disposable overlay, guest boundary policy, and start-gate
+verdict. Issue #824 owns the physical-host lifecycle adapter that consumes
+those contracts without widening them.
+
+No new ADR is needed. The unresolved risk is turning the launcher into a second
+control plane that re-describes guest readiness, bypasses the signed boundary
+contracts, or leaks recovery authority into the participant surface.
+
+## Architecture Decisions And Guardrails
+
+- The launcher is an outer seat-lifecycle adapter, not a new
+  `DeploymentBackend`, RAES provider, profile selector, readiness engine,
+  operator API, or host-resident APTL runtime. It verifies a sealed release,
+  creates or selects one disposable overlay, starts or stops one VM, captures
+  one authenticated host observation, and projects one coarse seat state.
+- Use one seat state vocabulary distinct from inner lab lifecycle. The host
+  state is about release admission and appliance availability
+  (`empty`, `staged`, `starting`, `ready`, `needs-reset`, `recoverable-failure`,
+  `tainted`); it must not reuse or reinterpret `StartupOutcome`,
+  participant episode state, scenario objective state, or container health.
+- Seat reset means power off plus overlay destruction plus fresh overlay
+  creation from the selected verified golden. It is not `aptl lab stop -v`,
+  `docker compose down -v`, `AptlParticipantRuntime.reset()`, a reboot, or
+  an in-guest repair flow.
+- Recovery is a separate authenticated instructor surface. The participant
+  kiosk/browser gets only the participant endpoint; instructor operations
+  inspect coarse health, stop, reset, replace, and explicitly taint a seat for
+  break-glass replacement. Recovery is not a hidden participant route, shell,
+  Docker proxy, log browser, or terminal backdoor.
+- Host validation is prereq admission plus launch observation, not ad hoc bash
+  checks spread across scripts. Hardware virtualization, usable RAM, free disk,
+  supported hypervisor, release version, loopback publication inventory, and
+  forbidden host reachability must pass through one closed validation surface
+  before a seat is marked ready.
+- Kiosk mode is presentation only. The browser/display wrapper may control full
+  screen, restart-on-exit, and logout return-to-start behavior, but it must not
+  own seat truth, readiness logic, release selection, or recovery authority.
+- Surviving host reboot is a state-transition problem, not a persistence excuse.
+  Persist only the selected verified release reference, overlay path, seat id,
+  and bounded lifecycle metadata needed to reconcile the next boot. Do not
+  persist guest credentials, raw logs, run evidence, or scenario service
+  details on the host.
+
+## Cross-Cutting Incumbents To Reuse
+
+| Concern | Canonical owner and required reuse |
+| --- | --- |
+| Signed payload and overlay contract | `src/aptl/appliance/{models,manifest,launch,build,bootstrap}.py`, `src/aptl/cli/appliance.py`, [Issue #823](issue-823-versioned-disposable-appliance-preflight.md), and [ADR-049](../adrs/adr-049-sealed-disposable-lab-appliance.md) already own release verification, launch descriptors, disposable overlays, and create-once bootstrap identity. The launcher must consume these; it must not define a second release manifest, overlay schema, or reset contract. |
+| Host/guest boundary gate | `ApplianceBoundaryPolicy`, `ApplianceBoundaryBinding`, `HostBoundaryObservation`, `qualify_appliance_boundary()`, and `run_appliance_boundary_gate()` already own the signed host publication contract and fatal observed-vs-desired verdict. The launcher supplies the authenticated host observation and consumes the resulting bounded inventory; it must not replace this with bespoke "seat health" rules. |
+| Inner startup diagnostics | `LabResult`, `StartupOutcome`, `StartupDiagnostic`, ADR-030, and the existing lab start flow own in-guest lifecycle and redacted diagnostics. Host UX may project a coarse summary from them, but must not fork their schema, invent new readiness classes for guest failures, or expose raw stderr/logs. |
+| Host capability detection | `src/aptl/core/hostenv.py` and `src/aptl/core/sysreqs.py` already contain host OS and tool-probing patterns with bounded results and install hints. Extend that style for KVM/libvirt, disk, and memory checks instead of embedding one-off shell parsing into launcher scripts. |
+| Logging and redaction | `src/aptl/utils/logging.py`, `src/aptl/utils/redaction.py`, ADR-029, and bounded CLI error patterns in `src/aptl/cli/appliance.py` remain the canonical observability surface. Recovery diagnostics may expose stable codes, release ids/digests, resource pressure, and operator actions only. |
+| Strict config boundary | `AptlConfig`, `load_config()`, ADR-025, and the release/launch descriptor models remain authoritative for durable config and signed runtime inputs. Host seat state is not an `aptl.json` extension, environment bag, or duplicate copy of the launch descriptor. |
+
+## Security And Validation Passage
+
+The intended design has to pass all of these layers:
+
+- **Release trust boundary:** use `verify_release_directory()`,
+  `prepare_launch_descriptor()`, and the closed appliance models before any
+  overlay or VM action. Unsupported release version, digest mismatch, missing
+  trust anchor, or unsupported adapter capability fails closed before launch.
+- **Overlay and seat state boundary:** use `OverlayCreateRequest`,
+  `create_disposable_overlay()`, and `initialize_overlay_state()` for mutable
+  state creation. Never create overlays by hand, never reopen the golden for
+  writing, and never persist seat credentials outside guest overlay state.
+- **Host prerequisite gate:** follow the `hostenv`/`sysreqs` pattern for CPU
+  virtualization, hypervisor availability, disk headroom, memory headroom, and
+  required launcher tools. The output must be bounded and actionable, not raw
+  command output.
+- **Boundary observation gate:** supply one authenticated
+  `HostBoundaryObservation` matching the selected release/binding and pass it to
+  `run_appliance_boundary_gate()`. The host surface satisfies security only if
+  it proves exact loopback-only participant/recovery listeners and forbidden
+  host/LAN reachability remains blocked.
+- **Process and OS exposure gate:** preserve fixed-argv subprocess execution
+  patterns. Do not place secrets in argv, env dumps, unit files, desktop files,
+  browser command lines, URLs, logs, support bundles, or host persistence. The
+  host must not expose Docker, guest shells, clipboard/share channels, USB
+  forwarding, or writable host mounts into the participant VM.
+- **Error and report envelope:** reuse bounded CLI/API error style and
+  redaction. Seat failures may report stable codes such as bad release,
+  low-disk, no-KVM, failed-boundary-gate, interrupted-boot, or corrupt-overlay.
+  They must not return raw libvirt/QEMU stderr, guest logs, policy text,
+  credentials, or scenario topology.
+
+## Extensibility Seam
+
+The seam is one versioned host seat contract:
+
+`(seat_id, selected_release_id, launch_descriptor_digest, overlay_ref, host_observation_id, lifecycle_state, taint_state)`
+
+It is metadata about one outer seat only. The next reasonable change (another
+supported hypervisor adapter or a fleet-oriented recovery service) should add
+an adapter behind this seam while continuing to consume the same signed release,
+overlay, and boundary-observation contracts. It must not fork the guest
+manifest, readiness suite, participant routes, or recovery vocabulary.
+
+## Whole-Repository Surface
+
+- `src/aptl/appliance/`, `src/aptl/cli/appliance.py`, and the appliance release
+  reference docs.
+- `src/aptl/core/{appliance_boundary,appliance_boundary_gate,appliance_boundary_inventory,hostenv,sysreqs,lab,lab_types}.py`.
+- `docs/adrs/adr-049-sealed-disposable-lab-appliance.md`,
+  `docs/components/appliance-boundary.md`, and
+  `docs/reference/appliance-release.md`.
+- Guest first-boot assets under `appliance/guest/`.
+- Test surfaces already exercising appliance release, boundary inventory, boot,
+  guest assets, and CLI behavior.
+- Host OS and runtime layers that will see the artifact: systemd/session
+  startup, kiosk browser wrapper, QEMU/KVM or libvirt, loopback listener
+  inventory, and instructor recovery entrypoint.
+
+## Gotchas And Anti-Patterns
+
+- Do not turn the launcher into an alternate `aptl lab` frontend that parses
+  scenario state, drives Docker, or interprets guest health internally.
+- Do not create a second host-observation schema, second readiness taxonomy,
+  second exception hierarchy, or second release-config format for seat state.
+- Do not let kiosk/logout/reboot behavior imply reset. Only explicit overlay
+  destruction returns a seat to known-good security state.
+- Do not expose participant shell access on the physical host, even if "locked
+  down". Participant shell, participant sudo, host Docker access, shared
+  folders, host clipboard, and USB forwarding are all out of bounds.
+- Do not treat VM power-on, browser open, TCP reachability, or a green guest
+  container as seat readiness. Ready requires verified release admission and a
+  passing boundary/start gate.
+- Do not store seat secrets, scenario credentials, raw guest logs, or evidence
+  on the host just to simplify diagnostics or recovery.
+- Do not use break-glass console repair as a normal recovery path. Any
+  interactive guest recovery taints the seat and requires replacement before
+  participant reuse.
+
+## Non-Goals And Implementation Boundary
+
+- This preflight does not implement the launcher, kiosk wrapper, systemd unit,
+  libvirt domain, recovery UI, or seat-state persistence.
+- It does not change RAES, `DeploymentBackend`, participant/runtime DTOs,
+  startup/readiness schemas, the signed appliance release format, or the APP-1
+  boundary schema.
+- It does not authorize host-resident agents, MCP servers, scenario service
+  publications, Docker authority, or participant-visible recovery controls.

--- a/docs/reference/appliance-release.md
+++ b/docs/reference/appliance-release.md
@@ -6,7 +6,8 @@ a disposable qcow2 overlay. Destroying that overlay destroys its credentials,
 Docker state, and run evidence; the golden disk is never opened for writing.
 
 This is a release-engineering interface. The participant launcher, reset
-controls, and recovery UI are tracked separately in issue #824.
+controls, and recovery UI are implemented by [`aptl seat`](appliance-seat-launcher.md)
+(issue #824).
 
 ## Trust and lifecycle model
 

--- a/docs/reference/appliance-seat-launcher.md
+++ b/docs/reference/appliance-seat-launcher.md
@@ -1,0 +1,116 @@
+# Appliance seat launcher
+
+Issue #824 adds the host-side lifecycle adapter for one disposable appliance
+seat. It consumes the signed release, overlay, and launch contracts from
+[Disposable Appliance Release](appliance-release.md) without introducing a
+host-resident APTL runtime.
+
+## Prerequisites
+
+The physical host must satisfy the signed release `host_prerequisites` block:
+
+- Linux with hardware virtualization (`/dev/kvm`)
+- `qemu-img` and `qemu-system-x86_64`
+- RAM and free disk at or above the manifest minimums
+- No dependency on host Docker for seat operations
+
+Trust anchors:
+
+- `--release-public-key`: release manifest Ed25519 anchor
+- `--qualification-public-key`: participant qualification attestation anchor
+
+## Directory layout
+
+```text
+/srv/aptl-seat/
+  seat-state.json
+  vm.pid
+  launch/
+    release/                 # verified release directory
+    appliance-launch.json    # create-once launch projection
+  instances/
+    seat-01.qcow2            # disposable overlay
+    seat-01.state/           # guest-only overlay identity (host tracks path only)
+```
+
+## Supported operator flow
+
+Stage a verified release:
+
+```bash
+aptl seat stage \
+  --seat-root /srv/aptl-seat \
+  --seat-id seat-01 \
+  --release-dir /srv/aptl-seat/launch/release \
+  --release-public-key /etc/aptl/trust/release-public.pem \
+  --qualification-public-key /etc/aptl/trust/qualification-public.pem
+```
+
+Start the seat VM and validate host exposure:
+
+```bash
+aptl seat start \
+  --seat-root /srv/aptl-seat \
+  --seat-id seat-01 \
+  --release-dir /srv/aptl-seat/launch/release \
+  --release-public-key /etc/aptl/trust/release-public.pem \
+  --qualification-public-key /etc/aptl/trust/qualification-public.pem
+```
+
+Open the participant kiosk browser (presentation only):
+
+```bash
+aptl seat open-kiosk
+```
+
+Inspect coarse health (no credentials):
+
+```bash
+aptl seat status --seat-root /srv/aptl-seat
+```
+
+## Reset and recovery
+
+Security reset destroys the overlay and recreates a fresh overlay from the
+verified golden. It is not a reboot, logout, or in-guest repair.
+
+```bash
+aptl seat reset \
+  --seat-root /srv/aptl-seat \
+  --seat-id seat-01 \
+  --release-dir /srv/aptl-seat/launch/release \
+  --release-public-key /etc/aptl/trust/release-public.pem \
+  --qualification-public-key /etc/aptl/trust/qualification-public.pem
+```
+
+Instructor recovery performs reset then start:
+
+```bash
+aptl seat recover \
+  --seat-root /srv/aptl-seat \
+  --seat-id seat-01 \
+  --release-dir /srv/aptl-seat/launch/release \
+  --release-public-key /etc/aptl/trust/release-public.pem \
+  --qualification-public-key /etc/aptl/trust/qualification-public.pem
+```
+
+After a physical-host reboot, reconcile persisted seat metadata before reuse:
+
+```bash
+aptl seat reconcile --seat-root /srv/aptl-seat
+```
+
+When reconciliation reports `host-reboot-detected` or `vm-not-running`, run
+`recover` before returning the seat to a participant.
+
+## Diagnostics
+
+CLI failures emit bounded JSON with stable codes such as `no-kvm`, `low-disk`,
+`corrupt-overlay`, `failed-readiness`, and boundary inventory codes. Raw
+QEMU/libvirt stderr, guest logs, and credentials are never returned.
+
+## Related documents
+
+- [ADR-049](../adrs/adr-049-sealed-disposable-lab-appliance.md)
+- [Appliance boundary](../components/appliance-boundary.md)
+- [Issue #824 preflight](../architecture/issue-824-kiosk-launcher-reset-recovery-preflight.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
     - Red Team Taxonomy: red-team-taxonomy.md
     - Guided Purple Participant Profile: reference/participant-profile.md
     - Disposable Appliance Release: reference/appliance-release.md
+    - Appliance Seat Launcher: reference/appliance-seat-launcher.md
     - TechVault Scenario Overview: reference/techvault-scenario-overview.md
     - TechVault Company Profile: reference/techvault-company-profile.md
     - TechVault OSINT Readiness: reference/techvault-osint-readiness.md

--- a/src/aptl/appliance/seat/__init__.py
+++ b/src/aptl/appliance/seat/__init__.py
@@ -1,0 +1,28 @@
+"""Host-side appliance seat lifecycle adapter."""
+
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.lifecycle import (
+    open_participant_kiosk,
+    reconcile_seat_after_reboot,
+    recover_seat,
+    reset_seat,
+    stage_seat,
+    start_seat,
+    status_seat,
+    stop_seat,
+)
+from aptl.appliance.seat.models import SeatRecord, SeatStatusProjection
+
+__all__ = [
+    "SeatLauncherError",
+    "SeatRecord",
+    "SeatStatusProjection",
+    "open_participant_kiosk",
+    "reconcile_seat_after_reboot",
+    "recover_seat",
+    "reset_seat",
+    "stage_seat",
+    "start_seat",
+    "status_seat",
+    "stop_seat",
+]

--- a/src/aptl/appliance/seat/__init__.py
+++ b/src/aptl/appliance/seat/__init__.py
@@ -1,8 +1,8 @@
 """Host-side appliance seat lifecycle adapter."""
 
 from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.kiosk import open_participant_kiosk
 from aptl.appliance.seat.lifecycle import (
-    open_participant_kiosk,
     reconcile_seat_after_reboot,
     recover_seat,
     reset_seat,

--- a/src/aptl/appliance/seat/context.py
+++ b/src/aptl/appliance/seat/context.py
@@ -1,0 +1,31 @@
+"""Shared seat launcher path and option contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from aptl.appliance.seat.observation import ListenerProbe
+
+
+@dataclass(frozen=True)
+class StartSeatOptions:
+    """Optional probes and overrides for ``start_seat``."""
+
+    prereq_overrides: dict[str, object] | None = None
+    listener_probe: ListenerProbe | None = None
+    docker_daemon_running: bool | None = None
+
+
+@dataclass(frozen=True)
+class SeatPaths:
+    """Contained directory layout for one physical seat."""
+
+    seat_root: Path
+    release_dir: Path
+    release_public_key: Path
+    qualification_public_key: Path
+    launch_dir: Path
+    launch_descriptor: Path
+    overlay_path: Path
+    overlay_state_dir: Path

--- a/src/aptl/appliance/seat/errors.py
+++ b/src/aptl/appliance/seat/errors.py
@@ -1,0 +1,12 @@
+"""Bounded seat-launcher failure codes."""
+
+from __future__ import annotations
+
+
+class SeatLauncherError(RuntimeError):
+    """A seat lifecycle operation failed with a stable operator-facing code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)

--- a/src/aptl/appliance/seat/exposure.py
+++ b/src/aptl/appliance/seat/exposure.py
@@ -1,0 +1,94 @@
+"""Host exposure inventory for the appliance seat launcher."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.core import hostenv
+
+
+FORBIDDEN_VM_FLAGS = (
+    "-usb",
+    "-spice",
+    "clipboard",
+    "share=on",
+)
+FORBIDDEN_VM_WRITABLE_SHARE_FLAGS = (
+    "readonly=off",
+    "security_model=mapped-xattr",
+)
+
+
+@dataclass(frozen=True)
+class HostExposureReport:
+    """Bounded host exposure inventory for instructor diagnostics."""
+
+    passed: bool
+    findings: tuple[str, ...]
+
+
+def audit_vm_argv(argv: tuple[str, ...]) -> HostExposureReport:
+    """Reject VM launch arguments that widen the physical-host boundary."""
+
+    findings: list[str] = []
+    joined = " ".join(argv)
+    for flag in FORBIDDEN_VM_FLAGS:
+        if flag in joined:
+            findings.append(f"host.exposure.forbidden-vm-flag:{flag}")
+    for flag in FORBIDDEN_VM_WRITABLE_SHARE_FLAGS:
+        if flag in joined:
+            findings.append(f"host.exposure.forbidden-vm-share:{flag}")
+    return HostExposureReport(passed=not findings, findings=tuple(findings))
+
+
+def audit_host_process_inventory(
+    *,
+    docker_daemon_running: bool | None = None,
+) -> HostExposureReport:
+    """Ensure the seat host does not require Docker for launcher operations."""
+
+    findings: list[str] = []
+    if hostenv.host_os() != hostenv.OS_LINUX:
+        return HostExposureReport(passed=True, findings=())
+    docker_running = (
+        _docker_daemon_running()
+        if docker_daemon_running is None
+        else docker_daemon_running
+    )
+    if docker_running:
+        findings.append("host.exposure.docker-daemon-present")
+    return HostExposureReport(passed=not findings, findings=tuple(findings))
+
+
+def _docker_daemon_running() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def require_host_exposure(
+    *,
+    vm_argv: tuple[str, ...],
+    docker_daemon_running: bool | None = None,
+) -> HostExposureReport:
+    """Fail closed when host exposure violates the appliance contract."""
+
+    vm_report = audit_vm_argv(vm_argv)
+    process_report = audit_host_process_inventory(
+        docker_daemon_running=docker_daemon_running
+    )
+    findings = vm_report.findings + process_report.findings
+    report = HostExposureReport(passed=not findings, findings=findings)
+    if not report.passed:
+        raise SeatLauncherError(report.findings[0], "host exposure inventory failed")
+    return report

--- a/src/aptl/appliance/seat/exposure.py
+++ b/src/aptl/appliance/seat/exposure.py
@@ -78,6 +78,8 @@ def audit_host_process_inventory(
 
 
 def _docker_daemon_running() -> bool:
+    """Return whether a local Docker daemon responds to ``docker info``."""
+
     try:
         result = subprocess.run(
             ["docker", "info"],

--- a/src/aptl/appliance/seat/exposure.py
+++ b/src/aptl/appliance/seat/exposure.py
@@ -29,6 +29,20 @@ class HostExposureReport:
     findings: tuple[str, ...]
 
 
+def _fsdev_options(argv: tuple[str, ...]) -> tuple[str, ...]:
+    """Return QEMU -fsdev option strings from a fixed argv list."""
+
+    options: list[str] = []
+    index = 0
+    while index < len(argv):
+        if argv[index] == "-fsdev" and index + 1 < len(argv):
+            options.append(argv[index + 1])
+            index += 2
+            continue
+        index += 1
+    return tuple(options)
+
+
 def audit_vm_argv(argv: tuple[str, ...]) -> HostExposureReport:
     """Reject VM launch arguments that widen the physical-host boundary."""
 
@@ -37,8 +51,9 @@ def audit_vm_argv(argv: tuple[str, ...]) -> HostExposureReport:
     for flag in FORBIDDEN_VM_FLAGS:
         if flag in joined:
             findings.append(f"host.exposure.forbidden-vm-flag:{flag}")
+    fsdev_joined = " ".join(_fsdev_options(argv))
     for flag in FORBIDDEN_VM_WRITABLE_SHARE_FLAGS:
-        if flag in joined:
+        if flag in fsdev_joined:
             findings.append(f"host.exposure.forbidden-vm-share:{flag}")
     return HostExposureReport(passed=not findings, findings=tuple(findings))
 

--- a/src/aptl/appliance/seat/kiosk.py
+++ b/src/aptl/appliance/seat/kiosk.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
 from dataclasses import dataclass
 
 
@@ -34,7 +35,34 @@ def build_kiosk_launch_plan(
     return KioskLaunchPlan(argv=argv, url=url)
 
 
+def open_participant_kiosk(
+    *,
+    participant_port: int = 443,
+    browser_command: str | None = None,
+    dry_run: bool = False,
+) -> KioskLaunchPlan:
+    """Launch or plan the participant kiosk browser wrapper."""
+
+    plan = build_kiosk_launch_plan(
+        participant_port=participant_port,
+        browser_command=browser_command,
+    )
+    if dry_run:
+        return plan
+    subprocess.Popen(
+        list(plan.argv),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        start_new_session=True,
+    )
+    return plan
+
+
 def _default_browser() -> str:
+    """Pick the first installed fullscreen-capable browser on the host."""
+
     for candidate in ("chromium-browser", "chromium", "google-chrome", "firefox"):
         if shutil.which(candidate):
             return candidate

--- a/src/aptl/appliance/seat/kiosk.py
+++ b/src/aptl/appliance/seat/kiosk.py
@@ -1,0 +1,41 @@
+"""Participant kiosk presentation wrapper."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class KioskLaunchPlan:
+    """Browser command for one loopback participant endpoint."""
+
+    argv: tuple[str, ...]
+    url: str
+
+
+def build_kiosk_launch_plan(
+    *,
+    participant_port: int = 443,
+    browser_command: str | None = None,
+) -> KioskLaunchPlan:
+    """Return a fullscreen browser argv without embedding secrets."""
+
+    url = f"https://127.0.0.1:{participant_port}/"
+    browser = browser_command or _default_browser()
+    argv = (
+        browser,
+        "--kiosk",
+        "--no-first-run",
+        "--disable-translate",
+        "--disable-session-crashed-bubble",
+        url,
+    )
+    return KioskLaunchPlan(argv=argv, url=url)
+
+
+def _default_browser() -> str:
+    for candidate in ("chromium-browser", "chromium", "google-chrome", "firefox"):
+        if shutil.which(candidate):
+            return candidate
+    return "xdg-open"

--- a/src/aptl/appliance/seat/lifecycle.py
+++ b/src/aptl/appliance/seat/lifecycle.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import subprocess
-from dataclasses import dataclass
 from pathlib import Path
 
 from aptl.appliance.bootstrap import initialize_overlay_state
@@ -16,9 +14,9 @@ from aptl.appliance.manifest import (
     verify_release_directory,
     _load_release_documents,
 )
+from aptl.appliance.seat.context import SeatPaths, StartSeatOptions
 from aptl.appliance.seat.errors import SeatLauncherError
 from aptl.appliance.seat.exposure import require_host_exposure
-from aptl.appliance.seat.kiosk import KioskLaunchPlan, build_kiosk_launch_plan
 from aptl.appliance.seat.models import SeatRecord, SeatStatusProjection
 from aptl.appliance.seat.observation import (
     build_host_observation,
@@ -26,6 +24,7 @@ from aptl.appliance.seat.observation import (
     host_boundary_findings,
     map_publications_to_listeners,
 )
+from aptl.appliance.seat.overlay_cleanup import remove_overlay_artifacts
 from aptl.appliance.seat.paths import contained_path, validate_seat_id
 from aptl.appliance.seat.persistence import load_seat_record, persist_seat_record
 from aptl.appliance.seat.prereqs import require_host_prerequisites
@@ -42,23 +41,15 @@ from aptl.core.appliance_boundary import (
     ApplianceBoundaryPolicy,
     load_boundary_policy,
 )
+from aptl.core.appliance_boundary_inventory import BoundaryEndpoint
 
-
-@dataclass(frozen=True)
-class SeatPaths:
-    """Contained directory layout for one physical seat."""
-
-    seat_root: Path
-    release_dir: Path
-    release_public_key: Path
-    qualification_public_key: Path
-    launch_dir: Path
-    launch_descriptor: Path
-    overlay_path: Path
-    overlay_state_dir: Path
+SEAT_RECORD_SCHEMA = "aptl.seat-record/v1"
+SEAT_NOT_STAGED = "seat is not staged"
 
 
 def _read_host_boot_id() -> str:
+    """Read the current physical-host boot identifier."""
+
     try:
         return Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
     except OSError as exc:
@@ -66,12 +57,16 @@ def _read_host_boot_id() -> str:
 
 
 def _launch_descriptor_digest(path: Path) -> str:
+    """Hash the launch descriptor bytes bound into the seat record."""
+
     payload = path.read_bytes()
     return f"sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
-def _policy_publications(policy: ApplianceBoundaryPolicy):
-    from aptl.core.appliance_boundary_inventory import BoundaryEndpoint
+def _policy_publications(
+    policy: ApplianceBoundaryPolicy,
+) -> tuple[BoundaryEndpoint, ...]:
+    """Project signed guest publications into listener inventory endpoints."""
 
     return tuple(
         BoundaryEndpoint(
@@ -87,6 +82,8 @@ def _policy_publications(policy: ApplianceBoundaryPolicy):
 def _load_verified_release(
     paths: SeatPaths,
 ) -> tuple[ApplianceReleaseInspection, ApplianceBoundaryPolicy]:
+    """Verify the release directory and load the signed boundary policy."""
+
     inspection = verify_release_directory(
         paths.release_dir,
         paths.release_public_key,
@@ -121,6 +118,8 @@ def _seat_paths(
     release_public_key: Path,
     qualification_public_key: Path,
 ) -> SeatPaths:
+    """Resolve contained seat paths for one launcher invocation."""
+
     validate_seat_id(seat_id)
     launch_dir = seat_root / "launch"
     overlay_path = contained_path(
@@ -179,7 +178,6 @@ def stage_seat(
     )
     planned = _policy_publications(policy)
     bundle = build_host_observation(
-        policy=policy,
         binding=binding.model_copy(update={"host_observation_id": "pending"}),
         boot_id=boot_id,
         listeners=planned,
@@ -197,7 +195,7 @@ def stage_seat(
     )
     digest = _launch_descriptor_digest(paths.launch_descriptor)
     record = SeatRecord(
-        schema_version="aptl.seat-record/v1",
+        schema_version=SEAT_RECORD_SCHEMA,
         seat_id=seat_id,
         selected_release_id=inspection.release_id,
         launch_descriptor_digest=digest,
@@ -226,6 +224,8 @@ def _relative_to_root(root: Path, path: Path, *, label: str) -> str:
 
 
 def _ensure_overlay(paths: SeatPaths, record: SeatRecord) -> None:
+    """Create the disposable overlay when the seat has none yet."""
+
     if paths.overlay_path.exists():
         return
     manifest, _signature = _load_release_documents(paths.release_dir)
@@ -259,12 +259,11 @@ def start_seat(
     release_dir: Path,
     release_public_key: Path,
     qualification_public_key: Path,
-    prereq_overrides: dict[str, object] | None = None,
-    listener_probe=None,
-    docker_daemon_running: bool | None = None,
+    options: StartSeatOptions | None = None,
 ) -> SeatRecord:
     """Create overlay when needed, start VM, and validate host exposure."""
 
+    launch_options = options or StartSeatOptions()
     record = load_seat_record(seat_root)
     paths = _seat_paths(
         seat_root,
@@ -280,7 +279,7 @@ def start_seat(
             release_dir=release_dir,
             release_public_key=release_public_key,
             qualification_public_key=qualification_public_key,
-            prereq_overrides=prereq_overrides,
+            prereq_overrides=launch_options.prereq_overrides,
         )
     starting = record.model_copy(update={"lifecycle_state": "starting"})
     persist_seat_record(seat_root, starting)
@@ -295,13 +294,13 @@ def start_seat(
         )
         argv = build_qemu_argv(spec)
         require_host_exposure(
-            vm_argv=argv, docker_daemon_running=docker_daemon_running
+            vm_argv=argv, docker_daemon_running=launch_options.docker_daemon_running
         )
         if read_vm_pid(seat_root) is None:
             vm = start_vm(spec)
             write_vm_pid(seat_root, vm.pid)
         inspection, policy = _load_verified_release(paths)
-        observed = collect_loopback_listeners(probe=listener_probe)
+        observed = collect_loopback_listeners(probe=launch_options.listener_probe)
         listeners = map_publications_to_listeners(policy, observed)
         binding = ApplianceBoundaryBinding(
             policy_digest=manifest.boundary.policy_digest,
@@ -315,7 +314,6 @@ def start_seat(
             host_observation_id=record.host_observation_id,
         )
         bundle = build_host_observation(
-            policy=policy,
             binding=binding,
             boot_id=binding.boot_id,
             listeners=listeners,
@@ -325,7 +323,7 @@ def start_seat(
         findings = host_boundary_findings(policy, binding, bundle.observation)
         if findings:
             failed = SeatRecord(
-                schema_version="aptl.seat-record/v1",
+                schema_version=SEAT_RECORD_SCHEMA,
                 seat_id=seat_id,
                 selected_release_id=inspection.release_id,
                 launch_descriptor_digest=record.launch_descriptor_digest,
@@ -338,7 +336,7 @@ def start_seat(
             persist_seat_record(seat_root, failed)
             raise SeatLauncherError(findings[0], "host boundary inventory failed")
         ready = SeatRecord(
-            schema_version="aptl.seat-record/v1",
+            schema_version=SEAT_RECORD_SCHEMA,
             seat_id=seat_id,
             selected_release_id=inspection.release_id,
             launch_descriptor_digest=record.launch_descriptor_digest,
@@ -359,9 +357,11 @@ def start_seat(
 
 
 def stop_seat(seat_root: Path) -> SeatRecord:
+    """Stop the tracked VM and return the seat to staged state."""
+
     record = load_seat_record(seat_root)
     if record is None:
-        raise SeatLauncherError("corrupt-seat-state", "seat is not staged")
+        raise SeatLauncherError("corrupt-seat-state", SEAT_NOT_STAGED)
     stop_vm(seat_root)
     updated = record.model_copy(update={"lifecycle_state": "staged"})
     persist_seat_record(seat_root, updated)
@@ -380,7 +380,7 @@ def reset_seat(
 
     record = load_seat_record(seat_root)
     if record is None:
-        raise SeatLauncherError("corrupt-seat-state", "seat is not staged")
+        raise SeatLauncherError("corrupt-seat-state", SEAT_NOT_STAGED)
     stop_vm(seat_root)
     paths = _seat_paths(
         seat_root,
@@ -389,22 +389,7 @@ def reset_seat(
         release_public_key=release_public_key,
         qualification_public_key=qualification_public_key,
     )
-    for target in (paths.overlay_path, paths.overlay_state_dir):
-        if target.is_dir():
-            for child in sorted(target.rglob("*"), reverse=True):
-                try:
-                    child.unlink()
-                except OSError:
-                    pass
-            try:
-                target.rmdir()
-            except OSError:
-                pass
-        elif target.exists() or target.is_symlink():
-            try:
-                target.unlink()
-            except OSError as exc:
-                raise SeatLauncherError("corrupt-overlay", "overlay reset failed") from exc
+    remove_overlay_artifacts(paths.overlay_path, paths.overlay_state_dir)
     updated = record.model_copy(update={"lifecycle_state": "needs-reset"})
     persist_seat_record(seat_root, updated)
     return stage_seat(
@@ -423,7 +408,7 @@ def recover_seat(
     release_dir: Path,
     release_public_key: Path,
     qualification_public_key: Path,
-    **start_kwargs: object,
+    options: StartSeatOptions | None = None,
 ) -> SeatRecord:
     """Instructor recovery: reset then start."""
 
@@ -440,7 +425,7 @@ def recover_seat(
         release_dir=release_dir,
         release_public_key=release_public_key,
         qualification_public_key=qualification_public_key,
-        **start_kwargs,
+        options=options,
     )
 
 
@@ -449,7 +434,7 @@ def reconcile_seat_after_reboot(seat_root: Path) -> SeatRecord:
 
     record = load_seat_record(seat_root)
     if record is None:
-        raise SeatLauncherError("corrupt-seat-state", "seat is not staged")
+        raise SeatLauncherError("corrupt-seat-state", SEAT_NOT_STAGED)
     boot_id = _read_host_boot_id()
     diagnostics: list[str] = []
     if boot_id != record.host_boot_id:
@@ -474,6 +459,8 @@ def reconcile_seat_after_reboot(seat_root: Path) -> SeatRecord:
 
 
 def status_seat(seat_root: Path) -> SeatStatusProjection:
+    """Return coarse seat health without credentials or topology."""
+
     record = load_seat_record(seat_root)
     if record is None:
         return SeatStatusProjection(
@@ -497,28 +484,3 @@ def status_seat(seat_root: Path) -> SeatStatusProjection:
         host_observation_id=record.host_observation_id,
         diagnostics=tuple(diagnostics),
     )
-
-
-def open_participant_kiosk(
-    *,
-    participant_port: int = 443,
-    browser_command: str | None = None,
-    dry_run: bool = False,
-) -> KioskLaunchPlan:
-    """Launch or plan the participant kiosk browser wrapper."""
-
-    plan = build_kiosk_launch_plan(
-        participant_port=participant_port,
-        browser_command=browser_command,
-    )
-    if dry_run:
-        return plan
-    subprocess.Popen(
-        list(plan.argv),
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        close_fds=True,
-        start_new_session=True,
-    )
-    return plan

--- a/src/aptl/appliance/seat/lifecycle.py
+++ b/src/aptl/appliance/seat/lifecycle.py
@@ -1,0 +1,524 @@
+"""Seat lifecycle orchestration for the host-side appliance adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from aptl.appliance.bootstrap import initialize_overlay_state
+from aptl.appliance.build import OverlayCreateRequest, create_disposable_overlay
+from aptl.appliance.launch import prepare_launch_descriptor
+from aptl.appliance.manifest import (
+    ApplianceManifestError,
+    ApplianceReleaseInspection,
+    verify_release_directory,
+    _load_release_documents,
+)
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.exposure import require_host_exposure
+from aptl.appliance.seat.kiosk import KioskLaunchPlan, build_kiosk_launch_plan
+from aptl.appliance.seat.models import SeatRecord, SeatStatusProjection
+from aptl.appliance.seat.observation import (
+    build_host_observation,
+    collect_loopback_listeners,
+    host_boundary_findings,
+    map_publications_to_listeners,
+)
+from aptl.appliance.seat.paths import contained_path, validate_seat_id
+from aptl.appliance.seat.persistence import load_seat_record, persist_seat_record
+from aptl.appliance.seat.prereqs import require_host_prerequisites
+from aptl.appliance.seat.vm import (
+    VmLaunchSpec,
+    build_qemu_argv,
+    read_vm_pid,
+    start_vm,
+    stop_vm,
+    write_vm_pid,
+)
+from aptl.core.appliance_boundary import (
+    ApplianceBoundaryBinding,
+    ApplianceBoundaryPolicy,
+    load_boundary_policy,
+)
+
+
+@dataclass(frozen=True)
+class SeatPaths:
+    """Contained directory layout for one physical seat."""
+
+    seat_root: Path
+    release_dir: Path
+    release_public_key: Path
+    qualification_public_key: Path
+    launch_dir: Path
+    launch_descriptor: Path
+    overlay_path: Path
+    overlay_state_dir: Path
+
+
+def _read_host_boot_id() -> str:
+    try:
+        return Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise SeatLauncherError("interrupted-boot", "host boot identity unavailable") from exc
+
+
+def _launch_descriptor_digest(path: Path) -> str:
+    payload = path.read_bytes()
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _policy_publications(policy: ApplianceBoundaryPolicy):
+    from aptl.core.appliance_boundary_inventory import BoundaryEndpoint
+
+    return tuple(
+        BoundaryEndpoint(
+            audience=item.audience,
+            address=item.address,
+            port=item.port,
+            protocol=item.protocol,
+        )
+        for item in policy.guest_publications
+    )
+
+
+def _load_verified_release(
+    paths: SeatPaths,
+) -> tuple[ApplianceReleaseInspection, ApplianceBoundaryPolicy]:
+    inspection = verify_release_directory(
+        paths.release_dir,
+        paths.release_public_key,
+        qualification_public_key_path=paths.qualification_public_key,
+    )
+    manifest, _signature = _load_release_documents(paths.release_dir)
+    policy_path = paths.release_dir / next(
+        artifact.path
+        for artifact in manifest.artifacts
+        if artifact.kind == "boundary-policy"
+    )
+    binding = ApplianceBoundaryBinding(
+        policy_digest=manifest.boundary.policy_digest,
+        payload_digest=manifest.payload_digest,
+        raes_plan_digest=manifest.delivery.participant_routes_digest,
+        raes_boundary_required=True,
+        boundary_helper_image=manifest.boundary.boundary_helper_image,
+        egress_proxy_image=manifest.boundary.egress_proxy_image,
+        boot_id=_read_host_boot_id(),
+        guest_daemon_id="pending-guest",
+        host_observation_id="pending",
+    )
+    policy = load_boundary_policy(policy_path, binding)
+    return inspection, policy
+
+
+def _seat_paths(
+    seat_root: Path,
+    *,
+    seat_id: str,
+    release_dir: Path,
+    release_public_key: Path,
+    qualification_public_key: Path,
+) -> SeatPaths:
+    validate_seat_id(seat_id)
+    launch_dir = seat_root / "launch"
+    overlay_path = contained_path(
+        seat_root, f"instances/{seat_id}.qcow2", label="overlay"
+    )
+    return SeatPaths(
+        seat_root=seat_root,
+        release_dir=release_dir,
+        release_public_key=release_public_key,
+        qualification_public_key=qualification_public_key,
+        launch_dir=launch_dir,
+        launch_descriptor=launch_dir / "appliance-launch.json",
+        overlay_path=overlay_path,
+        overlay_state_dir=contained_path(
+            seat_root, f"instances/{seat_id}.state", label="overlay state"
+        ),
+    )
+
+
+def stage_seat(
+    seat_root: Path,
+    *,
+    seat_id: str,
+    release_dir: Path,
+    release_public_key: Path,
+    qualification_public_key: Path,
+    prereq_overrides: dict[str, object] | None = None,
+) -> SeatRecord:
+    """Verify release, host prereqs, and publish a staged seat record."""
+
+    paths = _seat_paths(
+        seat_root,
+        seat_id=seat_id,
+        release_dir=release_dir,
+        release_public_key=release_public_key,
+        qualification_public_key=qualification_public_key,
+    )
+    inspection, policy = _load_verified_release(paths)
+    manifest, _signature = _load_release_documents(paths.release_dir)
+    require_host_prerequisites(
+        manifest.host_prerequisites,
+        seat_root=seat_root,
+        **(prereq_overrides or {}),
+    )
+    boot_id = _read_host_boot_id()
+    binding = ApplianceBoundaryBinding(
+        policy_digest=manifest.boundary.policy_digest,
+        payload_digest=manifest.payload_digest,
+        raes_plan_digest=manifest.delivery.participant_routes_digest,
+        raes_boundary_required=True,
+        boundary_helper_image=manifest.boundary.boundary_helper_image,
+        egress_proxy_image=manifest.boundary.egress_proxy_image,
+        boot_id=boot_id,
+        guest_daemon_id="pending-guest",
+        host_observation_id="pending",
+    )
+    planned = _policy_publications(policy)
+    bundle = build_host_observation(
+        policy=policy,
+        binding=binding.model_copy(update={"host_observation_id": "pending"}),
+        boot_id=boot_id,
+        listeners=planned,
+        forbidden_reachability_passed=True,
+        complete=True,
+    )
+    binding = binding.model_copy(update={"host_observation_id": bundle.observation_id})
+    paths.launch_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    prepare_launch_descriptor(
+        paths.release_dir,
+        paths.release_public_key,
+        paths.qualification_public_key,
+        paths.launch_descriptor,
+        host_observation_id=bundle.observation_id,
+    )
+    digest = _launch_descriptor_digest(paths.launch_descriptor)
+    record = SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id=seat_id,
+        selected_release_id=inspection.release_id,
+        launch_descriptor_digest=digest,
+        overlay_path=str(paths.overlay_path.relative_to(seat_root)),
+        host_observation_id=bundle.observation_id,
+        lifecycle_state="staged",
+        taint_state="clean",
+        host_boot_id=boot_id,
+    )
+    persist_seat_record(seat_root, record)
+    return record
+
+
+def _relative_to_root(root: Path, path: Path, *, label: str) -> str:
+    """Return a contained relative POSIX path or fail closed."""
+
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    try:
+        return resolved_path.relative_to(resolved_root).as_posix()
+    except ValueError as exc:
+        raise SeatLauncherError(
+            "corrupt-seat-state",
+            f"{label} must be contained by seat root",
+        ) from exc
+
+
+def _ensure_overlay(paths: SeatPaths, record: SeatRecord) -> None:
+    if paths.overlay_path.exists():
+        return
+    manifest, _signature = _load_release_documents(paths.release_dir)
+    golden_path = next(
+        artifact.path for artifact in manifest.artifacts if artifact.kind == "golden-disk"
+    )
+    golden_digest = next(
+        artifact.sha256 for artifact in manifest.artifacts if artifact.kind == "golden-disk"
+    )
+    release_rel = _relative_to_root(paths.seat_root, paths.release_dir, label="release")
+    request = OverlayCreateRequest(
+        schema_version="aptl.overlay-create/v1",
+        golden_image_path=f"{release_rel}/{golden_path}",
+        golden_image_digest=golden_digest,
+        launch_descriptor_path=_relative_to_root(
+            paths.seat_root, paths.launch_descriptor, label="launch descriptor"
+        ),
+        launch_descriptor_digest=record.launch_descriptor_digest,
+        overlay_path=_relative_to_root(
+            paths.seat_root, paths.overlay_path, label="overlay"
+        ),
+    )
+    create_disposable_overlay(paths.seat_root, request)
+    initialize_overlay_state(paths.overlay_state_dir)
+
+
+def start_seat(
+    seat_root: Path,
+    *,
+    seat_id: str,
+    release_dir: Path,
+    release_public_key: Path,
+    qualification_public_key: Path,
+    prereq_overrides: dict[str, object] | None = None,
+    listener_probe=None,
+    docker_daemon_running: bool | None = None,
+) -> SeatRecord:
+    """Create overlay when needed, start VM, and validate host exposure."""
+
+    record = load_seat_record(seat_root)
+    paths = _seat_paths(
+        seat_root,
+        seat_id=seat_id,
+        release_dir=release_dir,
+        release_public_key=release_public_key,
+        qualification_public_key=qualification_public_key,
+    )
+    if record is None or record.seat_id != seat_id:
+        record = stage_seat(
+            seat_root,
+            seat_id=seat_id,
+            release_dir=release_dir,
+            release_public_key=release_public_key,
+            qualification_public_key=qualification_public_key,
+            prereq_overrides=prereq_overrides,
+        )
+    starting = record.model_copy(update={"lifecycle_state": "starting"})
+    persist_seat_record(seat_root, starting)
+    try:
+        _ensure_overlay(paths, record)
+        manifest, _signature = _load_release_documents(paths.release_dir)
+        spec = VmLaunchSpec(
+            overlay_path=paths.overlay_path,
+            launch_mount=paths.launch_dir,
+            vcpus=manifest.host_prerequisites.vcpus,
+            memory_mib=manifest.host_prerequisites.memory_bytes // (1024 * 1024),
+        )
+        argv = build_qemu_argv(spec)
+        require_host_exposure(
+            vm_argv=argv, docker_daemon_running=docker_daemon_running
+        )
+        if read_vm_pid(seat_root) is None:
+            vm = start_vm(spec)
+            write_vm_pid(seat_root, vm.pid)
+        inspection, policy = _load_verified_release(paths)
+        observed = collect_loopback_listeners(probe=listener_probe)
+        listeners = map_publications_to_listeners(policy, observed)
+        binding = ApplianceBoundaryBinding(
+            policy_digest=manifest.boundary.policy_digest,
+            payload_digest=manifest.payload_digest,
+            raes_plan_digest=manifest.delivery.participant_routes_digest,
+            raes_boundary_required=True,
+            boundary_helper_image=manifest.boundary.boundary_helper_image,
+            egress_proxy_image=manifest.boundary.egress_proxy_image,
+            boot_id=_read_host_boot_id(),
+            guest_daemon_id="pending-guest",
+            host_observation_id=record.host_observation_id,
+        )
+        bundle = build_host_observation(
+            policy=policy,
+            binding=binding,
+            boot_id=binding.boot_id,
+            listeners=listeners,
+            forbidden_reachability_passed=True,
+            complete=True,
+        )
+        findings = host_boundary_findings(policy, binding, bundle.observation)
+        if findings:
+            failed = SeatRecord(
+                schema_version="aptl.seat-record/v1",
+                seat_id=seat_id,
+                selected_release_id=inspection.release_id,
+                launch_descriptor_digest=record.launch_descriptor_digest,
+                overlay_path=record.overlay_path,
+                host_observation_id=bundle.observation_id,
+                lifecycle_state="recoverable-failure",
+                taint_state=record.taint_state,
+                host_boot_id=binding.boot_id,
+            )
+            persist_seat_record(seat_root, failed)
+            raise SeatLauncherError(findings[0], "host boundary inventory failed")
+        ready = SeatRecord(
+            schema_version="aptl.seat-record/v1",
+            seat_id=seat_id,
+            selected_release_id=inspection.release_id,
+            launch_descriptor_digest=record.launch_descriptor_digest,
+            overlay_path=record.overlay_path,
+            host_observation_id=bundle.observation_id,
+            lifecycle_state="ready",
+            taint_state=record.taint_state,
+            host_boot_id=binding.boot_id,
+        )
+        persist_seat_record(seat_root, ready)
+        return ready
+    except SeatLauncherError:
+        raise
+    except (ApplianceManifestError, OSError, ValueError) as exc:
+        failed = starting.model_copy(update={"lifecycle_state": "recoverable-failure"})
+        persist_seat_record(seat_root, failed)
+        raise SeatLauncherError("failed-readiness", "seat start failed") from exc
+
+
+def stop_seat(seat_root: Path) -> SeatRecord:
+    record = load_seat_record(seat_root)
+    if record is None:
+        raise SeatLauncherError("corrupt-seat-state", "seat is not staged")
+    stop_vm(seat_root)
+    updated = record.model_copy(update={"lifecycle_state": "staged"})
+    persist_seat_record(seat_root, updated)
+    return updated
+
+
+def reset_seat(
+    seat_root: Path,
+    *,
+    seat_id: str,
+    release_dir: Path,
+    release_public_key: Path,
+    qualification_public_key: Path,
+) -> SeatRecord:
+    """Power off, destroy overlay state, and return to staged."""
+
+    record = load_seat_record(seat_root)
+    if record is None:
+        raise SeatLauncherError("corrupt-seat-state", "seat is not staged")
+    stop_vm(seat_root)
+    paths = _seat_paths(
+        seat_root,
+        seat_id=seat_id,
+        release_dir=release_dir,
+        release_public_key=release_public_key,
+        qualification_public_key=qualification_public_key,
+    )
+    for target in (paths.overlay_path, paths.overlay_state_dir):
+        if target.is_dir():
+            for child in sorted(target.rglob("*"), reverse=True):
+                try:
+                    child.unlink()
+                except OSError:
+                    pass
+            try:
+                target.rmdir()
+            except OSError:
+                pass
+        elif target.exists() or target.is_symlink():
+            try:
+                target.unlink()
+            except OSError as exc:
+                raise SeatLauncherError("corrupt-overlay", "overlay reset failed") from exc
+    updated = record.model_copy(update={"lifecycle_state": "needs-reset"})
+    persist_seat_record(seat_root, updated)
+    return stage_seat(
+        seat_root,
+        seat_id=seat_id,
+        release_dir=release_dir,
+        release_public_key=release_public_key,
+        qualification_public_key=qualification_public_key,
+    )
+
+
+def recover_seat(
+    seat_root: Path,
+    *,
+    seat_id: str,
+    release_dir: Path,
+    release_public_key: Path,
+    qualification_public_key: Path,
+    **start_kwargs: object,
+) -> SeatRecord:
+    """Instructor recovery: reset then start."""
+
+    reset_seat(
+        seat_root,
+        seat_id=seat_id,
+        release_dir=release_dir,
+        release_public_key=release_public_key,
+        qualification_public_key=qualification_public_key,
+    )
+    return start_seat(
+        seat_root,
+        seat_id=seat_id,
+        release_dir=release_dir,
+        release_public_key=release_public_key,
+        qualification_public_key=qualification_public_key,
+        **start_kwargs,
+    )
+
+
+def reconcile_seat_after_reboot(seat_root: Path) -> SeatRecord:
+    """Reconcile persisted seat state after a physical-host reboot."""
+
+    record = load_seat_record(seat_root)
+    if record is None:
+        raise SeatLauncherError("corrupt-seat-state", "seat is not staged")
+    boot_id = _read_host_boot_id()
+    diagnostics: list[str] = []
+    if boot_id != record.host_boot_id:
+        diagnostics.append("host-reboot-detected")
+    if read_vm_pid(seat_root) is None and record.lifecycle_state in {
+        "starting",
+        "ready",
+    }:
+        diagnostics.append("vm-not-running")
+        updated = record.model_copy(
+            update={
+                "lifecycle_state": "recoverable-failure",
+                "host_boot_id": boot_id,
+            }
+        )
+    else:
+        updated = record.model_copy(update={"host_boot_id": boot_id})
+    persist_seat_record(seat_root, updated)
+    if diagnostics:
+        raise SeatLauncherError(diagnostics[0], "seat requires instructor recovery")
+    return updated
+
+
+def status_seat(seat_root: Path) -> SeatStatusProjection:
+    record = load_seat_record(seat_root)
+    if record is None:
+        return SeatStatusProjection(
+            seat_id="unknown",
+            lifecycle_state="empty",
+            taint_state="clean",
+            selected_release_id="",
+            launch_descriptor_digest="sha256:" + "0" * 64,
+            host_observation_id="",
+            diagnostics=("seat-not-staged",),
+        )
+    diagnostics: list[str] = []
+    if read_vm_pid(seat_root) is None and record.lifecycle_state == "ready":
+        diagnostics.append("vm-not-running")
+    return SeatStatusProjection(
+        seat_id=record.seat_id,
+        lifecycle_state=record.lifecycle_state,
+        taint_state=record.taint_state,
+        selected_release_id=record.selected_release_id,
+        launch_descriptor_digest=record.launch_descriptor_digest,
+        host_observation_id=record.host_observation_id,
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def open_participant_kiosk(
+    *,
+    participant_port: int = 443,
+    browser_command: str | None = None,
+    dry_run: bool = False,
+) -> KioskLaunchPlan:
+    """Launch or plan the participant kiosk browser wrapper."""
+
+    plan = build_kiosk_launch_plan(
+        participant_port=participant_port,
+        browser_command=browser_command,
+    )
+    if dry_run:
+        return plan
+    subprocess.Popen(
+        list(plan.argv),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        start_new_session=True,
+    )
+    return plan

--- a/src/aptl/appliance/seat/models.py
+++ b/src/aptl/appliance/seat/models.py
@@ -1,0 +1,56 @@
+"""Versioned host seat contract persisted across reboot."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+SeatLifecycleState = Literal[
+    "empty",
+    "staged",
+    "starting",
+    "ready",
+    "needs-reset",
+    "recoverable-failure",
+    "tainted",
+]
+SeatTaintState = Literal["clean", "tainted"]
+
+
+class SeatRecord(BaseModel):
+    """Outer seat metadata; not a second launch descriptor or aptl.json extension."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["aptl.seat-record/v1"]
+    seat_id: str = Field(min_length=1, max_length=64)
+    selected_release_id: str = Field(min_length=1, max_length=128)
+    launch_descriptor_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    overlay_path: str = Field(min_length=1, max_length=160)
+    host_observation_id: str = Field(min_length=1, max_length=128)
+    lifecycle_state: SeatLifecycleState
+    taint_state: SeatTaintState = "clean"
+    host_boot_id: str = Field(min_length=1, max_length=128)
+
+    @field_validator("overlay_path")
+    @classmethod
+    def validate_overlay_path(cls, value: str) -> str:
+        if value.startswith("/") or ".." in value.split("/"):
+            raise ValueError("overlay path must be relative and contained")
+        return value
+
+
+class SeatStatusProjection(BaseModel):
+    """Coarse instructor-facing seat health without credentials or topology."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["aptl.seat-status/v1"] = "aptl.seat-status/v1"
+    seat_id: str
+    lifecycle_state: SeatLifecycleState
+    taint_state: SeatTaintState
+    selected_release_id: str
+    launch_descriptor_digest: str
+    host_observation_id: str
+    diagnostics: tuple[str, ...] = ()

--- a/src/aptl/appliance/seat/observation.py
+++ b/src/aptl/appliance/seat/observation.py
@@ -52,6 +52,8 @@ def collect_loopback_listeners(
 
 
 def _collect_listeners_via_ss() -> tuple[BoundaryEndpoint, ...]:
+    """Parse loopback TCP listeners from ``ss`` output when available."""
+
     try:
         result = subprocess.run(
             ["ss", "-H", "-ltn"],
@@ -117,7 +119,6 @@ def map_publications_to_listeners(
 
 def build_host_observation(
     *,
-    policy: ApplianceBoundaryPolicy,
     binding: ApplianceBoundaryBinding,
     boot_id: str,
     listeners: tuple[BoundaryEndpoint, ...],

--- a/src/aptl/appliance/seat/observation.py
+++ b/src/aptl/appliance/seat/observation.py
@@ -1,0 +1,178 @@
+"""Authenticated outer-host boundary observation for seat launch."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+import rfc8785
+
+from aptl.core.appliance_boundary import ApplianceBoundaryBinding, ApplianceBoundaryPolicy
+from aptl.core.appliance_boundary_inventory import (
+    BoundaryEndpoint,
+    HostBoundaryObservation,
+)
+
+ListenerProbe = Callable[[], tuple[BoundaryEndpoint, ...]]
+
+
+@dataclass(frozen=True)
+class HostObservationBundle:
+    """Observation plus the digest bound into the launch descriptor."""
+
+    observation: HostBoundaryObservation
+    observation_id: str
+
+
+def observation_id_for(observation: HostBoundaryObservation) -> str:
+    """Derive a stable host observation digest independent of completion flags."""
+
+    payload = {
+        "policy_digest": observation.policy_digest,
+        "payload_digest": observation.payload_digest,
+        "boot_id": observation.boot_id,
+        "listeners": [item.model_dump(mode="json") for item in observation.listeners],
+        "forbidden_reachability_passed": observation.forbidden_reachability_passed,
+    }
+    digest = hashlib.sha256(rfc8785.dumps(payload)).hexdigest()
+    return f"sha256:{digest}"
+
+
+def collect_loopback_listeners(
+    *,
+    probe: ListenerProbe | None = None,
+) -> tuple[BoundaryEndpoint, ...]:
+    """Return TCP listeners bound on loopback addresses."""
+
+    if probe is not None:
+        return probe()
+    return _collect_listeners_via_ss()
+
+
+def _collect_listeners_via_ss() -> tuple[BoundaryEndpoint, ...]:
+    try:
+        result = subprocess.run(
+            ["ss", "-H", "-ltn"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ()
+    if result.returncode != 0:
+        return ()
+    endpoints: list[BoundaryEndpoint] = []
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        local = parts[3]
+        if local.startswith("[::1]:"):
+            _, port_text = local.split("]:", 1)
+            host = "127.0.0.1"
+        elif local.startswith("127.0.0.1:"):
+            _, port_text = local.split(":", 1)
+            host = "127.0.0.1"
+        else:
+            continue
+        try:
+            port = int(port_text)
+        except ValueError:
+            continue
+        endpoints.append(
+            BoundaryEndpoint(
+                audience="participant",
+                address=host,
+                port=port,
+                protocol="tcp",
+            )
+        )
+    return tuple(endpoints)
+
+
+def map_publications_to_listeners(
+    policy: ApplianceBoundaryPolicy,
+    observed: Iterable[BoundaryEndpoint],
+) -> tuple[BoundaryEndpoint, ...]:
+    """Attach signed publication audiences to observed loopback listeners."""
+
+    by_port = {(item.address, item.port, item.protocol) for item in observed}
+    mapped: list[BoundaryEndpoint] = []
+    for publication in policy.guest_publications:
+        key = (publication.address, publication.port, publication.protocol)
+        if key in by_port:
+            mapped.append(
+                BoundaryEndpoint(
+                    audience=publication.audience,
+                    address=publication.address,
+                    port=publication.port,
+                    protocol=publication.protocol,
+                )
+            )
+    return tuple(mapped)
+
+
+def build_host_observation(
+    *,
+    policy: ApplianceBoundaryPolicy,
+    binding: ApplianceBoundaryBinding,
+    boot_id: str,
+    listeners: tuple[BoundaryEndpoint, ...],
+    forbidden_reachability_passed: bool,
+    complete: bool = True,
+) -> HostObservationBundle:
+    """Construct one authenticated host observation for the signed binding."""
+
+    observation = HostBoundaryObservation(
+        observation_id="pending",
+        policy_digest=binding.policy_digest,
+        payload_digest=binding.payload_digest,
+        boot_id=boot_id,
+        complete=complete,
+        listeners=listeners,
+        forbidden_reachability_passed=forbidden_reachability_passed,
+    )
+    observation_id = observation_id_for(observation)
+    finalized = observation.model_copy(update={"observation_id": observation_id})
+    return HostObservationBundle(
+        observation=finalized,
+        observation_id=observation_id,
+    )
+
+
+def host_boundary_findings(
+    policy: ApplianceBoundaryPolicy,
+    binding: ApplianceBoundaryBinding,
+    host: HostBoundaryObservation,
+) -> tuple[str, ...]:
+    """Return host-only boundary finding codes."""
+
+    findings: list[str] = []
+    if host.observation_id != binding.host_observation_id:
+        findings.append("boundary.host-observation-identity-mismatch")
+    if host.policy_digest != binding.policy_digest:
+        findings.append("boundary.host-policy-digest-mismatch")
+    if host.payload_digest != binding.payload_digest:
+        findings.append("boundary.host-payload-digest-mismatch")
+    if host.boot_id != binding.boot_id:
+        findings.append("boundary.host-boot-identity-mismatch")
+    if not host.complete:
+        findings.append("boundary.host-observation-incomplete")
+    if not host.forbidden_reachability_passed:
+        findings.append("boundary.host-forbidden-reachability")
+    expected = {
+        (item.audience, item.address, item.port, item.protocol)
+        for item in policy.guest_publications
+    }
+    observed = {
+        (item.audience, item.address, item.port, item.protocol)
+        for item in host.listeners
+    }
+    if observed - expected:
+        findings.append("boundary.host-listener-unapproved")
+    if expected - observed:
+        findings.append("boundary.host-listener-missing")
+    return tuple(findings)

--- a/src/aptl/appliance/seat/overlay_cleanup.py
+++ b/src/aptl/appliance/seat/overlay_cleanup.py
@@ -7,22 +7,34 @@ from pathlib import Path
 from aptl.appliance.seat.errors import SeatLauncherError
 
 
+def _remove_directory_tree(target: Path) -> None:
+    """Remove one directory tree without following symlinks."""
+
+    for child in sorted(target.rglob("*"), reverse=True):
+        try:
+            child.unlink()
+        except OSError:
+            pass
+    try:
+        target.rmdir()
+    except OSError:
+        pass
+
+
+def _remove_file_or_symlink(target: Path) -> None:
+    """Remove one overlay file or symlink."""
+
+    try:
+        target.unlink()
+    except OSError as exc:
+        raise SeatLauncherError("corrupt-overlay", "overlay reset failed") from exc
+
+
 def remove_overlay_artifacts(*targets: Path) -> None:
     """Delete overlay files or directories without touching the golden release."""
 
     for target in targets:
         if target.is_dir():
-            for child in sorted(target.rglob("*"), reverse=True):
-                try:
-                    child.unlink()
-                except OSError:
-                    pass
-            try:
-                target.rmdir()
-            except OSError:
-                pass
+            _remove_directory_tree(target)
         elif target.exists() or target.is_symlink():
-            try:
-                target.unlink()
-            except OSError as exc:
-                raise SeatLauncherError("corrupt-overlay", "overlay reset failed") from exc
+            _remove_file_or_symlink(target)

--- a/src/aptl/appliance/seat/overlay_cleanup.py
+++ b/src/aptl/appliance/seat/overlay_cleanup.py
@@ -1,0 +1,28 @@
+"""Overlay artifact removal for seat reset operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aptl.appliance.seat.errors import SeatLauncherError
+
+
+def remove_overlay_artifacts(*targets: Path) -> None:
+    """Delete overlay files or directories without touching the golden release."""
+
+    for target in targets:
+        if target.is_dir():
+            for child in sorted(target.rglob("*"), reverse=True):
+                try:
+                    child.unlink()
+                except OSError:
+                    pass
+            try:
+                target.rmdir()
+            except OSError:
+                pass
+        elif target.exists() or target.is_symlink():
+            try:
+                target.unlink()
+            except OSError as exc:
+                raise SeatLauncherError("corrupt-overlay", "overlay reset failed") from exc

--- a/src/aptl/appliance/seat/paths.py
+++ b/src/aptl/appliance/seat/paths.py
@@ -1,0 +1,36 @@
+"""Seat identifier validation and contained path resolution."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from aptl.appliance.seat.errors import SeatLauncherError
+
+_SEAT_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+
+def validate_seat_id(seat_id: str) -> str:
+    """Reject seat identifiers that can escape the seat root via path segments."""
+
+    if not _SEAT_ID.fullmatch(seat_id):
+        raise SeatLauncherError(
+            "invalid-seat-id",
+            "seat id must be a bounded lowercase identifier",
+        )
+    return seat_id
+
+
+def contained_path(seat_root: Path, relative: str, *, label: str) -> Path:
+    """Resolve one relative path and require it stays under seat_root."""
+
+    root = seat_root.resolve()
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise SeatLauncherError(
+            "invalid-seat-id",
+            f"{label} must remain contained by seat root",
+        ) from exc
+    return candidate

--- a/src/aptl/appliance/seat/persistence.py
+++ b/src/aptl/appliance/seat/persistence.py
@@ -1,0 +1,96 @@
+"""Owner-only atomic persistence for the host seat contract."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+from pathlib import Path
+
+import rfc8785
+from pydantic import ValidationError
+
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.models import SeatRecord
+
+
+def _ensure_seat_root(seat_root: Path) -> None:
+    if seat_root.is_symlink():
+        raise SeatLauncherError(
+            "corrupt-seat-state", "seat root must not be a symlink"
+        )
+    try:
+        seat_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        seat_root.chmod(0o700)
+        info = seat_root.stat(follow_symlinks=False)
+    except OSError as exc:
+        raise SeatLauncherError(
+            "corrupt-seat-state", "seat root is unavailable"
+        ) from exc
+    if not stat.S_ISDIR(info.st_mode):
+        raise SeatLauncherError("corrupt-seat-state", "seat root is not a directory")
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        raise SeatLauncherError(
+            "corrupt-seat-state", "seat root must be owner-only"
+        )
+
+
+def seat_state_path(seat_root: Path) -> Path:
+    return seat_root / "seat-state.json"
+
+
+def load_seat_record(seat_root: Path) -> SeatRecord | None:
+    """Load persisted seat metadata when present and valid."""
+
+    path = seat_state_path(seat_root)
+    if not path.exists():
+        return None
+    try:
+        info = path.stat(follow_symlinks=False)
+        if stat.S_ISLNK(info.st_mode):
+            raise SeatLauncherError(
+                "corrupt-seat-state", "seat state must not be a symlink"
+            )
+        if stat.S_IMODE(info.st_mode) != 0o600:
+            raise SeatLauncherError(
+                "corrupt-seat-state", "seat state must be owner-only"
+            )
+        flags = os.O_RDONLY | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        with os.fdopen(fd, "rb") as handle:
+            payload = handle.read()
+        return SeatRecord.model_validate_json(payload)
+    except SeatLauncherError:
+        raise
+    except (OSError, ValidationError, ValueError) as exc:
+        raise SeatLauncherError("corrupt-seat-state", "seat state is invalid") from exc
+
+
+def persist_seat_record(seat_root: Path, record: SeatRecord) -> None:
+    """Atomically publish seat metadata."""
+
+    _ensure_seat_root(seat_root)
+    path = seat_state_path(seat_root)
+    temporary = path.with_name(f".seat-state.{os.getpid()}-{secrets.token_hex(8)}")
+    payload = rfc8785.dumps(record.model_dump(mode="json"))
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(temporary, flags, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except OSError as exc:
+        raise SeatLauncherError(
+            "corrupt-seat-state", "seat state could not be persisted"
+        ) from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/src/aptl/appliance/seat/persistence.py
+++ b/src/aptl/appliance/seat/persistence.py
@@ -15,6 +15,8 @@ from aptl.appliance.seat.models import SeatRecord
 
 
 def _ensure_seat_root(seat_root: Path) -> None:
+    """Create or validate an owner-only seat root directory."""
+
     if seat_root.is_symlink():
         raise SeatLauncherError(
             "corrupt-seat-state", "seat root must not be a symlink"
@@ -36,6 +38,8 @@ def _ensure_seat_root(seat_root: Path) -> None:
 
 
 def seat_state_path(seat_root: Path) -> Path:
+    """Return the canonical seat-state path under one seat root."""
+
     return seat_root / "seat-state.json"
 
 

--- a/src/aptl/appliance/seat/prereqs.py
+++ b/src/aptl/appliance/seat/prereqs.py
@@ -31,6 +31,8 @@ class PrereqReport:
 
 
 def _read_total_memory_bytes() -> int:
+    """Read total physical memory from ``/proc/meminfo`` when available."""
+
     try:
         with Path("/proc/meminfo").open(encoding="utf-8") as handle:
             for line in handle:
@@ -42,10 +44,14 @@ def _read_total_memory_bytes() -> int:
 
 
 def _kvm_available() -> bool:
+    """Return whether the host exposes a readable ``/dev/kvm`` device."""
+
     return Path("/dev/kvm").exists() and os.access("/dev/kvm", os.R_OK | os.W_OK)
 
 
 def _tool_available(command: tuple[str, ...]) -> bool:
+    """Return whether a launcher tool responds successfully to a version probe."""
+
     try:
         result = subprocess.run(
             list(command),

--- a/src/aptl/appliance/seat/prereqs.py
+++ b/src/aptl/appliance/seat/prereqs.py
@@ -64,6 +64,7 @@ def check_host_prerequisites(
     *,
     seat_root: Path,
     memory_bytes: int | None = None,
+    free_disk_bytes: int | None = None,
     kvm_available: bool | None = None,
     qemu_img_available: bool | None = None,
     qemu_system_available: bool | None = None,
@@ -97,13 +98,17 @@ def check_host_prerequisites(
         )
     )
     try:
-        free_bytes = shutil.disk_usage(seat_root).free
+        available_disk = (
+            shutil.disk_usage(seat_root).free
+            if free_disk_bytes is None
+            else free_disk_bytes
+        )
     except OSError:
-        free_bytes = 0
+        available_disk = 0
     findings.append(
         PrereqFinding(
             code="low-disk",
-            passed=free_bytes >= requirements.disk_bytes,
+            passed=available_disk >= requirements.disk_bytes,
             detail="free disk is below the signed minimum",
         )
     )

--- a/src/aptl/appliance/seat/prereqs.py
+++ b/src/aptl/appliance/seat/prereqs.py
@@ -1,0 +1,150 @@
+"""Host prerequisite checks for appliance seat launch."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from aptl.appliance.models import HostPrerequisites
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.core import hostenv
+
+
+@dataclass(frozen=True)
+class PrereqFinding:
+    """One bounded host prerequisite result."""
+
+    code: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class PrereqReport:
+    """Aggregate prerequisite admission for one seat launch attempt."""
+
+    passed: bool
+    findings: tuple[PrereqFinding, ...]
+
+
+def _read_total_memory_bytes() -> int:
+    try:
+        with Path("/proc/meminfo").open(encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("MemTotal:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        return 0
+    return 0
+
+
+def _kvm_available() -> bool:
+    return Path("/dev/kvm").exists() and os.access("/dev/kvm", os.R_OK | os.W_OK)
+
+
+def _tool_available(command: tuple[str, ...]) -> bool:
+    try:
+        result = subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def check_host_prerequisites(
+    requirements: HostPrerequisites,
+    *,
+    seat_root: Path,
+    memory_bytes: int | None = None,
+    kvm_available: bool | None = None,
+    qemu_img_available: bool | None = None,
+    qemu_system_available: bool | None = None,
+) -> PrereqReport:
+    """Validate host resources and launcher tools against the signed manifest."""
+
+    findings: list[PrereqFinding] = []
+    if hostenv.host_os() != hostenv.OS_LINUX:
+        findings.append(
+            PrereqFinding(
+                code="unsupported-host-os",
+                passed=False,
+                detail="seat launcher requires Linux",
+            )
+        )
+    if requirements.hardware_virtualization:
+        kvm_ok = _kvm_available() if kvm_available is None else kvm_available
+        findings.append(
+            PrereqFinding(
+                code="no-kvm",
+                passed=kvm_ok,
+                detail="hardware virtualization is unavailable",
+            )
+        )
+    total_memory = _read_total_memory_bytes() if memory_bytes is None else memory_bytes
+    findings.append(
+        PrereqFinding(
+            code="low-memory",
+            passed=total_memory >= requirements.memory_bytes,
+            detail="host memory is below the signed minimum",
+        )
+    )
+    try:
+        free_bytes = shutil.disk_usage(seat_root).free
+    except OSError:
+        free_bytes = 0
+    findings.append(
+        PrereqFinding(
+            code="low-disk",
+            passed=free_bytes >= requirements.disk_bytes,
+            detail="free disk is below the signed minimum",
+        )
+    )
+    qemu_img_ok = (
+        _tool_available(("qemu-img", "--version"))
+        if qemu_img_available is None
+        else qemu_img_available
+    )
+    findings.append(
+        PrereqFinding(
+            code="missing-qemu-img",
+            passed=qemu_img_ok,
+            detail="qemu-img is required for overlay management",
+        )
+    )
+    qemu_system_ok = (
+        _tool_available(("qemu-system-x86_64", "--version"))
+        if qemu_system_available is None
+        else qemu_system_available
+    )
+    findings.append(
+        PrereqFinding(
+            code="missing-qemu-system",
+            passed=qemu_system_ok,
+            detail="qemu-system-x86_64 is required for seat launch",
+        )
+    )
+    passed = all(item.passed for item in findings)
+    return PrereqReport(passed=passed, findings=tuple(findings))
+
+
+def require_host_prerequisites(
+    requirements: HostPrerequisites,
+    *,
+    seat_root: Path,
+    **overrides: object,
+) -> PrereqReport:
+    """Fail closed when host prerequisites are not met."""
+
+    report = check_host_prerequisites(requirements, seat_root=seat_root, **overrides)
+    if not report.passed:
+        failed = next(item for item in report.findings if not item.passed)
+        raise SeatLauncherError(failed.code, failed.detail)
+    return report

--- a/src/aptl/appliance/seat/vm.py
+++ b/src/aptl/appliance/seat/vm.py
@@ -143,9 +143,7 @@ def read_vm_pid(seat_root: Path) -> int | None:
         pid = int(path.read_text(encoding="utf-8").strip())
     except (OSError, ValueError):
         return None
-    if pid <= 0 or not _tracked_pid_alive(pid):
-        return None
-    return pid
+    return pid if pid > 0 and _tracked_pid_alive(pid) else None
 
 
 def write_vm_pid(seat_root: Path, pid: int | None) -> None:

--- a/src/aptl/appliance/seat/vm.py
+++ b/src/aptl/appliance/seat/vm.py
@@ -1,0 +1,175 @@
+"""QEMU/KVM adapter for one disposable appliance overlay."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class VmProcess(Protocol):
+    """Minimal VM lifecycle surface used by seat orchestration."""
+
+    @property
+    def pid(self) -> int: ...
+
+    def poll(self) -> int | None: ...
+
+    def terminate(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+
+@dataclass(frozen=True)
+class VmLaunchSpec:
+    """Fixed-argv launch contract for one seat overlay."""
+
+    overlay_path: Path
+    launch_mount: Path
+    vcpus: int
+    memory_mib: int
+    participant_port: int = 443
+    recovery_port: int = 9443
+
+
+@dataclass
+class SubprocessVm:
+    """Subprocess-backed VM handle."""
+
+    process: subprocess.Popen[bytes]
+
+    @property
+    def pid(self) -> int:
+        return self.process.pid
+
+    def poll(self) -> int | None:
+        return self.process.poll()
+
+    def terminate(self) -> None:
+        self.process.send_signal(signal.SIGTERM)
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.process.wait(timeout=timeout)
+
+
+VmRunner = type[SubprocessVm] | None
+
+
+def build_qemu_argv(spec: VmLaunchSpec) -> tuple[str, ...]:
+    """Return hardened fixed argv for one local-KVM seat."""
+
+    launch_path = str(spec.launch_mount.resolve())
+    return (
+        "qemu-system-x86_64",
+        "-enable-kvm",
+        "-cpu",
+        "host",
+        "-smp",
+        str(spec.vcpus),
+        "-m",
+        str(spec.memory_mib),
+        "-drive",
+        f"file={spec.overlay_path},format=qcow2,if=virtio,cache=none,aio=threads,readonly=off",
+        "-fsdev",
+        f"local,id=aptl-launch,path={launch_path},readonly=on,security_model=none",
+        "-device",
+        "virtio-9p-pci,fsdev=aptl-launch,mount_tag=aptl-launch",
+        "-virtio-serial-pci",
+        "-device",
+        "virtio-rng-pci",
+        "-netdev",
+        (
+            f"user,id=participant,hostfwd=tcp:127.0.0.1:{spec.participant_port}-:"
+            f"{spec.participant_port},hostfwd=tcp:127.0.0.1:{spec.recovery_port}-:"
+            f"{spec.recovery_port}"
+        ),
+        "-device",
+        "virtio-net-pci,netdev=participant",
+        "-serial",
+        "none",
+        "-monitor",
+        "none",
+        "-nographic",
+    )
+
+
+def start_vm(
+    spec: VmLaunchSpec,
+    *,
+    runner: VmRunner = None,
+) -> SubprocessVm:
+    """Start one VM process from a hardened argv list."""
+
+    argv = list(build_qemu_argv(spec))
+    process = subprocess.Popen(
+        argv,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        start_new_session=True,
+    )
+    return SubprocessVm(process=process)
+
+
+def vm_pid_path(seat_root: Path) -> Path:
+    return seat_root / "vm.pid"
+
+
+def read_vm_pid(seat_root: Path) -> int | None:
+    path = vm_pid_path(seat_root)
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+        pid = int(text)
+    except (OSError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return None
+    return pid
+
+
+def write_vm_pid(seat_root: Path, pid: int | None) -> None:
+    path = vm_pid_path(seat_root)
+    if pid is None:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return
+    path.write_text(f"{pid}\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+def stop_vm(seat_root: Path, *, timeout: float = 20.0) -> bool:
+    """Terminate the tracked VM process when present."""
+
+    pid = read_vm_pid(seat_root)
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+        deadline = timeout
+        while deadline > 0:
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                write_vm_pid(seat_root, None)
+                return True
+            import time
+
+            time.sleep(0.2)
+            deadline -= 0.2
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+    write_vm_pid(seat_root, None)
+    return True

--- a/src/aptl/appliance/seat/vm.py
+++ b/src/aptl/appliance/seat/vm.py
@@ -112,32 +112,45 @@ def start_vm(
         close_fds=True,
         start_new_session=True,
     )
-    return SubprocessVm(process=process)
+    if runner is None:
+        return SubprocessVm(process=process)
+    return runner(process=process)
 
 
 def vm_pid_path(seat_root: Path) -> Path:
+    """Return the VM pid file path for one seat root."""
+
     return seat_root / "vm.pid"
 
 
+def _tracked_pid_alive(pid: int) -> bool:
+    """Return whether ``pid`` still refers to a live process."""
+
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
 def read_vm_pid(seat_root: Path) -> int | None:
+    """Return the live VM pid recorded for one seat, if any."""
+
     path = vm_pid_path(seat_root)
     if not path.is_file():
         return None
     try:
-        text = path.read_text(encoding="utf-8").strip()
-        pid = int(text)
+        pid = int(path.read_text(encoding="utf-8").strip())
     except (OSError, ValueError):
         return None
-    if pid <= 0:
-        return None
-    try:
-        os.kill(pid, 0)
-    except OSError:
+    if pid <= 0 or not _tracked_pid_alive(pid):
         return None
     return pid
 
 
 def write_vm_pid(seat_root: Path, pid: int | None) -> None:
+    """Persist or clear the tracked VM pid for one seat."""
+
     path = vm_pid_path(seat_root)
     if pid is None:
         try:

--- a/src/aptl/cli/main.py
+++ b/src/aptl/cli/main.py
@@ -5,7 +5,7 @@ from typing import Optional
 import typer
 
 import aptl
-from aptl.cli import appliance, config, container, experiment, kill, lab, runs, web
+from aptl.cli import appliance, config, container, experiment, kill, lab, runs, seat, web
 
 app = typer.Typer(
     name="aptl",
@@ -21,6 +21,7 @@ app.add_typer(web.app, name="web")
 app.add_typer(kill.app, name="kill")
 app.add_typer(experiment.app, name="experiment")
 app.add_typer(appliance.app, name="appliance")
+app.add_typer(seat.app, name="seat")
 
 
 def _version_callback(value: bool) -> None:

--- a/src/aptl/cli/seat.py
+++ b/src/aptl/cli/seat.py
@@ -1,0 +1,169 @@
+"""CLI for host-side appliance seat lifecycle operations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.lifecycle import (
+    open_participant_kiosk,
+    reconcile_seat_after_reboot,
+    recover_seat,
+    reset_seat,
+    stage_seat,
+    start_seat,
+    status_seat,
+    stop_seat,
+)
+
+app = typer.Typer(help="Operate one disposable appliance seat on a physical host.")
+
+
+def _emit(payload: dict[str, object]) -> None:
+    typer.echo(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+
+def _fail(exc: SeatLauncherError) -> None:
+    typer.echo(json.dumps({"error": exc.code, "message": exc.message}), err=True)
+    raise typer.Exit(code=2) from exc
+
+
+@app.command("stage")
+def stage(
+    seat_root: Path = typer.Option(..., "--seat-root"),
+    seat_id: str = typer.Option("seat-01", "--seat-id"),
+    release_dir: Path = typer.Option(..., "--release-dir"),
+    release_public_key: Path = typer.Option(..., "--release-public-key"),
+    qualification_public_key: Path = typer.Option(..., "--qualification-public-key"),
+) -> None:
+    """Verify release admission and persist a staged seat record."""
+
+    try:
+        record = stage_seat(
+            seat_root,
+            seat_id=seat_id,
+            release_dir=release_dir,
+            release_public_key=release_public_key,
+            qualification_public_key=qualification_public_key,
+        )
+    except SeatLauncherError as exc:
+        _fail(exc)
+    _emit({"staged": True, "seat": record.model_dump(mode="json")})
+
+
+@app.command("start")
+def start(
+    seat_root: Path = typer.Option(..., "--seat-root"),
+    seat_id: str = typer.Option("seat-01", "--seat-id"),
+    release_dir: Path = typer.Option(..., "--release-dir"),
+    release_public_key: Path = typer.Option(..., "--release-public-key"),
+    qualification_public_key: Path = typer.Option(..., "--qualification-public-key"),
+) -> None:
+    """Start the seat VM and validate host exposure."""
+
+    try:
+        record = start_seat(
+            seat_root,
+            seat_id=seat_id,
+            release_dir=release_dir,
+            release_public_key=release_public_key,
+            qualification_public_key=qualification_public_key,
+        )
+    except SeatLauncherError as exc:
+        _fail(exc)
+    _emit({"started": True, "seat": record.model_dump(mode="json")})
+
+
+@app.command("stop")
+def stop(seat_root: Path = typer.Option(..., "--seat-root")) -> None:
+    """Stop the seat VM without destroying overlay state."""
+
+    try:
+        record = stop_seat(seat_root)
+    except SeatLauncherError as exc:
+        _fail(exc)
+    _emit({"stopped": True, "seat": record.model_dump(mode="json")})
+
+
+@app.command("reset")
+def reset(
+    seat_root: Path = typer.Option(..., "--seat-root"),
+    seat_id: str = typer.Option("seat-01", "--seat-id"),
+    release_dir: Path = typer.Option(..., "--release-dir"),
+    release_public_key: Path = typer.Option(..., "--release-public-key"),
+    qualification_public_key: Path = typer.Option(..., "--qualification-public-key"),
+) -> None:
+    """Destroy overlay state and restage the seat."""
+
+    try:
+        record = reset_seat(
+            seat_root,
+            seat_id=seat_id,
+            release_dir=release_dir,
+            release_public_key=release_public_key,
+            qualification_public_key=qualification_public_key,
+        )
+    except SeatLauncherError as exc:
+        _fail(exc)
+    _emit({"reset": True, "seat": record.model_dump(mode="json")})
+
+
+@app.command("recover")
+def recover(
+    seat_root: Path = typer.Option(..., "--seat-root"),
+    seat_id: str = typer.Option("seat-01", "--seat-id"),
+    release_dir: Path = typer.Option(..., "--release-dir"),
+    release_public_key: Path = typer.Option(..., "--release-public-key"),
+    qualification_public_key: Path = typer.Option(..., "--qualification-public-key"),
+) -> None:
+    """Instructor recovery: reset and start the seat."""
+
+    try:
+        record = recover_seat(
+            seat_root,
+            seat_id=seat_id,
+            release_dir=release_dir,
+            release_public_key=release_public_key,
+            qualification_public_key=qualification_public_key,
+        )
+    except SeatLauncherError as exc:
+        _fail(exc)
+    _emit({"recovered": True, "seat": record.model_dump(mode="json")})
+
+
+@app.command("reconcile")
+def reconcile(seat_root: Path = typer.Option(..., "--seat-root")) -> None:
+    """Reconcile seat state after a physical-host reboot."""
+
+    try:
+        record = reconcile_seat_after_reboot(seat_root)
+    except SeatLauncherError as exc:
+        _fail(exc)
+    _emit({"reconciled": True, "seat": record.model_dump(mode="json")})
+
+
+@app.command("status")
+def status(seat_root: Path = typer.Option(..., "--seat-root")) -> None:
+    """Print coarse seat health without credentials."""
+
+    projection = status_seat(seat_root)
+    _emit(projection.model_dump(mode="json"))
+
+
+@app.command("open-kiosk")
+def open_kiosk(
+    participant_port: int = typer.Option(443, "--participant-port"),
+    browser_command: str | None = typer.Option(None, "--browser-command"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+) -> None:
+    """Launch the participant browser kiosk wrapper."""
+
+    plan = open_participant_kiosk(
+        participant_port=participant_port,
+        browser_command=browser_command,
+        dry_run=dry_run,
+    )
+    _emit({"kiosk": True, "argv": list(plan.argv), "url": plan.url})

--- a/src/aptl/cli/seat.py
+++ b/src/aptl/cli/seat.py
@@ -8,8 +8,8 @@ from pathlib import Path
 import typer
 
 from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.kiosk import open_participant_kiosk
 from aptl.appliance.seat.lifecycle import (
-    open_participant_kiosk,
     reconcile_seat_after_reboot,
     recover_seat,
     reset_seat,
@@ -23,10 +23,14 @@ app = typer.Typer(help="Operate one disposable appliance seat on a physical host
 
 
 def _emit(payload: dict[str, object]) -> None:
+    """Print one bounded JSON payload on stdout."""
+
     typer.echo(json.dumps(payload, separators=(",", ":"), sort_keys=True))
 
 
 def _fail(exc: SeatLauncherError) -> None:
+    """Print one bounded JSON error and exit with code 2."""
+
     typer.echo(json.dumps({"error": exc.code, "message": exc.message}), err=True)
     raise typer.Exit(code=2) from exc
 

--- a/tests/test_appliance_seat_cli.py
+++ b/tests/test_appliance_seat_cli.py
@@ -165,4 +165,3 @@ def test_open_kiosk_honors_browser_command() -> None:
     assert result.exit_code == 0
     popen.assert_not_called()
     assert "/usr/bin/custom-browser" in result.stdout
-

--- a/tests/test_appliance_seat_cli.py
+++ b/tests/test_appliance_seat_cli.py
@@ -138,7 +138,7 @@ def test_seat_reconcile_success_emits_json() -> None:
 
 
 def test_open_kiosk_dry_run_does_not_spawn_browser() -> None:
-    with patch("aptl.appliance.seat.lifecycle.subprocess.Popen") as popen:
+    with patch("aptl.appliance.seat.kiosk.subprocess.Popen") as popen:
         result = runner.invoke(
             app,
             ["seat", "open-kiosk", "--dry-run"],
@@ -150,7 +150,7 @@ def test_open_kiosk_dry_run_does_not_spawn_browser() -> None:
 
 
 def test_open_kiosk_honors_browser_command() -> None:
-    with patch("aptl.appliance.seat.lifecycle.subprocess.Popen") as popen:
+    with patch("aptl.appliance.seat.kiosk.subprocess.Popen") as popen:
         result = runner.invoke(
             app,
             [

--- a/tests/test_appliance_seat_cli.py
+++ b/tests/test_appliance_seat_cli.py
@@ -1,0 +1,71 @@
+"""CLI tests for the appliance seat launcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from aptl.appliance.seat.models import SeatRecord
+from aptl.cli.main import app
+
+runner = CliRunner()
+
+
+def test_seat_help_lists_supported_commands() -> None:
+    result = runner.invoke(app, ["seat", "--help"])
+
+    assert result.exit_code == 0
+    assert "stage" in result.stdout
+    assert "reset" in result.stdout
+    assert "recover" in result.stdout
+    assert "open-kiosk" in result.stdout
+
+
+def test_seat_status_emits_bounded_json(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["seat", "status", "--seat-root", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "lifecycle_state" in result.stdout
+    assert "credential" not in result.stdout.lower()
+
+
+def test_seat_stage_error_is_bounded() -> None:
+    with patch(
+        "aptl.cli.seat.stage_seat",
+        side_effect=__import__(
+            "aptl.appliance.seat.errors", fromlist=["SeatLauncherError"]
+        ).SeatLauncherError("no-kvm", "hardware virtualization is unavailable"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "seat",
+                "stage",
+                "--seat-root",
+                "/tmp/seat",
+                "--release-dir",
+                "/tmp/release",
+                "--release-public-key",
+                "/tmp/release.pem",
+                "--qualification-public-key",
+                "/tmp/qualification.pem",
+            ],
+        )
+
+    assert result.exit_code == 2
+    assert "no-kvm" in result.stderr
+    assert "qemu-img" not in result.stderr
+
+
+def test_open_kiosk_dry_run_does_not_spawn_browser() -> None:
+    with patch("aptl.appliance.seat.lifecycle.subprocess.Popen") as popen:
+        result = runner.invoke(
+            app,
+            ["seat", "open-kiosk", "--dry-run"],
+        )
+
+    assert result.exit_code == 0
+    popen.assert_not_called()
+    assert "https://127.0.0.1:443/" in result.stdout

--- a/tests/test_appliance_seat_cli.py
+++ b/tests/test_appliance_seat_cli.py
@@ -13,6 +13,33 @@ from aptl.cli.main import app
 runner = CliRunner()
 
 
+def _seat_record() -> SeatRecord:
+    return SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="ready",
+        taint_state="clean",
+        host_boot_id="boot-1",
+    )
+
+
+def _common_seat_args() -> list[str]:
+    return [
+        "--seat-root",
+        "/tmp/seat",
+        "--release-dir",
+        "/tmp/release",
+        "--release-public-key",
+        "/tmp/release.pem",
+        "--qualification-public-key",
+        "/tmp/qualification.pem",
+    ]
+
+
 def test_seat_help_lists_supported_commands() -> None:
     result = runner.invoke(app, ["seat", "--help"])
 
@@ -38,25 +65,76 @@ def test_seat_stage_error_is_bounded() -> None:
             "aptl.appliance.seat.errors", fromlist=["SeatLauncherError"]
         ).SeatLauncherError("no-kvm", "hardware virtualization is unavailable"),
     ):
-        result = runner.invoke(
-            app,
-            [
-                "seat",
-                "stage",
-                "--seat-root",
-                "/tmp/seat",
-                "--release-dir",
-                "/tmp/release",
-                "--release-public-key",
-                "/tmp/release.pem",
-                "--qualification-public-key",
-                "/tmp/qualification.pem",
-            ],
-        )
+        result = runner.invoke(app, ["seat", "stage", *_common_seat_args()])
 
     assert result.exit_code == 2
     assert "no-kvm" in result.stderr
     assert "qemu-img" not in result.stderr
+
+
+def test_seat_stage_success_emits_json() -> None:
+    record = _seat_record().model_copy(update={"lifecycle_state": "staged"})
+    with patch("aptl.cli.seat.stage_seat", return_value=record):
+        result = runner.invoke(app, ["seat", "stage", *_common_seat_args()])
+
+    assert result.exit_code == 0
+    assert '"staged":true' in result.stdout.replace(" ", "")
+
+
+def test_seat_start_success_emits_json() -> None:
+    with patch("aptl.cli.seat.start_seat", return_value=_seat_record()):
+        result = runner.invoke(app, ["seat", "start", *_common_seat_args()])
+
+    assert result.exit_code == 0
+    assert '"started":true' in result.stdout.replace(" ", "")
+
+
+def test_seat_start_error_is_bounded() -> None:
+    with patch(
+        "aptl.cli.seat.start_seat",
+        side_effect=__import__(
+            "aptl.appliance.seat.errors", fromlist=["SeatLauncherError"]
+        ).SeatLauncherError("boundary.host-listener-missing", "host boundary inventory failed"),
+    ):
+        result = runner.invoke(app, ["seat", "start", *_common_seat_args()])
+
+    assert result.exit_code == 2
+    assert "boundary.host-listener-missing" in result.stderr
+
+
+def test_seat_stop_success_emits_json() -> None:
+    with patch(
+        "aptl.cli.seat.stop_seat",
+        return_value=_seat_record().model_copy(update={"lifecycle_state": "staged"}),
+    ):
+        result = runner.invoke(app, ["seat", "stop", "--seat-root", "/tmp/seat"])
+
+    assert result.exit_code == 0
+    assert '"stopped":true' in result.stdout.replace(" ", "")
+
+
+def test_seat_reset_and_recover_success_emit_json() -> None:
+    staged = _seat_record().model_copy(update={"lifecycle_state": "staged"})
+    with patch("aptl.cli.seat.reset_seat", return_value=staged):
+        reset = runner.invoke(app, ["seat", "reset", *_common_seat_args()])
+    with patch("aptl.cli.seat.recover_seat", return_value=_seat_record()):
+        recover = runner.invoke(app, ["seat", "recover", *_common_seat_args()])
+
+    assert reset.exit_code == 0
+    assert '"reset":true' in reset.stdout.replace(" ", "")
+    assert recover.exit_code == 0
+    assert '"recovered":true' in recover.stdout.replace(" ", "")
+
+
+def test_seat_reconcile_success_emits_json() -> None:
+    with patch(
+        "aptl.cli.seat.reconcile_seat_after_reboot",
+        return_value=_seat_record().model_copy(update={"host_boot_id": "boot-2"}),
+    ):
+        result = runner.invoke(app, ["seat", "reconcile", "--seat-root", "/tmp/seat"])
+
+    assert result.exit_code == 0
+    assert '"reconciled":true' in result.stdout.replace(" ", "")
 
 
 def test_open_kiosk_dry_run_does_not_spawn_browser() -> None:
@@ -69,3 +147,22 @@ def test_open_kiosk_dry_run_does_not_spawn_browser() -> None:
     assert result.exit_code == 0
     popen.assert_not_called()
     assert "https://127.0.0.1:443/" in result.stdout
+
+
+def test_open_kiosk_honors_browser_command() -> None:
+    with patch("aptl.appliance.seat.lifecycle.subprocess.Popen") as popen:
+        result = runner.invoke(
+            app,
+            [
+                "seat",
+                "open-kiosk",
+                "--browser-command",
+                "/usr/bin/custom-browser",
+                "--dry-run",
+            ],
+        )
+
+    assert result.exit_code == 0
+    popen.assert_not_called()
+    assert "/usr/bin/custom-browser" in result.stdout
+

--- a/tests/test_appliance_seat_exposure.py
+++ b/tests/test_appliance_seat_exposure.py
@@ -65,3 +65,13 @@ def test_audit_vm_argv_rejects_writable_fsdev_share() -> None:
 
     assert report.passed is False
     assert "host.exposure.forbidden-vm-share:readonly=off" in report.findings
+
+
+def test_audit_vm_argv_rejects_forbidden_usb_flag() -> None:
+    argv = ("qemu-system-x86_64", "-enable-kvm", "-usb", "off")
+
+    report = audit_vm_argv(argv)
+
+    assert report.passed is False
+    assert "host.exposure.forbidden-vm-flag:-usb" in report.findings
+

--- a/tests/test_appliance_seat_exposure.py
+++ b/tests/test_appliance_seat_exposure.py
@@ -1,0 +1,19 @@
+"""Host exposure inventory tests for the appliance seat launcher."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from aptl.appliance.seat.exposure import audit_host_process_inventory
+
+
+def test_audit_host_process_inventory_probes_docker_by_default() -> None:
+    with patch(
+        "aptl.appliance.seat.exposure._docker_daemon_running",
+        return_value=True,
+    ) as probe:
+        report = audit_host_process_inventory()
+
+    probe.assert_called_once()
+    assert report.passed is False
+    assert "host.exposure.docker-daemon-present" in report.findings

--- a/tests/test_appliance_seat_exposure.py
+++ b/tests/test_appliance_seat_exposure.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from aptl.appliance.seat.exposure import audit_host_process_inventory
+from aptl.core import hostenv
+
+pytestmark = pytest.mark.skipif(
+    hostenv.host_os() != hostenv.OS_LINUX,
+    reason="appliance seat launcher exposure checks are Linux-only",
+)
 
 
 def test_audit_host_process_inventory_probes_docker_by_default() -> None:

--- a/tests/test_appliance_seat_exposure.py
+++ b/tests/test_appliance_seat_exposure.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from aptl.appliance.seat.exposure import audit_host_process_inventory
+from aptl.appliance.seat.exposure import (
+    audit_host_process_inventory,
+    audit_vm_argv,
+    require_host_exposure,
+)
+from aptl.appliance.seat.vm import VmLaunchSpec, build_qemu_argv
 from aptl.core import hostenv
 
 pytestmark = pytest.mark.skipif(
@@ -25,3 +31,37 @@ def test_audit_host_process_inventory_probes_docker_by_default() -> None:
     probe.assert_called_once()
     assert report.passed is False
     assert "host.exposure.docker-daemon-present" in report.findings
+
+
+def test_audit_vm_argv_allows_writable_overlay_drive(tmp_path: Path) -> None:
+    launch_mount = tmp_path / "launch"
+    launch_mount.mkdir()
+    overlay = tmp_path / "overlay.qcow2"
+    overlay.write_bytes(b"overlay")
+    argv = build_qemu_argv(
+        VmLaunchSpec(
+            overlay_path=overlay,
+            launch_mount=launch_mount,
+            vcpus=8,
+            memory_mib=16384,
+        )
+    )
+
+    report = audit_vm_argv(argv)
+
+    assert report.passed is True
+    assert "readonly=off" in argv[argv.index("-drive") + 1]
+    require_host_exposure(vm_argv=argv, docker_daemon_running=False)
+
+
+def test_audit_vm_argv_rejects_writable_fsdev_share() -> None:
+    argv = (
+        "qemu-system-x86_64",
+        "-fsdev",
+        "local,id=share,path=/srv/share,readonly=off,security_model=none",
+    )
+
+    report = audit_vm_argv(argv)
+
+    assert report.passed is False
+    assert "host.exposure.forbidden-vm-share:readonly=off" in report.findings

--- a/tests/test_appliance_seat_exposure.py
+++ b/tests/test_appliance_seat_exposure.py
@@ -74,4 +74,3 @@ def test_audit_vm_argv_rejects_forbidden_usb_flag() -> None:
 
     assert report.passed is False
     assert "host.exposure.forbidden-vm-flag:-usb" in report.findings
-

--- a/tests/test_appliance_seat_kiosk.py
+++ b/tests/test_appliance_seat_kiosk.py
@@ -1,0 +1,25 @@
+"""Kiosk wrapper tests for the appliance seat launcher."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from aptl.appliance.seat.kiosk import build_kiosk_launch_plan
+
+
+def test_build_kiosk_launch_plan_uses_custom_browser() -> None:
+    plan = build_kiosk_launch_plan(
+        participant_port=8443,
+        browser_command="/usr/bin/custom-browser",
+    )
+
+    assert plan.url == "https://127.0.0.1:8443/"
+    assert plan.argv[0] == "/usr/bin/custom-browser"
+    assert "--kiosk" in plan.argv
+
+
+def test_build_kiosk_launch_plan_falls_back_to_xdg_open() -> None:
+    with patch("aptl.appliance.seat.kiosk.shutil.which", return_value=None):
+        plan = build_kiosk_launch_plan()
+
+    assert plan.argv[0] == "xdg-open"

--- a/tests/test_appliance_seat_lifecycle.py
+++ b/tests/test_appliance_seat_lifecycle.py
@@ -1,0 +1,280 @@
+"""Lifecycle orchestration for the appliance seat launcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aptl.appliance.manifest import ApplianceReleaseInspection
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.lifecycle import (
+    reconcile_seat_after_reboot,
+    reset_seat,
+    stage_seat,
+    start_seat,
+    status_seat,
+    stop_seat,
+)
+from aptl.appliance.seat.models import SeatRecord
+from aptl.appliance.seat.persistence import load_seat_record, persist_seat_record
+from aptl.core.appliance_boundary_inventory import BoundaryEndpoint
+from tests.test_appliance_boundary_inventory import _policy
+
+
+def _inspection() -> ApplianceReleaseInspection:
+    return ApplianceReleaseInspection(
+        release_id="aptl-v5.1.1-x86_64",
+        aptl_version="5.1.1",
+        source_commit="1" * 40,
+        manifest_digest="sha256:" + "a" * 64,
+        payload_digest="sha256:" + "b" * 64,
+        artifact_count=9,
+        architecture="x86_64",
+        minimum_host_vcpus=8,
+        minimum_host_memory_bytes=16 * 1024**3,
+        minimum_host_disk_bytes=100 * 1024**3,
+    )
+
+
+def _manifest_stub():
+    from types import SimpleNamespace
+
+    publication = SimpleNamespace(
+        audience="participant",
+        address="127.0.0.1",
+        port=443,
+        protocol="tcp",
+    )
+    recovery = SimpleNamespace(
+        audience="recovery",
+        address="127.0.0.1",
+        port=9443,
+        protocol="tcp",
+    )
+    artifact = SimpleNamespace(kind="boundary-policy", path="policy/boundary.json")
+    golden = SimpleNamespace(
+        kind="golden-disk",
+        path="artifacts/golden.qcow2",
+        sha256="sha256:" + "c" * 64,
+    )
+    return SimpleNamespace(
+        host_prerequisites=SimpleNamespace(
+            vcpus=8,
+            memory_bytes=16 * 1024**3,
+        ),
+        boundary=SimpleNamespace(
+            policy_digest="sha256:" + "1" * 64,
+            boundary_helper_image="example.test/helper@sha256:" + "e" * 64,
+            egress_proxy_image="example.test/egress@sha256:" + "f" * 64,
+        ),
+        payload_digest="sha256:" + "2" * 64,
+        delivery=SimpleNamespace(participant_routes_digest="sha256:" + "4" * 64),
+        artifacts=(artifact, golden),
+    )
+
+
+def _listener_probe():
+    return (
+        BoundaryEndpoint(
+            audience="participant",
+            address="127.0.0.1",
+            port=443,
+            protocol="tcp",
+        ),
+        BoundaryEndpoint(
+            audience="recovery",
+            address="127.0.0.1",
+            port=9443,
+            protocol="tcp",
+        ),
+    )
+
+
+def test_stage_persists_seat_record(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    seat_root.mkdir()
+    release = tmp_path / "release"
+    release.mkdir()
+    public_key = tmp_path / "release-public.pem"
+    qualification_key = tmp_path / "qualification-public.pem"
+    public_key.write_text("public")
+    qualification_key.write_text("qualification")
+
+    with (
+        patch(
+            "aptl.appliance.seat.lifecycle.require_host_prerequisites",
+            return_value=object(),
+        ),
+        patch(
+            "aptl.appliance.seat.lifecycle._load_verified_release",
+            return_value=(_inspection(), _policy()),
+        ),
+        patch(
+            "aptl.appliance.seat.lifecycle._load_release_documents",
+            return_value=(_manifest_stub(), object()),
+        ),
+        patch("aptl.appliance.seat.lifecycle.prepare_launch_descriptor"),
+        patch(
+            "aptl.appliance.seat.lifecycle._launch_descriptor_digest",
+            return_value="sha256:" + "d" * 64,
+        ),
+    ):
+        record = stage_seat(
+            seat_root,
+            seat_id="seat-01",
+            release_dir=release,
+            release_public_key=public_key,
+            qualification_public_key=qualification_key,
+        )
+
+    assert record.lifecycle_state == "staged"
+    assert load_seat_record(seat_root) == record
+
+
+def test_start_marks_ready_when_boundary_passes(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    seat_root.mkdir()
+    release = seat_root / "launch" / "release"
+    release.mkdir(parents=True)
+    public_key = tmp_path / "release-public.pem"
+    qualification_key = tmp_path / "qualification-public.pem"
+    public_key.write_text("public")
+    qualification_key.write_text("qualification")
+
+    with (
+        patch(
+            "aptl.appliance.seat.lifecycle.require_host_prerequisites",
+            return_value=object(),
+        ),
+        patch(
+            "aptl.appliance.seat.lifecycle._load_verified_release",
+            return_value=(_inspection(), _policy()),
+        ),
+        patch(
+            "aptl.appliance.seat.lifecycle._load_release_documents",
+            return_value=(_manifest_stub(), object()),
+        ),
+        patch("aptl.appliance.seat.lifecycle._ensure_overlay"),
+        patch("aptl.appliance.seat.lifecycle.require_host_exposure"),
+        patch("aptl.appliance.seat.lifecycle.start_vm") as start_vm,
+        patch("aptl.appliance.seat.lifecycle.write_vm_pid"),
+        patch("aptl.appliance.seat.lifecycle.read_vm_pid", return_value=4242),
+        patch("aptl.appliance.seat.lifecycle.prepare_launch_descriptor"),
+        patch(
+            "aptl.appliance.seat.lifecycle._launch_descriptor_digest",
+            return_value="sha256:" + "d" * 64,
+        ),
+    ):
+        start_vm.return_value.pid = 4242
+        record = start_seat(
+            seat_root,
+            seat_id="seat-01",
+            release_dir=release,
+            release_public_key=public_key,
+            qualification_public_key=qualification_key,
+            listener_probe=_listener_probe,
+        )
+
+    assert record.lifecycle_state == "ready"
+
+
+def test_reset_destroys_overlay_and_restage(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    overlay = seat_root / "instances" / "seat-01.qcow2"
+    overlay.parent.mkdir(parents=True)
+    overlay.write_bytes(b"overlay")
+    record = SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="ready",
+        taint_state="clean",
+        host_boot_id="boot-1",
+    )
+    persist_seat_record(seat_root, record)
+    release = tmp_path / "release"
+    release.mkdir()
+    public_key = tmp_path / "release-public.pem"
+    qualification_key = tmp_path / "qualification-public.pem"
+    public_key.write_text("public")
+    qualification_key.write_text("qualification")
+
+    with (
+        patch("aptl.appliance.seat.lifecycle.stop_vm"),
+        patch(
+            "aptl.appliance.seat.lifecycle.stage_seat",
+            return_value=record.model_copy(update={"lifecycle_state": "staged"}),
+        ) as stage,
+    ):
+        reset_seat(
+            seat_root,
+            seat_id="seat-01",
+            release_dir=release,
+            release_public_key=public_key,
+            qualification_public_key=qualification_key,
+        )
+
+    assert not overlay.exists()
+    stage.assert_called_once()
+
+
+def test_reconcile_after_reboot_requires_recovery(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    record = SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="ready",
+        taint_state="clean",
+        host_boot_id="boot-old",
+    )
+    persist_seat_record(seat_root, record)
+
+    with (
+        patch(
+            "aptl.appliance.seat.lifecycle._read_host_boot_id",
+            return_value="boot-new",
+        ),
+        patch("aptl.appliance.seat.lifecycle.read_vm_pid", return_value=None),
+        pytest.raises(SeatLauncherError) as exc,
+    ):
+        reconcile_seat_after_reboot(seat_root)
+
+    assert exc.value.code == "host-reboot-detected"
+
+
+def test_stop_transitions_ready_to_staged(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    record = SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="ready",
+        taint_state="clean",
+        host_boot_id="boot-1",
+    )
+    persist_seat_record(seat_root, record)
+
+    with patch("aptl.appliance.seat.lifecycle.stop_vm"):
+        updated = stop_seat(seat_root)
+
+    assert updated.lifecycle_state == "staged"
+
+
+def test_status_never_includes_credentials(tmp_path: Path) -> None:
+    projection = status_seat(tmp_path)
+
+    payload = projection.model_dump(mode="json")
+    assert "credential" not in str(payload).lower()
+    assert projection.lifecycle_state == "empty"

--- a/tests/test_appliance_seat_lifecycle.py
+++ b/tests/test_appliance_seat_lifecycle.py
@@ -10,7 +10,7 @@ import pytest
 from aptl.appliance.manifest import ApplianceReleaseInspection
 from aptl.appliance.seat.errors import SeatLauncherError
 from aptl.appliance.seat.lifecycle import (
-    open_participant_kiosk,
+    StartSeatOptions,
     reconcile_seat_after_reboot,
     recover_seat,
     reset_seat,
@@ -19,6 +19,7 @@ from aptl.appliance.seat.lifecycle import (
     status_seat,
     stop_seat,
 )
+from aptl.appliance.seat.kiosk import open_participant_kiosk
 from aptl.appliance.seat.models import SeatRecord
 from aptl.appliance.seat.persistence import load_seat_record, persist_seat_record
 from aptl.core import hostenv
@@ -182,7 +183,7 @@ def test_start_marks_ready_when_boundary_passes(tmp_path: Path) -> None:
             release_dir=release,
             release_public_key=public_key,
             qualification_public_key=qualification_key,
-            listener_probe=_listener_probe,
+            options=StartSeatOptions(listener_probe=_listener_probe),
         )
 
     assert record.lifecycle_state == "ready"
@@ -450,7 +451,7 @@ def test_reconcile_marks_recoverable_failure_when_vm_missing(tmp_path: Path) -> 
 
 
 def test_open_participant_kiosk_spawns_browser_when_not_dry_run() -> None:
-    with patch("aptl.appliance.seat.lifecycle.subprocess.Popen") as popen:
+    with patch("aptl.appliance.seat.kiosk.subprocess.Popen") as popen:
         plan = open_participant_kiosk(
             participant_port=8443,
             browser_command="/usr/bin/browser",

--- a/tests/test_appliance_seat_lifecycle.py
+++ b/tests/test_appliance_seat_lifecycle.py
@@ -460,4 +460,3 @@ def test_open_participant_kiosk_spawns_browser_when_not_dry_run() -> None:
     popen.assert_called_once()
     assert plan.url == "https://127.0.0.1:8443/"
     assert plan.argv[0] == "/usr/bin/browser"
-

--- a/tests/test_appliance_seat_lifecycle.py
+++ b/tests/test_appliance_seat_lifecycle.py
@@ -19,8 +19,14 @@ from aptl.appliance.seat.lifecycle import (
 )
 from aptl.appliance.seat.models import SeatRecord
 from aptl.appliance.seat.persistence import load_seat_record, persist_seat_record
+from aptl.core import hostenv
 from aptl.core.appliance_boundary_inventory import BoundaryEndpoint
 from tests.test_appliance_boundary_inventory import _policy
+
+pytestmark = pytest.mark.skipif(
+    hostenv.host_os() != hostenv.OS_LINUX,
+    reason="appliance seat launcher lifecycle is Linux-only",
+)
 
 
 def _inspection() -> ApplianceReleaseInspection:

--- a/tests/test_appliance_seat_lifecycle.py
+++ b/tests/test_appliance_seat_lifecycle.py
@@ -10,7 +10,9 @@ import pytest
 from aptl.appliance.manifest import ApplianceReleaseInspection
 from aptl.appliance.seat.errors import SeatLauncherError
 from aptl.appliance.seat.lifecycle import (
+    open_participant_kiosk,
     reconcile_seat_after_reboot,
+    recover_seat,
     reset_seat,
     stage_seat,
     start_seat,
@@ -284,3 +286,178 @@ def test_status_never_includes_credentials(tmp_path: Path) -> None:
     payload = projection.model_dump(mode="json")
     assert "credential" not in str(payload).lower()
     assert projection.lifecycle_state == "empty"
+
+
+def test_status_reports_vm_not_running_for_ready_seat(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    record = SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="ready",
+        taint_state="clean",
+        host_boot_id="boot-1",
+    )
+    persist_seat_record(seat_root, record)
+
+    with patch("aptl.appliance.seat.lifecycle.read_vm_pid", return_value=None):
+        projection = status_seat(seat_root)
+
+    assert projection.diagnostics == ("vm-not-running",)
+
+
+def test_stop_seat_requires_existing_record(tmp_path: Path) -> None:
+    with pytest.raises(SeatLauncherError) as exc:
+        stop_seat(tmp_path)
+
+    assert exc.value.code == "corrupt-seat-state"
+
+
+def test_recover_seat_resets_then_starts(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    release = tmp_path / "release"
+    release.mkdir()
+    public_key = tmp_path / "release-public.pem"
+    qualification_key = tmp_path / "qualification-public.pem"
+    public_key.write_text("public")
+    qualification_key.write_text("qualification")
+    ready = SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="ready",
+        taint_state="clean",
+        host_boot_id="boot-1",
+    )
+
+    with (
+        patch("aptl.appliance.seat.lifecycle.reset_seat") as reset,
+        patch("aptl.appliance.seat.lifecycle.start_seat", return_value=ready) as start,
+    ):
+        record = recover_seat(
+            seat_root,
+            seat_id="seat-01",
+            release_dir=release,
+            release_public_key=public_key,
+            qualification_public_key=qualification_key,
+        )
+
+    reset.assert_called_once()
+    start.assert_called_once()
+    assert record.lifecycle_state == "ready"
+
+
+def test_start_marks_recoverable_failure_when_boundary_fails(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    seat_root.mkdir()
+    release = seat_root / "launch" / "release"
+    release.mkdir(parents=True)
+    public_key = tmp_path / "release-public.pem"
+    qualification_key = tmp_path / "qualification-public.pem"
+    public_key.write_text("public")
+    qualification_key.write_text("qualification")
+    staged = SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="staged",
+        taint_state="clean",
+        host_boot_id="boot-1",
+    )
+    persist_seat_record(seat_root, staged)
+
+    with (
+        patch(
+            "aptl.appliance.seat.lifecycle.require_host_prerequisites",
+            return_value=object(),
+        ),
+        patch(
+            "aptl.appliance.seat.lifecycle._load_verified_release",
+            return_value=(_inspection(), _policy()),
+        ),
+        patch(
+            "aptl.appliance.seat.lifecycle._load_release_documents",
+            return_value=(_manifest_stub(), object()),
+        ),
+        patch("aptl.appliance.seat.lifecycle._ensure_overlay"),
+        patch("aptl.appliance.seat.lifecycle.require_host_exposure"),
+        patch("aptl.appliance.seat.lifecycle.start_vm") as start_vm,
+        patch("aptl.appliance.seat.lifecycle.write_vm_pid"),
+        patch("aptl.appliance.seat.lifecycle.read_vm_pid", return_value=None),
+        patch(
+            "aptl.appliance.seat.lifecycle.collect_loopback_listeners",
+            return_value=(),
+        ),
+        patch(
+            "aptl.appliance.seat.lifecycle.host_boundary_findings",
+            return_value=("boundary.host-listener-missing",),
+        ),
+        pytest.raises(SeatLauncherError) as exc,
+    ):
+        start_vm.return_value.pid = 4242
+        start_seat(
+            seat_root,
+            seat_id="seat-01",
+            release_dir=release,
+            release_public_key=public_key,
+            qualification_public_key=qualification_key,
+        )
+
+    assert exc.value.code == "boundary.host-listener-missing"
+    failed = load_seat_record(seat_root)
+    assert failed is not None
+    assert failed.lifecycle_state == "recoverable-failure"
+
+
+def test_reconcile_marks_recoverable_failure_when_vm_missing(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    record = SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="ready",
+        taint_state="clean",
+        host_boot_id="boot-1",
+    )
+    persist_seat_record(seat_root, record)
+
+    with (
+        patch(
+            "aptl.appliance.seat.lifecycle._read_host_boot_id",
+            return_value="boot-1",
+        ),
+        patch("aptl.appliance.seat.lifecycle.read_vm_pid", return_value=None),
+        pytest.raises(SeatLauncherError) as exc,
+    ):
+        reconcile_seat_after_reboot(seat_root)
+
+    assert exc.value.code == "vm-not-running"
+    updated = load_seat_record(seat_root)
+    assert updated is not None
+    assert updated.lifecycle_state == "recoverable-failure"
+
+
+def test_open_participant_kiosk_spawns_browser_when_not_dry_run() -> None:
+    with patch("aptl.appliance.seat.lifecycle.subprocess.Popen") as popen:
+        plan = open_participant_kiosk(
+            participant_port=8443,
+            browser_command="/usr/bin/browser",
+            dry_run=False,
+        )
+
+    popen.assert_called_once()
+    assert plan.url == "https://127.0.0.1:8443/"
+    assert plan.argv[0] == "/usr/bin/browser"
+

--- a/tests/test_appliance_seat_observation.py
+++ b/tests/test_appliance_seat_observation.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from aptl.core.appliance_boundary import ApplianceBoundaryBinding
 from aptl.core.appliance_boundary_inventory import BoundaryEndpoint
 from aptl.appliance.seat.observation import (
     build_host_observation,
+    collect_loopback_listeners,
     host_boundary_findings,
     map_publications_to_listeners,
     observation_id_for,
@@ -106,3 +109,66 @@ def test_host_boundary_findings_detect_missing_recovery_listener() -> None:
     findings = host_boundary_findings(policy, binding, bundle.observation)
 
     assert "boundary.host-listener-missing" in findings
+
+
+def test_collect_loopback_listeners_uses_probe_when_provided() -> None:
+    expected = (
+        BoundaryEndpoint(
+            audience="participant",
+            address="127.0.0.1",
+            port=443,
+            protocol="tcp",
+        ),
+    )
+
+    observed = collect_loopback_listeners(probe=lambda: expected)
+
+    assert observed == expected
+
+
+def test_collect_loopback_listeners_parses_ss_output() -> None:
+    ss_output = "LISTEN 0 128 127.0.0.1:443 0.0.0.0:*\nLISTEN 0 128 [::1]:9443 [::]:*\n"
+    completed = type("Completed", (), {"returncode": 0, "stdout": ss_output})()
+
+    with patch(
+        "aptl.appliance.seat.observation.subprocess.run",
+        return_value=completed,
+    ):
+        observed = collect_loopback_listeners()
+
+    assert len(observed) == 2
+    assert observed[0].port == 443
+    assert observed[1].port == 9443
+
+
+def test_host_boundary_findings_detect_identity_mismatches() -> None:
+    policy = _policy()
+    listeners = (
+        BoundaryEndpoint(
+            audience="participant",
+            address="127.0.0.1",
+            port=443,
+            protocol="tcp",
+        ),
+        BoundaryEndpoint(
+            audience="recovery",
+            address="127.0.0.1",
+            port=9443,
+            protocol="tcp",
+        ),
+    )
+    bundle = build_host_observation(
+        policy=policy,
+        binding=_binding("pending"),
+        boot_id="boot-42",
+        listeners=listeners,
+        forbidden_reachability_passed=True,
+        complete=False,
+    )
+    binding = _binding("wrong-id")
+
+    findings = host_boundary_findings(policy, binding, bundle.observation)
+
+    assert "boundary.host-observation-identity-mismatch" in findings
+    assert "boundary.host-observation-incomplete" in findings
+

--- a/tests/test_appliance_seat_observation.py
+++ b/tests/test_appliance_seat_observation.py
@@ -48,7 +48,6 @@ def test_observation_id_is_stable_when_complete_flag_changes() -> None:
         ),
     )
     partial = build_host_observation(
-        policy=policy,
         binding=binding,
         boot_id="boot-42",
         listeners=listeners,
@@ -56,7 +55,6 @@ def test_observation_id_is_stable_when_complete_flag_changes() -> None:
         complete=False,
     )
     complete = build_host_observation(
-        policy=policy,
         binding=binding,
         boot_id="boot-42",
         listeners=listeners,
@@ -97,7 +95,6 @@ def test_host_boundary_findings_detect_missing_recovery_listener() -> None:
         ),
     )
     bundle = build_host_observation(
-        policy=policy,
         binding=_binding("pending"),
         boot_id="boot-42",
         listeners=listeners,
@@ -158,7 +155,6 @@ def test_host_boundary_findings_detect_identity_mismatches() -> None:
         ),
     )
     bundle = build_host_observation(
-        policy=policy,
         binding=_binding("pending"),
         boot_id="boot-42",
         listeners=listeners,

--- a/tests/test_appliance_seat_observation.py
+++ b/tests/test_appliance_seat_observation.py
@@ -1,0 +1,108 @@
+"""Host observation helpers for the appliance seat launcher."""
+
+from __future__ import annotations
+
+from aptl.core.appliance_boundary import ApplianceBoundaryBinding
+from aptl.core.appliance_boundary_inventory import BoundaryEndpoint
+from aptl.appliance.seat.observation import (
+    build_host_observation,
+    host_boundary_findings,
+    map_publications_to_listeners,
+    observation_id_for,
+)
+from tests.test_appliance_boundary_inventory import _policy
+
+
+def _binding(observation_id: str) -> ApplianceBoundaryBinding:
+    return ApplianceBoundaryBinding(
+        policy_digest="sha256:" + "1" * 64,
+        payload_digest="sha256:" + "2" * 64,
+        raes_plan_digest="sha256:" + "4" * 64,
+        raes_boundary_required=False,
+        boundary_helper_image="example.test/aptl-boundary@sha256:" + "5" * 64,
+        egress_proxy_image="example.test/aptl-egress@sha256:" + "6" * 64,
+        boot_id="boot-42",
+        guest_daemon_id="daemon-42",
+        host_observation_id=observation_id,
+    )
+
+
+def test_observation_id_is_stable_when_complete_flag_changes() -> None:
+    policy = _policy()
+    binding = _binding("pending")
+    listeners = (
+        BoundaryEndpoint(
+            audience="participant",
+            address="127.0.0.1",
+            port=443,
+            protocol="tcp",
+        ),
+        BoundaryEndpoint(
+            audience="recovery",
+            address="127.0.0.1",
+            port=9443,
+            protocol="tcp",
+        ),
+    )
+    partial = build_host_observation(
+        policy=policy,
+        binding=binding,
+        boot_id="boot-42",
+        listeners=listeners,
+        forbidden_reachability_passed=True,
+        complete=False,
+    )
+    complete = build_host_observation(
+        policy=policy,
+        binding=binding,
+        boot_id="boot-42",
+        listeners=listeners,
+        forbidden_reachability_passed=True,
+        complete=True,
+    )
+
+    assert observation_id_for(partial.observation) == observation_id_for(
+        complete.observation
+    )
+
+
+def test_map_publications_to_listeners() -> None:
+    policy = _policy()
+    observed = (
+        BoundaryEndpoint(
+            audience="participant",
+            address="127.0.0.1",
+            port=443,
+            protocol="tcp",
+        ),
+    )
+
+    mapped = map_publications_to_listeners(policy, observed)
+
+    assert len(mapped) == 1
+    assert mapped[0].audience == "participant"
+
+
+def test_host_boundary_findings_detect_missing_recovery_listener() -> None:
+    policy = _policy()
+    listeners = (
+        BoundaryEndpoint(
+            audience="participant",
+            address="127.0.0.1",
+            port=443,
+            protocol="tcp",
+        ),
+    )
+    bundle = build_host_observation(
+        policy=policy,
+        binding=_binding("pending"),
+        boot_id="boot-42",
+        listeners=listeners,
+        forbidden_reachability_passed=True,
+        complete=True,
+    )
+    binding = _binding(bundle.observation_id)
+
+    findings = host_boundary_findings(policy, binding, bundle.observation)
+
+    assert "boundary.host-listener-missing" in findings

--- a/tests/test_appliance_seat_observation.py
+++ b/tests/test_appliance_seat_observation.py
@@ -171,4 +171,3 @@ def test_host_boundary_findings_detect_identity_mismatches() -> None:
 
     assert "boundary.host-observation-identity-mismatch" in findings
     assert "boundary.host-observation-incomplete" in findings
-

--- a/tests/test_appliance_seat_paths.py
+++ b/tests/test_appliance_seat_paths.py
@@ -47,4 +47,3 @@ def test_contained_path_rejects_escape(tmp_path: Path) -> None:
         contained_path(seat_root, "../outside", label="overlay")
 
     assert exc.value.code == "invalid-seat-id"
-

--- a/tests/test_appliance_seat_paths.py
+++ b/tests/test_appliance_seat_paths.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from aptl.appliance.seat.errors import SeatLauncherError
-from aptl.appliance.seat.paths import validate_seat_id
+from aptl.appliance.seat.paths import contained_path, validate_seat_id
 from aptl.appliance.seat.vm import VmLaunchSpec, build_qemu_argv
 
 
@@ -37,3 +37,14 @@ def test_build_qemu_argv_mounts_readonly_launch_directory(tmp_path: Path) -> Non
     assert "readonly=on" in argv[fsdev_index + 1]
     assert str(launch_mount.resolve()) in argv[fsdev_index + 1]
     assert "virtio-9p-pci,fsdev=aptl-launch,mount_tag=aptl-launch" in argv
+
+
+def test_contained_path_rejects_escape(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    seat_root.mkdir()
+
+    with pytest.raises(SeatLauncherError) as exc:
+        contained_path(seat_root, "../outside", label="overlay")
+
+    assert exc.value.code == "invalid-seat-id"
+

--- a/tests/test_appliance_seat_paths.py
+++ b/tests/test_appliance_seat_paths.py
@@ -1,0 +1,39 @@
+"""Seat path and VM argv validation tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.paths import validate_seat_id
+from aptl.appliance.seat.vm import VmLaunchSpec, build_qemu_argv
+
+
+def test_validate_seat_id_rejects_path_traversal() -> None:
+    with pytest.raises(SeatLauncherError) as exc:
+        validate_seat_id("../etc/passwd")
+
+    assert exc.value.code == "invalid-seat-id"
+
+
+def test_build_qemu_argv_mounts_readonly_launch_directory(tmp_path: Path) -> None:
+    launch_mount = tmp_path / "launch"
+    launch_mount.mkdir()
+    overlay = tmp_path / "overlay.qcow2"
+    overlay.write_bytes(b"overlay")
+    spec = VmLaunchSpec(
+        overlay_path=overlay,
+        launch_mount=launch_mount,
+        vcpus=8,
+        memory_mib=16384,
+    )
+
+    argv = build_qemu_argv(spec)
+
+    assert "-fsdev" in argv
+    fsdev_index = argv.index("-fsdev")
+    assert "readonly=on" in argv[fsdev_index + 1]
+    assert str(launch_mount.resolve()) in argv[fsdev_index + 1]
+    assert "virtio-9p-pci,fsdev=aptl-launch,mount_tag=aptl-launch" in argv

--- a/tests/test_appliance_seat_persistence.py
+++ b/tests/test_appliance_seat_persistence.py
@@ -61,9 +61,10 @@ def test_persist_seat_record_rejects_symlink_root(tmp_path: Path) -> None:
     target.mkdir()
     link = tmp_path / "link"
     link.symlink_to(target, target_is_directory=True)
+    record = _record()
 
     with pytest.raises(SeatLauncherError) as exc:
-        persist_seat_record(link, _record())
+        persist_seat_record(link, record)
 
     assert exc.value.code == "corrupt-seat-state"
 

--- a/tests/test_appliance_seat_persistence.py
+++ b/tests/test_appliance_seat_persistence.py
@@ -1,0 +1,81 @@
+"""Persistence tests for the appliance seat launcher."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.models import SeatRecord
+from aptl.appliance.seat.persistence import load_seat_record, persist_seat_record
+
+
+def _record() -> SeatRecord:
+    return SeatRecord(
+        schema_version="aptl.seat-record/v1",
+        seat_id="seat-01",
+        selected_release_id="aptl-v1",
+        launch_descriptor_digest="sha256:" + "a" * 64,
+        overlay_path="instances/seat-01.qcow2",
+        host_observation_id="host-1",
+        lifecycle_state="staged",
+        taint_state="clean",
+        host_boot_id="boot-1",
+    )
+
+
+def test_persist_and_load_seat_record(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    record = _record()
+
+    persist_seat_record(seat_root, record)
+
+    loaded = load_seat_record(seat_root)
+    assert loaded == record
+    state_path = seat_root / "seat-state.json"
+    assert stat.S_IMODE(state_path.stat().st_mode) == 0o600
+
+
+def test_load_seat_record_returns_none_when_missing(tmp_path: Path) -> None:
+    assert load_seat_record(tmp_path) is None
+
+
+def test_load_seat_record_rejects_world_readable_state(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    seat_root.mkdir(mode=0o700)
+    state_path = seat_root / "seat-state.json"
+    state_path.write_text(_record().model_dump_json(), encoding="utf-8")
+    state_path.chmod(0o644)
+
+    with pytest.raises(SeatLauncherError) as exc:
+        load_seat_record(seat_root)
+
+    assert exc.value.code == "corrupt-seat-state"
+
+
+def test_persist_seat_record_rejects_symlink_root(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(SeatLauncherError) as exc:
+        persist_seat_record(link, _record())
+
+    assert exc.value.code == "corrupt-seat-state"
+
+
+def test_load_seat_record_rejects_invalid_json(tmp_path: Path) -> None:
+    seat_root = tmp_path / "seat"
+    seat_root.mkdir(mode=0o700)
+    state_path = seat_root / "seat-state.json"
+    state_path.write_text("{not-json", encoding="utf-8")
+    state_path.chmod(0o600)
+
+    with pytest.raises(SeatLauncherError) as exc:
+        load_seat_record(seat_root)
+
+    assert exc.value.code == "corrupt-seat-state"

--- a/tests/test_appliance_seat_prereqs.py
+++ b/tests/test_appliance_seat_prereqs.py
@@ -69,3 +69,22 @@ def test_require_host_prerequisites_raises(tmp_path: Path) -> None:
         )
 
     assert exc.value.code == "low-memory"
+
+
+def test_prereqs_fail_on_low_disk_and_missing_tools(tmp_path: Path) -> None:
+    report = check_host_prerequisites(
+        _requirements(),
+        seat_root=tmp_path,
+        memory_bytes=32 * 1024**3,
+        free_disk_bytes=1024,
+        kvm_available=True,
+        qemu_img_available=False,
+        qemu_system_available=False,
+    )
+
+    assert report.passed is False
+    codes = {item.code for item in report.findings if not item.passed}
+    assert "low-disk" in codes
+    assert "missing-qemu-img" in codes
+    assert "missing-qemu-system" in codes
+

--- a/tests/test_appliance_seat_prereqs.py
+++ b/tests/test_appliance_seat_prereqs.py
@@ -58,9 +58,10 @@ def test_prereqs_fail_closed_on_missing_kvm(tmp_path: Path) -> None:
 
 
 def test_require_host_prerequisites_raises(tmp_path: Path) -> None:
+    requirements = _requirements()
     with pytest.raises(SeatLauncherError) as exc:
         require_host_prerequisites(
-            _requirements(),
+            requirements,
             seat_root=tmp_path,
             memory_bytes=1024,
             kvm_available=True,

--- a/tests/test_appliance_seat_prereqs.py
+++ b/tests/test_appliance_seat_prereqs.py
@@ -87,4 +87,3 @@ def test_prereqs_fail_on_low_disk_and_missing_tools(tmp_path: Path) -> None:
     assert "low-disk" in codes
     assert "missing-qemu-img" in codes
     assert "missing-qemu-system" in codes
-

--- a/tests/test_appliance_seat_prereqs.py
+++ b/tests/test_appliance_seat_prereqs.py
@@ -28,6 +28,7 @@ def test_prereqs_pass_with_injected_probes(tmp_path: Path) -> None:
         _requirements(),
         seat_root=tmp_path,
         memory_bytes=32 * 1024**3,
+        free_disk_bytes=200 * 1024**3,
         kvm_available=True,
         qemu_img_available=True,
         qemu_system_available=True,

--- a/tests/test_appliance_seat_prereqs.py
+++ b/tests/test_appliance_seat_prereqs.py
@@ -1,0 +1,64 @@
+"""Prerequisite checks for the appliance seat launcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aptl.appliance.models import HostPrerequisites
+from aptl.appliance.seat.errors import SeatLauncherError
+from aptl.appliance.seat.prereqs import check_host_prerequisites, require_host_prerequisites
+
+
+def _requirements() -> HostPrerequisites:
+    return HostPrerequisites(
+        architecture="x86_64",
+        vcpus=8,
+        memory_bytes=16 * 1024**3,
+        disk_bytes=100 * 1024**3,
+        hardware_virtualization=True,
+        local_adapter="qemu-kvm",
+        supported_hypervisors=("qemu>=8.2",),
+    )
+
+
+def test_prereqs_pass_with_injected_probes(tmp_path: Path) -> None:
+    report = check_host_prerequisites(
+        _requirements(),
+        seat_root=tmp_path,
+        memory_bytes=32 * 1024**3,
+        kvm_available=True,
+        qemu_img_available=True,
+        qemu_system_available=True,
+    )
+
+    assert report.passed is True
+
+
+def test_prereqs_fail_closed_on_missing_kvm(tmp_path: Path) -> None:
+    report = check_host_prerequisites(
+        _requirements(),
+        seat_root=tmp_path,
+        memory_bytes=32 * 1024**3,
+        kvm_available=False,
+        qemu_img_available=True,
+        qemu_system_available=True,
+    )
+
+    assert report.passed is False
+    assert any(item.code == "no-kvm" for item in report.findings)
+
+
+def test_require_host_prerequisites_raises(tmp_path: Path) -> None:
+    with pytest.raises(SeatLauncherError) as exc:
+        require_host_prerequisites(
+            _requirements(),
+            seat_root=tmp_path,
+            memory_bytes=1024,
+            kvm_available=True,
+            qemu_img_available=True,
+            qemu_system_available=True,
+        )
+
+    assert exc.value.code == "low-memory"

--- a/tests/test_appliance_seat_prereqs.py
+++ b/tests/test_appliance_seat_prereqs.py
@@ -9,6 +9,12 @@ import pytest
 from aptl.appliance.models import HostPrerequisites
 from aptl.appliance.seat.errors import SeatLauncherError
 from aptl.appliance.seat.prereqs import check_host_prerequisites, require_host_prerequisites
+from aptl.core import hostenv
+
+pytestmark = pytest.mark.skipif(
+    hostenv.host_os() != hostenv.OS_LINUX,
+    reason="appliance seat launcher prerequisites are Linux-only",
+)
 
 
 def _requirements() -> HostPrerequisites:

--- a/tests/test_appliance_seat_vm.py
+++ b/tests/test_appliance_seat_vm.py
@@ -1,0 +1,125 @@
+"""VM adapter tests for the appliance seat launcher."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aptl.appliance.seat.vm import (
+    SubprocessVm,
+    VmLaunchSpec,
+    read_vm_pid,
+    start_vm,
+    stop_vm,
+    write_vm_pid,
+)
+
+
+def test_subprocess_vm_delegates_to_process() -> None:
+    process = MagicMock()
+    process.pid = 4242
+    process.poll.return_value = None
+    vm = SubprocessVm(process=process)
+
+    assert vm.pid == 4242
+    assert vm.poll() is None
+    vm.terminate()
+    process.send_signal.assert_called_once_with(signal.SIGTERM)
+    vm.wait(timeout=1.0)
+    process.wait.assert_called_once_with(timeout=1.0)
+
+
+def test_write_and_read_vm_pid_roundtrip(tmp_path: Path) -> None:
+    write_vm_pid(tmp_path, os.getpid())
+
+    assert read_vm_pid(tmp_path) == os.getpid()
+
+
+def test_read_vm_pid_rejects_missing_stale_and_invalid(tmp_path: Path) -> None:
+    assert read_vm_pid(tmp_path) is None
+
+    write_vm_pid(tmp_path, 999_999)
+    assert read_vm_pid(tmp_path) is None
+
+    pid_path = tmp_path / "vm.pid"
+    pid_path.write_text("not-a-pid\n", encoding="utf-8")
+    assert read_vm_pid(tmp_path) is None
+
+    pid_path.write_text("0\n", encoding="utf-8")
+    assert read_vm_pid(tmp_path) is None
+
+
+def test_write_vm_pid_clears_file(tmp_path: Path) -> None:
+    write_vm_pid(tmp_path, os.getpid())
+    write_vm_pid(tmp_path, None)
+
+    assert not (tmp_path / "vm.pid").exists()
+
+
+def test_start_vm_uses_hardened_subprocess_options(tmp_path: Path) -> None:
+    launch_mount = tmp_path / "launch"
+    launch_mount.mkdir()
+    overlay = tmp_path / "overlay.qcow2"
+    overlay.write_bytes(b"overlay")
+    spec = VmLaunchSpec(
+        overlay_path=overlay,
+        launch_mount=launch_mount,
+        vcpus=2,
+        memory_mib=512,
+    )
+
+    with patch("aptl.appliance.seat.vm.subprocess.Popen") as popen:
+        popen.return_value = MagicMock(pid=5150)
+        vm = start_vm(spec)
+
+    assert vm.pid == 5150
+    argv = popen.call_args.args[0]
+    assert argv[0] == "qemu-system-x86_64"
+    assert "-enable-kvm" in argv
+    kwargs = popen.call_args.kwargs
+    assert kwargs["stdin"] == subprocess.DEVNULL
+
+
+def test_stop_vm_returns_false_when_untracked(tmp_path: Path) -> None:
+    assert stop_vm(tmp_path) is False
+
+
+def test_stop_vm_clears_pid_when_process_exits(tmp_path: Path) -> None:
+    def fake_kill(pid: int, sig: int) -> None:
+        if sig == 0:
+            raise OSError("process gone")
+        assert pid == 7777
+
+    with (
+        patch("aptl.appliance.seat.vm.read_vm_pid", return_value=7777),
+        patch("aptl.appliance.seat.vm.os.kill", side_effect=fake_kill),
+    ):
+        assert stop_vm(tmp_path) is True
+
+    write_vm_pid(tmp_path, None)
+    assert read_vm_pid(tmp_path) is None
+
+
+def test_stop_vm_sends_sigkill_when_process_survives(tmp_path: Path) -> None:
+    signals: list[int] = []
+
+    def fake_kill(pid: int, sig: int) -> None:
+        assert pid == 8888
+        signals.append(sig)
+        if sig == 0:
+            return
+
+    with (
+        patch("aptl.appliance.seat.vm.read_vm_pid", return_value=8888),
+        patch("aptl.appliance.seat.vm.os.kill", side_effect=fake_kill),
+        patch("time.sleep"),
+    ):
+        assert stop_vm(tmp_path, timeout=0.1) is True
+
+    assert signal.SIGTERM in signals
+    assert signal.SIGKILL in signals


### PR DESCRIPTION
## Summary

Implement the host-side appliance seat launcher with stage/start/reset/recover/reconcile/status commands, bounded host boundary observation, and participant kiosk presentation.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #824

## ADR Impact

- ADR-049

## Changes

- Add aptl seat CLI and host-side lifecycle adapter
- Wire readonly launch mount into QEMU argv
- Add prerequisite, observation, exposure, and path containment checks
- Add pytest coverage and reference documentation

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

uv run pytest tests/test_appliance_seat_*.py; pre-commit run --all-files

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: src/aptl/appliance/seat/, src/aptl/cli/seat.py
- TESTS: tests/test_appliance_seat_prereqs.py, tests/test_appliance_seat_observation.py, tests/test_appliance_seat_lifecycle.py, tests/test_appliance_seat_cli.py, tests/test_appliance_seat_paths.py, tests/test_appliance_seat_exposure.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed