### PR TITLE
fix: preserve bounded participant execution semantics

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,6 +156,8 @@ The victim and kali containers publish no host ports; use
 
 ## Preflights
 
+- [Issue #859 Idempotent Stuttering In Bounded Participant Realizations](issue-859-idempotent-stuttering-preflight.md)
+- [Issue #858 Bounded Participant Choice Transport](issue-858-bounded-participant-choice-transport-preflight.md)
 - [Issue #852 Dev-To-Main Promotion](issue-852-devmain-promotion-preflight.md)
 - [Issue #847 OpenSSF Scorecard](issue-847-openssf-scorecard-preflight.md)
 - [EXP-005 Safe Parameter Binding And Provenance](exp-005-safe-parameter-binding-provenance-preflight.md)

--- a/docs/architecture/issue-858-bounded-participant-choice-transport-preflight.md
+++ b/docs/architecture/issue-858-bounded-participant-choice-transport-preflight.md
@@ -1,0 +1,147 @@
+# Issue #858 Bounded Participant Choice Transport Preflight
+
+This note fixes the design boundaries for bounding installed-participant choice
+transport without changing delivered RAES candidate semantics. It is
+architecture guidance, not an implementation plan. No new ADR is needed:
+`docs/architecture/issue-557-participant-implementation-binding-preflight.md`,
+`docs/architecture/issue-821-participant-workbench-preflight.md`,
+ADR-029, ADR-033, ADR-044, ADR-046, and ADR-049 already own the relevant
+runtime, secret, evidence, and appliance boundaries.
+
+## Architecture decisions
+
+- Keep the authoritative decision surface unchanged. RAES remains the source of
+  truth for `ParticipantDecisionSurfaceV2Model`,
+  `ParticipantDecisionSurfaceSelectionV2Model`, projection/delivery,
+  proposal identity, selection binding, and admission. The bounded transport is
+  a provider-facing view over the already delivered candidate set, not a second
+  decision-surface contract.
+- Keep the compact form outside RAES admission. APTL may derive a bounded
+  solicitation representation from `turn.candidates` for the installed
+  provider, but the provider response must resolve back to exactly one original
+  delivered candidate before `admit_participant_decision_surface_selection_v2()`
+  runs. The existing delivered candidate remains the only object that reaches
+  RAES binding and native realization.
+- Reuse existing proposal identity. `proposal_ref` is already the canonical,
+  delivered, per-candidate identity. Do not invent a second permanent action
+  id, a transport-only semantic id, or an alternate admission path. If the
+  bounded representation needs a shorter provider-facing token, that token is a
+  transient alias for one delivered `proposal_ref`, recorded only as transport
+  metadata.
+- Make compaction structural, not semantic. The accepted lossiness is limited
+  to repeated trusted coordinates that the participant did not choose. Do not
+  drop candidates, merge semantically distinct candidates, or normalize away
+  governed dimensions that determine native operation or readback.
+- Keep the complete solicitation authoritative in evidence. Evaluator evidence
+  must continue to retain the full delivered solicitation fingerprint, selected
+  delivered candidate identity, and existing admission receipts/diagnostics.
+  The compact transport may be retained as an additional bounded transport
+  record or digest, but it must not replace the authoritative delivered-view
+  fingerprint.
+- Bound size with code-owned limits at the installed-provider seam. The limit is
+  an execution-policy concern owned by the decision-provider boundary, not a
+  scenario field, profile field, prompt instruction, or user input. Existing
+  adapter prompt/output limits remain the incumbent shape for these ceilings.
+- Fail closed before provider-side action authority can expand. Missing,
+  malformed, ambiguous, out-of-range, duplicate, or out-of-set provider outputs
+  are solicitation failures and never reach RAES admission, behavior history, or
+  native realization.
+
+No ADR is needed. This issue constrains how an existing installed-provider
+boundary serializes an already authoritative RAES decision surface; it does not
+change the durable product architecture.
+
+## Canonical incumbents to reuse
+
+| Concern | Canonical owner and required reuse |
+|---|---|
+| Exact decision surface and delivery | `project_participant_turn()`, `project_participant_decision_surface_v2()`, `deliver_surface()`, `ParticipantDecisionTurn`, and `candidate_selections()` own exact-cut projection, delivery, and full finite candidate enumeration. |
+| Candidate identity and governed semantics | `ParticipantDecisionSurfaceSelectionV2Model`, existing `proposal_ref` construction in `candidate_selections()`, `argument_shape_ref`, and `resolve_participant_action_arguments()` own the exact candidate meaning. |
+| Provider solicitation workflow | `ParticipantDecisionSolicitation`, `ManagedAgentSelectionProvider`, `parse_provider_selection()`, `AptlParticipantRuntime.solicit_selection()`, and `run_participant_turn()` own provider invocation, hostile-output parsing, replay/budget gates, and fail-closed solicitation status. |
+| Admission and native realization | `admit_projected_participant_selection()`, `_build_admission_request()`, `_build_binding_resolvers()`, `RuntimeControlPlane.admit_participant_decision_surface_selection_v2()`, and RAES base runtime admission remain the only admission path. |
+| Evidence and persistence | `ParticipantControlEvidence`, `persist_control_evidence()`, `solicitation_fingerprint()`, `selection_fingerprint()`, `_persist_admission_evidence()`, `RunStorageBackend.append_jsonl()`, and immutable action-transaction publication remain the evidence owners. |
+| Installed-provider execution limits | `build_selection_provider()`, `DecisionAgentLaunch`, `ManagedAgentAdapter`, `ClaudeCodeManagedAgentAdapter`, `CodexManagedAgentAdapter`, `BoundedProcessRunner`, and their existing timeout/prompt/output caps own installed-provider execution policy. |
+| Qualification and hostile-boundary tests | `validate_participant_agency_qualification()`, `validate_participant_agency_readiness()`, boundary challenges in `participant_qualification_boundaries.py`, and `tests/test_bounded_participant_runtime.py` remain the contract and regression suites. |
+| Logging and diagnostics | RAES `Diagnostic`, participant operation status, `get_logger()`, and the existing redacted workbench/participant error translation remain the observability vocabulary. Do not add a second exception family or prompt-bound diagnostic format. |
+
+Do not add a second candidate DTO, a second binder, a second selection parser,
+another evidence schema for authoritative selection identity, or a provider-name
+branch in scenario logic.
+
+## Security and validation passage
+
+| Layer | Required behavior |
+|---|---|
+| RAES shape and binding | The bounded transport starts from already validated delivered candidates. Before admission, provider output must resolve to one delivered `ParticipantDecisionSurfaceSelectionV2Model`, after which the existing RAES binder re-checks `delivery_ref`, `proposal_ref`, `argument_shape_ref`, apparatus refs, and governed arguments. |
+| Solicitation parser / hostile-output gate | Treat provider output as hostile. Keep the current bounded outer envelope, JSON parsing, and strict closed-world membership check in `AptlParticipantRuntime.solicit_selection()`. Add bounded-transport parsing there or immediately adjacent, not in native handlers. Raw provider text never becomes action authority. |
+| Config and env shape | No scenario, profile, API, or operator config field should define candidate compaction rules or provider-visible mappings. If a durable ceiling must vary by provider, keep it in the existing closed provider registry/adapter construction path, not `AptlConfig`, `.env`, or participant-visible payloads, unless a genuine repo-wide setting is later justified. |
+| Secret handling | Reuse the existing `EphemeralCredentialBroker`, fixed argv, stdin prompt delivery, and redacted diagnostics. Compact transport must not move credentials, hidden evaluator truth, backend handles, or extra topology into provider-visible prompt content. |
+| OS/process exposure | Prompt bytes still flow over stdin to the admitted executable. Do not place compacted candidate maps, fingerprints used as credentials, or prompt payloads in argv, filenames, URLs, or environment variables. Existing work-dir, timeout, and output-cap limits remain in force. |
+| Error envelopes | Prompt-bound overflow, malformed alias selection, ambiguous alias mapping, and out-of-range selection are solicitation failures surfaced through the existing participant operation failure path and control evidence. Do not leak raw provider output, parser traces, or the full prompt body in diagnostics. |
+| Persistence and evidence | Preserve `solicitation_fingerprint()` over the authoritative full delivered solicitation and retain the selected delivered candidate digest/ref. If compact transport metadata is persisted, record it as supplemental transport evidence tied to the same run/episode/solicitation ids, never as a replacement authority. |
+| API/CLI ingress | This change adds no new ingress. Existing CLI/operator boundaries remain unchanged. Do not add an operator override to pass raw compacted candidate payloads or choose alternate transport modes at runtime. |
+
+## Extensibility seam
+
+The seam belongs at the installed-provider transport boundary:
+
+`(authoritative_solicitation, compact_representation, compact_id ↔ delivered proposal_ref mapping, size_limit_bytes_or_chars, provider_parser)`
+
+The compact mapping is derived and ephemeral. It must not contain new semantic
+fields, duplicated governed argument schemas, or realization data not already
+present in the delivered surface. The next reasonable variation is another
+provider with a different safe prompt budget; that should require only a
+different limit/parser policy at this seam, not changes to RAES projection,
+candidate enumeration, evidence schema, or native action handlers.
+
+## Whole-repository surface in scope
+
+- `src/aptl/backends/raes_participant_provider.py`
+- `src/aptl/backends/raes_participant_driver.py`
+- `src/aptl/backends/raes_participant_runtime.py`
+- `src/aptl/backends/raes_participant_control_evidence.py`
+- `src/aptl/backends/raes_participant_candidates.py`
+- `src/aptl/validation/participant_agency_readiness.py`
+- `src/aptl/validation/participant_agency_qualification.py`
+- `src/aptl/validation/participant_qualification_boundaries.py`
+- `src/aptl/validation/participant_readiness_provider.py`
+- `src/aptl/workbench/{runtime,agent,codex_agent,process}.py`
+- `tests/test_bounded_participant_runtime.py` and related participant
+  qualification/readiness tests
+- existing issue-557 / issue-821 architecture notes and ADR-029/033/044/046/049
+
+## Gotchas and anti-patterns
+
+- Do not send the full authoritative candidate JSON through the provider prompt
+  and separately add a compact alias layer; that keeps the original overflow and
+  adds concept confusion.
+- Do not admit a provider response by reconstructing a near-match from
+  user-visible fields. Admission must resolve to one exact delivered candidate,
+  not “best effort” semantic equivalence.
+- Do not replace `proposal_ref` with a new permanent identifier or infer
+  selected identity from list position alone without a fail-closed mapping.
+- Do not duplicate `ParticipantDecisionSurfaceSelectionV2Model`,
+  governed-argument validators, or `resolve_participant_action_arguments()` in
+  APTL transport code.
+- Do not move compaction into scenario authoring, RAES model compilation, native
+  action handlers, or evidence publication. The change belongs at provider
+  solicitation and its immediate parser/mapping boundary.
+- Do not weaken out-of-set rejection merely because a compact token decodes to a
+  valid action name. Membership is against the delivered candidate set for that
+  exact state cut.
+- Do not log or persist the full provider prompt body, raw provider response, or
+  hidden evaluator context as a debugging shortcut. Keep evidence digest-based
+  and redacted unless existing authoritative records already retain the allowed
+  content.
+- Do not tune transport size by dropping candidates from large red/blue surfaces.
+  Candidate-count reduction changes the experiment and is out of scope.
+
+## Non-goals and boundaries
+
+This issue does not redesign RAES decision-surface projection, candidate
+enumeration, participant apparatus/exposure policy, native realizations,
+participant workbench routing, provider credential brokerage, or run-store
+layout. It does not add a new API route, CLI option, config file schema,
+scenario syntax, evidence store, logger, exception hierarchy, or admission
+workflow. It does not change the authoritative delivered candidate set, only
+how that set is compactly represented to an installed decision-only provider.

--- a/docs/architecture/issue-859-idempotent-stuttering-preflight.md
+++ b/docs/architecture/issue-859-idempotent-stuttering-preflight.md
@@ -1,0 +1,139 @@
+# Issue #859 Idempotent Stuttering Preflight
+
+This note fixes the architecture guardrails for truthful idempotent
+participant-action outcomes in bounded participant realizations. It is design
+guidance, not an implementation plan. No new ADR is needed:
+[ADR-029](../adrs/adr-029-control-plane-secret-handling.md),
+[ADR-033](../adrs/adr-033-agent-reasoning-trace-boundary.md),
+[ADR-044](../adrs/adr-044-raes-aligned-run-reproducibility-record.md),
+[ADR-046](../adrs/adr-046-dynamic-raes-scenario-realization.md),
+[ADR-049](../adrs/adr-049-sealed-disposable-lab-appliance.md), and the
+existing participant preflights already own the relevant runtime, evidence,
+secret, and appliance boundaries.
+
+## Architecture Decisions
+
+- Keep semantic truth in the verified native operation. The closed native
+  handler remains the only owner of whether the requested postcondition was
+  independently established. `VerifiedParticipantOperation.success`,
+  `established_preconditions`, `established_effects`, `pre_state`,
+  `post_state`, and `state_changed` remain the truth surface; digest inequality
+  is evidence of mutation, not the success criterion.
+- Keep mutation policy explicit and per realization. Extend the incumbent
+  `ParticipantActionRealization` record so it separates `mutates_state` from
+  `allows_idempotent_stutter`; that record is the correct seam. Do not infer
+  stutter permission from provider identity, behavior name, scenario name,
+  action text, or digest equality alone.
+- Keep fail-closed mutation enforcement after semantic readback. A successful
+  native observation may remain a terminal failure when the realization policy
+  is contradicted: undeclared no-change mutations still fail closed for
+  `mutates_state=True` plus `allows_idempotent_stutter=False`, and undeclared
+  state changes still fail closed for `mutates_state=False`.
+- Keep participant-visible authority unchanged. The participant still receives
+  the same RAES-selected action surface and the same `ParticipantActionResult`
+  semantics. Mutation-versus-stutter policy is evaluator/control evidence, not
+  participant action authority.
+- Keep truthful digests and history on permitted stutters. When a realization
+  declares stuttering success and the postcondition is independently verified,
+  the accepted record must preserve the real pre/post digests,
+  `state_changed: false`, established preconditions/effects, and the existing
+  portable attempted/transition/observation history sequence.
+- Keep success/failure taxonomy incumbent. Failed postcondition verification,
+  unmet prerequisites, unsupported arguments, malformed provider output, and
+  backend failures continue to use the existing failure classes and RAES
+  operation/evidence pathways. This issue does not add a new exception family,
+  readiness state, or participant outcome category.
+
+No ADR is needed. This change tightens the meaning of an existing realization
+policy field and its evidence path; it does not change the durable product
+architecture.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical owner and required reuse |
+| --- | --- |
+| Per-action mutation policy | `src/aptl/backends/raes_participant_realizations.py` owns the closed realization registry, `ParticipantActionRealization`, and `mutates_state`. Add `allows_idempotent_stutter` there and keep policy declaration at that seam. |
+| Semantic truth and readback | `src/aptl/backends/raes_participant_fixture_core.py` owns `VerifiedParticipantOperation`, canonical pre/post state digests, `state_changed`, and established precondition/effect reporting. Native handlers continue to prove effects by separate semantic readback, not by command success or declared intent. |
+| Policy enforcement | `src/aptl/backends/raes_participant_realization_execution.py` owns `_enforce_mutation_claim()` and the conversion from verified native observation to accepted or rejected native execution. Keep the fail-closed contradiction check here rather than duplicating it in handlers, readiness, or qualification code. |
+| RAES admission and history | `src/aptl/backends/raes_participant_runtime.py`, `src/aptl/backends/raes_participant_driver.py`, `BaseParticipantRuntime.admit_action()`, and `ParticipantNativeActionExecution` own the attempted/transition/observation commit path. Do not rebuild history logic for stutters. |
+| Evidence and persistence | `src/aptl/backends/raes_participant_realization_execution.py`, `src/aptl/backends/raes_participant_evidence_publication.py`, `src/aptl/backends/raes_participant_control_evidence.py`, and `RunStorageBackend` own evaluator/participant records, immutable transaction publication, and recoverable JSONL projections. Reuse the existing evidence schemas; extend the incumbent action-evidence record only if additional mutation-policy disclosure is necessary. |
+| Qualification/readiness | `src/aptl/validation/participant_agency_readiness.py`, `src/aptl/validation/participant_agency_qualification.py`, `src/aptl/validation/participant_readiness_provider.py`, and `tests/test_bounded_participant_runtime.py` own the end-to-end readiness and qualification contract. Reuse those suites instead of adding ad hoc probes or a parallel qualification harness. |
+| Logging and diagnostics | Existing RAES `Diagnostic`, participant `failure_class`, `ApplyResult`, `OperationState`, `get_logger()`, and `redact()` remain the observability vocabulary. Do not create a second mutation-policy diagnostic format or exception hierarchy. |
+
+Do not add a second mutation-policy DTO, a duplicate state-change validator, a
+second evidence schema for semantic digests, another participant failure
+taxonomy, or a behavior-name/provider-name branch that decides stutter policy.
+
+## Security And Validation Passage
+
+| Layer | Required behavior |
+| --- | --- |
+| RAES action admission and governed-argument validation | The action still enters through the existing exact-cut projection, delivered candidate, and RAES admission path. `resolve_participant_action_arguments()` and the existing binder remain the only governed-argument authority. This issue does not widen the action surface or add a bypass around RAES request validation. |
+| Closed realization registry | Stutter permission is code-owned closed data in `BPA_ACTION_REALIZATIONS`. Keep it out of scenario names, provider config, prompt text, `.env`, CLI flags, run-store payload overrides, or participant-visible transport. |
+| Native handler boundary | Handlers continue to receive only resolved governed arguments and realized targets. They may observe and mutate only the contract-specific synthetic state they already own. No new shell, Docker, SSH, network, or provider authority is introduced. |
+| Semantic-state digest and readback shaping | The canonical digest remains `_mapping_digest()` over the verified pre/post state maps. Do not add a second digest algorithm, lossy projection, or synthetic “mutation token” to decide success. Exact pre/post state maps remain the source of the digest and of `state_changed`. |
+| Error envelope and leakage | Contradictions between declared mutation policy and observed semantics still fail through existing `failure_class="backend_error"` and RAES operation diagnostics. Do not leak raw backend stderr, handler internals, provider output, hidden evaluator truth, or unredacted state payloads into participant-visible observations or diagnostics. |
+| Persistence and evidence | Accepted stutters must persist the truthful digests, `state_changed: false`, established preconditions/effects, and the declared policy flags through the existing action transaction and evaluator projection. Rejected undeclared stutters still retain the existing failure path and must not be silently rewritten as success during publication or readiness summarization. |
+| OS/process exposure | No new OS/process surface is needed. Existing private `/run/aptl` episode state, fixed argv, stdin prompt delivery, bounded child environment, and run-store write paths remain unchanged. This issue must not move semantic state, digests, or policy through argv, environment variables, or filenames. |
+
+## Extensibility Seam
+
+The seam belongs on the incumbent closed realization policy:
+
+`(action_contract_address, operation, target_nodes, mutates_state, allows_idempotent_stutter, observer_kind)`
+
+That is the next-change-friendly parameterization. If a future action needs a
+stricter or richer mutation policy, extend this closed realization record and
+keep `_enforce_mutation_claim()` as the single enforcement point. Do not
+distribute policy across handlers, readiness heuristics, provider parsers, or
+evidence post-processors.
+
+## Whole-Repository Surface In Scope
+
+- `src/aptl/backends/raes_participant_realizations.py`
+- `src/aptl/backends/raes_participant_realization_execution.py`
+- `src/aptl/backends/raes_participant_fixture_core.py`
+- `src/aptl/backends/raes_participant_runtime.py`
+- `src/aptl/backends/raes_participant_driver.py`
+- `src/aptl/backends/raes_participant_evidence_publication.py`
+- `src/aptl/backends/raes_participant_control_evidence.py`
+- `src/aptl/validation/participant_agency_readiness.py`
+- `src/aptl/validation/participant_agency_qualification.py`
+- `src/aptl/validation/participant_readiness_provider.py`
+- `docs/raes/bounded-participant-agency-readiness.md`
+- `tests/test_bounded_participant_runtime.py`
+- existing participant preflights and ADR-029/033/044/046/049
+
+## Gotchas And Anti-Patterns
+
+- Do not equate “success” with `post_state_digest != pre_state_digest`. That is
+  exactly the hidden deterministic-progression assumption this issue must
+  remove.
+- Do not infer stutter permission from provider identity, behavior name,
+  scenario name, action summary text, or whether the same arguments were
+  repeated.
+- Do not move mutation-policy checks into the provider boundary, readiness
+  reporter, qualification summarizer, or evidence publication layer. Those
+  layers may report policy, but they must not become the authority that decides
+  whether the semantic result is acceptable.
+- Do not fabricate a changed digest, synthetic nonce, or extra state field to
+  force repeated success paths to look mutating.
+- Do not accept an undeclared no-change result merely because the action is
+  usually idempotent. Default remains fail closed unless the closed realization
+  explicitly declares `allows_idempotent_stutter=True`.
+- Do not collapse precondition failure, postcondition failure, unsupported
+  arguments, and backend contradiction into one generic “stutter” bucket.
+- Do not add duplicate evidence schemas, duplicate validation helpers, or a new
+  exception hierarchy for mutation-policy mismatches.
+
+## Non-Goals And Boundaries
+
+This issue does not redesign RAES decision-surface projection, provider
+solicitation, action admission, participant visibility, run-store layout,
+episode lifecycle, or the closed synthetic handler model. It does not add a
+new API route, CLI flag, scenario field, config schema, prompt instruction,
+logger, exception type, or persistence backend. It does not make read-only
+actions mutating, and it does not relax backend/postcondition/precondition
+failures into successful outcomes. The scope is limited to truthful
+representation of declared idempotent stuttering within the existing bounded
+participant realization and evidence pipeline.

--- a/docs/raes/bounded-participant-agency-readiness.md
+++ b/docs/raes/bounded-participant-agency-readiness.md
@@ -88,11 +88,19 @@ credential lease:
 
 The child receives no action tools, MCP servers, shell, Docker, SSH, browser,
 or backend handle. It only chooses one complete candidate from the delivered
-RAES decision surface. Each finite governed choice is represented by a
-distinct proposal, and the selected values materially determine the native
-semantic operation and independent readback. RAES re-resolves the exact state
-cut, delivery, apparatus, and governed arguments before APTL can execute a
-closed realization.
+RAES decision surface. APTL presents the installed provider with a bounded,
+numbered transport view containing every action identity and governed argument
+map. The number is a transient alias for one delivered `proposal_ref`; APTL
+resolves it to the unchanged full selection before RAES admission. The complete
+delivered solicitation remains the evidence authority.
+
+Each finite governed choice is represented by a distinct proposal, and the
+selected values materially determine the native semantic operation and
+independent readback. RAES re-resolves the exact state cut, delivery,
+apparatus, proposal, and governed arguments before APTL can execute a closed
+realization. Missing, malformed, duplicate, or out-of-range transport choices
+fail before admission. Installed-provider prompts remain bounded to 32,768
+characters.
 
 Run each implementation separately:
 

--- a/src/aptl/backends/raes_participant_provider.py
+++ b/src/aptl/backends/raes_participant_provider.py
@@ -181,7 +181,7 @@ def _parse_compact_selection(raw: str, *, candidate_count: int) -> int:
         raise ValueError("compact participant selection envelope is invalid")
     try:
         payload = json.loads(raw, object_pairs_hook=_unique_json_object)
-    except (json.JSONDecodeError, ValueError) as exc:
+    except ValueError as exc:
         raise ValueError("compact participant selection is not valid JSON") from exc
     if not isinstance(payload, Mapping) or set(payload) != {"candidate"}:
         raise ValueError("compact participant selection must contain one candidate")

--- a/src/aptl/backends/raes_participant_provider.py
+++ b/src/aptl/backends/raes_participant_provider.py
@@ -83,32 +83,127 @@ class ManagedAgentSelectionProvider:
         return self._implementation_version
 
     def select(self, solicitation: ParticipantDecisionSolicitation) -> str:
-        prompt = json.dumps(
-            {
-                "instruction": (
-                    "Choose one candidate that advances the visible task. "
-                    "Return exactly that candidate JSON object with no prose, "
-                    "markdown, or additional keys. You do not execute actions."
-                ),
-                "participant_view": dict(solicitation.participant_view),
-                "rendered_context": [
-                    dict(item) for item in solicitation.rendered_context
-                ],
-                "observation_history": [
-                    dict(item) for item in solicitation.observation_history
-                ],
-                "candidate_selections": [
-                    dict(candidate)
-                    for candidate in solicitation.candidate_selections
-                ],
-            },
-            separators=(",", ":"),
-            sort_keys=True,
+        prompt, aliases = _compact_selection_prompt(solicitation)
+        raw_selection = self._adapter.respond(self._handle, prompt)
+        candidate_number = _parse_compact_selection(
+            raw_selection,
+            candidate_count=len(aliases),
         )
-        return self._adapter.respond(self._handle, prompt)
+        proposal_ref = aliases[candidate_number]
+        candidate = solicitation.candidate_selections[candidate_number]
+        if candidate.get("proposal_ref") != proposal_ref:
+            raise ValueError(
+                "compact participant selection did not resolve to its "
+                "delivered proposal"
+            )
+        return json.dumps(candidate, separators=(",", ":"), sort_keys=True)
 
     def close(self) -> None:
         self._adapter.close(self._handle)
+
+
+def _compact_selection_prompt(
+    solicitation: ParticipantDecisionSolicitation,
+) -> tuple[str, tuple[str, ...]]:
+    """Render every delivered choice without repeating trusted coordinates."""
+
+    actions: list[str] = []
+    action_indexes: dict[str, int] = {}
+    candidates: list[list[object]] = []
+    aliases: list[str] = []
+    alias_set: set[str] = set()
+    for candidate_number, candidate in enumerate(
+        solicitation.candidate_selections
+    ):
+        address = candidate.get("action_contract_address")
+        proposal_ref = candidate.get("proposal_ref")
+        arguments = candidate.get("arguments")
+        if (
+            not isinstance(address, str)
+            or not address
+            or not isinstance(proposal_ref, str)
+            or not proposal_ref
+            or not isinstance(arguments, Mapping)
+            or proposal_ref in alias_set
+        ):
+            raise ValueError(
+                "compact participant selection candidates are invalid or ambiguous"
+            )
+        action_number = action_indexes.get(address)
+        if action_number is None:
+            action_number = len(actions)
+            action_indexes[address] = action_number
+            actions.append(address)
+        aliases.append(proposal_ref)
+        alias_set.add(proposal_ref)
+        candidates.append(
+            [
+                candidate_number,
+                action_number,
+                dict(arguments),
+            ]
+        )
+    if not candidates:
+        raise ValueError("compact participant selection has no candidates")
+    prompt = json.dumps(
+        {
+            "instruction": (
+                "Choose one candidate that advances the visible task. "
+                'Return exactly {"candidate":N}, where N is one candidate '
+                "number from the delivered list. Return no prose, markdown, "
+                "or additional keys. You do not execute actions."
+            ),
+            "participant_view": dict(solicitation.participant_view),
+            "rendered_context": [
+                dict(item) for item in solicitation.rendered_context
+            ],
+            "observation_history": [
+                dict(item) for item in solicitation.observation_history
+            ],
+            "candidate_encoding": [
+                "candidate",
+                "action",
+                "arguments",
+            ],
+            "actions": actions,
+            "candidates": candidates,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return prompt, tuple(aliases)
+
+
+def _parse_compact_selection(raw: str, *, candidate_count: int) -> int:
+    """Parse exactly one transient alias into the delivered candidate tuple."""
+
+    if not isinstance(raw, str) or not raw or len(raw) > 128_000:
+        raise ValueError("compact participant selection envelope is invalid")
+    try:
+        payload = json.loads(raw, object_pairs_hook=_unique_json_object)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ValueError("compact participant selection is not valid JSON") from exc
+    if not isinstance(payload, Mapping) or set(payload) != {"candidate"}:
+        raise ValueError("compact participant selection must contain one candidate")
+    candidate_number = payload["candidate"]
+    if (
+        type(candidate_number) is not int
+        or candidate_number < 0
+        or candidate_number >= candidate_count
+    ):
+        raise ValueError("compact participant selection candidate is out of range")
+    return candidate_number
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """Reject duplicate JSON members before an alias can become authority."""
+
+    result: dict[str, object] = {}
+    for name, value in pairs:
+        if name in result:
+            raise ValueError("compact participant selection contains duplicate keys")
+        result[name] = value
+    return result
 
 
 def parse_provider_selection(

--- a/src/aptl/backends/raes_participant_realization_execution.py
+++ b/src/aptl/backends/raes_participant_realization_execution.py
@@ -187,6 +187,7 @@ def _enforce_mutation_claim(
         observation.success
         and realization.mutates_state
         and not observation.state_changed
+        and not realization.allows_idempotent_stutter
     ):
         contradiction = (
             "trusted semantic readback did not observe the declared state change",
@@ -278,6 +279,9 @@ def _action_evidence_record(
         "target_refs": list(context.realization.target_nodes),
         "observer_kind": context.realization.observer_kind,
         "mutates_state": context.realization.mutates_state,
+        "allows_idempotent_stutter": (
+            context.realization.allows_idempotent_stutter
+        ),
         "pre_state_digest": observation.pre_state_digest,
         "post_state_digest": observation.post_state_digest,
         "state_changed": observation.state_changed,

--- a/src/aptl/backends/raes_participant_realizations.py
+++ b/src/aptl/backends/raes_participant_realizations.py
@@ -56,6 +56,7 @@ class ParticipantActionRealization:
     operation: ParticipantOperation
     target_nodes: tuple[str, ...]
     mutates_state: bool
+    allows_idempotent_stutter: bool
     observer_kind: str
 
 
@@ -82,6 +83,7 @@ def _action(
     nodes: tuple[str, ...],
     *,
     mutates_state: bool = False,
+    allows_idempotent_stutter: bool = False,
     observer: str = "bounded-observation",
 ) -> ParticipantActionRealization:
     """Build the internal operation for the bounded participant workflow."""
@@ -91,6 +93,7 @@ def _action(
         operation=operation,
         target_nodes=nodes,
         mutates_state=mutates_state,
+        allows_idempotent_stutter=allows_idempotent_stutter,
         observer_kind=observer,
     )
 
@@ -102,6 +105,7 @@ _BPA_ACTIONS = (
         ParticipantOperation.SYNTHETIC_SESSION,
         ("webapp", "db"),
         mutates_state=True,
+        allows_idempotent_stutter=True,
         observer="session-pre-post",
     ),
     _action("view-permitted-account", ParticipantOperation.CUSTOMER_STATE, ("db",)),
@@ -118,6 +122,7 @@ _BPA_ACTIONS = (
         ParticipantOperation.CUSTOMER_STATE,
         ("db",),
         mutates_state=True,
+        allows_idempotent_stutter=True,
         observer="profile-and-protected-fields-pre-post",
     ),
     _action(
@@ -131,6 +136,7 @@ _BPA_ACTIONS = (
         ParticipantOperation.SUPPORT_STATE,
         ("db",),
         mutates_state=True,
+        allows_idempotent_stutter=True,
         observer="support-request-pre-post",
     ),
     _action("inspect-own-support-request", ParticipantOperation.SUPPORT_STATE, ("db",)),
@@ -139,6 +145,7 @@ _BPA_ACTIONS = (
         ParticipantOperation.SUPPORT_STATE,
         ("db",),
         mutates_state=True,
+        allows_idempotent_stutter=True,
         observer="support-note-pre-post",
     ),
     _action(
@@ -149,6 +156,7 @@ _BPA_ACTIONS = (
         ParticipantOperation.PUBLIC_HTTP,
         ("kali", "webapp"),
         mutates_state=True,
+        allows_idempotent_stutter=True,
         observer="request-and-response-pre-post",
     ),
     _action("inspect-response-metadata", ParticipantOperation.PUBLIC_HTTP, ("kali",)),
@@ -157,6 +165,7 @@ _BPA_ACTIONS = (
         ParticipantOperation.SYNTHETIC_AUTH,
         ("kali", "webapp", "defender-console"),
         mutates_state=True,
+        allows_idempotent_stutter=True,
         observer="authentication-and-telemetry-pre-post",
     ),
     _action("inspect-auth-outcome", ParticipantOperation.SYNTHETIC_AUTH, ("kali",)),
@@ -190,6 +199,7 @@ _BPA_ACTIONS = (
         ParticipantOperation.ALERT_STATE,
         ("event-store",),
         mutates_state=True,
+        allows_idempotent_stutter=True,
         observer="alert-classification-pre-post",
     ),
     _action(
@@ -207,6 +217,7 @@ _BPA_ACTIONS = (
         ParticipantOperation.RESPONSE_STATE,
         ("webapp", "event-store"),
         mutates_state=True,
+        allows_idempotent_stutter=True,
         observer="response-target-and-unrelated-state-pre-post",
     ),
     _action(

--- a/src/aptl/validation/participant_readiness_provider.py
+++ b/src/aptl/validation/participant_readiness_provider.py
@@ -23,6 +23,7 @@ _PROVIDER_VERSION_ENVIRONMENT = {
     "NO_COLOR": "1",
 }
 _INSTALLED_VERSION_UNAVAILABLE = "installed participant provider version is unavailable"
+MAX_INSTALLED_PARTICIPANT_PROMPT_CHARS = 32_768
 
 
 def build_selection_provider(
@@ -100,11 +101,13 @@ def _launch_adapter(
             claude_executable=executable,
             work_dir=work_dir,
             timeout_seconds=MAX_PARTICIPANT_DECISION_SECONDS,
+            max_prompt_chars=MAX_INSTALLED_PARTICIPANT_PROMPT_CHARS,
         )
     return CodexManagedAgentAdapter(
         codex_executable=executable,
         work_dir=work_dir,
         timeout_seconds=MAX_PARTICIPANT_DECISION_SECONDS,
+        max_prompt_chars=MAX_INSTALLED_PARTICIPANT_PROMPT_CHARS,
     )
 
 

--- a/tests/test_bounded_participant_runtime.py
+++ b/tests/test_bounded_participant_runtime.py
@@ -435,12 +435,13 @@ def test_invalid_compact_selection_fails_before_admission_or_realization(
         episode_id="invalid-compact-selection",
     )
     provider, _ = _managed_provider('{"candidate":201}')
+    apparatus = _apparatus(participant)
 
     with pytest.raises(ValueError, match="participant selection operation failed"):
         run_participant_turn(
             control,
             behavior_specification_address=behavior,
-            apparatus=_apparatus(participant),
+            apparatus=apparatus,
             provider=provider,
         )
 

--- a/tests/test_bounded_participant_runtime.py
+++ b/tests/test_bounded_participant_runtime.py
@@ -24,6 +24,7 @@ from aptl.backends.raes_participant_driver import (
 )
 from aptl.backends.raes_participant_provider import (
     DeterministicSelectionProvider,
+    ManagedAgentSelectionProvider,
     ParticipantDecisionSolicitation,
     candidate_payloads,
 )
@@ -276,6 +277,224 @@ def _apparatus(participant_address: str):
     )
 
 
+def _run_selected_action(
+    control: AptlParticipantControlPlane,
+    model: object,
+    *,
+    behavior_address: str,
+    participant_address: str,
+    action_name: str,
+):
+    """Run one named delivered action through the production participant path."""
+
+    apparatus = _apparatus(participant_address)
+    turn = project_participant_turn(
+        runtime_model=model,
+        runtime_snapshot=control.snapshot,
+        behavior_specification_address=behavior_address,
+        apparatus=apparatus,
+    )
+    candidate_index = next(
+        index
+        for index, candidate in enumerate(turn.candidates)
+        if candidate.action_contract_address.endswith(f".{action_name}")
+    )
+    return run_participant_turn(
+        control,
+        behavior_specification_address=behavior_address,
+        apparatus=apparatus,
+        provider=DeterministicSelectionProvider(candidate_index=candidate_index),
+    )
+
+
+def _solicitation_for_behavior(
+    tmp_path: Path,
+    behavior_address: str,
+) -> ParticipantDecisionSolicitation:
+    control, model, _, _ = _runtime(tmp_path)
+    participant = _participant_for(model, behavior_address)
+    episode_id = f"managed-{behavior_address.rsplit('.', 1)[-1]}"
+    control.initialize_participant_episode(participant, episode_id=episode_id)
+    turn = project_participant_turn(
+        runtime_model=model,
+        runtime_snapshot=control.snapshot,
+        behavior_specification_address=behavior_address,
+        apparatus=_apparatus(participant),
+    )
+    view = turn.surface.participant_view
+    return ParticipantDecisionSolicitation(
+        participant_address=participant,
+        episode_id=episode_id,
+        solicitation_id="participant-selection-solicitations.managed-1",
+        participant_view=view.model_dump(mode="json"),
+        rendered_context=turn.rendered_context,
+        observation_history=turn.observation_history,
+        candidate_selections=candidate_payloads(turn.candidates),
+    )
+
+
+class _ManagedResponseAdapter:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.messages: list[str] = []
+
+    def respond(self, _handle: object, message: str) -> str:
+        self.messages.append(message)
+        return self.response
+
+    def close(self, _handle: object) -> None:
+        return None
+
+
+def _managed_provider(
+    response: str,
+) -> tuple[ManagedAgentSelectionProvider, _ManagedResponseAdapter]:
+    adapter = _ManagedResponseAdapter(response)
+    provider = ManagedAgentSelectionProvider(
+        adapter=adapter,
+        handle=object(),
+        implementation_name="managed-test-provider",
+        implementation_version="1.0.0",
+    )
+    return provider, adapter
+
+
+def test_managed_provider_compacts_large_surface_and_maps_exact_candidate(
+    tmp_path: Path,
+) -> None:
+    solicitation = _solicitation_for_behavior(
+        tmp_path,
+        "participant.behavior-specification.triage-authentication-event",
+    )
+    assert len(solicitation.candidate_selections) == 201
+    provider, adapter = _managed_provider('{"candidate":200}')
+
+    selection = json.loads(provider.select(solicitation))
+
+    assert selection == solicitation.candidate_selections[200]
+    prompt = json.loads(adapter.messages[0])
+    assert len(adapter.messages[0]) <= (
+        participant_readiness_provider.MAX_INSTALLED_PARTICIPANT_PROMPT_CHARS
+    )
+    assert "candidate_selections" not in prompt
+    assert prompt["candidate_encoding"] == [
+        "candidate",
+        "action",
+        "arguments",
+    ]
+    assert len(prompt["candidates"]) == len(solicitation.candidate_selections)
+    assert {
+        prompt["actions"][candidate[1]]
+        for candidate in prompt["candidates"]
+    } == {
+        item["action_contract_address"]
+        for item in solicitation.candidate_selections
+    }
+    assert {
+        candidate[0] for candidate in prompt["candidates"]
+    } == set(range(len(solicitation.candidate_selections)))
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "",
+        "not-json",
+        "[]",
+        "{}",
+        '{"candidate":true}',
+        '{"candidate":"0"}',
+        '{"candidate":-1}',
+        '{"candidate":201}',
+        '{"candidate":0,"extra":1}',
+        '{"candidate":0,"candidate":1}',
+    ],
+)
+def test_managed_provider_rejects_invalid_compact_selections(
+    tmp_path: Path,
+    response: str,
+) -> None:
+    solicitation = _solicitation_for_behavior(
+        tmp_path,
+        "participant.behavior-specification.triage-authentication-event",
+    )
+    provider, _ = _managed_provider(response)
+
+    with pytest.raises(ValueError, match="compact participant selection"):
+        provider.select(solicitation)
+
+
+def test_invalid_compact_selection_fails_before_admission_or_realization(
+    tmp_path: Path,
+) -> None:
+    control, model, backend, store = _runtime(tmp_path)
+    behavior = "participant.behavior-specification.triage-authentication-event"
+    participant = _participant_for(model, behavior)
+    control.initialize_participant_episode(
+        participant,
+        episode_id="invalid-compact-selection",
+    )
+    provider, _ = _managed_provider('{"candidate":201}')
+
+    with pytest.raises(ValueError, match="participant selection operation failed"):
+        run_participant_turn(
+            control,
+            behavior_specification_address=behavior,
+            apparatus=_apparatus(participant),
+            provider=provider,
+        )
+
+    assert control.snapshot.participant_behavior_history == {}
+    assert backend.calls == []
+    record = json.loads(
+        (
+            store.get_run_path("readiness-run")
+            / "evaluator/participant-control-evidence.jsonl"
+        ).read_text()
+    )
+    assert record["solicitation_state"] == "failed"
+    assert record["admission_operation_id"] is None
+    assert record["selected_action_contract_address"] is None
+
+
+def test_installed_provider_adapters_use_the_bounded_choice_prompt_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[dict[str, object]] = []
+
+    class _Adapter:
+        def __init__(self, **kwargs: object) -> None:
+            captured.append(kwargs)
+
+    monkeypatch.setattr(
+        participant_readiness_provider,
+        "ClaudeCodeManagedAgentAdapter",
+        _Adapter,
+    )
+    monkeypatch.setattr(
+        participant_readiness_provider,
+        "CodexManagedAgentAdapter",
+        _Adapter,
+    )
+
+    participant_readiness_provider._launch_adapter(
+        "claude",
+        tmp_path / "claude",
+        tmp_path / "claude-work",
+    )
+    participant_readiness_provider._launch_adapter(
+        "codex",
+        tmp_path / "codex",
+        tmp_path / "codex-work",
+    )
+
+    assert [item["max_prompt_chars"] for item in captured] == [
+        participant_readiness_provider.MAX_INSTALLED_PARTICIPANT_PROMPT_CHARS,
+        participant_readiness_provider.MAX_INSTALLED_PARTICIPANT_PROMPT_CHARS,
+    ]
+
+
 def test_all_nine_behaviors_project_the_exact_compiled_action_sets(
     tmp_path: Path,
 ) -> None:
@@ -468,6 +687,100 @@ def test_each_governed_variant_changes_the_verified_native_semantics(
             )
             digests.add(digest)
         assert len(digests) == len(candidates)
+
+
+def test_participant_pipeline_accepts_only_declared_idempotent_stutters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    behavior = "participant.behavior-specification.complete-normal-session"
+    action_name = "authenticate-synthetic-user"
+    action_address = f"participant.action-contract.{action_name}"
+
+    control, model, _, store = _runtime(tmp_path / "permitted")
+    participant = _participant_for(model, behavior)
+    control.initialize_participant_episode(
+        participant,
+        episode_id="permitted-idempotent-stutter",
+    )
+    for _ in range(2):
+        outcome = _run_selected_action(
+            control,
+            model,
+            behavior_address=behavior,
+            participant_address=participant,
+            action_name=action_name,
+        )
+        assert (
+            control.get_operation(outcome.admission_receipt.operation_id).state
+            is OperationState.SUCCEEDED
+        )
+
+    evidence_path = (
+        store.get_run_path("readiness-run")
+        / "evaluator/participant-action-evidence.jsonl"
+    )
+    evidence = [
+        json.loads(line) for line in evidence_path.read_text().splitlines()
+    ]
+    assert [record["state_changed"] for record in evidence] == [True, False]
+    assert evidence[-1]["allows_idempotent_stutter"] is True
+    assert evidence[-1]["status"] == "succeeded"
+    assert (
+        control.snapshot.participant_behavior_history[participant][-1][
+            "action_result"
+        ]["status"]
+        == "succeeded"
+    )
+
+    strict_realization = replace(
+        BPA_ACTION_REALIZATIONS[action_address],
+        allows_idempotent_stutter=False,
+    )
+    monkeypatch.setattr(
+        raes_participant_realizations,
+        "BPA_ACTION_REALIZATIONS",
+        {
+            **BPA_ACTION_REALIZATIONS,
+            action_address: strict_realization,
+        },
+    )
+    assert (
+        BPA_ACTION_REALIZATIONS[
+            "participant.action-contract.sign-out-session"
+        ].allows_idempotent_stutter
+        is False
+    )
+
+    control, model, _, store = _runtime(tmp_path / "strict")
+    participant = _participant_for(model, behavior)
+    control.initialize_participant_episode(
+        participant,
+        episode_id="undeclared-idempotent-stutter",
+    )
+    for _ in range(2):
+        _run_selected_action(
+            control,
+            model,
+            behavior_address=behavior,
+            participant_address=participant,
+            action_name=action_name,
+        )
+
+    evidence_path = (
+        store.get_run_path("readiness-run")
+        / "evaluator/participant-action-evidence.jsonl"
+    )
+    evidence = [
+        json.loads(line) for line in evidence_path.read_text().splitlines()
+    ]
+    assert [record["state_changed"] for record in evidence] == [True, False]
+    assert evidence[-1]["allows_idempotent_stutter"] is False
+    assert evidence[-1]["status"] == "failed"
+    assert evidence[-1]["failure_class"] == "backend_error"
+    terminal = control.snapshot.participant_behavior_history[participant][-1]
+    assert terminal["action_result"]["status"] == "failed"
+    assert terminal["action_result"]["failure_class"] == "backend_error"
 
 
 def test_provider_invocation_is_a_raes_operation_and_admission_commits_history(
@@ -847,6 +1160,13 @@ def test_all_26_action_realizations_execute_through_raes_v2(
         record["action_contract_address"] for record in evaluator_records
     } == EXPECTED_ACTION_ADDRESSES
     assert all(set(record["target_refs"]) <= set(NODES) for record in evaluator_records)
+    assert all(
+        record["allows_idempotent_stutter"]
+        is BPA_ACTION_REALIZATIONS[
+            record["action_contract_address"]
+        ].allows_idempotent_stutter
+        for record in evaluator_records
+    )
     touched_containers = {name for name, _ in backend.calls}
     assert {
         "aptl-webapp",


### PR DESCRIPTION
## Summary

Preserve every delivered RAES participant choice through a bounded installed-provider transport, and represent independently verified idempotent action stutters truthfully. This also resolves the execution gap tracked in #859.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #858

## ADR Impact

- ADR-021
- ADR-029
- ADR-033
- ADR-044
- ADR-046
- ADR-049

## Changes

- Map compact transient candidate numbers back to unchanged delivered proposals before RAES admission, with strict hostile-output parsing and a code-owned prompt bound.
- Declare idempotent-stutter policy per closed realization and retain truthful mutation-policy evidence without weakening semantic readback.
- Document both architecture boundaries and add production-path regression coverage for accepted and rejected stutters.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Focused participant runtime/workbench tests passed. The configured completion suite, TechVault integration gate, repository policy gate, and pre-commit suite passed. A live installed-provider qualification completed green, red, and blue episodes with eight admitted actions each; all deterministic paths, full 26-action coverage, and boundary challenges BC-01 through BC-10 passed with official capture disabled.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #858 ← src/aptl/backends/raes_participant_provider.py, #859 ← src/aptl/backends/raes_participant_realizations.py, #859 ← src/aptl/backends/raes_participant_realization_execution.py
- TESTS: #858 ← tests/test_bounded_participant_runtime.py, #859 ← tests/test_bounded_participant_runtime.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.