### PR TITLE
feat(workshop): add hosted backup seat runbook

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -174,3 +174,4 @@ The victim and kali containers publish no host ports; use
 - [Issue #821 In-Appliance Participant Workbench](issue-821-participant-workbench-preflight.md)
 - [Issue #823 Versioned Disposable Lab Appliance](issue-823-versioned-disposable-appliance-preflight.md)
 - [Issue #824 Kiosk Launcher, Reset, And Recovery](issue-824-kiosk-launcher-reset-recovery-preflight.md)
+- [Issue #825 Hosted Desktop Seat](issue-825-hosted-backup-seat-preflight.md)

--- a/docs/architecture/issue-825-hosted-backup-seat-preflight.md
+++ b/docs/architecture/issue-825-hosted-backup-seat-preflight.md
@@ -1,0 +1,218 @@
+# Issue #825 Hosted Desktop Seat Preflight
+
+This note sets the design guardrails for the Black Hat Arsenal hosted-seat
+proof. It is guidance, not an implementation plan. The GitHub issue owns the
+delivery shape: one Ubuntu EC2 VM, one Linux account, one Amazon DCV session,
+one Caddy instance, and one hostname per participant.
+
+No new ADR is needed. This is a tested AWS operator procedure, not a new APTL
+deployment architecture. The main risks are replacing the issue's per-seat
+topology with shared ingress, duplicating APTL readiness and configuration in
+cloud scripts, or presenting a mutable developer-host recipe as a qualified
+sealed appliance.
+
+The pinned recipe must verify its exact syntax against the official
+[DCV authentication](https://docs.aws.amazon.com/dcv/latest/adminguide/security-authentication.html),
+[DCV parameter](https://docs.aws.amazon.com/dcv/latest/adminguide/config-param-ref.html),
+[DCV EC2 licensing](https://docs.aws.amazon.com/dcv/latest/adminguide/setting-up-license.html),
+and [Caddy reverse-proxy](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy)
+contracts. Those vendor contracts are versioned inputs, not details to infer
+from a previously working host.
+
+## Architecture Decisions And Guardrails
+
+- One logical seat is one EC2 instance. Caddy and DCV run on that same
+  instance. `seat01.<lab-domain>` resolves to that instance; Caddy accepts
+  public HTTP/HTTPS and proxies to `https://127.0.0.1:8443`. There is no shared
+  gateway, load balancer, bastion, claim service, or cross-seat upstream map.
+- The live proof creates or reuses exactly `seat01`. It must not launch
+  `seat02` through `seat12`. The class procedure repeats one parameterized,
+  admitted operation for the twelve canonical seat identifiers; it does not
+  introduce fleet state or per-seat APTL choices.
+- Amazon DCV, not Caddy, authenticates the participant. DCV uses `system`
+  authentication through its Linux PAM service. The session owner and OS user
+  are the same `seatNN` identity, and only that owner is authorized for the
+  session. Caddy performs TLS termination and proxying only; do not add Basic
+  Auth, forward an asserted identity, or create another APTL authentication
+  system.
+- DCV's TCP web endpoint binds only IPv4 and IPv6 loopback on port 8443.
+  Disable the QUIC frontend because the browser path is TCP through Caddy and
+  no public UDP path is required. Pin DCV's allowed HTTP host and WebSocket
+  origin patterns to the exact seat hostname. Preserve the external Host and
+  origin semantics through Caddy and validate the upstream TLS certificate;
+  do not use `tls_insecure_skip_verify`.
+- Caddy has one exact-host site block and one fixed loopback upstream. Its
+  automatic-HTTPS state, admin endpoint, logs, and systemd privileges remain
+  local and hardened. Port 80 exists only for the selected ACME challenge and
+  HTTP-to-HTTPS redirect. Unknown hosts must not fall through to the seat.
+- Each seat security group admits public TCP 80 and 443, plus TCP 22 only from
+  the exact operator source CIDR. It admits no UDP 443, TCP/UDP 8443, RDP,
+  Docker, victim, SOC, APTL API, observability, or management port. Do not
+  assign public IPv6 unless the runbook validates and audits the equivalent
+  IPv6 rules and negative probes.
+- The host firewall is defense in depth; the security group is the mandatory
+  outer enforcement layer. APTL deliberately publishes victim ports 8080 and
+  5353 on wildcard host addresses, while its management ports are loopback
+  only. Internet-negative probes must therefore cover actual runtime
+  listeners, not assume every Docker publication is loopback.
+- Caddy's 443 and DCV's 8443 conflict with APTL's default Wazuh-dashboard and
+  MISP host ports. Reuse the existing `APTL_HP_*`/`resolve_host_ports()`
+  mechanism and pin one common host-recipe override before every lab start.
+  Do not stop Caddy/DCV, edit Compose, or make a different decision per seat.
+- The seat account is a participant identity, not an operator identity. It
+  receives no sudo, SSH authorization, or direct Docker socket membership.
+  Operator SSH uses a separate key-authenticated account and remains
+  source-restricted. The supported workbench/agent boundary owns participant
+  access to MCP operations; granting Docker-root authority merely because the
+  VM is disposable is not an acceptable shortcut.
+- The host recipe pins Ubuntu AMI identity and owner, architecture, instance
+  type, encrypted root volume size, APTL release/profile identity, coding-agent
+  version, MCP artifacts, DCV/Caddy versions, and non-secret service
+  configuration. A mutable package name, `latest`, or an arbitrary checkout is
+  not a tested recipe. The current guided profile requires at least x86-64,
+  8 vCPUs, 16 GiB RAM, and 100 GiB disk; the selected instance type must also
+  include measured desktop/DCV headroom.
+- The purpose-tagged `aptl-bh-test` host may be reused only after capturing a
+  secret-free baseline and proving the trial will not read, modify, stash, or
+  clean its unrelated source changes. Use a released/staged artifact and a
+  separate runtime directory. Record every changed package, account, group,
+  file, unit, firewall rule, security-group rule, IAM association, DNS record,
+  and Caddy/DCV state needed to restore the host.
+- A signed ADR-049 appliance image may supply the tested host payload, but a
+  mutable Ubuntu recipe does not become an appliance merely by running on
+  EC2. Unless release verification and appliance-boundary qualification pass,
+  the evidence proves only this hosted contingency procedure and must not be
+  cited as sealed-appliance parity.
+- Amazon DCV on EC2 needs narrowly scoped access to its regional license
+  object in S3. If an instance role is required, grant only the documented
+  `s3:GetObject` resource for the `us-east-2` DCV license bucket and ledger it.
+  Do not attach a general S3, SSM, deployment, or administrator role. Require
+  IMDSv2 and an appropriate metadata hop limit.
+- Failed-seat replacement is cold replacement under the same logical
+  `seatNN` assignment: withdraw the assignment, terminate or restore the old
+  trial host as appropriate, prove its issue-created mutable storage and
+  access material are gone, launch the same recipe, update DNS, create a fresh
+  passphrase, and rerun ingress plus semantic readiness. It is not an EC2
+  reboot, inner lab reset, disk restore, or in-place repair.
+
+## Cross-Cutting Incumbents To Reuse
+
+| Concern | Canonical owner and required reuse |
+| --- | --- |
+| Hosted operational precedent | `docs/workshop/emergency-rollout.md` owns the existing AWS capacity, golden-host, assignment, and teardown lessons. Reuse those lessons, but replace its legacy RDP, claim-page, broad seven-MCP, and fleet assumptions with the issue's DCV/manual-assignment shape. |
+| APTL host lifecycle | `aptl lab init`, `aptl lab start`, `aptl lab status`, `aptl lab info`, and `aptl lab stop -v` remain the only supported lab lifecycle entrypoints. `core.lab`'s `LabResult`, `StartupOutcome`, and `StartupDiagnostic` own inner startup truth; raw Compose commands and a second hosted lifecycle do not. |
+| Host ports and exposure | `docker-compose.yml`, `src/aptl/core/host_ports.py`, `src/aptl/core/endpoints.py`, and `tests/test_docker_compose_port_bindings.py` own APTL host-port meanings and remapping. The security group intersects that runtime surface; it does not redefine it. |
+| Profile and readiness | `ParticipantProfileManifest`, `ParticipantReadinessSuite`, `load_participant_profile()`, `run_participant_mcp_smoke()`, and `evaluate_participant_qualification()` own the guided browser, exact MCP inventory, and semantic red/blue checks. The current bounded MCP set is `aptl-red`, `aptl-indexer`, and `aptl-wazuh`, not the legacy seven-server list. |
+| Coding agent boundary | `ClaudeCodeManagedAgentAdapter`, `WorkbenchRuntime`, `EphemeralCredentialBroker`, generated strict MCP config, and `BoundedProcessRunner` own the action-capable participant agent path. The current Codex adapter is decision-only and cannot be substituted as evidence of real MCP operation. |
+| Configuration and generated state | Strict `AptlConfig`/`load_config()`, `load_dotenv()`, `EnvVars`, placeholder detection, ADR-025, and ADR-028 remain authoritative. AWS, DNS, DCV, Caddy, seat assignment, and operator inputs are not new `aptl.json`, `.env`, or RAES fields. |
+| Secrets and process safety | ADR-029, `aptl.utils.redaction.redact()`, TypeScript redaction parity, `curl_safe`, `pathsafe`, owner-only atomic writers, and fixed argv-list subprocesses are mandatory precedents. Redaction does not cure a password already exposed through argv, environment, user data, shell history, or logs. |
+| Persistence, errors, and evidence | `LocalRunStore` is the incumbent redacting structured persistence boundary for APTL run evidence. AWS procedure evidence remains a separate redacted operator record with stable step labels and bounded summaries; do not invent APTL DTOs, exceptions, or runstore schemas for a shell runbook. |
+| Seat vocabulary | `validate_seat_id()` supplies the repository's bounded lowercase identifier precedent, but issue #825 narrows it further to `^seat(0[1-9]\|1[0-2])$`. Appliance `SeatRecord` and its overlay lifecycle are not cloud-instance state and must not be copied into an AWS ledger. |
+
+## Security And Validation Passage
+
+The intended procedure crosses every layer below. Passing one layer does not
+waive another.
+
+| Layer | Required behavior |
+| --- | --- |
+| Operator identity and input gate | Pin `--profile catalyst-dev` and `--region us-east-2` on every AWS call; reject configured SSO fields; verify the expected STS account/caller before mutation and again before teardown. Validate the exact seat ID, hostname suffix, hosted zone, AMI owner/state/architecture, instance type, subnet route, volume settings, key reference, operator single-host CIDR, and local tool versions. Never inspect or copy AWS credential files. |
+| Recipe and supply chain admission | Record immutable Ubuntu AMI and APTL/profile identities plus tested DCV, Caddy, Docker, coding-agent, MCP, and package versions or digests. Use the profile's minimum hardware and asset closure. Unknown provenance, moving download URLs without a recorded version/checksum, an undersized host, or a dirty source checkout fails before assignment. |
+| AWS request and bootstrap shape | Use structured AWS JSON/query output, fixed quoting, exact IDs, and no `eval` or human-table parsing. User data and instance tags are non-secret because EC2 and cloud-init expose them. Require encrypted EBS, delete-on-termination for created seats, IMDSv2, and a trial ownership tag plus role/seat tags on every issue-created resource. |
+| Seat credential boundary | Generate one independent high-entropy passphrase per seat with a cryptographic source under an owner-only local directory. Publish the credential file with create-exclusive/no-follow/atomic semantics and mode `0600`. Set the Linux password through an encrypted operator channel and stdin-safe hashing/update path; plaintext or its hash must not appear in argv, exported environment, user data, SSM parameters/command history, logs, screenshots, Caddy config, or evidence. `/etc/shadow` is the expected verifier store. |
+| Agent and lab credential boundary | Seat credentials, APTL `.env` service credentials, DCV certificates, operator SSH keys, and model-provider credentials are different secret classes. The runbook must name the tested model-auth mechanism and its teardown. Reuse the workbench broker/config boundary; never bake agent auth into the AMI, credential CSV, user data, shared home, or participant-readable MCP config. |
+| DCV authentication and authorization | Pin `[security] authentication="system"` and the expected PAM service; create exactly one owner session for the matching `seatNN` user; deny collaboration/other-user access and unneeded DCV transfer/device features. Prove correct credentials succeed and missing/wrong credentials fail with the same generic external result. A reachable login page or an OS desktop login is not sufficient authentication evidence. |
+| HTTP, WebSocket, and TLS boundary | Caddy accepts only the exact seat hostname, redirects HTTP, serves a valid public certificate, and proxies WebSocket traffic to the fixed loopback DCV endpoint. DCV accepts only the exact public Host and HTTPS Origin. Validate the loopback upstream certificate and bound timeouts; keep Caddy administration and auth/header logging non-public. |
+| Host and cloud exposure | DCV web and QUIC listeners, Caddy, SSH, Docker publications, host firewall, security group, subnet/public-address state, and IPv4/IPv6 must agree. Externally probe allowed 80/443, operator-only 22 from both allowed and disallowed sources where feasible, and deny 8443, 3389, Docker, APTL API, victim, SOC, and management ports. Also inspect `ss` and Docker runtime publications so an accidental wildcard DCV bind cannot hide behind a passing proxy test. |
+| APTL validation shapes | Load the strict guided profile and its referenced `aptl.json`, readiness suite, asset lock, scenario, and workbench profiles through the existing validators. Start through `aptl lab start`; preserve the canonical `.env` parser, placeholder checks, generated config, host-port resolver, startup diagnostics, and fixed profile. Do not pass hosted values around those parsers. |
+| Readiness and evidence | Separately prove desktop/browser usability, installed agent version, exact MCP inventory, `kali_run_command` returning `uid=1000(kali)`, the bounded failed-SSH operation, and matching indexer and Wazuh rule-5710 results. Use `run_participant_mcp_smoke()` semantics; `tools/list`, HTTP 200, container health, or a visual desktop alone is not readiness. Store only versions, immutable identities, timestamps, stable check IDs, outcomes, counts, and redacted summaries. |
+| Error and observability envelope | Disable shell tracing around secrets. Apply shared redaction before committed structured evidence and log stable operation labels rather than raw AWS, DCV, Caddy, PAM, agent, or MCP payloads. Do not commit full environment dumps, cloud-init output, `describe-*` responses, auth attempts, private addresses, process listings, session tokens, command lines, or raw backend results. |
+| Reuse, replacement, and teardown | Classify each ledger entry as created or reused. Destructive commands resolve exact created IDs from the owner-only ledger, verify account/region/tags, delete in dependency order, wait for terminal state, and independently discover leftovers by trial tag. A reused host instead follows recorded compensating restore actions and a baseline diff. Final audit covers instances, volumes, snapshots/AMIs, ENIs, addresses, security groups/rules, DNS, IAM roles/profiles, key pairs, DCV/Caddy state, OS users/groups/passwords, agent auth, credential files, and temporary access material. |
+
+## Extensibility Seam And Whole-Repository Scope
+
+The only new seam is one parameterized operator seat input:
+
+`(trial_id, seat_id, hostname, aws_profile, region, ami_id, instance_type,
+subnet_id, security_group_id, operator_cidr, operator_key_ref,
+root_volume_gib, host_recipe_id)`
+
+The runbook derives `username == seat_id`, the fixed loopback DCV upstream, and
+the common APTL port overrides from that input. It is not a persisted APTL DTO
+or fleet database. The same admitted operation accepts `seat01` for proof and
+later `seat01` through `seat12`; a future event may change domain, AMI,
+instance type, subnet, volume, or operator source without editing the
+canonical host recipe. Provider-neutral or dynamic-routing fields do not
+belong at this seam.
+
+Implementation has to reconcile these repository and runtime surfaces:
+
+- issue #825, ADR-025, ADR-028, ADR-029, ADR-039, ADR-049, and issue #821;
+- `docs/workshop/emergency-rollout.md`, installation/deployment guidance, and
+  the guided workshop walkthrough;
+- `participant-profiles/guided-purple-v1/`, `src/aptl/validation/`,
+  `src/aptl/workbench/`, and their exact profile/agent/MCP tests;
+- `src/aptl/core/{config,env,lab,lab_types,host_ports,endpoints,runstore}.py`,
+  `src/aptl/utils/{pathsafe,redaction,logging,curl_safe}.py`, and MCP redaction
+  parity;
+- `docker-compose.yml`, `.mcp.json.example`, `.gitignore`,
+  `.gitguardian.yaml`, secret-protection hooks, Vale/MkDocs, and the Ground
+  Control host/range boundary declarations;
+- AWS STS, EC2/AMI/EBS/ENI, VPC/subnet/routes, security groups, public
+  addressing, Route 53, IAM/instance profiles, S3 license access, IMDS, and
+  user data;
+- Ubuntu PAM/accounts/groups/sudo/SSH, Docker and host firewall behavior,
+  Caddy configuration/storage/logging/systemd, DCV configuration/PAM/session
+  permissions/TLS/logging/systemd, and browser HTTPS/WebSocket behavior.
+
+## Gotchas And Anti-Patterns
+
+- Do not add an `AwsDeploymentBackend`, Terraform/CDK, fleet orchestrator,
+  cloud config schema, shared ingress tier, or claim database for this proof.
+- Do not use a shared gateway, Caddy Basic Auth, external-auth header, public
+  8443, participant SSH/VPN/RDP, or one Linux account shared by seats.
+- Do not call a developer host, EC2 instance, AMI, signed appliance payload,
+  Docker image, and participant seat the same artifact.
+- Do not add `seatNN`, hostname, password, model credential, AWS ID, or
+  cloud-init state to the golden recipe. Those are per-launch state.
+- Do not add the participant to sudo or the Docker group, expose the operator
+  API/terminal, or treat per-VM isolation as permission to abandon least
+  privilege inside the seat.
+- Do not let Docker claim 443/8443, stop Caddy/DCV during lab start, or edit
+  Compose to resolve the collision. Pin the existing host-port overrides in
+  the common recipe and verify their runtime projection.
+- Do not rely on UFW alone for Docker-published ports, on security-group
+  intent without an external negative probe, or on IPv4 results when public
+  IPv6 exists.
+- Do not use `authentication="none"`, wildcard DCV host/origin regexes,
+  default collaborative session permissions, public QUIC, a Caddy catch-all,
+  an unverified upstream certificate, or request/header debug logging.
+- Do not pass a passphrase or password hash to `useradd`, `usermod`,
+  `chpasswd`, SSH, Caddy, or another tool in argv or an environment variable.
+  Redaction after execution cannot remove OS-level exposure.
+- Do not confuse the seat password with an APTL service password, model token,
+  DCV TLS key, operator SSH key, or AWS credential.
+- Do not copy the legacy seven-server workshop smoke list. Do not accept
+  `tools/list`, TCP reachability, HTTP 200, or container health as proof of
+  the real red/blue workflow.
+- Do not use tags as the sole deletion selector, delete a reused host, omit
+  waiters, assume delete-on-termination worked, or declare teardown complete
+  before the independent resource and host-baseline audits pass.
+
+## Non-Goals And Implementation Boundary
+
+- This preflight does not create or modify AWS resources, the reused host,
+  DNS, security groups, IAM, users, passwords, Caddy/DCV configuration, APTL
+  runtime state, scripts, the runbook, or live evidence.
+- It does not implement twelve seats, self-service assignment, shared ingress,
+  autoscaling, regional failover, multi-provider abstraction, billing,
+  participant account UI, or a new authentication service.
+- It does not change RAES, `DeploymentBackend`, `AptlConfig`, participant
+  profile/readiness schemas, MCP tool schemas, the workbench agent contract,
+  exception hierarchies, runstore/evidence schemas, or inner lifecycle logic.
+- It does not qualify ADR-049 payload parity unless the tested image passes
+  that existing signed release and boundary contract.
+- It does not authorize per-seat APTL configuration decisions, public lab or
+  management services, participant Docker/sudo/SSH, mutable failed-seat
+  repair, preservation of participant disks, or model credentials in the
+  participant handout.

--- a/docs/workshop/hosted-backup-seats.md
+++ b/docs/workshop/hosted-backup-seats.md
@@ -1,0 +1,764 @@
+# Hosted Backup Seats For A Workshop
+
+This is the contingency procedure for giving up to twelve participants an
+isolated APTL workstation when their own laptop cannot run the lab. It is
+deliberately a runbook, not a fleet platform.
+
+The unit of work is one seat:
+
+```text
+participant browser
+        |
+        | HTTPS, seat01.<event-domain>
+        v
+one Ubuntu EC2 VM
+  Caddy :80/:443
+        |
+        | verified TLS, loopback only
+        v
+  Amazon DCV :8443
+        |
+        | PAM login as seat01
+        v
+  GNOME desktop + coding agent + APTL
+```
+
+Repeat that unit for `seat01` through `seat12`. Each participant receives one
+URL, one matching username, and one independent passphrase. There is no VPN,
+RDP, participant SSH, shared Linux account, claim page, load balancer, or
+shared application gateway.
+
+## Current Go/No-Go Truth
+
+The hosted access design and one complete seat were proven on July 28, 2026 in
+`us-east-2`. The proof covered:
+
+- an Ubuntu 24.04 `m6i.4xlarge` host with 16 vCPUs, 64 GiB RAM, and a 200 GiB
+  root disk;
+- a public certificate for the exact seat hostname and HTTP-to-HTTPS redirect;
+- Caddy as the only public web listener and DCV bound to loopback;
+- rejection of a wrong participant password and acceptance of the right one;
+- a rendered 1440 by 900 GNOME desktop, not just a reachable DCV login page;
+- a terminal owned by `seat01` and Claude Code `2.1.220`;
+- the guided APTL lab reporting every required container healthy;
+- the real bounded red operation, failed-SSH operation, indexer investigation,
+  and Wazuh investigation;
+- a stop/start recovery in 95 seconds followed by the same four passing
+  semantic operations.
+
+This is a **conditional go**, not a claim that the current APTL development
+branch is event-ready. The exact tested payload is pinned below because the
+current release paths found during the proof did not produce the required
+participant lab:
+
+- PyPI `aptl-labs==5.1.1` does not contain the guided participant profile.
+- The current development scenario materialization starts image-free Debian
+  placeholders that exit instead of the required Kali and victim services.
+- The older working Kali Dockerfile uses a stale NodeSource installation path.
+- A desktop install can start NetworkManager and interrupt an EC2 host that is
+  using `systemd-networkd`.
+- Avahi claims UDP port 5353, which conflicts with an APTL-published service.
+
+Do not improvise around those facts on the event morning. Stage the exact
+tested payload, build the class canary, and preserve its Docker image cache
+before deciding that twelve seats are available.
+
+Model authentication is a separate go/no-go item. The proof installed and
+launched the coding-agent binary, but did not place a model credential on the
+host or make a billed model call. Before the event, decide whether each
+participant signs in with their own account or whether an approved event
+credential broker will be used. Never bake model credentials into an AMI,
+user data, a participant handout, or the seat-state directory.
+
+## Tested Recipe
+
+| Component | Pinned proof input |
+| --- | --- |
+| AWS CLI profile and region | `catalyst-dev`, `us-east-2`, no SSO |
+| Ubuntu AMI | `ami-0dc6aa44dbcdd872e`, Canonical owner `099720109477`, `ubuntu-noble-24.04-amd64-server-20260714` |
+| Instance size | `m6i.4xlarge` |
+| Event root volume | 200 GiB encrypted gp3, delete on termination |
+| Amazon DCV | `nice-dcv-server` and `nice-dcv-web-viewer` `2025.0.20103-1` |
+| Caddy | `2.11.4` |
+| Docker | Engine `29.6.2`, Compose plugin `5.3.1` |
+| Host Node.js | `20.20.2` |
+| Coding agent | Claude Code `2.1.220` |
+| Working APTL payload | commit `e9373f5bec57b2c315c4a9c5d7ab837983b19595` |
+| Wazuh certificate helper | `config/wazuh-certs-tool.sh` from commit `ec54ee2da2cd59c58eb17f1dd7737483901b1838` |
+| Guided profile and semantic validator | commit `583e100853ac42240de4827678a20d94edb93d7d` |
+| Kali build repair | `tools/workshop/hosted-seat-kali-node.patch`, SHA-256 `71ea3832154d25ce8004e9bd9da8275282f4ff33bdf771ae7e50a8bf34376f4c` |
+| APTL host ports | Wazuh dashboard `9443`, MISP `9444`; Caddy keeps `443`, DCV keeps `8443` |
+
+The reused proof host predated this runbook and had an unencrypted root volume.
+That proves the workload and access path, not encrypted EC2 launch. Every
+newly created event seat must use the encrypted block-device mapping below.
+
+## Two Days Before The Event
+
+Complete these gates while there is still time to change course:
+
+1. Confirm the AWS account, region, quota, subnet, and operator source IP.
+2. Build one canary from the tested recipe.
+3. Put a real event-domain A record on the canary and rerun the TLS and browser
+   checks. The proof used `sslip.io` only because no owned hosted zone was
+   available in the test account.
+4. Authenticate the chosen coding agent as the participant will and make one
+   harmless model call through the intended credential boundary.
+5. Run the four semantic MCP checks.
+6. Stop and start the lab once using the recovery gate in this runbook.
+7. Preserve the canary and its Docker cache. An optional event AMI can reduce
+   launch time, but it is a mutable contingency image, not an ADR-049 sealed
+   APTL appliance.
+8. Check that 192 Standard On-Demand vCPUs, plus replacement headroom, are
+   available if all twelve `m6i.4xlarge` seats may run at once.
+
+Do not launch twelve seats merely to prove that one repeatable seat works.
+
+## Operator Inputs
+
+Use a private operator directory outside the repository:
+
+```bash
+umask 077
+export AWS_PROFILE=catalyst-dev
+export AWS_REGION=us-east-2
+export TRIAL_ID=blackhat-arsenal
+export EVENT_DOMAIN=labs.example.org
+export OPERATOR_CIDR=203.0.113.10/32
+export EXPECTED_AWS_ACCOUNT=123456789012
+export AMI_ID=ami-0dc6aa44dbcdd872e
+export SUBNET_ID=subnet-replace-me
+export STATE_DIR=/secure/operator-state/blackhat-arsenal
+export PAYLOAD_DIR=/secure/operator-state/hosted-seat-payload
+mkdir -m 0700 "$STATE_DIR"
+```
+
+Replace every example value. Do not put these exports in shell startup files.
+The event domain must be one you control. `OPERATOR_CIDR` must be one exact
+public IPv4 address, not a venue or corporate network range.
+
+Reject SSO configuration and confirm the caller before mutation:
+
+```bash
+test -z "$(aws configure get sso_session --profile "$AWS_PROFILE")"
+test -z "$(aws configure get sso_start_url --profile "$AWS_PROFILE")"
+test -z "$(aws configure get sso_region --profile "$AWS_PROFILE")"
+test "$(aws sts get-caller-identity \
+  --profile "$AWS_PROFILE" \
+  --query Account \
+  --output text)" = "$EXPECTED_AWS_ACCOUNT"
+```
+
+Check the Standard On-Demand quota:
+
+```bash
+aws service-quotas get-service-quota \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --service-code ec2 \
+  --quota-code L-1216C47A \
+  --query 'Quota.{Value:Value,Unit:Unit}' \
+  --output table
+```
+
+Stage the exact source inputs once from the APTL repository. This bundle has
+no credentials, generated `.env`, or runtime state:
+
+```bash
+uv run python tools/workshop/stage_hosted_seat_payload.py \
+  --repo-root . \
+  --output-dir "$PAYLOAD_DIR"
+
+sha256sum "$PAYLOAD_DIR/manifest.json"
+```
+
+The stager resolves all three commits from Git, replaces the certificate
+helper, requires the admitted Kali patch to apply cleanly, copies the semantic
+smoke helper, and writes a manifest. It refuses to overwrite a prior payload.
+Build it before the event and keep that exact directory for every seat.
+
+## Create The Shared Event Security Group
+
+One event security group may be attached to all twelve otherwise independent
+VMs. Create it once in the selected VPC:
+
+```bash
+VPC_ID="$(aws ec2 describe-subnets \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --subnet-ids "$SUBNET_ID" \
+  --query 'Subnets[0].VpcId' \
+  --output text)"
+
+SG_ID="$(aws ec2 create-security-group \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --group-name "$TRIAL_ID-seats" \
+  --description "$TRIAL_ID hosted desktop seats" \
+  --vpc-id "$VPC_ID" \
+  --tag-specifications \
+    "ResourceType=security-group,Tags=[{Key=aptl-trial,Value=$TRIAL_ID}]" \
+  --query GroupId \
+  --output text)"
+
+aws ec2 authorize-security-group-ingress \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --group-id "$SG_ID" \
+  --ip-permissions \
+    "IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=$OPERATOR_CIDR,Description=event-operator}]" \
+    'IpProtocol=tcp,FromPort=80,ToPort=80,IpRanges=[{CidrIp=0.0.0.0/0,Description=acme-and-redirect}]' \
+    'IpProtocol=tcp,FromPort=443,ToPort=443,IpRanges=[{CidrIp=0.0.0.0/0,Description=participant-dcv}]'
+```
+
+There must be no ingress for UDP 443, TCP/UDP 8443, RDP, Docker, the victim,
+Wazuh, or another APTL service. Do not assign public IPv6 for this event
+recipe.
+
+## Prepare One Seat
+
+The helper accepts only `seat01` through `seat12`, binds the username to the
+exact hostname, generates an independent 256-bit passphrase, and creates every
+file once with owner-only permissions:
+
+```bash
+export SEAT_ID=seat01
+export SEAT_HOSTNAME="$SEAT_ID.$EVENT_DOMAIN"
+
+uv run python tools/workshop/hosted_seat.py prepare \
+  --state-dir "$STATE_DIR" \
+  --trial-id "$TRIAL_ID" \
+  --seat-id "$SEAT_ID" \
+  --hostname "$SEAT_HOSTNAME"
+```
+
+The command prints paths but never the passphrase. It refuses to overwrite an
+existing credential or follow a symlink. The only participant secret is:
+
+```text
+$STATE_DIR/credentials/seat01.json
+```
+
+Do not open all credential files on a projected screen. Give each participant
+only their URL, username, and passphrase.
+
+## Launch One VM
+
+The following launches exactly the selected seat. It does not loop:
+
+```bash
+INSTANCE_ID="$(aws ec2 run-instances \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --image-id "$AMI_ID" \
+  --instance-type m6i.4xlarge \
+  --subnet-id "$SUBNET_ID" \
+  --security-group-ids "$SG_ID" \
+  --associate-public-ip-address \
+  --metadata-options \
+    HttpEndpoint=enabled,HttpTokens=required,HttpPutResponseHopLimit=1 \
+  --block-device-mappings \
+    'DeviceName=/dev/sda1,Ebs={VolumeSize=200,VolumeType=gp3,Encrypted=true,DeleteOnTermination=true}' \
+  --tag-specifications \
+    "ResourceType=instance,Tags=[{Key=Name,Value=$TRIAL_ID-$SEAT_ID},{Key=aptl-trial,Value=$TRIAL_ID},{Key=aptl-seat,Value=$SEAT_ID}]" \
+    "ResourceType=volume,Tags=[{Key=aptl-trial,Value=$TRIAL_ID},{Key=aptl-seat,Value=$SEAT_ID}]" \
+  --count 1 \
+  --query 'Instances[0].InstanceId' \
+  --output text)"
+
+aws ec2 wait instance-status-ok \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --instance-ids "$INSTANCE_ID"
+
+PUBLIC_IP="$(aws ec2 describe-instances \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].PublicIpAddress' \
+  --output text)"
+```
+
+Record the instance and resulting volume IDs in the private seat ledger. Check
+that the AMI is still available, x86-64, and owned by Canonical before every
+event launch. Check the volume reports `Encrypted=true` and
+`DeleteOnTermination=true`.
+
+Create or update the exact DNS A record:
+
+```text
+seat01.labs.example.org.  60  IN  A  <PUBLIC_IP>
+```
+
+Wait until the public resolver used by participants returns that address.
+
+For temporary operator access, use EC2 Instance Connect instead of creating an
+AWS key-pair resource:
+
+```bash
+KEY_DIR="$(mktemp -d)"
+chmod 0700 "$KEY_DIR"
+ssh-keygen -q -t ed25519 -N '' -f "$KEY_DIR/operator"
+
+AZ="$(aws ec2 describe-instances \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].Placement.AvailabilityZone' \
+  --output text)"
+
+aws ec2-instance-connect send-ssh-public-key \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --instance-id "$INSTANCE_ID" \
+  --availability-zone "$AZ" \
+  --instance-os-user ubuntu \
+  --ssh-public-key "file://$KEY_DIR/operator.pub"
+```
+
+Repeat the `send-ssh-public-key` call immediately before each SSH connection;
+the admission is short-lived.
+
+## Provision The Host
+
+Use a clean Ubuntu host or a prebuilt event image that passed this exact
+procedure. Do not provision over an unrelated working checkout.
+
+First record the cloud Netplan baseline and reserve APTL's UDP 5353 before
+installing the desktop:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" '
+  set -e
+  sudo install -d -m 0700 /root/aptl-network-baseline
+  sudo cp -a /etc/netplan/. /root/aptl-network-baseline/
+  sudo systemctl mask avahi-daemon.service avahi-daemon.socket
+  sudo apt-get update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ubuntu-desktop-minimal gdm3 curl ca-certificates gnupg jq openssl \
+    python3 python3-venv pipx
+'
+```
+
+The desktop installs NetworkManager. Make its ownership explicit instead of
+letting it race the cloud image's `systemd-networkd` configuration:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" '
+  set -e
+  PRIMARY_MAC="$(cat /sys/class/net/ens5/address)"
+  printf "%s\n" \
+    "network:" \
+    "  version: 2" \
+    "  renderer: NetworkManager" \
+    "  ethernets:" \
+    "    ens5:" \
+    "      match:" \
+    "        macaddress: \"$PRIMARY_MAC\"" \
+    "      dhcp4: true" \
+    "      dhcp6: false" \
+    "      set-name: \"ens5\"" |
+    sudo tee /etc/netplan/50-cloud-init.yaml >/dev/null
+  sudo chmod 0600 /etc/netplan/50-cloud-init.yaml
+  sudo systemctl unmask \
+    NetworkManager.service NetworkManager-wait-online.service
+  sudo systemctl enable \
+    NetworkManager.service NetworkManager-wait-online.service
+  sudo netplan apply
+  sudo systemctl disable systemd-networkd.service \
+    systemd-networkd-wait-online.service
+  sudo systemctl enable --now systemd-resolved.service gdm3.service
+'
+```
+
+The transition may close the current SSH connection. Send the EC2 Instance
+Connect key again, reconnect, and require `NetworkManager` to be active with
+the expected private address. Reboot the canary once and require both EC2
+status checks plus SSH to recover before installing the lab. The live proof's
+original network outage occurred because this renderer/owner decision was
+left implicit.
+
+Install the tested Docker Engine, Compose plugin, Node.js, and npm before
+staging APTL. The Docker package versions below are the proof versions:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" '
+  set -e
+  sudo install -m 0755 -d /etc/apt/keyrings
+  sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    -o /etc/apt/keyrings/docker.asc
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
+  . /etc/os-release
+  printf "Types: deb\nURIs: https://download.docker.com/linux/ubuntu\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n" \
+    "$VERSION_CODENAME" |
+    sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y \
+    docker-ce=5:29.6.2-1~ubuntu.24.04~noble \
+    docker-ce-cli=5:29.6.2-1~ubuntu.24.04~noble \
+    containerd.io=2.2.6-1~ubuntu.24.04~noble \
+    docker-buildx-plugin=0.35.0-1~ubuntu.24.04~noble \
+    docker-compose-plugin=5.3.1-1~ubuntu.24.04~noble
+  sudo usermod -aG docker ubuntu
+'
+```
+
+The participant is intentionally not added to the Docker group. Install the
+proof Node.js archive for the operator-owned APTL build:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" '
+  set -e
+  cd /tmp
+  curl -fLO \
+    https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.xz
+  printf "%s  %s\n" \
+    df770b2a6f130ed8627c9782c988fda9669fa23898329a61a871e32f965e007d \
+    node-v20.20.2-linux-x64.tar.xz | sha256sum --check
+  sudo tar -xJf node-v20.20.2-linux-x64.tar.xz -C /opt
+  sudo ln -s /opt/node-v20.20.2-linux-x64/bin/node /usr/local/bin/node
+  sudo ln -s /opt/node-v20.20.2-linux-x64/bin/npm /usr/local/bin/npm
+  sudo ln -s /opt/node-v20.20.2-linux-x64/bin/npx /usr/local/bin/npx
+  node --version
+  npm --version
+'
+```
+
+Install the pinned Amazon DCV packages:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" '
+  set -e
+  install -d -m 0700 /tmp/dcv-install
+  cd /tmp/dcv-install
+  curl -fLO https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY
+  curl -fLO \
+    https://d1uj6qtbmh3dt5.cloudfront.net/2025.0/Servers/nice-dcv-2025.0-20103-ubuntu2404-x86_64.tgz
+  printf "%s  %s\n" \
+    a39374d39f2d849bd13ee101970bb9eea15a8c5ec743799b7cbb7f562ece9e17 \
+    nice-dcv-2025.0-20103-ubuntu2404-x86_64.tgz | sha256sum --check
+  gpg --import NICE-GPG-KEY
+  tar -xzf nice-dcv-2025.0-20103-ubuntu2404-x86_64.tgz
+  cd nice-dcv-2025.0-20103-ubuntu2404-x86_64
+  sudo apt-get install -y \
+    ./nice-dcv-server_2025.0.20103-1_amd64.ubuntu2404.deb \
+    ./nice-dcv-web-viewer_2025.0.20103-1_amd64.ubuntu2404.deb
+  sudo usermod -aG video dcv
+'
+```
+
+Install Caddy from its signed stable Debian repository and confirm the
+resulting version is the canary version before continuing:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" '
+  set -e
+  sudo apt-get install -y \
+    debian-keyring debian-archive-keyring apt-transport-https
+  curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/gpg.key |
+    sudo gpg --dearmor -o \
+      /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt |
+    sudo tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+  sudo chmod o+r /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  sudo chmod o+r /etc/apt/sources.list.d/caddy-stable.list
+  sudo apt-get update
+  sudo apt-get install -y caddy=2.11.4
+  caddy version
+'
+```
+
+Copy the generated non-secret configurations:
+
+```bash
+scp -i "$KEY_DIR/operator" \
+  "$STATE_DIR/generated/$SEAT_ID/dcv.conf" \
+  "$STATE_DIR/generated/$SEAT_ID/$SEAT_ID.perm" \
+  "$STATE_DIR/generated/$SEAT_ID/Caddyfile" \
+  "$STATE_DIR/generated/$SEAT_ID/aptl-host-ports.env" \
+  ubuntu@"$PUBLIC_IP":/tmp/
+
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" "
+  set -e
+  sudo install -m 0644 /tmp/dcv.conf /etc/dcv/dcv.conf
+  sudo install -m 0644 /tmp/$SEAT_ID.perm /etc/dcv/$SEAT_ID.perm
+  sudo install -m 0644 /tmp/Caddyfile /etc/caddy/Caddyfile
+  sudo install -d -m 0755 /opt/aptl-event
+  sudo install -m 0600 /tmp/aptl-host-ports.env \
+    /opt/aptl-event/aptl-host-ports.env
+  rm -f /tmp/dcv.conf /tmp/$SEAT_ID.perm /tmp/Caddyfile \
+    /tmp/aptl-host-ports.env
+"
+```
+
+Create a private CA and exact-host leaf certificate for Caddy's verified
+loopback connection to DCV. This is not the public browser certificate; Caddy
+obtains that automatically:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" "
+  set -e
+  sudo install -d -m 0700 /root/aptl-dcv-pki
+  sudo openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 \
+    -out /root/aptl-dcv-pki/ca.key
+  sudo openssl req -x509 -new -sha256 -days 14 \
+    -key /root/aptl-dcv-pki/ca.key \
+    -subj '/CN=APTL DCV upstream CA' \
+    -out /root/aptl-dcv-pki/ca.pem
+  sudo openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+    -out /root/aptl-dcv-pki/dcv.key
+  sudo openssl req -new \
+    -key /root/aptl-dcv-pki/dcv.key \
+    -subj '/CN=$SEAT_HOSTNAME' \
+    -addext 'subjectAltName=DNS:$SEAT_HOSTNAME' \
+    -out /root/aptl-dcv-pki/dcv.csr
+  sudo openssl x509 -req -sha256 -days 14 \
+    -in /root/aptl-dcv-pki/dcv.csr \
+    -CA /root/aptl-dcv-pki/ca.pem \
+    -CAkey /root/aptl-dcv-pki/ca.key \
+    -CAcreateserial -copy_extensions copy \
+    -out /root/aptl-dcv-pki/dcv.pem
+  sudo install -o dcv -g dcv -m 0600 \
+    /root/aptl-dcv-pki/dcv.key /etc/dcv/dcv.key
+  sudo install -o dcv -g dcv -m 0600 \
+    /root/aptl-dcv-pki/dcv.pem /etc/dcv/dcv.pem
+  sudo install -o root -g caddy -m 0640 \
+    /root/aptl-dcv-pki/ca.pem /etc/dcv/dcv-upstream-ca.pem
+"
+```
+
+Create the participant without sudo, Docker, or SSH access, and send the
+password only through the encrypted SSH channel and `chpasswd` stdin:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" "
+  set -e
+  sudo useradd --create-home --shell /bin/bash '$SEAT_ID'
+  sudo install -d -o '$SEAT_ID' -g '$SEAT_ID' -m 0700 \
+    '/home/$SEAT_ID/.config'
+  sudo install -o '$SEAT_ID' -g '$SEAT_ID' -m 0600 /dev/null \
+    '/home/$SEAT_ID/.config/gnome-initial-setup-done'
+"
+
+jq -r '"\(.username):\(.passphrase)"' \
+  "$STATE_DIR/credentials/$SEAT_ID.json" |
+  ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" 'sudo chpasswd'
+```
+
+Keep shell tracing disabled around that pipeline. Do not pass the password or
+its hash in argv, an environment variable, user data, a tag, or a log.
+
+Transfer the previously staged payload and install it in `/opt/aptl-event`,
+not in the participant's home:
+
+```bash
+tar -C "$PAYLOAD_DIR" -czf "$STATE_DIR/hosted-seat-payload.tar.gz" .
+scp -i "$KEY_DIR/operator" \
+  "$STATE_DIR/hosted-seat-payload.tar.gz" \
+  ubuntu@"$PUBLIC_IP":/tmp/
+
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" '
+  set -e
+  sudo install -d -o ubuntu -g ubuntu -m 0750 /opt/aptl-event
+  sudo -u ubuntu tar -C /opt/aptl-event -xzf \
+    /tmp/hosted-seat-payload.tar.gz
+  rm -f /tmp/hosted-seat-payload.tar.gz
+  python3 -m venv /opt/aptl-event/lab-runtime
+  /opt/aptl-event/lab-runtime/bin/pip install \
+    /opt/aptl-event/lab-source
+  python3 -m venv /opt/aptl-event/profile-runtime
+  /opt/aptl-event/profile-runtime/bin/pip install \
+    /opt/aptl-event/profile-source
+  install -d -m 0750 /opt/aptl-event/workshop
+  cp -a /opt/aptl-event/lab-source/. /opt/aptl-event/workshop/
+'
+```
+
+Initialize the lab in the separate working directory and retain its generated
+`.env` only on the host with owner-only permissions. Do not run either APTL
+runtime from an arbitrary checkout.
+
+The payload's Kali build must be cold-built at least once before the event.
+The patch intentionally replaces the stale NodeSource step only inside the
+Kali image with Kali's signed `nodejs` and `npm` packages.
+
+Install the coding agent using its supported per-user installer as
+`$SEAT_ID`. Do not use `sudo npm install -g`, do not share another user's
+authentication directory, and do not authenticate until the event's model
+credential decision is approved.
+
+Start DCV and create exactly one owner session:
+
+```bash
+ssh -i "$KEY_DIR/operator" ubuntu@"$PUBLIC_IP" "
+  set -e
+  sudo systemctl enable --now dcvserver caddy
+  sudo dcv create-session \
+    --type=console \
+    --owner '$SEAT_ID' \
+    --user '$SEAT_ID' \
+    --permissions-file '/etc/dcv/$SEAT_ID.perm' \
+    --max-concurrent-clients 1 \
+    --disable-login-monitor \
+    '$SEAT_ID'
+  sudo dcv set-display-layout --session '$SEAT_ID' 1440x900
+"
+```
+
+The explicit single-display command is required. The proof initially produced
+a black browser canvas when DCV exposed GNOME as four 800 by 600 outputs.
+
+## Start And Prove The Lab
+
+In the APTL working directory, load only the two host-port overrides and start
+the pinned scenario through the APTL CLI:
+
+```bash
+set -a
+. /opt/aptl-event/aptl-host-ports.env
+set +a
+/opt/aptl-event/lab-runtime/bin/aptl lab start \
+  --scenario techvault-attacker-target
+/opt/aptl-event/lab-runtime/bin/aptl lab status
+```
+
+Run the repository helper with the working project and the separately pinned
+profile root:
+
+```bash
+/opt/aptl-event/profile-runtime/bin/python \
+  /opt/aptl-event/hosted_seat.py smoke \
+  --project-dir /opt/aptl-event/workshop \
+  --profile-root /opt/aptl-event/profile-source
+```
+
+It must report all four stable IDs as `passed`:
+
+```text
+mcp.red.kali-command
+mcp.red.ssh-authentication-attack
+mcp.blue.indexer-investigation
+mcp.blue.wazuh-investigation
+```
+
+The helper selects only `aptl-red`, `aptl-indexer`, and `aptl-wazuh` from the
+profile. It does not load facilitator-only MCP registrations and prints
+redacted outcomes rather than backend payloads.
+
+## Seat Admission Checklist
+
+A seat is assignable only when every item passes:
+
+- `https://seatNN.<event-domain>` has a valid certificate for the exact name;
+- HTTP redirects to that HTTPS URL;
+- a wrong password is rejected and the seat's password succeeds;
+- the browser shows a usable GNOME desktop at 1440 by 900;
+- the terminal identity is the matching `seatNN`;
+- `id -nG seatNN` contains only `seatNN`;
+- the coding-agent version is the admitted version and the approved
+  authentication path completes;
+- `aptl lab status` reports the required containers healthy;
+- all four semantic MCP checks pass;
+- public 80 and 443 are reachable;
+- public 8443, 3389, 8080, 9200, 9443, 9444, and 55000 are not reachable;
+- `ss` shows DCV 8443 only on `127.0.0.1` and `::1`;
+- Caddy is the only public listener on 80 and 443;
+- SSH is reachable only from the operator CIDR;
+- the instance has no public IPv6 address.
+
+Do not admit a seat based on a login page, `docker ps`, MCP `tools/list`, or
+HTTP 200 alone.
+
+## Repeat For Twelve
+
+Keep a private assignment table:
+
+| Seat | Hostname | Instance ID | Volume ID | Public IP | DNS checked | Admission checked | Assigned |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `seat01` | `seat01.<event-domain>` |  |  |  |  |  |  |
+| ... | ... |  |  |  |  |  |  |
+| `seat12` | `seat12.<event-domain>` |  |  |  |  |  |  |
+
+For each row, change only `SEAT_ID`, derive `SEAT_HOSTNAME`, and repeat
+**Prepare One Seat** through **Seat Admission Checklist**. Never run an
+unreviewed launch loop. Two operators can divide the rows, but one operator
+must audit the final instance, DNS, credential, and admission mappings.
+
+If time is short, launch from the already-proven event image, then rotate the
+seat password, create the seat-specific DCV certificate/configuration, update
+DNS, and rerun every admission check. An image does not make a copied seat
+ready.
+
+## Recovery During The Event
+
+For an inner lab restart:
+
+```bash
+/opt/aptl-event/lab-runtime/bin/aptl lab stop
+
+until ! ss -lntH 'sport = :9200' | grep -q .; do
+  sleep 1
+done
+
+set -a
+. /opt/aptl-event/aptl-host-ports.env
+set +a
+/opt/aptl-event/lab-runtime/bin/aptl lab start \
+  --scenario techvault-attacker-target
+/opt/aptl-event/profile-runtime/bin/python \
+  /opt/aptl-event/hosted_seat.py smoke \
+  --project-dir /opt/aptl-event/workshop \
+  --profile-root /opt/aptl-event/profile-source
+```
+
+The wait is mandatory. In the proof, one immediate restart saw Docker's old
+9200 listener, automatically remapped the indexer to 20000, and correctly
+failed both blue MCP checks. The gated retry kept 9200, reached APTL ready in
+79 seconds, and passed all four operations.
+
+If the VM itself is suspect, withdraw the seat, terminate it, launch the same
+recipe under the same logical seat ID, issue a new passphrase, update its DNS
+record, and rerun admission. Do not preserve or repair participant state under
+event pressure.
+
+## Teardown
+
+First withdraw the participant assignment. Then, for every exact instance ID
+in the private ledger:
+
+```bash
+aws ec2 terminate-instances \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --instance-ids "$INSTANCE_ID"
+
+aws ec2 wait instance-terminated \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --instance-ids "$INSTANCE_ID"
+```
+
+Delete the twelve DNS records, then delete the exact event security group.
+Remove the temporary EC2 Instance Connect key directory and the owner-only
+credential/state directory with an explicit, reviewed path.
+
+Independently search the expected account and region for the `aptl-trial`
+value. The final audit must find no running or stopped instances, available
+volumes, snapshots, AMIs, ENIs, elastic IPs, security groups, DNS records,
+temporary IAM resources, AWS key pairs, participant credentials, model
+authentication state, or operator SSH material created for the trial.
+
+For a reused host, do not terminate it. Stop the lab with `aptl lab stop -v`,
+close the DCV session, remove the participant account and its home, restore
+the baseline DCV/Caddy/service/package state from the change ledger, remove
+the exact event directories, and prove the original public listeners,
+accounts, security-group rules, and unrelated checkout are unchanged.
+
+## Vendor References
+
+- [Install Amazon DCV on Ubuntu](https://docs.aws.amazon.com/dcv/latest/adminguide/setting-up-installing-linux-server.html)
+- [Amazon DCV server parameter reference](https://docs.aws.amazon.com/dcv/latest/adminguide/config-param-ref.html)
+- [Amazon DCV authentication](https://docs.aws.amazon.com/dcv/latest/adminguide/security-authentication.html)
+- [Caddy installation](https://caddyserver.com/docs/install)
+- [Caddy reverse proxy](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy)
+- [Claude Code setup](https://docs.anthropic.com/en/docs/claude-code/getting-started)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
   - Workshop:
     - Playbook: workshop/playbook.md
     - Lab Walkthrough: workshop/walkthrough.md
+    - Hosted Backup Seats: workshop/hosted-backup-seats.md
   - Architecture:
     - Overview: architecture/index.md
     - Networking: architecture/networking.md
@@ -89,6 +90,7 @@ nav:
     - "Issue #557 Participant Implementation Binding Preflight": architecture/issue-557-participant-implementation-binding-preflight.md
     - "Issue #821 In-Appliance Participant Workbench Preflight": architecture/issue-821-participant-workbench-preflight.md
     - "Issue #823 Versioned Disposable Lab Appliance Preflight": architecture/issue-823-versioned-disposable-appliance-preflight.md
+    - "Issue #825 Hosted Desktop Seat Preflight": architecture/issue-825-hosted-backup-seat-preflight.md
     - "Issue #845 RAES Hard-Rename Preflight": architecture/issue-845-raes-hard-rename-preflight.md
   - Deployment: deployment.md
   - Components:

--- a/tests/test_hosted_seat_helper.py
+++ b/tests/test_hosted_seat_helper.py
@@ -1,0 +1,293 @@
+"""Tests for the issue #825 hosted-seat operator helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+
+HELPER_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "workshop" / "hosted_seat.py"
+)
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("hosted_seat", HELPER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def helper():
+    return _load_helper()
+
+
+@pytest.mark.parametrize(
+    "seat_id",
+    [*(f"seat{index:02d}" for index in range(1, 13))],
+)
+def test_only_canonical_class_seats_are_accepted(helper, seat_id: str) -> None:
+    assert helper.validate_seat_id(seat_id) == seat_id
+
+
+@pytest.mark.parametrize(
+    "seat_id",
+    [
+        "seat00",
+        "seat13",
+        "seat1",
+        "SEAT01",
+        "../seat01",
+        "seat01.example.com",
+        "participant01",
+        "",
+    ],
+)
+def test_noncanonical_seats_are_rejected(helper, seat_id: str) -> None:
+    with pytest.raises(ValueError, match="seat01 through seat12"):
+        helper.validate_seat_id(seat_id)
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "*.labs.example.com",
+        "seat01",
+        "seat01..example.com",
+        "Seat01.labs.example.com",
+        "seat01.labs.example.com.",
+        "seat01_labs.example.com",
+        "-seat01.labs.example.com",
+        "127.0.0.1",
+        "seat01.labs.example.com:443",
+    ],
+)
+def test_unsafe_or_noncanonical_hostnames_are_rejected(helper, hostname: str) -> None:
+    with pytest.raises(ValueError, match="canonical lowercase DNS hostname"):
+        helper.validate_hostname(hostname)
+
+
+def test_hostname_must_match_the_seat(helper) -> None:
+    with pytest.raises(ValueError, match="must start with seat01"):
+        helper.validate_seat_hostname("seat01", "seat02.labs.example.com")
+
+
+def test_rendered_dcv_config_is_loopback_system_auth_and_exact_host(helper) -> None:
+    rendered = helper.render_dcv_config("seat01.labs.example.com")
+
+    assert 'authentication="system"' in rendered
+    assert 'pam-service-name="dcv"' in rendered
+    assert "web-listen-endpoints=['127.0.0.1:8443', '[::1]:8443']" in rendered
+    assert "enable-quic-frontend=false" in rendered
+    assert (
+        'allowed-http-host-regex="^seat01\\.labs\\.example\\.com(:443)?$"' in rendered
+    )
+    assert (
+        'allowed-ws-origin-regex="^https://seat01\\.labs\\.example\\.com'
+        '(:443)?$"' in rendered
+    )
+    assert "0.0.0.0" not in rendered
+    assert 'authentication="none"' not in rendered
+
+
+def test_rendered_caddyfile_has_exact_host_and_verified_loopback_tls(helper) -> None:
+    rendered = helper.render_caddyfile("seat01.labs.example.com")
+
+    assert "seat01.labs.example.com {" in rendered
+    assert "reverse_proxy https://127.0.0.1:8443" in rendered
+    assert "header_up Host seat01.labs.example.com" in rendered
+    assert "tls_server_name seat01.labs.example.com" in rendered
+    assert "tls_trust_pool file /etc/dcv/dcv-upstream-ca.pem" in rendered
+    assert "protocols h1 h2" in rendered
+    assert "h3" not in rendered
+    assert "tls_insecure_skip_verify" not in rendered
+    assert "\n:8443 {" not in rendered
+    assert "*." not in rendered
+
+
+def test_host_port_overrides_reserve_caddy_and_dcv_ports(helper) -> None:
+    assert helper.host_port_overrides() == {
+        "APTL_HP_WAZUH_DASHBOARD_5601": "9443",
+        "APTL_HP_MISP_443": "9444",
+    }
+
+
+def test_dcv_permissions_limit_the_owner_to_interactive_desktop_features(
+    helper,
+) -> None:
+    assert helper.render_dcv_permissions() == (
+        "[permissions]\n%owner% allow display keyboard mouse pointer audio-out\n"
+    )
+
+
+def test_prepare_creates_private_create_once_state_without_disclosing_secret(
+    helper, tmp_path: Path, capsys
+) -> None:
+    state_dir = tmp_path / "operator-state"
+
+    result = helper.prepare_seat(
+        state_dir=state_dir,
+        trial_id="bh-arsenal-825-proof",
+        seat_id="seat01",
+        hostname="seat01.labs.example.com",
+        token_bytes=lambda count: b"\x01" * count,
+    )
+
+    credentials = json.loads(result.credential_file.read_text(encoding="utf-8"))
+    ledger = json.loads(result.ledger_file.read_text(encoding="utf-8"))
+    assert credentials["username"] == "seat01"
+    assert len(credentials["passphrase"]) >= 32
+    assert credentials["passphrase"] not in result.public_summary()
+    assert credentials["passphrase"] not in result.dcv_config_file.read_text()
+    assert credentials["passphrase"] not in result.caddyfile.read_text()
+    assert credentials["passphrase"] not in result.ledger_file.read_text()
+    assert ledger == {
+        "schema": "aptl.hosted-seat-input/v1",
+        "trial_id": "bh-arsenal-825-proof",
+        "seat_id": "seat01",
+        "username": "seat01",
+        "hostname": "seat01.labs.example.com",
+        "dcv_upstream": "https://127.0.0.1:8443",
+        "aws_profile": "catalyst-dev",
+        "aws_region": "us-east-2",
+    }
+    assert capsys.readouterr().out == ""
+
+    for directory in (
+        state_dir,
+        state_dir / "credentials",
+        state_dir / "ledgers",
+        state_dir / "generated",
+        state_dir / "generated" / "seat01",
+    ):
+        assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+    for path in (
+        result.credential_file,
+        result.ledger_file,
+        result.dcv_config_file,
+        result.caddyfile,
+        result.dcv_permissions_file,
+        result.host_ports_file,
+    ):
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    with pytest.raises(FileExistsError):
+        helper.prepare_seat(
+            state_dir=state_dir,
+            trial_id="bh-arsenal-825-proof",
+            seat_id="seat01",
+            hostname="seat01.labs.example.com",
+        )
+
+
+def test_prepare_refuses_symlinked_state_directory(helper, tmp_path: Path) -> None:
+    real_state = tmp_path / "real"
+    real_state.mkdir()
+    state_link = tmp_path / "operator-state"
+    state_link.symlink_to(real_state, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        helper.prepare_seat(
+            state_dir=state_link,
+            trial_id="bh-arsenal-825-proof",
+            seat_id="seat01",
+            hostname="seat01.labs.example.com",
+        )
+
+
+def test_cli_prints_only_a_nonsecret_machine_summary(
+    helper, tmp_path: Path, capsys
+) -> None:
+    exit_code = helper.main(
+        [
+            "prepare",
+            "--state-dir",
+            str(tmp_path / "state"),
+            "--trial-id",
+            "bh-arsenal-825-proof",
+            "--seat-id",
+            "seat01",
+            "--hostname",
+            "seat01.labs.example.com",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    summary = json.loads(output)
+    credential = json.loads(Path(summary["credential_file"]).read_text())
+    assert credential["passphrase"] not in output
+    assert summary["seat_id"] == "seat01"
+    assert summary["hostname"] == "seat01.labs.example.com"
+
+
+def test_mcp_registration_specs_select_only_the_profile_surface(
+    helper, tmp_path: Path
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "aptl-red": {
+                        "command": "node",
+                        "args": ["/project/mcp-red/dist/index.js"],
+                        "env": {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"},
+                    },
+                    "aptl-wazuh": {
+                        "command": "node",
+                        "args": ["/project/mcp-wazuh/dist/index.js"],
+                    },
+                    "facilitator-only": {
+                        "command": "node",
+                        "args": ["/project/facilitator.js"],
+                        "env": {"SENSITIVE_VALUE": "must-not-be-admitted"},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    specs = helper.load_mcp_registration_specs(project, ("aptl-red", "aptl-wazuh"))
+
+    assert set(specs) == {"aptl-red", "aptl-wazuh"}
+    assert specs["aptl-red"].argv == (
+        "node",
+        "/project/mcp-red/dist/index.js",
+    )
+    assert "SENSITIVE_VALUE" not in specs["aptl-red"].env
+    assert specs["aptl-wazuh"].env == {}
+
+
+def test_mcp_registration_specs_fail_closed_on_missing_or_invalid_entries(
+    helper, tmp_path: Path
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "aptl-red": {
+                        "command": "node",
+                        "args": "not-a-list",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="invalid MCP registration"):
+        helper.load_mcp_registration_specs(project, ("aptl-red",))
+    with pytest.raises(ValueError, match="missing MCP registration"):
+        helper.load_mcp_registration_specs(project, ("aptl-wazuh",))

--- a/tests/test_stage_hosted_seat_payload.py
+++ b/tests/test_stage_hosted_seat_payload.py
@@ -1,0 +1,100 @@
+"""Tests for deterministic hosted-seat source staging."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STAGER_PATH = REPO_ROOT / "tools" / "workshop" / "stage_hosted_seat_payload.py"
+
+
+def _load_stager():
+    spec = importlib.util.spec_from_file_location(
+        "stage_hosted_seat_payload", STAGER_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stage_payload_materializes_pinned_layers_and_repairs(tmp_path: Path) -> None:
+    stager = _load_stager()
+    output = tmp_path / "payload"
+
+    manifest_path = stager.stage_payload(REPO_ROOT, output)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schema"] == "aptl.hosted-seat-payload/v1"
+    assert manifest["lab_commit"] == stager.LAB_COMMIT
+    assert manifest["profile_commit"] == stager.PROFILE_COMMIT
+    assert manifest["kali_patch"]["sha256"] == stager.PATCH_SHA256
+    assert manifest["hosted_seat_helper"]["sha256"] == stager.HELPER_SHA256
+    assert (
+        output / "profile-source" / "participant-profiles" / "guided-purple-v1"
+    ).is_dir()
+    kali_dockerfile = (
+        output / "lab-source" / "containers" / "kali" / "Dockerfile"
+    ).read_text(encoding="utf-8")
+    assert "apt-get install -y nodejs npm" in kali_dockerfile
+    assert "deb.nodesource.com/node_20.x" not in kali_dockerfile
+    cert_helper = output / "lab-source" / stager.CERT_HELPER_PATH
+    assert stager._sha256(cert_helper) == manifest["certificate_helper"]["sha256"]
+    assert (output / "hosted_seat.py").is_file()
+
+    with pytest.raises(FileExistsError):
+        stager.stage_payload(REPO_ROOT, output)
+
+
+def test_stage_payload_accepts_owner_only_mode_from_secure_umask(
+    tmp_path: Path,
+) -> None:
+    stager = _load_stager()
+    output = tmp_path / "private-payload"
+    prior_umask = os.umask(0o077)
+    try:
+        stager.stage_payload(REPO_ROOT, output)
+    finally:
+        os.umask(prior_umask)
+
+    assert output.stat().st_mode & 0o777 == 0o700
+
+
+def test_stage_payload_rejects_a_changed_helper_digest(tmp_path: Path) -> None:
+    stager = _load_stager()
+    stager.HELPER_SHA256 = "0" * 64
+
+    with pytest.raises(ValueError, match="helper does not match"):
+        stager.stage_payload(REPO_ROOT, tmp_path / "payload")
+
+
+def test_stage_payload_rejects_a_changed_patch_digest(tmp_path: Path) -> None:
+    stager = _load_stager()
+    stager.PATCH_SHA256 = "0" * 64
+
+    with pytest.raises(ValueError, match="Kali patch does not match"):
+        stager.stage_payload(REPO_ROOT, tmp_path / "payload")
+
+
+def test_stage_payload_refuses_a_repository_subdirectory(tmp_path: Path) -> None:
+    stager = _load_stager()
+
+    with pytest.raises(ValueError, match="must be the APTL Git top-level directory"):
+        stager.stage_payload(REPO_ROOT / "tools", tmp_path / "payload")
+
+
+def test_stage_payload_refuses_a_non_repository_root(tmp_path: Path) -> None:
+    stager = _load_stager()
+
+    with pytest.raises(subprocess.CalledProcessError):
+        stager.stage_payload(tmp_path, tmp_path / "payload")

--- a/tools/workshop/hosted-seat-kali-node.patch
+++ b/tools/workshop/hosted-seat-kali-node.patch
@@ -1,0 +1,19 @@
+diff --git a/containers/kali/Dockerfile b/containers/kali/Dockerfile
+--- a/containers/kali/Dockerfile
++++ b/containers/kali/Dockerfile
+@@ -76,12 +76,9 @@ RUN mkdir -p /home/kali/operations && \
+     setcap cap_net_raw,cap_net_admin+eip /usr/bin/dumpcap
+
+ RUN apt-get update && \
+-    apt-get install -y ca-certificates curl gnupg && \
+-    mkdir -p /etc/apt/keyrings && \
+-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+-    apt-get update && \
+-    apt-get install -y nodejs && \
++    apt-get install -y nodejs npm && \
++    node --version && \
++    npm --version && \
+     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ RUN sudo -u kali ssh-keygen -t rsa -b 2048 -f /home/kali/.ssh/id_rsa -N "" && \

--- a/tools/workshop/hosted_seat.py
+++ b/tools/workshop/hosted_seat.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Prepare create-once local state for the issue #825 hosted-seat runbook."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import ipaddress
+import json
+import os
+import re
+import secrets
+import stat
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+from aptl.utils.pathsafe import create_exclusive_nofollow
+
+
+_SEAT_ID = re.compile(r"^seat(?:0[1-9]|1[0-2])$")
+_TRIAL_ID = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_DNS_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_AWS_PROFILE = "catalyst-dev"
+_AWS_REGION = "us-east-2"
+
+
+class PreparedSeat(NamedTuple):
+    """Paths written for one admitted seat without its secret value."""
+
+    state_dir: Path
+    seat_id: str
+    hostname: str
+    credential_file: Path
+    ledger_file: Path
+    dcv_config_file: Path
+    dcv_permissions_file: Path
+    caddyfile: Path
+    host_ports_file: Path
+
+    def public_summary(self) -> str:
+        """Return a deterministic machine summary that contains no passphrase."""
+
+        return json.dumps(
+            {
+                "seat_id": self.seat_id,
+                "hostname": self.hostname,
+                "state_dir": str(self.state_dir),
+                "credential_file": str(self.credential_file),
+                "ledger_file": str(self.ledger_file),
+                "dcv_config_file": str(self.dcv_config_file),
+                "dcv_permissions_file": str(self.dcv_permissions_file),
+                "caddyfile": str(self.caddyfile),
+                "host_ports_file": str(self.host_ports_file),
+            },
+            sort_keys=True,
+        )
+
+
+class McpRegistrationSpec(NamedTuple):
+    """One validated process registration read from operator-owned lab state."""
+
+    argv: tuple[str, ...]
+    env: dict[str, str]
+
+
+def validate_seat_id(seat_id: str) -> str:
+    """Require one of the twelve issue-authorized seat identifiers."""
+
+    if not _SEAT_ID.fullmatch(seat_id):
+        raise ValueError("seat id must be seat01 through seat12")
+    return seat_id
+
+
+def validate_hostname(hostname: str) -> str:
+    """Require a canonical lowercase DNS hostname rather than a URL or wildcard."""
+
+    labels = hostname.split(".")
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        is_ip = False
+    else:
+        is_ip = True
+    if (
+        hostname != hostname.lower()
+        or len(hostname) > 253
+        or len(labels) < 3
+        or is_ip
+        or any(not _DNS_LABEL.fullmatch(label) for label in labels)
+    ):
+        raise ValueError("hostname must be a canonical lowercase DNS hostname")
+    return hostname
+
+
+def validate_seat_hostname(seat_id: str, hostname: str) -> tuple[str, str]:
+    """Bind a canonical seat identifier to its one exact hostname."""
+
+    seat = validate_seat_id(seat_id)
+    host = validate_hostname(hostname)
+    if not host.startswith(f"{seat}."):
+        raise ValueError(f"hostname must start with {seat}.")
+    return seat, host
+
+
+def render_dcv_config(hostname: str) -> str:
+    """Render the security-sensitive DCV server projection."""
+
+    host = validate_hostname(hostname)
+    exact_host = re.escape(host)
+    return (
+        "[connectivity]\n"
+        "web-port=8443\n"
+        "web-listen-endpoints=['127.0.0.1:8443', '[::1]:8443']\n"
+        "enable-quic-frontend=false\n"
+        "idle-timeout=120\n"
+        "\n"
+        "[security]\n"
+        'authentication="system"\n'
+        'pam-service-name="dcv"\n'
+        "authentication-threshold=3\n"
+        "max-connections-per-user=1\n"
+        f'allowed-http-host-regex="^{exact_host}(:443)?$"\n'
+        f'allowed-ws-origin-regex="^https://{exact_host}(:443)?$"\n'
+        f'server-fqdn="{host}"\n'
+        "\n"
+        "[session-management]\n"
+        "max-concurrent-sessions=1\n"
+        "max-sessions-per-user=1\n"
+        "max-concurrent-clients=1\n"
+    )
+
+
+def render_caddyfile(hostname: str) -> str:
+    """Render one exact-host Caddy proxy with verified loopback TLS."""
+
+    host = validate_hostname(hostname)
+    return (
+        "{\n"
+        "\tadmin 127.0.0.1:2019\n"
+        "\tservers {\n"
+        "\t\tprotocols h1 h2\n"
+        "\t}\n"
+        "}\n"
+        "\n"
+        f"{host} {{\n"
+        "\treverse_proxy https://127.0.0.1:8443 {\n"
+        f"\t\theader_up Host {host}\n"
+        "\t\ttransport http {\n"
+        "\t\t\ttls_trust_pool file /etc/dcv/dcv-upstream-ca.pem\n"
+        f"\t\t\ttls_server_name {host}\n"
+        "\t\t\tdial_timeout 5s\n"
+        "\t\t\tresponse_header_timeout 30s\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}\n"
+    )
+
+
+def render_dcv_permissions() -> str:
+    """Grant the seat owner only the features required for the workshop."""
+
+    return "[permissions]\n%owner% allow display keyboard mouse pointer audio-out\n"
+
+
+def host_port_overrides() -> dict[str, str]:
+    """Return the common APTL overrides that reserve 443 and 8443."""
+
+    return {
+        "APTL_HP_WAZUH_DASHBOARD_5601": "9443",
+        "APTL_HP_MISP_443": "9444",
+    }
+
+
+def load_mcp_registration_specs(
+    project_dir: Path, server_ids: Sequence[str]
+) -> dict[str, McpRegistrationSpec]:
+    """Select the exact admitted MCP processes without loading extra secrets."""
+
+    project = project_dir.resolve()
+    document = json.loads((project / ".mcp.json").read_text(encoding="utf-8"))
+    servers = document.get("mcpServers") if isinstance(document, dict) else None
+    if not isinstance(servers, dict):
+        raise ValueError("invalid MCP registration document")
+    selected: dict[str, McpRegistrationSpec] = {}
+    for server_id in server_ids:
+        raw = servers.get(server_id)
+        if raw is None:
+            raise ValueError(f"missing MCP registration: {server_id}")
+        if not isinstance(raw, dict):
+            raise ValueError(f"invalid MCP registration: {server_id}")
+        command = raw.get("command")
+        args = raw.get("args", [])
+        environment = raw.get("env", {})
+        if (
+            not isinstance(command, str)
+            or not command
+            or not isinstance(args, list)
+            or any(not isinstance(item, str) for item in args)
+            or not isinstance(environment, dict)
+            or any(
+                not isinstance(key, str) or not isinstance(value, str)
+                for key, value in environment.items()
+            )
+        ):
+            raise ValueError(f"invalid MCP registration: {server_id}")
+        selected[server_id] = McpRegistrationSpec(
+            argv=(command, *args),
+            env=dict(environment),
+        )
+    return selected
+
+
+def run_semantic_mcp_smoke(
+    project_dir: Path,
+    profile_path: Path | None = None,
+    profile_root: Path | None = None,
+) -> tuple[dict[str, str], ...]:
+    """Run the profile's real red-to-blue MCP operations and redact responses."""
+
+    from aptl.validation.participant_mcp_smoke import (
+        McpRegistration,
+        run_participant_mcp_smoke,
+    )
+    from aptl.validation.participant_profile import load_participant_profile
+
+    project = project_dir.resolve()
+    binding_root = (profile_root or project).resolve()
+    selected_profile = profile_path or (
+        binding_root / "participant-profiles" / "guided-purple-v1" / "profile.json"
+    )
+    profile = load_participant_profile(binding_root, selected_profile)
+    specs = load_mcp_registration_specs(project, profile.mcp_server_ids)
+    safe_environment = {
+        key: value
+        for key in ("HOME", "LANG", "LC_ALL", "LOGNAME", "PATH", "USER")
+        if (value := os.environ.get(key)) is not None
+    }
+    registrations = {
+        server_id: McpRegistration(
+            argv=spec.argv,
+            cwd=project,
+            env={**safe_environment, **spec.env},
+        )
+        for server_id, spec in specs.items()
+    }
+    evidence = run_participant_mcp_smoke(profile, registrations)
+    return tuple(
+        {
+            "check_id": item.check_id,
+            "status": item.status,
+            "summary": item.summary,
+        }
+        for item in evidence
+    )
+
+
+def _ensure_private_directory(path: Path) -> None:
+    """Create or admit one owner-only directory without following a symlink."""
+
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        path.mkdir(mode=0o700)
+        metadata = path.lstat()
+    if stat.S_ISLNK(metadata.st_mode):
+        raise ValueError(f"state directory must not be a symlink: {path}")
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"state path must be a directory: {path}")
+    if metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise ValueError(f"state directory must be owner-only (0700): {path}")
+
+
+def _json_bytes(value: object) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def _create_private_file(base_dir: Path, relative: Path, content: bytes) -> Path:
+    create_exclusive_nofollow(base_dir, relative, content)
+    path = base_dir / relative
+    if stat.S_IMODE(path.stat().st_mode) != 0o600:
+        raise RuntimeError(f"created file is not owner-only: {relative}")
+    return path
+
+
+def _passphrase(token_bytes: Callable[[int], bytes]) -> str:
+    return base64.urlsafe_b64encode(token_bytes(32)).rstrip(b"=").decode("ascii")
+
+
+def prepare_seat(
+    *,
+    state_dir: Path,
+    trial_id: str,
+    seat_id: str,
+    hostname: str,
+    token_bytes: Callable[[int], bytes] = secrets.token_bytes,
+) -> PreparedSeat:
+    """Create the secret and deterministic configuration for one seat exactly once."""
+
+    seat, host = validate_seat_hostname(seat_id, hostname)
+    if not _TRIAL_ID.fullmatch(trial_id):
+        raise ValueError("trial id must be a bounded lowercase identifier")
+    state = state_dir.absolute()
+    _ensure_private_directory(state)
+    for relative in (
+        Path("credentials"),
+        Path("ledgers"),
+        Path("generated"),
+        Path("generated") / seat,
+    ):
+        _ensure_private_directory(state / relative)
+
+    passphrase = _passphrase(token_bytes)
+    credential_file = _create_private_file(
+        state,
+        Path("credentials") / f"{seat}.json",
+        _json_bytes({"username": seat, "passphrase": passphrase}),
+    )
+    ledger = {
+        "schema": "aptl.hosted-seat-input/v1",
+        "trial_id": trial_id,
+        "seat_id": seat,
+        "username": seat,
+        "hostname": host,
+        "dcv_upstream": "https://127.0.0.1:8443",
+        "aws_profile": _AWS_PROFILE,
+        "aws_region": _AWS_REGION,
+    }
+    ledger_file = _create_private_file(
+        state, Path("ledgers") / f"{seat}.json", _json_bytes(ledger)
+    )
+    generated = Path("generated") / seat
+    dcv_config_file = _create_private_file(
+        state, generated / "dcv.conf", render_dcv_config(host).encode()
+    )
+    dcv_permissions_file = _create_private_file(
+        state, generated / f"{seat}.perm", render_dcv_permissions().encode()
+    )
+    caddyfile = _create_private_file(
+        state, generated / "Caddyfile", render_caddyfile(host).encode()
+    )
+    host_ports_file = _create_private_file(
+        state,
+        generated / "aptl-host-ports.env",
+        "".join(
+            f"{key}={value}\n" for key, value in host_port_overrides().items()
+        ).encode(),
+    )
+    return PreparedSeat(
+        state_dir=state,
+        seat_id=seat,
+        hostname=host,
+        credential_file=credential_file,
+        ledger_file=ledger_file,
+        dcv_config_file=dcv_config_file,
+        dcv_permissions_file=dcv_permissions_file,
+        caddyfile=caddyfile,
+        host_ports_file=host_ports_file,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prepare create-once local state for one hosted APTL seat."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--state-dir", type=Path, required=True)
+    prepare.add_argument("--trial-id", required=True)
+    prepare.add_argument("--seat-id", required=True)
+    prepare.add_argument("--hostname", required=True)
+    smoke = subparsers.add_parser("smoke")
+    smoke.add_argument("--project-dir", type=Path, required=True)
+    smoke.add_argument("--profile-path", type=Path)
+    smoke.add_argument("--profile-root", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the helper and print only the non-secret result."""
+
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "prepare":
+        result = prepare_seat(
+            state_dir=arguments.state_dir,
+            trial_id=arguments.trial_id,
+            seat_id=arguments.seat_id,
+            hostname=arguments.hostname,
+        )
+        print(result.public_summary())
+        return 0
+    evidence = run_semantic_mcp_smoke(
+        arguments.project_dir, arguments.profile_path, arguments.profile_root
+    )
+    print(json.dumps(evidence, sort_keys=True))
+    return 0 if all(item["status"] == "passed" for item in evidence) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/workshop/stage_hosted_seat_payload.py
+++ b/tools/workshop/stage_hosted_seat_payload.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Stage the exact non-secret source payload proven for hosted workshop seats."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import stat
+import subprocess
+import tarfile
+from pathlib import Path
+from typing import Final
+
+
+LAB_COMMIT: Final = "e9373f5bec57b2c315c4a9c5d7ab837983b19595"
+CERT_HELPER_COMMIT: Final = "ec54ee2da2cd59c58eb17f1dd7737483901b1838"
+PROFILE_COMMIT: Final = "583e100853ac42240de4827678a20d94edb93d7d"
+CERT_HELPER_PATH: Final = Path("config/wazuh-certs-tool.sh")
+PATCH_PATH: Final = Path("tools/workshop/hosted-seat-kali-node.patch")
+HELPER_PATH: Final = Path("tools/workshop/hosted_seat.py")
+PATCH_SHA256: Final = "71ea3832154d25ce8004e9bd9da8275282f4ff33bdf771ae7e50a8bf34376f4c"
+HELPER_SHA256: Final = (
+    "d9668f172322a4a7d05c325d384afc33e7e66353864465b18c5f64b604e9f4f4"
+)
+
+
+def _run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    stdout: int | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        check=True,
+        stdin=subprocess.DEVNULL,
+        stdout=stdout,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _require_repository(repo_root: Path) -> Path:
+    repo = repo_root.resolve()
+    resolved = (
+        _run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=repo,
+            stdout=subprocess.PIPE,
+        )
+        .stdout.decode()
+        .strip()
+    )
+    if Path(resolved).resolve() != repo:
+        raise ValueError("repo root must be the APTL Git top-level directory")
+    for commit in (LAB_COMMIT, CERT_HELPER_COMMIT, PROFILE_COMMIT):
+        _run(["git", "cat-file", "-e", f"{commit}^{{commit}}"], cwd=repo)
+    patch = repo / PATCH_PATH
+    if _sha256(patch) != PATCH_SHA256:
+        raise ValueError("hosted-seat Kali patch does not match its admitted digest")
+    if _sha256(repo / HELPER_PATH) != HELPER_SHA256:
+        raise ValueError("hosted-seat helper does not match its admitted digest")
+    return repo
+
+
+def _extract_commit(repo: Path, commit: str, destination: Path) -> None:
+    archive = destination.parent / f".{destination.name}.tar"
+    _run(
+        [
+            "git",
+            "archive",
+            "--format=tar",
+            f"--output={archive}",
+            commit,
+        ],
+        cwd=repo,
+    )
+    destination.mkdir(mode=0o750)
+    with tarfile.open(archive, mode="r:") as source:
+        source.extractall(destination, filter="data")
+    archive.unlink()
+
+
+def _git_file(repo: Path, commit: str, relative: Path) -> bytes:
+    return _run(
+        ["git", "show", f"{commit}:{relative.as_posix()}"],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+    ).stdout
+
+
+def stage_payload(repo_root: Path, output_dir: Path) -> Path:
+    """Create one immutable-input bundle without credentials or generated state."""
+
+    repo = _require_repository(repo_root)
+    output = output_dir.absolute()
+    output.mkdir(mode=0o750)
+    if stat.S_IMODE(output.stat().st_mode) not in {0o700, 0o750}:
+        raise ValueError("new payload directory must have mode 0700 or 0750")
+
+    lab_source = output / "lab-source"
+    profile_source = output / "profile-source"
+    _extract_commit(repo, LAB_COMMIT, lab_source)
+    _extract_commit(repo, PROFILE_COMMIT, profile_source)
+
+    cert_helper = lab_source / CERT_HELPER_PATH
+    cert_helper.write_bytes(_git_file(repo, CERT_HELPER_COMMIT, CERT_HELPER_PATH))
+    cert_helper.chmod(0o755)
+
+    patch = repo / PATCH_PATH
+    _run(["git", "apply", "--check", str(patch)], cwd=lab_source)
+    _run(["git", "apply", str(patch)], cwd=lab_source)
+
+    helper = output / "hosted_seat.py"
+    shutil.copyfile(repo / HELPER_PATH, helper)
+    helper.chmod(0o755)
+
+    manifest = {
+        "schema": "aptl.hosted-seat-payload/v1",
+        "lab_commit": LAB_COMMIT,
+        "certificate_helper": {
+            "commit": CERT_HELPER_COMMIT,
+            "path": CERT_HELPER_PATH.as_posix(),
+            "sha256": _sha256(cert_helper),
+        },
+        "profile_commit": PROFILE_COMMIT,
+        "kali_patch": {
+            "path": PATCH_PATH.as_posix(),
+            "sha256": PATCH_SHA256,
+        },
+        "hosted_seat_helper": {
+            "path": HELPER_PATH.as_posix(),
+            "sha256": HELPER_SHA256,
+        },
+    }
+    manifest_path = output / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    manifest_path.chmod(0o644)
+    return manifest_path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Stage the exact source layers for the hosted-seat runbook."
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    arguments = _parser().parse_args()
+    manifest = stage_payload(arguments.repo_root, arguments.output_dir)
+    print(json.dumps({"manifest": str(manifest)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a reproducible operator runbook and deterministic helpers for provisioning one isolated Amazon DCV desktop seat per workshop participant, with exact-host TLS, account-level authentication, least-privilege network exposure, semantic MCP smoke checks, recovery timing, and teardown guidance. The workflow was exercised end to end on one catalyst-dev EC2 host in us-east-2 and fully removed afterward.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #825

## ADR Impact

- ADR-021

## Changes

- Document the 12-seat Black Hat Arsenal topology, provisioning sequence, credential handoff, admission checklist, warm recovery, and teardown procedure.
- Add a fail-closed hosted-seat helper for seat identity, private credential state, DCV and Caddy configuration, APTL port overrides, and redacted semantic MCP smoke checks.
- Add deterministic payload staging from pinned repository commits with admitted helper and Kali patch digests.
- Add unit and integration coverage for seat validation, secure file handling, generated configuration, semantic smoke behavior, payload staging, repository boundaries, and tamper rejection.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Passed `uv run pytest -n auto -k "not integration"`, `uv run pytest -n auto tests/test_techvault_static_gate.py -m integration`, `make policy`, `pre-commit run --all-files`, and strict MkDocs build. Live proof used one m6i.4xlarge Ubuntu host in catalyst-dev/us-east-2: authenticated browser DCV desktop, exact-host public TLS, loopback-only DCV, closed sensitive ports, healthy APTL containers, all four participant semantic MCP checks, 95-second corrected warm recovery, and complete teardown with EC2 health restored.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #825 ← docs/workshop/hosted-backup-seats.md, Issue #825 ← tools/workshop/hosted_seat.py, Issue #825 ← tools/workshop/stage_hosted_seat_payload.py
- TESTS: Issue #825 ← tests/test_hosted_seat_helper.py, Issue #825 ← tests/test_stage_hosted_seat_payload.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.