### PR TITLE
fix: bind explicit models to installed participants

### DIFF
--- a/aptl.json
+++ b/aptl.json
@@ -16,5 +16,11 @@
     "run_storage": {
         "backend": "local",
         "local_path": "./runs"
+    },
+    "experiment": {
+        "participant_models": {
+            "claude": "claude-sonnet-4-5-20250929",
+            "codex": "gpt-5-nano-2025-08-07"
+        }
     }
 }

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,6 +156,7 @@ The victim and kali containers publish no host ports; use
 
 ## Preflights
 
+- [Issue #862 Explicit Participant Model Selection](issue-862-explicit-participant-model-selection-preflight.md)
 - [Issue #859 Idempotent Stuttering In Bounded Participant Realizations](issue-859-idempotent-stuttering-preflight.md)
 - [Issue #858 Bounded Participant Choice Transport](issue-858-bounded-participant-choice-transport-preflight.md)
 - [Issue #852 Dev-To-Main Promotion](issue-852-devmain-promotion-preflight.md)

--- a/docs/architecture/issue-862-explicit-participant-model-selection-preflight.md
+++ b/docs/architecture/issue-862-explicit-participant-model-selection-preflight.md
@@ -1,0 +1,267 @@
+# Issue #862 Explicit Participant Model Selection Preflight
+
+This note fixes the architecture boundaries for explicit model selection by
+installed participant providers. It is design guidance, not an implementation
+plan. No new ADR is needed: ADR-025 owns strict first-party configuration,
+ADR-029 owns secret handling, ADR-032 and ADR-033 own participant isolation and
+reasoning-capture boundaries, ADR-044 owns reproducibility records, and the
+issue-557 and issue-858 preflights own installed-provider execution and choice
+transport.
+
+## Architecture decisions
+
+- Treat the selected `(provider, model)` pair as non-secret participant
+  apparatus configuration. It is not a scenario value, RAES action argument,
+  credential, prompt instruction, participant response, executable identity,
+  workbench profile, or deployment provider.
+- The canonical durable authority is a strict nested field under
+  `AptlConfig.experiment`. It has the same provider-neutral meaning for every
+  installed provider: one provider key selects one bounded, canonical model
+  identifier. A selected installed provider with no admitted model fails
+  closed. The deterministic fixture does not have a model and remains exempt.
+- Do not give model selection a CLI flag, environment override, user-config
+  fallback, scenario extension, or prompt field. The CLI may select the closed
+  provider id; the already validated APTL configuration selects its model.
+  Checked-in or study-specific `aptl.json` can therefore freeze the non-secret
+  identity while credentials remain outside study records.
+- Validate in two stages. Strict Pydantic validation owns shape, length,
+  character, provider-key, and explicitness checks. The provider mapping also
+  rejects product defaults, empty/default/latest sentinels, and rolling aliases
+  that do not name the frozen provider model required by the protocol. Only a
+  bounded real provider request with the selected credential can prove that the
+  leased API project may access that model. Unsupported or inaccessible models
+  fail that request without fallback or a second model attempt.
+- Carry the admitted model through the existing sealed `AgentLaunch` boundary.
+  Every model-bearing invocation through `ManagedAgentAdapter`, including both
+  decision-only and profile launches, must receive an explicit admitted model.
+  `DecisionAgentLaunch` and `ProfileLaunch` must not leave an interactive
+  Claude path that can still inherit a product default. Production appliance
+  assembly may transport the already admitted value through
+  `ApplianceWorkbenchSettings`; it must not introduce a second default or
+  configuration authority.
+- Provider-specific launch mechanics remain inside the existing adapters.
+  Claude Code and Codex CLI both receive their explicit model through their
+  native `--model` argument. Claude retains `--bare`, no session persistence,
+  and no fallback model. Codex retains `--ignore-user-config`,
+  `--ignore-rules`, strict config, ephemeral read-only execution, and all
+  current feature disables. Model configuration supplies only the model
+  argument; it cannot supply arbitrary argv, profiles, tools, feature flags,
+  endpoints, environment variables, or fallback policy.
+- Keep three identities distinct:
+  1. the installed provider and requested model;
+  2. the admitted CLI adapter implementation name and discovered CLI version;
+  3. the RAES participant implementation manifest and selection.
+
+  Do not encode the model into `implementation_name`,
+  `implementation_version`, actor provenance, or the CLI version. The RAES
+  `ParticipantImplementationSelectionModel.configuration_ref` and
+  `configuration_digest` pin the admitted non-secret provider/model
+  configuration; the existing manifest ref/digest continues to identify the
+  implementation contract.
+- Use one provider-neutral provenance projection: `provider`, `model`,
+  configuration ref/digest, CLI implementation identity/version, and RAES
+  manifest/selection refs. Extend the existing participant control and
+  readiness/qualification records at their canonical builders. Do not create a
+  parallel model-provenance DTO or provider-specific fields such as
+  `claude_model` and `codex_model`.
+- The configuration digest covers a versioned, canonical, secret-free
+  projection of the selected provider and exact model, using the repository's
+  existing RFC 8785/SHA-256 pattern. It never covers a token, ambient
+  environment, project credential, raw config file, or provider error.
+  Configuration ref/digest must be attached before the apparatus is projected
+  or a selection is solicited.
+- Evidence must survive turn-zero failure. A readiness report for missing,
+  malformed, unsupported, or inaccessible model selection records the selected
+  provider and admitted model identity when one exists, plus a stable redacted
+  failure classification. Successful per-turn control evidence also records
+  the same pair and the RAES configuration ref/digest. The root qualification
+  report carries the pair used for all installed green/red/blue children.
+- Amend or version the existing readiness, qualification, and control-evidence
+  schemas once at their current serialization owners. Do not silently change a
+  published `v1` meaning in one writer while leaving tests, renderers, or other
+  consumers on the old contract.
+
+## Canonical incumbents to reuse
+
+| Concern | Canonical owner and required reuse |
+| --- | --- |
+| First-party apparatus configuration | `ExperimentSettings`, `AptlConfig`, `load_config()`, `resolve_config_for_cli()`, ADR-025, and `tests/test_config.py`. Keep `extra="forbid"` and strict scalar validation; do not add a pass-through provider options dictionary. |
+| Closed provider selection | `build_selection_provider()`, `_launch_adapter()`, `installed_version()`, and the existing provider/credential mapping in `participant_readiness_provider.py`. Add the admitted model as a parameter at this seam rather than creating dynamic provider discovery or a plugin registry. |
+| Sealed adapter handoff | `AgentLaunch`, `DecisionAgentLaunch`, `ProfileLaunch`, and `ManagedAgentAdapter` in `workbench/runtime.py`. These are the existing secret-free handoff and provider-neutral launch protocol. |
+| Provider mechanics | `ClaudeCodeManagedAgentAdapter` and `CodexManagedAgentAdapter` own exact argv and result parsing. `_admitted_executable()`, `_prepare_work_dir()`, private config checks, and `BoundedProcessRunner` remain unchanged authorities for executable, filesystem, timeout, output, and process-group safety. |
+| Credentials and environment | `EphemeralCredentialBroker`, `contains_placeholder()`, the adapters' minimal base environments, and ADR-029. Lease only `ANTHROPIC_API_KEY` or `CODEX_API_KEY` for the selected provider; model identity is configuration, not a credential alias. |
+| RAES participant provenance | `build_participant_apparatus()`, `ParticipantApparatus`, RAES `ParticipantImplementationManifestModel`, `ParticipantImplementationSelectionModel`, `canonical_contract_digest()`, and the existing apparatus projection/binder. Use selection configuration ref/digest rather than a local RAES mirror. |
+| Decision-only enforcement | `ManagedAgentSelectionProvider`, `ParticipantDecisionSolicitation`, compact-choice parsing, `AptlParticipantRuntime.solicit_selection()`, exact delivered-candidate membership, and RAES admission. Explicit model selection does not alter any of these authorities. |
+| Control evidence | `ParticipantControlEvidence`, `_control_evidence_payload()`, `solicitation_fingerprint()`, and `persist_control_evidence()`. Add provider/model configuration identity here for successful and failed solicitations; retain the full delivered solicitation fingerprint. |
+| Readiness and qualification evidence | `ParticipantReadinessRequest`, `ParticipantReadinessReport`, `ParticipantQualificationReport`, `validate_participant_agency_readiness()`, `validate_participant_agency_qualification()`, and their existing run-store writers/renderers. These own pre-capture failure and green/red/blue qualification evidence. |
+| Persistence and redaction | `RunStorageBackend`, `LocalRunStore` JSON/JSONL methods, `redact()`, `is_sensitive_key()`, `is_secret_shaped_value()`, and ADR-044. Provider/model identity is intentionally reproducible and non-secret; credentials and raw provider diagnostics remain excluded. |
+| Diagnostics and logging | `AgentExecutionError` inside the adapter boundary, existing readiness failure reports, RAES `Diagnostic`/operation status, `get_logger()`, and shared redaction. Enrich the existing translation with stable model-selection classifications; do not add another exception hierarchy or readiness taxonomy. |
+| Verification workflow | `tests/test_config.py`, `tests/test_participant_workbench_adapter.py`, `tests/test_bounded_participant_runtime.py`, participant CLI tests, and `docs/raes/bounded-participant-agency-readiness.md`. Extend these existing seams and the canonical pre-capture suite. |
+
+## Security and cross-cutting passage
+
+| Layer | Required behavior |
+| --- | --- |
+| Auth and ingress | The existing CLI/config-loading boundary remains the only new operator path; this issue adds no API route. The participant cannot submit provider or model fields. If a future API exposes this setting, it must use existing authenticated config DTO conventions and the same strict `AptlConfig` validator rather than a second request-only schema. |
+| Strict config shape | `load_config()` validates the complete `aptl.json` into strict nested Pydantic models. Unknown providers/options, coercible non-strings, blank or oversized ids, control characters, product-default sentinels, and prohibited rolling aliases fail before process launch. Absence is allowed only while no installed provider is selected; selection makes it fatal. |
+| Provider boundary | The closed provider mapping resolves exactly one model and one credential alias. The adapter defensively verifies that `launch.provider` matches its own provider and that an admitted model is present. A model string never selects another provider, local/OSS mode, base URL, profile, or credential source. |
+| RAES shape and apparatus binding | Build the existing manifest and selection only after model configuration admission. RAES model validation checks the manifest/selection shape, and selection configuration ref/digest binds the exact provider/model configuration to the same participant, exposure policy, decision surface, and run. Model choice grants no action or observation authority. |
+| Secret and environment binding | Credentials continue through `EphemeralCredentialBroker` and placeholder checks into a minimal explicit child environment. Do not inherit project/user/provider environment wholesale. Do not place credentials, organization/project ids, or secret-derived digests in model configuration or evidence. |
+| OS/process exposure | The exact model id is intentionally non-secret and may appear in process argv. Credentials remain absent from argv, prompt stdin, paths, and URLs. Existing absolute executable ownership/mode checks, private work directories, no-shell invocation, bounded output, timeout, and whole-process-group teardown remain mandatory. Version discovery remains credential-free and does not consult the selected model. |
+| User/product configuration isolation | Codex must continue using its private `CODEX_HOME` plus `--ignore-user-config`; Claude must continue using `--bare` and explicit tool/settings restrictions. The explicit `--model` is additive to these isolation flags, not a replacement for them. Neither adapter may consult a CLI profile, user setting, project rule, or product default to fill a missing model. |
+| Decision-only compartment | Model selection is orthogonal to tool authority. Keep Codex feature disables, read-only sandbox, empty tool inventory, Claude `--tools ""`, no MCP config for decision launches, compact selection parsing, exact candidate resolution, and RAES admission unchanged. For each solicitation, both adapters bind the same exact provider-native schema: one integer `candidate` bounded from zero through the final alias in that delivered candidate set, with no additional properties. Codex receives each distinct range schema from a create-once `0600` file inside its private run directory. The parser and exact-candidate resolver independently enforce the same bounds after generation. A model id cannot add tools, MCP servers, shell access, filesystem writes, browsing, subagents, or native action authority. |
+| Provider output and errors | Treat stdout/stderr and JSON events as hostile and bounded. Adapters may classify known provider model-not-found/access-denied failures into stable secret-free messages, but must not persist or echo raw stderr, response bodies, request ids, account/project details, stack traces, or provider output. Unknown failures retain the existing generic failure. Apply `redact()` before any diagnostic crosses the adapter boundary. |
+| Accessibility validation | Do not add a raw HTTP model-list/probe path or duplicate provider client. The first bounded, tool-disabled provider request and the live green/red/blue qualification are the accessibility proof for the exact credential lease and model. Failure is terminal for that configured pair; no implicit fallback, alias resolution, or retry with another model is allowed. |
+| Persistence and evidence | Existing run-store path containment and JSON/JSONL redaction remain the only persistence boundary. Record provider, exact model, configuration ref/digest, CLI version, RAES manifest/selection refs, outcome, and `official_capture_started: false`. Never record credentials, ambient configuration, raw prompt/completion, or raw provider diagnostics. |
+| Error envelope | Missing/malformed selection is a deterministic configuration failure; unsupported/inaccessible selection is an installed-provider failure. Both use the existing readiness/control failure envelopes with stable classifications and non-secret provider/model identity. They are not degraded lab readiness, successful episodes with warnings, or RAES action failures. |
+
+## Extensibility seam
+
+The seam remains the existing installed-provider construction and launch
+boundary:
+
+```text
+(provider_id, model_id, configuration_ref, configuration_digest,
+ executable, credential_alias, adapter_factory)
+```
+
+The provider-neutral fields flow through `AgentLaunch`, participant apparatus,
+control evidence, and readiness evidence. The adapter factory alone translates
+them to provider-native argv and provider-native safe error classification.
+Adding the next installed provider should require one strict config entry, one
+closed provider mapping entry, and one adapter implementation; it must not
+require changes to RAES decision surfaces, action realizations, candidate
+transport, credential brokerage, run-store layout, or the provider-neutral
+evidence fields.
+
+Do not generalize this seam into arbitrary command/argv/environment
+configuration. Provider registration remains code-owned and closed.
+
+## Whole-repository surface in scope
+
+- `src/aptl/core/config.py`, `src/aptl/cli/_common.py`, and
+  `src/aptl/cli/participant_readiness.py`;
+- `src/aptl/validation/participant_readiness_provider.py`,
+  `participant_readiness_models.py`, `participant_agency_readiness.py`,
+  `participant_qualification_models.py`, and
+  `participant_agency_qualification.py`;
+- `src/aptl/workbench/runtime.py`, `agent.py`, `codex_agent.py`,
+  `credentials.py`, `process.py`, and `bootstrap.py`;
+- `src/aptl/backends/raes_participant_provider.py`,
+  `raes_participant_apparatus_models.py`, `raes_participant_apparatus.py`,
+  `raes_participant_control_evidence.py`, `raes_participant_driver.py`, and
+  `raes_participant_runtime.py`;
+- `src/aptl/core/runstore.py`, `src/aptl/utils/redaction.py`, and
+  `src/aptl/utils/logging.py`;
+- checked-in and participant-profile `aptl.json` examples that intentionally
+  freeze an installed model, plus signed appliance workbench assembly where it
+  launches an installed participant;
+- the config, CLI, workbench-adapter, bounded-participant runtime,
+  readiness/qualification, redaction, and run-store tests; and
+- `docs/raes/bounded-participant-agency-readiness.md`, which must show
+  non-secret model selection/freeze separately from credential setup and retain
+  official capture disabled.
+
+No deployment backend, Compose topology, MCP server, web frontend, scenario
+SDL, or RAES action-envelope expansion is in scope.
+
+## Live qualification obligations discovered after preflight
+
+The explicit-model implementation made the installed Codex qualification
+executable end to end. That live run exposed two incumbent defects which must
+be repaired before issue 862 can truthfully satisfy its live acceptance gate:
+
+- the projection offered actions whose declared successful-observation
+  prerequisites did not yet hold at the exact episode state cut, including a
+  repeat sign-out without a fresh authentication; and
+- the native HTTP probe realization encoded `HEAD` as a generic custom method
+  instead of the provider's dedicated head-only operation.
+
+The subsequent immutable-model qualification also showed that a pinned model
+can obey the bounded decision protocol only if its provider-native structured
+output constraint is explicit and reflects the current candidate count.
+Codex therefore receives the same exact compact, range-bounded selection schema
+as Claude through `--output-schema`; each distinct schema is sealed as a
+private create-once file and adds no participant capability. Provider-native
+generation constraints do not replace APTL's independent parser, range check,
+exact candidate resolution, or RAES admission. Provider access errors may
+appear in nested Codex JSONL error items, so classification inspects both
+top-level and nested messages but emits only the same stable secret-free
+diagnostic.
+
+These repairs do not let model selection change the RAES action envelope,
+governed arguments, tools, or authority. Candidate projection filters the
+already-declared actions by the same prerequisite relation enforced again at
+realization admission. The HTTP repair makes the existing declared `HEAD`
+choice match its native semantics. The boundary suite uses an ineligible
+`TRACE` mutation to retain proof that a governed method cannot be replaced by
+an out-of-surface value.
+
+The affected incumbent owners are
+`raes_participant_candidates.py`, `raes_participant_projection.py`,
+`raes_participant_realizations.py`,
+`raes_participant_realization_execution.py`, and
+`participant_qualification_boundaries.py`. These are implementation
+obligations discovered by the required live gate, not a redesign of the model
+selection seam.
+
+## Gotchas and anti-patterns
+
+- Do not fix Codex alone. Claude Code and Codex must consume the same admitted
+  provider/model provenance contract even though their flags and result
+  envelopes differ.
+- Do not leave `ProfileLaunch` or appliance workbench assembly as a
+  default-inheriting escape hatch while fixing only `DecisionAgentLaunch`.
+- Do not accept `--model` on the readiness CLI, `MODEL` in the environment,
+  provider output, prompt text, a scenario extension, or user CLI
+  configuration as apparatus authority.
+- Do not use aliases such as `default`, `latest`, a product family nickname, or
+  an omitted value when the research protocol requires a frozen model
+  identity.
+- Do not enable Claude fallback models, retry Codex with its product default,
+  or treat a different accessible model as equivalent after failure.
+- Do not encode model identity into implementation name/version, actor
+  provenance, provider executable version, workbench profile, or RAES action
+  address. Those concepts have different owners and lifecycles.
+- Do not add provider-specific model fields to every report. Persist the one
+  provider-neutral pair and its configuration identity.
+- Do not add a generic provider options mapping, free-form argv, configuration
+  profile, base URL, arbitrary credential alias, or tool list to
+  `AptlConfig`. Explicit model selection must not become a general CLI
+  pass-through.
+- Do not validate access with `curl`, a new SDK client, an unbounded model-list
+  request, or credentials in argv. Reuse the admitted adapter and bounded live
+  qualification.
+- Do not expose raw CLI stderr or JSON error events to make diagnostics useful.
+  Classify known failures and otherwise preserve the existing generic,
+  secret-free envelope.
+- Do not hash credentials into a configuration digest or assume redaction after
+  persistence repairs an unsafe record.
+- Do not let model selection change prompt/candidate semantics, tool inventory,
+  decision-only flags, RAES exposure policy, action envelope, native
+  realization, or evidence visibility. State-qualifying an incumbent action
+  against its declared prerequisite and correcting an incumbent realization
+  to match its declared method are independent live-gate repairs documented
+  above.
+- Do not claim accessibility from config validation or a CLI version command.
+  It is proved only by the exact credential/model request and the live
+  qualification result.
+
+## Non-goals and boundaries
+
+This issue does not add model routing, fallback, benchmarking, automatic model
+discovery, capability negotiation, price/budget selection, provider plugins,
+local/OSS providers, arbitrary endpoints, new credential sources, or a general
+participant configuration framework. It does not make model choice an EXP-005
+factor, scenario variable, participant action, or participant-visible choice.
+
+It does not redesign RAES manifests, decision surfaces, compact choice
+transport, workbench tools, deployment, MCP, capture, run-store layout, API
+authentication, or appliance egress policy. The limited incumbent
+qualification repairs documented above align projection and realization with
+the already-declared RAES semantics. It does not capture prompts, completions,
+reasoning, or raw provider errors.
+
+The live Codex green/red/blue qualification is an implementation acceptance
+gate, not part of this architecture preflight. It must use an explicitly
+selected accessible model and preserve `official_capture_started: false`.

--- a/docs/raes/bounded-participant-agency-readiness.md
+++ b/docs/raes/bounded-participant-agency-readiness.md
@@ -80,6 +80,31 @@ root report lists their stable run IDs and evidence paths.
 
 ## Installed Provider Qualification
 
+Installed providers do not inherit a product default model. Freeze the exact
+non-secret provider selection in `aptl.json`:
+
+```json
+{
+  "experiment": {
+    "participant_models": {
+      "claude": "claude-sonnet-4-5-20250929",
+      "codex": "gpt-5-nano-2025-08-07"
+    }
+  }
+}
+```
+
+The selected model is passed explicitly to the provider process. Missing,
+invalid, unsupported, or inaccessible selections fail closed; APTL does not
+fall back to another model. Credentials remain separate from this
+configuration. For every solicitation, both installed adapters bind the same
+exact response schema using their provider-native structured-output mechanism:
+one integer `candidate`, bounded from zero through the final candidate alias
+delivered for that state cut, with no additional properties. Codex receives
+each distinct range schema from a private, create-once file inside the run
+directory. APTL still parses the result independently and resolves the alias
+only against the complete delivered solicitation.
+
 The installed-provider modes use one provider-specific, non-placeholder
 credential lease:
 
@@ -89,18 +114,21 @@ credential lease:
 The child receives no action tools, MCP servers, shell, Docker, SSH, browser,
 or backend handle. It only chooses one complete candidate from the delivered
 RAES decision surface. APTL presents the installed provider with a bounded,
-numbered transport view containing every action identity and governed argument
-map. The number is a transient alias for one delivered `proposal_ref`; APTL
-resolves it to the unchanged full selection before RAES admission. The complete
+numbered transport view containing every action identity whose declared
+prerequisites hold at that exact state cut, with every governed argument map.
+The number is a transient alias for one delivered `proposal_ref`; APTL resolves
+it to the unchanged full selection before RAES admission. The complete
 delivered solicitation remains the evidence authority.
 
-Each finite governed choice is represented by a distinct proposal, and the
-selected values materially determine the native semantic operation and
-independent readback. RAES re-resolves the exact state cut, delivery,
-apparatus, proposal, and governed arguments before APTL can execute a closed
-realization. Missing, malformed, duplicate, or out-of-range transport choices
-fail before admission. Installed-provider prompts remain bounded to 32,768
-characters.
+While an action is eligible, each finite governed choice is represented by a
+distinct proposal, and the selected values materially determine the native
+semantic operation and independent readback. Projection and realization
+admission independently enforce successful-observation prerequisites; a
+sign-out requires a fresh authentication after any earlier sign-out. RAES
+re-resolves the exact state cut, delivery, apparatus, proposal, and governed
+arguments before APTL can execute a closed realization. Missing, malformed,
+duplicate, stale, or out-of-range transport choices fail before admission.
+Installed-provider prompts remain bounded to 32,768 characters.
 
 Run each implementation separately:
 
@@ -122,6 +150,16 @@ Each command repeats the deterministic qualification and adds bounded green,
 red, and blue episodes for that installed implementation. Missing or unsafe
 executables, credentials, malformed output, timeouts, and out-of-surface
 selections fail with redacted readiness evidence.
+
+The root `aptl.participant-readiness-suite-report/v2` identifies the installed
+provider and model. Each child
+`aptl.participant-readiness-report/v2` does the same, including failures before
+the first turn. Successful and rejected solicitations write
+`aptl.participant-control-evidence/v2` records that join the provider/model pair
+to the RAES implementation manifest, implementation selection, and canonical
+configuration ref/digest. These records are the proof that the qualified CLI
+implementation actually used the configured model under the selected RAES
+apparatus.
 
 ## Single-Trajectory Diagnostics
 

--- a/participant-profiles/guided-purple-v1/aptl.json
+++ b/participant-profiles/guided-purple-v1/aptl.json
@@ -16,5 +16,11 @@
   "run_storage": {
     "backend": "local",
     "local_path": "./runs"
+  },
+  "experiment": {
+    "participant_models": {
+      "claude": "claude-sonnet-4-5-20250929",
+      "codex": "gpt-5-nano-2025-08-07"
+    }
   }
 }

--- a/participant-profiles/guided-purple-v1/asset-lock.json
+++ b/participant-profiles/guided-purple-v1/asset-lock.json
@@ -19,7 +19,7 @@
       "asset_id": "aptl-config",
       "kind": "project-file",
       "source": "participant-profiles/guided-purple-v1/aptl.json",
-      "sha256": "be9e7f8bf0485085ae1903bf47c4566d101367bf2d0b7abc42e1479ac0b2bf4c"
+      "sha256": "77b204f81901d9a0b49572a0b1fa06d583419445a34f908d7e04b62a62520043"
     },
     {
       "asset_id": "raes-scenario",

--- a/participant-profiles/guided-purple-v1/profile.json
+++ b/participant-profiles/guided-purple-v1/profile.json
@@ -13,7 +13,7 @@
   },
   "config": {
     "path": "participant-profiles/guided-purple-v1/aptl.json",
-    "sha256": "be9e7f8bf0485085ae1903bf47c4566d101367bf2d0b7abc42e1479ac0b2bf4c"
+    "sha256": "77b204f81901d9a0b49572a0b1fa06d583419445a34f908d7e04b62a62520043"
   },
   "readiness": {
     "path": "participant-profiles/guided-purple-v1/readiness.json",
@@ -29,7 +29,7 @@
     "asset_lock_schema": "aptl.participant-asset-lock/v1",
     "qualification_report_schema": "aptl.participant-qualification/v1",
     "asset_lock_ref": "participant-profiles/guided-purple-v1/asset-lock.json",
-    "asset_lock_sha256": "1868aa5a9c73700fa064c74cbec7163af0068232a959a7f729860d439604ce64",
+    "asset_lock_sha256": "8bb505ae9c69e1959814fb64df4db893ad2459355732e76561bdf1b348ca4057",
     "qualification_report_ref": "release/qualification/guided-purple-v1.json"
   },
   "budgets": {

--- a/src/aptl/backends/raes_participant_apparatus.py
+++ b/src/aptl/backends/raes_participant_apparatus.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping
+from dataclasses import dataclass
 
 import rfc8785
 from raes_contracts.contracts import (
@@ -67,6 +68,24 @@ _CONCEPT_BINDINGS = (
 _MODEL_CONFIGURATION_TARGET = "model.identifier"
 
 
+@dataclass(frozen=True)
+class _ApparatusRefs:
+    """Stable contract references for one participant run."""
+
+    manifest: str
+    selection: str
+    policy: str
+
+
+@dataclass(frozen=True)
+class _ManifestAssembly:
+    """Manifest payload plus its optional bound model configuration."""
+
+    payload: dict[str, object]
+    configuration_ref: str | None
+    configuration_digest: str | None
+
+
 def build_participant_apparatus(
     *,
     participant_address: str,
@@ -78,19 +97,63 @@ def build_participant_apparatus(
 ) -> ParticipantApparatus:
     """Build the manifest and exact run selection for one installed agent."""
 
-    manifest_ref = (
-        "participant-implementation-manifests."
-        f"{implementation_name}.{implementation_version}"
+    refs = _apparatus_refs(
+        participant_address,
+        implementation_name,
+        implementation_version,
+        run_id,
     )
-    selection_ref = (
-        f"participant-implementation-selections.{run_id}."
-        f"{participant_address.removeprefix('participant.behavior.')}"
+    assembly = _manifest_assembly(
+        implementation_name,
+        implementation_version,
+        provider_name,
+        model,
     )
-    policy_id = (
-        f"participant-exposure-policies.{run_id}."
-        f"{participant_address.removeprefix('participant.behavior.')}"
+    manifest = ParticipantImplementationManifestModel.model_validate(assembly.payload)
+    selection = _implementation_selection(
+        participant_address,
+        refs,
+        manifest,
+        assembly,
     )
-    manifest_payload: dict[str, object] = {
+    return ParticipantApparatus(
+        implementation_selection_ref=refs.selection,
+        manifest_ref=refs.manifest,
+        manifest=manifest,
+        selection=selection,
+        provider=provider_name,
+        model=model,
+    )
+
+
+def _apparatus_refs(
+    participant_address: str,
+    implementation_name: str,
+    implementation_version: str,
+    run_id: str,
+) -> _ApparatusRefs:
+    """Derive stable references for one participant apparatus."""
+
+    participant_suffix = participant_address.removeprefix("participant.behavior.")
+    return _ApparatusRefs(
+        manifest=(
+            "participant-implementation-manifests."
+            f"{implementation_name}.{implementation_version}"
+        ),
+        selection=f"participant-implementation-selections.{run_id}.{participant_suffix}",
+        policy=f"participant-exposure-policies.{run_id}.{participant_suffix}",
+    )
+
+
+def _manifest_assembly(
+    implementation_name: str,
+    implementation_version: str,
+    provider_name: str,
+    model: str | None,
+) -> _ManifestAssembly:
+    """Build one manifest payload and optional model configuration binding."""
+
+    payload: dict[str, object] = {
         "identity": {
             "name": implementation_name,
             "version": implementation_version,
@@ -121,39 +184,55 @@ def build_participant_apparatus(
             ],
         },
     }
-    configuration_ref: str | None = None
-    configuration_digest: str | None = None
-    if model is not None:
-        configuration_payload = {
-            "schema": "aptl.installed-participant-model-configuration/v1",
-            "provider": provider_name,
-            "model": model,
-        }
-        configuration_digest = canonical_mapping_digest(configuration_payload)
-        configuration_ref = (
-            "participant-implementation-configurations."
-            f"{provider_name}.{configuration_digest.removeprefix('sha256:')[:16]}"
-        )
-        manifest_payload["configuration_registry"] = ConfigurationTargetRegistryModel(
-            owner=BindingOwnerModel(
-                contract_id="participant-implementation-manifest/v1",
-                contract_version="1",
-                validator_id="aptl-installed-participant-model",
-                validator_version="1",
-            ),
-            targets={
-                _MODEL_CONFIGURATION_TARGET: ConfigurationTargetDeclarationModel(
-                    target_id=_MODEL_CONFIGURATION_TARGET,
-                    value_type=BindingScalarType.STRING,
-                    allowed_value_kinds=["literal"],
-                    sensitivity="internal",
-                )
-            },
-        ).model_dump(mode="json")
-    manifest = ParticipantImplementationManifestModel.model_validate(manifest_payload)
+    if model is None:
+        return _ManifestAssembly(payload, None, None)
+    configuration_payload = {
+        "schema": "aptl.installed-participant-model-configuration/v1",
+        "provider": provider_name,
+        "model": model,
+    }
+    configuration_digest = canonical_mapping_digest(configuration_payload)
+    configuration_ref = (
+        "participant-implementation-configurations."
+        f"{provider_name}.{configuration_digest.removeprefix('sha256:')[:16]}"
+    )
+    payload["configuration_registry"] = _model_configuration_registry()
+    return _ManifestAssembly(payload, configuration_ref, configuration_digest)
+
+
+def _model_configuration_registry() -> dict[str, object]:
+    """Declare the literal internal model identifier binding."""
+
+    registry = ConfigurationTargetRegistryModel(
+        owner=BindingOwnerModel(
+            contract_id="participant-implementation-manifest/v1",
+            contract_version="1",
+            validator_id="aptl-installed-participant-model",
+            validator_version="1",
+        ),
+        targets={
+            _MODEL_CONFIGURATION_TARGET: ConfigurationTargetDeclarationModel(
+                target_id=_MODEL_CONFIGURATION_TARGET,
+                value_type=BindingScalarType.STRING,
+                allowed_value_kinds=["literal"],
+                sensitivity="internal",
+            )
+        },
+    )
+    return registry.model_dump(mode="json")
+
+
+def _implementation_selection(
+    participant_address: str,
+    refs: _ApparatusRefs,
+    manifest: ParticipantImplementationManifestModel,
+    assembly: _ManifestAssembly,
+) -> ParticipantImplementationSelectionModel:
+    """Bind one exact manifest, model configuration, and exposure policy."""
+
     policy_digest = canonical_mapping_digest(
         {
-            "policy_id": policy_id,
+            "policy_id": refs.policy,
             "version": "1",
             "participant_address": participant_address,
             "disclosed_classes": ["task-statement", "observation-stream"],
@@ -164,14 +243,14 @@ def build_participant_apparatus(
         {
             "participant_address": participant_address,
             "implementation_identity": manifest.identity.model_dump(mode="json"),
-            "manifest_ref": manifest_ref,
+            "manifest_ref": refs.manifest,
             "manifest_digest": canonical_contract_digest(manifest),
-            "configuration_ref": configuration_ref,
-            "configuration_digest": configuration_digest,
+            "configuration_ref": assembly.configuration_ref,
+            "configuration_digest": assembly.configuration_digest,
             "selected_decision_surface_mode": "autonomous",
             "participant_contract_versions": list(_PARTICIPANT_SELECTION_CONTRACTS),
             "exposure_policy": {
-                "policy_id": policy_id,
+                "policy_id": refs.policy,
                 "policy_version": "1",
                 "policy_digest": policy_digest,
                 "exposure_policy_kinds": [
@@ -190,14 +269,7 @@ def build_participant_apparatus(
             },
         }
     )
-    return ParticipantApparatus(
-        implementation_selection_ref=selection_ref,
-        manifest_ref=manifest_ref,
-        manifest=manifest,
-        selection=selection,
-        provider=provider_name,
-        model=model,
-    )
+    return selection
 
 
 def canonical_mapping_digest(value: Mapping[str, object]) -> str:

--- a/src/aptl/backends/raes_participant_apparatus.py
+++ b/src/aptl/backends/raes_participant_apparatus.py
@@ -7,6 +7,10 @@ from collections.abc import Mapping
 
 import rfc8785
 from raes_contracts.contracts import (
+    BindingOwnerModel,
+    BindingScalarType,
+    ConfigurationTargetDeclarationModel,
+    ConfigurationTargetRegistryModel,
     ParticipantImplementationManifestModel,
     ParticipantImplementationSelectionModel,
 )
@@ -28,6 +32,8 @@ __all__ = [
 _PARTICIPANT_CONTRACTS = (
     "participant-implementation-manifest-v1",
     "participant-implementation-provenance-v1",
+    "experiment-binding-descriptors-v1",
+    "participant-configuration-result-v1",
     "participant-episode-state-envelope-v1",
     "participant-episode-history-event-stream-v1",
     "participant-behavior-history-event-stream-v1",
@@ -58,6 +64,7 @@ _CONCEPT_BINDINGS = (
         "family": "provenance-and-evidence",
     },
 )
+_MODEL_CONFIGURATION_TARGET = "model.identifier"
 
 
 def build_participant_apparatus(
@@ -65,6 +72,8 @@ def build_participant_apparatus(
     participant_address: str,
     implementation_name: str,
     implementation_version: str,
+    provider_name: str,
+    model: str | None,
     run_id: str,
 ) -> ParticipantApparatus:
     """Build the manifest and exact run selection for one installed agent."""
@@ -81,41 +90,67 @@ def build_participant_apparatus(
         f"participant-exposure-policies.{run_id}."
         f"{participant_address.removeprefix('participant.behavior.')}"
     )
-    manifest = ParticipantImplementationManifestModel.model_validate(
-        {
-            "identity": {
-                "name": implementation_name,
-                "version": implementation_version,
-            },
-            "implementation_kind": "agent",
-            "supported_contract_versions": list(_PARTICIPANT_CONTRACTS),
-            "compatibility": {
-                "participant_runtimes": ["aptl"],
-                "processors": ["raes-reference-processor"],
-                "backends": ["aptl"],
-            },
-            "concept_bindings": list(_CONCEPT_BINDINGS),
-            "constraints": {
-                "max_parallel_episodes": "1",
-                "action_execution": "none; decision source only",
-                "decision_payload": "RAES participant-decision-surface-v2 view",
-            },
-            "capabilities": {
-                "supported_participant_contracts": list(
-                    _PARTICIPANT_SELECTION_CONTRACTS
-                ),
-                "supported_decision_surface_modes": ["autonomous"],
-                # The installed CLI is a decision source only.  It is never
-                # given participant action, shell, browser, filesystem,
-                # network, or MCP affordances.
-                "tool_affordance_expectations": ["x-aptl:no-action-tools"],
-                "exposure_policy_kinds": [
-                    "task-statement",
-                    "observation-stream",
-                ],
-            },
+    manifest_payload: dict[str, object] = {
+        "identity": {
+            "name": implementation_name,
+            "version": implementation_version,
+        },
+        "implementation_kind": "agent",
+        "supported_contract_versions": list(_PARTICIPANT_CONTRACTS),
+        "compatibility": {
+            "participant_runtimes": ["aptl"],
+            "processors": ["raes-reference-processor"],
+            "backends": ["aptl"],
+        },
+        "concept_bindings": list(_CONCEPT_BINDINGS),
+        "constraints": {
+            "max_parallel_episodes": "1",
+            "action_execution": "none; decision source only",
+            "decision_payload": "RAES participant-decision-surface-v2 view",
+        },
+        "capabilities": {
+            "supported_participant_contracts": list(_PARTICIPANT_SELECTION_CONTRACTS),
+            "supported_decision_surface_modes": ["autonomous"],
+            # The installed CLI is a decision source only. It is never
+            # given participant action, shell, browser, filesystem,
+            # network, or MCP affordances.
+            "tool_affordance_expectations": ["x-aptl:no-action-tools"],
+            "exposure_policy_kinds": [
+                "task-statement",
+                "observation-stream",
+            ],
+        },
+    }
+    configuration_ref: str | None = None
+    configuration_digest: str | None = None
+    if model is not None:
+        configuration_payload = {
+            "schema": "aptl.installed-participant-model-configuration/v1",
+            "provider": provider_name,
+            "model": model,
         }
-    )
+        configuration_digest = canonical_mapping_digest(configuration_payload)
+        configuration_ref = (
+            "participant-implementation-configurations."
+            f"{provider_name}.{configuration_digest.removeprefix('sha256:')[:16]}"
+        )
+        manifest_payload["configuration_registry"] = ConfigurationTargetRegistryModel(
+            owner=BindingOwnerModel(
+                contract_id="participant-implementation-manifest/v1",
+                contract_version="1",
+                validator_id="aptl-installed-participant-model",
+                validator_version="1",
+            ),
+            targets={
+                _MODEL_CONFIGURATION_TARGET: ConfigurationTargetDeclarationModel(
+                    target_id=_MODEL_CONFIGURATION_TARGET,
+                    value_type=BindingScalarType.STRING,
+                    allowed_value_kinds=["literal"],
+                    sensitivity="internal",
+                )
+            },
+        ).model_dump(mode="json")
+    manifest = ParticipantImplementationManifestModel.model_validate(manifest_payload)
     policy_digest = canonical_mapping_digest(
         {
             "policy_id": policy_id,
@@ -131,6 +166,8 @@ def build_participant_apparatus(
             "implementation_identity": manifest.identity.model_dump(mode="json"),
             "manifest_ref": manifest_ref,
             "manifest_digest": canonical_contract_digest(manifest),
+            "configuration_ref": configuration_ref,
+            "configuration_digest": configuration_digest,
             "selected_decision_surface_mode": "autonomous",
             "participant_contract_versions": list(_PARTICIPANT_SELECTION_CONTRACTS),
             "exposure_policy": {
@@ -158,6 +195,8 @@ def build_participant_apparatus(
         manifest_ref=manifest_ref,
         manifest=manifest,
         selection=selection,
+        provider=provider_name,
+        model=model,
     )
 
 

--- a/src/aptl/backends/raes_participant_apparatus_models.py
+++ b/src/aptl/backends/raes_participant_apparatus_models.py
@@ -21,6 +21,8 @@ class ParticipantApparatus:
     manifest_ref: str
     manifest: ParticipantImplementationManifestModel
     selection: ParticipantImplementationSelectionModel
+    provider: str
+    model: str | None
 
 
 @dataclass(frozen=True)

--- a/src/aptl/backends/raes_participant_candidates.py
+++ b/src/aptl/backends/raes_participant_candidates.py
@@ -20,11 +20,23 @@ _MAX_CANDIDATE_VARIANTS_PER_ACTION = 4096
 def candidate_selections(
     surface: ParticipantDecisionSurfaceV2Model,
     runtime_model: object,
+    *,
+    completed_action_sequence: tuple[str, ...],
 ) -> tuple[ParticipantDecisionSurfaceSelectionV2Model, ...]:
-    """Resolve selections for the bounded participant workflow."""
+    """Resolve choices whose native prerequisites hold at this state cut."""
+
+    from aptl.backends.raes_participant_realizations import (
+        unmet_required_prior_actions,
+    )
+
     assert surface.delivery is not None
     candidates: list[ParticipantDecisionSurfaceSelectionV2Model] = []
     for entry in surface.participant_view.action_entries:
+        if unmet_required_prior_actions(
+            entry.action_contract_address,
+            completed_action_sequence,
+        ):
+            continue
         contract = runtime_model.action_contracts[entry.action_contract_address]
         for arguments in _governed_argument_variants(contract.argument_definitions):
             variant_digest = hashlib.sha256(rfc8785.dumps(arguments)).hexdigest()[:16]

--- a/src/aptl/backends/raes_participant_control_evidence.py
+++ b/src/aptl/backends/raes_participant_control_evidence.py
@@ -65,7 +65,7 @@ def _control_evidence_payload(
     delivery = turn.surface.delivery
     selection = evidence.selection
     return {
-        "schema": "aptl.participant-control-evidence/v1",
+        "schema": "aptl.participant-control-evidence/v2",
         "run_id": authority.run_id,
         "participant_address": view.participant_address,
         "episode_id": view.episode_id,
@@ -77,9 +77,17 @@ def _control_evidence_payload(
         "delivery_ref": delivery.delivery_ref if delivery is not None else None,
         "implementation_name": evidence.provider.implementation_name,
         "implementation_version": evidence.provider.implementation_version,
+        "provider": turn.apparatus.provider,
+        "model": turn.apparatus.model,
         "implementation_manifest_ref": turn.apparatus.manifest_ref,
         "implementation_manifest_digest": turn.apparatus.selection.manifest_digest,
         "implementation_selection_ref": turn.apparatus.implementation_selection_ref,
+        "implementation_configuration_ref": (
+            turn.apparatus.selection.configuration_ref
+        ),
+        "implementation_configuration_digest": (
+            turn.apparatus.selection.configuration_digest
+        ),
         "exposure_policy_ref": turn.apparatus.selection.exposure_policy.policy_id,
         "solicitation_id": evidence.solicitation.solicitation_id,
         "solicitation_operation_id": evidence.solicitation_receipt.operation_id,

--- a/src/aptl/backends/raes_participant_fixture_core.py
+++ b/src/aptl/backends/raes_participant_fixture_core.py
@@ -283,9 +283,11 @@ def _http_status(
         "0",
         "--proto",
         "=http",
-        "-X",
-        method,
     ]
+    if method == "HEAD":
+        command.append("--head")
+    else:
+        command.extend(("-X", method))
     command.append(f"{_LAB_HTTP_ORIGIN}{endpoint}")
     return _checked_exec(
         context.backend,
@@ -315,10 +317,12 @@ def _http_response_metadata(
         "0",
         "--proto",
         "=http",
-        "-X",
-        method,
-        f"{_LAB_HTTP_ORIGIN}{endpoint}",
     ]
+    if method == "HEAD":
+        command.append("--head")
+    else:
+        command.extend(("-X", method))
+    command.append(f"{_LAB_HTTP_ORIGIN}{endpoint}")
     observed = _checked_exec(
         context.backend,
         context.container(source_node),

--- a/src/aptl/backends/raes_participant_projection.py
+++ b/src/aptl/backends/raes_participant_projection.py
@@ -97,7 +97,11 @@ def project_participant_turn(
             context.visible_context_refs,
         ),
         observation_history=_render_observation_history(context.history),
-        candidates=candidate_selections(delivered, runtime_model),
+        candidates=candidate_selections(
+            delivered,
+            runtime_model,
+            completed_action_sequence=_completed_action_sequence(context.history),
+        ),
         apparatus=replace(apparatus, selection=exact_selection),
     )
 
@@ -395,3 +399,17 @@ def _render_observation_history(
             }
         )
     return tuple(rendered)
+
+
+def _completed_action_sequence(
+    history: tuple[ParticipantBehaviorHistoryEvent, ...],
+) -> tuple[str, ...]:
+    """Return successful observed actions in episode order."""
+
+    return tuple(
+        event.action_contract_address
+        for event in history
+        if event.event_type.value == "observation_emitted"
+        and event.action_result is not None
+        and event.action_result.to_payload()["status"] == "succeeded"
+    )

--- a/src/aptl/backends/raes_participant_provider.py
+++ b/src/aptl/backends/raes_participant_provider.py
@@ -29,6 +29,12 @@ class ParticipantSelectionProvider(Protocol):
     """Select one complete RAES proposal without executing its action."""
 
     @property
+    def provider_name(self) -> str: ...
+
+    @property
+    def model(self) -> str | None: ...
+
+    @property
     def implementation_name(self) -> str: ...
 
     @property
@@ -42,15 +48,15 @@ class DeterministicSelectionProvider:
 
     implementation_name = "aptl-deterministic-selection-fixture"
     implementation_version = "1.0.0"
+    provider_name = "deterministic"
+    model = None
 
     def __init__(self, *, candidate_index: int = 0) -> None:
         self._candidate_index = candidate_index
 
     def select(self, solicitation: ParticipantDecisionSolicitation) -> str:
         try:
-            candidate = solicitation.candidate_selections[
-                self._candidate_index
-            ]
+            candidate = solicitation.candidate_selections[self._candidate_index]
         except IndexError as exc:
             raise ValueError(
                 "deterministic provider candidate index is outside the surface"
@@ -66,13 +72,25 @@ class ManagedAgentSelectionProvider:
         *,
         adapter: ManagedAgentAdapter,
         handle: object,
+        provider_name: str,
+        model: str,
         implementation_name: str,
         implementation_version: str,
     ) -> None:
         self._adapter = adapter
         self._handle = handle
+        self._provider_name = provider_name
+        self._model = model
         self._implementation_name = implementation_name
         self._implementation_version = implementation_version
+
+    @property
+    def provider_name(self) -> str:
+        return self._provider_name
+
+    @property
+    def model(self) -> str:
+        return self._model
 
     @property
     def implementation_name(self) -> str:
@@ -84,7 +102,11 @@ class ManagedAgentSelectionProvider:
 
     def select(self, solicitation: ParticipantDecisionSolicitation) -> str:
         prompt, aliases = _compact_selection_prompt(solicitation)
-        raw_selection = self._adapter.respond(self._handle, prompt)
+        raw_selection = self._adapter.respond(
+            self._handle,
+            prompt,
+            response_schema=_compact_selection_schema(len(aliases)),
+        )
         candidate_number = _parse_compact_selection(
             raw_selection,
             candidate_count=len(aliases),
@@ -112,9 +134,7 @@ def _compact_selection_prompt(
     candidates: list[list[object]] = []
     aliases: list[str] = []
     alias_set: set[str] = set()
-    for candidate_number, candidate in enumerate(
-        solicitation.candidate_selections
-    ):
+    for candidate_number, candidate in enumerate(solicitation.candidate_selections):
         address = candidate.get("action_contract_address")
         proposal_ref = candidate.get("proposal_ref")
         arguments = candidate.get("arguments")
@@ -154,9 +174,7 @@ def _compact_selection_prompt(
                 "or additional keys. You do not execute actions."
             ),
             "participant_view": dict(solicitation.participant_view),
-            "rendered_context": [
-                dict(item) for item in solicitation.rendered_context
-            ],
+            "rendered_context": [dict(item) for item in solicitation.rendered_context],
             "observation_history": [
                 dict(item) for item in solicitation.observation_history
             ],
@@ -172,6 +190,25 @@ def _compact_selection_prompt(
         sort_keys=True,
     )
     return prompt, tuple(aliases)
+
+
+def _compact_selection_schema(candidate_count: int) -> Mapping[str, object]:
+    """Constrain structured output to the current delivered candidate range."""
+
+    if candidate_count <= 0:
+        raise ValueError("compact participant selection has no candidates")
+    return {
+        "type": "object",
+        "properties": {
+            "candidate": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": candidate_count - 1,
+            }
+        },
+        "required": ["candidate"],
+        "additionalProperties": False,
+    }
 
 
 def _parse_compact_selection(raw: str, *, candidate_count: int) -> int:
@@ -216,9 +253,7 @@ def parse_provider_selection(
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise ValueError(
-            "participant provider did not return valid JSON"
-        ) from exc
+        raise ValueError("participant provider did not return valid JSON") from exc
     if not isinstance(payload, Mapping):
         raise ValueError("participant provider selection must be one JSON object")
     return ParticipantDecisionSurfaceSelectionV2Model.model_validate(payload)
@@ -229,6 +264,4 @@ def candidate_payloads(
 ) -> tuple[Mapping[str, object], ...]:
     """Return defensive JSON projections for the provider boundary."""
 
-    return tuple(
-        candidate.model_dump(mode="json") for candidate in candidates
-    )
+    return tuple(candidate.model_dump(mode="json") for candidate in candidates)

--- a/src/aptl/backends/raes_participant_realization_execution.py
+++ b/src/aptl/backends/raes_participant_realization_execution.py
@@ -279,9 +279,7 @@ def _action_evidence_record(
         "target_refs": list(context.realization.target_nodes),
         "observer_kind": context.realization.observer_kind,
         "mutates_state": context.realization.mutates_state,
-        "allows_idempotent_stutter": (
-            context.realization.allows_idempotent_stutter
-        ),
+        "allows_idempotent_stutter": (context.realization.allows_idempotent_stutter),
         "pre_state_digest": observation.pre_state_digest,
         "post_state_digest": observation.post_state_digest,
         "state_changed": observation.state_changed,
@@ -460,10 +458,11 @@ def _unmet_prior_actions(
 ) -> tuple[str, ...]:
     """Return required prior actions without successful episode observations."""
 
-    from aptl.backends.raes_participant_realizations import REQUIRED_PRIOR_ACTIONS
+    from aptl.backends.raes_participant_realizations import (
+        unmet_required_prior_actions,
+    )
 
-    required = REQUIRED_PRIOR_ACTIONS.get(request.action_contract_address, ())
-    completed = {
+    completed = tuple(
         str(event.get("action_contract_address"))
         for event in snapshot.participant_behavior_history.get(
             request.participant_address, []
@@ -472,8 +471,8 @@ def _unmet_prior_actions(
         and event.get("event_type") == "observation_emitted"
         and isinstance(event.get("action_result"), Mapping)
         and event["action_result"].get("status") == "succeeded"
-    }
-    return tuple(address for address in required if address not in completed)
+    )
+    return unmet_required_prior_actions(request.action_contract_address, completed)
 
 
 def persist_action_evidence(

--- a/src/aptl/backends/raes_participant_realizations.py
+++ b/src/aptl/backends/raes_participant_realizations.py
@@ -270,6 +270,45 @@ _REQUIRED_PRIOR_ACTIONS: Mapping[str, tuple[str, ...]] = {
     ),
 }
 REQUIRED_PRIOR_ACTIONS = _REQUIRED_PRIOR_ACTIONS
+_FRESH_REQUIRED_PRIOR_ACTIONS: Mapping[str, tuple[str, ...]] = {
+    "participant.action-contract.sign-out-session": (_AUTHENTICATE_ACTION,),
+}
+
+
+def unmet_required_prior_actions(
+    action_contract_address: str,
+    successful_action_sequence: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Return missing or consumed successful-observation prerequisites."""
+
+    required = _REQUIRED_PRIOR_ACTIONS.get(action_contract_address, ())
+    completed = set(successful_action_sequence)
+    unmet = [address for address in required if address not in completed]
+    for address in _FRESH_REQUIRED_PRIOR_ACTIONS.get(
+        action_contract_address,
+        (),
+    ):
+        prior_index = _last_index(successful_action_sequence, address)
+        action_index = _last_index(
+            successful_action_sequence,
+            action_contract_address,
+        )
+        if prior_index <= action_index and address not in unmet:
+            unmet.append(address)
+    return tuple(unmet)
+
+
+def _last_index(values: tuple[str, ...], expected: str) -> int:
+    """Return the last matching index, or -1 when absent."""
+
+    return next(
+        (
+            index
+            for index in range(len(values) - 1, -1, -1)
+            if values[index] == expected
+        ),
+        -1,
+    )
 
 
 def _node_containers(realization_details: Mapping[str, object]) -> dict[str, str]:

--- a/src/aptl/core/config.py
+++ b/src/aptl/core/config.py
@@ -17,10 +17,11 @@ log = get_logger("config")
 _NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 _PARTICIPANT_MODEL_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,127}$")
 _IMMUTABLE_PARTICIPANT_MODEL_PATTERNS = {
-    "claude": re.compile(r"^claude-[a-z0-9-]+-[0-9]{8}$"),
+    "claude": re.compile(r"^claude-[a-z0-9-]+-\d{8}$", flags=re.ASCII),
     "codex": re.compile(
-        r"^(?:codex-[a-z0-9._-]+|gpt-[a-z0-9._-]+|o[0-9][a-z0-9._-]*)"
-        r"-[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        r"^(?:codex-[a-z0-9._-]+|gpt-[a-z0-9._-]+|o\d[a-z0-9._-]*)"
+        r"-\d{4}-\d{2}-\d{2}$",
+        flags=re.ASCII,
     ),
 }
 _CONFIG_FILENAMES = ["aptl.json"]

--- a/src/aptl/core/config.py
+++ b/src/aptl/core/config.py
@@ -8,13 +8,21 @@ import re
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from aptl.utils.logging import get_logger
 
 log = get_logger("config")
 
 _NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+_PARTICIPANT_MODEL_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,127}$")
+_IMMUTABLE_PARTICIPANT_MODEL_PATTERNS = {
+    "claude": re.compile(r"^claude-[a-z0-9-]+-[0-9]{8}$"),
+    "codex": re.compile(
+        r"^(?:codex-[a-z0-9._-]+|gpt-[a-z0-9._-]+|o[0-9][a-z0-9._-]*)"
+        r"-[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    ),
+}
 _CONFIG_FILENAMES = ["aptl.json"]
 
 
@@ -65,10 +73,7 @@ class ContainerSettings(BaseModel):
 
     def enabled_profiles(self) -> list[str]:
         """Return docker compose profile names for enabled containers."""
-        return [
-            name for name in type(self).model_fields
-            if getattr(self, name)
-        ]
+        return [name for name in type(self).model_fields if getattr(self, name)]
 
 
 class RunStorageConfig(BaseModel):
@@ -187,6 +192,51 @@ class LabLifecyclePolicyConfig(BaseModel):
         return v
 
 
+def validate_installed_participant_model_id(provider: str, value: str) -> str:
+    """Validate one explicit, non-secret installed-provider model identity."""
+
+    immutable_pattern = _IMMUTABLE_PARTICIPANT_MODEL_PATTERNS.get(provider)
+    if (
+        immutable_pattern is None
+        or not isinstance(value, str)
+        or not _PARTICIPANT_MODEL_PATTERN.fullmatch(value)
+        or not immutable_pattern.fullmatch(value)
+    ):
+        raise ValueError("installed participant model identifier is invalid")
+    return value
+
+
+class InstalledParticipantModels(BaseModel):
+    """Closed model selections for APTL's installed participant providers."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    claude: str | None = Field(default=None, strict=True, max_length=128)
+    codex: str | None = Field(default=None, strict=True, max_length=128)
+
+    @field_validator("claude", "codex")
+    @classmethod
+    def validate_model(cls, value: str | None, info: ValidationInfo) -> str | None:
+        """Reject implicit, ambiguous, or unsafe provider model identities."""
+
+        if value is None:
+            return None
+        assert info.field_name is not None
+        return validate_installed_participant_model_id(info.field_name, value)
+
+    def model_for(self, provider: str) -> str:
+        """Return one configured model or fail closed for installed use."""
+
+        if provider not in {"claude", "codex"}:
+            raise ValueError("unknown installed participant provider")
+        model = getattr(self, provider)
+        if model is None:
+            raise ValueError(
+                f"installed participant model is not configured for {provider}"
+            )
+        return model
+
+
 class ExperimentSettings(BaseModel):
     """Strict non-secret apparatus settings approved for experiment binding."""
 
@@ -197,6 +247,9 @@ class ExperimentSettings(BaseModel):
         strict=True,
         ge=1,
         le=3600,
+    )
+    participant_models: InstalledParticipantModels = Field(
+        default_factory=InstalledParticipantModels
     )
 
 
@@ -250,8 +303,7 @@ def load_config(path: Path) -> AptlConfig:
     # `except (FileNotFoundError, ValueError)` see a consistent shape.
     if not isinstance(data, dict):
         raise ValueError(
-            f"Config root must be a JSON object, got "
-            f"{type(data).__name__}: {path}"
+            f"Config root must be a JSON object, got {type(data).__name__}: {path}"
         )
 
     log.debug("Loaded config from %s", path)

--- a/src/aptl/validation/participant_agency_qualification.py
+++ b/src/aptl/validation/participant_agency_qualification.py
@@ -51,6 +51,8 @@ class _SequentialSelectionProvider:
 
     implementation_name = "aptl-deterministic-sequence-fixture"
     implementation_version = "1.0.0"
+    provider_name = "deterministic"
+    model = None
 
     def __init__(self) -> None:
         """Initialize one fresh authored-sequence cursor."""
@@ -99,6 +101,11 @@ def validate_participant_agency_qualification(
     """Run the complete readiness contract without starting study capture."""
 
     _validate_qualification_options(installed_provider, installed_turns)
+    installed_model = (
+        getattr(config.experiment.participant_models, installed_provider)
+        if installed_provider is not None
+        else None
+    )
     selected_run_id = run_id or f"participant-qualification-{uuid4().hex}"
     run_store.create_run(selected_run_id)
     deployment = backend or get_backend(config, project_dir)
@@ -125,7 +132,13 @@ def validate_participant_agency_qualification(
     if not checks[0].passed:
         return _persist_qualification_report(
             run_store,
-            _qualification_report(context, checks, set(), installed_provider),
+            _qualification_report(
+                context,
+                checks,
+                set(),
+                installed_provider,
+                installed_model,
+            ),
         )
     positive_checks, covered_actions = _positive_trajectory_checks(context)
     checks.extend(positive_checks)
@@ -153,6 +166,7 @@ def validate_participant_agency_qualification(
         checks,
         covered_actions,
         installed_provider,
+        installed_model,
     )
     return _persist_qualification_report(run_store, report)
 
@@ -301,6 +315,7 @@ def _installed_provider_checks(
                     _ACTION_EVIDENCE_PATH,
                 ),
                 details={
+                    "model": trajectory.model,
                     "completed_turns": trajectory.completed_turns,
                     "terminal_statuses": [
                         outcome["status"] for outcome in trajectory.terminal_outcomes
@@ -316,6 +331,7 @@ def _qualification_report(
     checks: list[ParticipantQualificationCheck],
     covered_actions: set[str],
     installed_provider: str | None,
+    installed_model: str | None,
 ) -> ParticipantQualificationReport:
     """Build the complete secret-free qualification report."""
 
@@ -327,6 +343,7 @@ def _qualification_report(
         covered_action_contracts=tuple(sorted(covered_actions)),
         checks=tuple(checks),
         installed_provider=installed_provider,
+        installed_model=installed_model,
     )
 
 

--- a/src/aptl/validation/participant_agency_readiness.py
+++ b/src/aptl/validation/participant_agency_readiness.py
@@ -35,6 +35,10 @@ from aptl.validation.participant_readiness_provider import (
     build_selection_provider,
     installed_version,
 )
+from aptl.validation.participant_readiness_reports import (
+    configured_readiness_model,
+    persist_failed_readiness_report,
+)
 from aptl.workbench.process import AgentExecutionError
 
 if TYPE_CHECKING:
@@ -109,11 +113,11 @@ def validate_participant_agency_readiness(
     _validate_readiness_request(request)
     selected_run_id = request.run_id or f"participant-readiness-{uuid4().hex}"
     request.run_store.create_run(selected_run_id)
-    selected_model = _configured_model(request)
+    selected_model = configured_readiness_model(request)
     try:
         context = _prepare_readiness_context(request, selected_run_id)
     except _ReadinessFailure as exc:
-        return _persist_failed_report(
+        return persist_failed_readiness_report(
             request.run_store,
             selected_run_id,
             request.provider_name,
@@ -130,7 +134,7 @@ def validate_participant_agency_readiness(
             if str(exc).startswith("installed participant model is not configured")
             else type(exc).__name__
         )
-        return _persist_failed_report(
+        return persist_failed_readiness_report(
             request.run_store,
             selected_run_id,
             request.provider_name,
@@ -368,7 +372,7 @@ def _terminate_and_persist(
         ),
         run_id=context.run_id,
         provider=context.request.provider_name,
-        model=_configured_model(context.request),
+        model=configured_readiness_model(context.request),
         behavior=context.request.behavior_name,
         participant_address=context.participant_address,
         selected_actions=trajectory.selected_actions,
@@ -471,46 +475,3 @@ def _installed_version(executable: Path) -> str:
 
 def _noop() -> None:
     """No-op cleanup for deterministic selection providers."""
-
-
-def _persist_failed_report(
-    run_store: RunStorageBackend,
-    run_id: str,
-    provider: str,
-    model: str | None,
-    behavior: str,
-    participant_address: str,
-    *diagnostics: str,
-) -> ParticipantReadinessReport:
-    """Persist failed report for the bounded participant workflow."""
-    report = ParticipantReadinessReport(
-        passed=False,
-        run_id=run_id,
-        provider=provider,
-        model=model,
-        behavior=behavior,
-        participant_address=participant_address,
-        selected_actions=(),
-        completed_turns=0,
-        diagnostics=tuple(diagnostics),
-    )
-    run_store.write_json(
-        run_id,
-        "participant/readiness-report.json",
-        report.to_payload(),
-    )
-    return report
-
-
-def _configured_model(request: ParticipantReadinessRequest) -> str | None:
-    """Return admitted non-secret model provenance without triggering launch."""
-
-    if request.provider_override is not None:
-        return request.provider_override.model
-    if request.provider_name == "deterministic":
-        return None
-    return getattr(
-        request.config.experiment.participant_models,
-        request.provider_name,
-        None,
-    )

--- a/src/aptl/validation/participant_agency_readiness.py
+++ b/src/aptl/validation/participant_agency_readiness.py
@@ -38,6 +38,7 @@ from aptl.validation.participant_readiness_provider import (
 from aptl.workbench.process import AgentExecutionError
 
 if TYPE_CHECKING:
+    from aptl.core.config import AptlConfig
     from aptl.core.deployment.backend import DeploymentBackend
     from aptl.core.runstore import RunStorageBackend
 

--- a/src/aptl/validation/participant_agency_readiness.py
+++ b/src/aptl/validation/participant_agency_readiness.py
@@ -35,6 +35,7 @@ from aptl.validation.participant_readiness_provider import (
     build_selection_provider,
     installed_version,
 )
+from aptl.workbench.process import AgentExecutionError
 
 if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
@@ -107,6 +108,7 @@ def validate_participant_agency_readiness(
     _validate_readiness_request(request)
     selected_run_id = request.run_id or f"participant-readiness-{uuid4().hex}"
     request.run_store.create_run(selected_run_id)
+    selected_model = _configured_model(request)
     try:
         context = _prepare_readiness_context(request, selected_run_id)
     except _ReadinessFailure as exc:
@@ -114,6 +116,7 @@ def validate_participant_agency_readiness(
             request.run_store,
             selected_run_id,
             request.provider_name,
+            selected_model,
             request.behavior_name,
             exc.participant_address,
             str(exc),
@@ -121,13 +124,19 @@ def validate_participant_agency_readiness(
     try:
         provider, cleanup = _resolve_selection_provider(request, selected_run_id)
     except (OSError, RuntimeError, ValueError) as exc:
+        diagnostic = (
+            "installed participant model is not configured"
+            if str(exc).startswith("installed participant model is not configured")
+            else type(exc).__name__
+        )
         return _persist_failed_report(
             request.run_store,
             selected_run_id,
             request.provider_name,
+            selected_model,
             request.behavior_name,
             context.participant_address,
-            f"participant decision provider is unavailable: {type(exc).__name__}",
+            f"participant decision provider is unavailable: {diagnostic}",
         )
     trajectory = _run_readiness_trajectory(context, provider, cleanup)
     return _terminate_and_persist(context, trajectory)
@@ -228,6 +237,7 @@ def _resolve_selection_provider(
         return request.provider_override, _noop
     return _selection_provider(
         request.provider_name,
+        config=request.config,
         project_dir=request.project_dir,
         run_id=run_id,
     )
@@ -248,6 +258,8 @@ def _run_readiness_trajectory(
             participant_address=context.participant_address,
             implementation_name=provider.implementation_name,
             implementation_version=provider.implementation_version,
+            provider_name=provider.provider_name,
+            model=provider.model,
             run_id=context.run_id,
         )
         for _ in range(context.request.turns):
@@ -260,6 +272,8 @@ def _run_readiness_trajectory(
                 diagnostics,
             ):
                 break
+    except AgentExecutionError as exc:
+        diagnostics.append(f"participant provider request failed: {exc}")
     except (OSError, RuntimeError, ValueError) as exc:
         diagnostics.append(
             f"participant readiness trajectory failed: {type(exc).__name__}"
@@ -353,6 +367,7 @@ def _terminate_and_persist(
         ),
         run_id=context.run_id,
         provider=context.request.provider_name,
+        model=_configured_model(context.request),
         behavior=context.request.behavior_name,
         participant_address=context.participant_address,
         selected_actions=trajectory.selected_actions,
@@ -433,6 +448,7 @@ def _verify_live_materialization(
 def _selection_provider(
     provider_name: str,
     *,
+    config: AptlConfig,
     project_dir: Path,
     run_id: str,
 ) -> tuple[ParticipantSelectionProvider, Callable[[], None]]:
@@ -440,6 +456,7 @@ def _selection_provider(
 
     return build_selection_provider(
         provider_name,
+        config=config,
         project_dir=project_dir,
         run_id=run_id,
     )
@@ -459,6 +476,7 @@ def _persist_failed_report(
     run_store: RunStorageBackend,
     run_id: str,
     provider: str,
+    model: str | None,
     behavior: str,
     participant_address: str,
     *diagnostics: str,
@@ -468,6 +486,7 @@ def _persist_failed_report(
         passed=False,
         run_id=run_id,
         provider=provider,
+        model=model,
         behavior=behavior,
         participant_address=participant_address,
         selected_actions=(),
@@ -480,3 +499,17 @@ def _persist_failed_report(
         report.to_payload(),
     )
     return report
+
+
+def _configured_model(request: ParticipantReadinessRequest) -> str | None:
+    """Return admitted non-secret model provenance without triggering launch."""
+
+    if request.provider_override is not None:
+        return request.provider_override.model
+    if request.provider_name == "deterministic":
+        return None
+    return getattr(
+        request.config.experiment.participant_models,
+        request.provider_name,
+        None,
+    )

--- a/src/aptl/validation/participant_agency_readiness.py
+++ b/src/aptl/validation/participant_agency_readiness.py
@@ -44,7 +44,6 @@ from aptl.workbench.process import AgentExecutionError
 if TYPE_CHECKING:
     from aptl.core.config import AptlConfig
     from aptl.core.deployment.backend import DeploymentBackend
-    from aptl.core.runstore import RunStorageBackend
 
 SCENARIO_RELATIVE_PATH = Path("scenarios/bounded-participant-agency-techvault.sdl.yaml")
 _PROVIDER_VERSION_ENVIRONMENT = {

--- a/src/aptl/validation/participant_live_proof.py
+++ b/src/aptl/validation/participant_live_proof.py
@@ -147,6 +147,8 @@ def run_participant_action_proof(
             participant_address=participant_address,
             implementation_name="aptl-curated-live-proof",
             implementation_version="1.0.0",
+            provider_name="deterministic",
+            model=None,
             run_id="curated-live-proof",
         )
         request = ParticipantActionAdmissionRequest(

--- a/src/aptl/validation/participant_qualification_boundaries.py
+++ b/src/aptl/validation/participant_qualification_boundaries.py
@@ -134,7 +134,7 @@ def _selection_boundary_challenge(
         apparatus=context.apparatus,
     )
     candidate = (
-        _candidate(turn, "inspect-response-metadata")
+        _candidate(turn, "probe-permitted-endpoint")
         if challenge_id == "BC-04"
         else turn.candidates[0]
     )
@@ -181,13 +181,16 @@ def _mutate_selection_challenge(
         }
     elif challenge_id == "BC-04":
         payload["arguments"] = {
-            "fields": ["status", "content-type", "content-length", "location"]
+            "endpoint": "/",
+            "method": "TRACE",
         }
     elif challenge_id == "BC-05":
         stale_apparatus = build_participant_apparatus(
             participant_address=context.participant_address,
             implementation_name="aptl-stale-challenge-fixture",
             implementation_version=context.apparatus.manifest.identity.version,
+            provider_name="deterministic",
+            model=None,
             run_id=f"{context.run_id}-prior-episode",
         )
         stale_apparatus = replace(

--- a/src/aptl/validation/participant_qualification_boundary_environment.py
+++ b/src/aptl/validation/participant_qualification_boundary_environment.py
@@ -99,6 +99,8 @@ def prepare_challenge_context(
             participant_address=participant_address,
             implementation_name="aptl-controlled-challenge-fixture",
             implementation_version="1.0.0",
+            provider_name="deterministic",
+            model=None,
             run_id=run_id,
         ),
         run_store=run_store,

--- a/src/aptl/validation/participant_qualification_challenge_support.py
+++ b/src/aptl/validation/participant_qualification_challenge_support.py
@@ -26,6 +26,8 @@ class StaticResponseProvider:
 
     implementation_name = "aptl-controlled-challenge-fixture"
     implementation_version = "1.0.0"
+    provider_name = "deterministic"
+    model = None
 
     def __init__(self, response: str) -> None:
         """Retain one controlled provider response."""
@@ -44,6 +46,8 @@ class TimeoutSelectionProvider:
 
     implementation_name = "aptl-timeout-challenge-fixture"
     implementation_version = "1.0.0"
+    provider_name = "deterministic"
+    model = None
 
     def __init__(self) -> None:
         """Initialize child-process observation state."""

--- a/src/aptl/validation/participant_qualification_models.py
+++ b/src/aptl/validation/participant_qualification_models.py
@@ -41,13 +41,14 @@ class ParticipantQualificationReport:
     covered_action_contracts: tuple[str, ...]
     checks: tuple[ParticipantQualificationCheck, ...]
     installed_provider: str | None = None
+    installed_model: str | None = None
     official_capture_started: bool = False
 
     def to_payload(self) -> dict[str, object]:
         """Serialize the secret-free qualification report."""
 
         return {
-            "schema": "aptl.participant-agency-qualification/v1",
+            "schema": "aptl.participant-agency-qualification/v2",
             "passed": self.passed,
             "run_id": self.run_id,
             "scenario_source_sha256": self.scenario_source_sha256,
@@ -55,6 +56,7 @@ class ParticipantQualificationReport:
             "covered_action_contracts": list(self.covered_action_contracts),
             "checks": [check.to_payload() for check in self.checks],
             "installed_provider": self.installed_provider,
+            "installed_model": self.installed_model,
             "official_capture_started": self.official_capture_started,
         }
 
@@ -71,6 +73,7 @@ class ParticipantQualificationReport:
             f"compiled model sha256: {self.compiled_model_sha256}",
             f"action coverage: {len(self.covered_action_contracts)}/26",
             f"installed provider: {self.installed_provider or 'not requested'}",
+            f"installed model: {self.installed_model or 'not applicable'}",
             "official capture: not started",
         ]
         lines.extend(

--- a/src/aptl/validation/participant_readiness_models.py
+++ b/src/aptl/validation/participant_readiness_models.py
@@ -37,6 +37,7 @@ class ParticipantReadinessReport:
     passed: bool
     run_id: str
     provider: str
+    model: str | None
     behavior: str
     participant_address: str
     selected_actions: tuple[str, ...]
@@ -52,10 +53,11 @@ class ParticipantReadinessReport:
         """Serialize the readiness outcome without provider secrets."""
 
         return {
-            "schema": "aptl.participant-agency-readiness/v1",
+            "schema": "aptl.participant-agency-readiness/v2",
             "passed": self.passed,
             "run_id": self.run_id,
             "provider": self.provider,
+            "model": self.model,
             "behavior": self.behavior,
             "participant_address": self.participant_address,
             "selected_actions": list(self.selected_actions),
@@ -81,6 +83,7 @@ class ParticipantReadinessReport:
             f"participant agency readiness: {status}",
             f"run id: {self.run_id}",
             f"provider: {self.provider}",
+            f"model: {self.model or 'not applicable'}",
             f"behavior: {self.behavior}",
             f"turns: {self.completed_turns}",
             f"selected actions: {actions}",

--- a/src/aptl/validation/participant_readiness_provider.py
+++ b/src/aptl/validation/participant_readiness_provider.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from aptl.backends.raes_participant_driver import MAX_PARTICIPANT_DECISION_SECONDS
 from aptl.backends.raes_participant_provider import (
@@ -17,6 +18,9 @@ from aptl.workbench.agent import ClaudeCodeManagedAgentAdapter, _admitted_execut
 from aptl.workbench.codex_agent import CodexManagedAgentAdapter
 from aptl.workbench.credentials import EphemeralCredentialBroker
 from aptl.workbench.runtime import DecisionAgentLaunch
+
+if TYPE_CHECKING:
+    from aptl.core.config import AptlConfig
 
 _PROVIDER_VERSION_ENVIRONMENT = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
@@ -29,6 +33,7 @@ MAX_INSTALLED_PARTICIPANT_PROMPT_CHARS = 32_768
 def build_selection_provider(
     provider_name: str,
     *,
+    config: AptlConfig,
     project_dir: Path,
     run_id: str,
 ) -> tuple[ParticipantSelectionProvider, Callable[[], None]]:
@@ -40,6 +45,7 @@ def build_selection_provider(
         )
 
         return DeterministicSelectionProvider(), _noop
+    model = config.experiment.participant_models.model_for(provider_name)
     discovered_executable = shutil.which(provider_name)
     if discovered_executable is None:
         raise ValueError(
@@ -58,7 +64,11 @@ def build_selection_provider(
     try:
         adapter = _launch_adapter(provider_name, executable, work_dir)
         handle = adapter.launch(
-            DecisionAgentLaunch(provider=provider_name, run_id=run_id),
+            DecisionAgentLaunch(
+                provider=provider_name,
+                run_id=run_id,
+                model=model,
+            ),
             lease,
         )
         inventory = adapter.list_tools(handle)
@@ -74,6 +84,8 @@ def build_selection_provider(
     provider = ManagedAgentSelectionProvider(
         adapter=adapter,
         handle=handle,
+        provider_name=provider_name,
+        model=model,
         implementation_name=f"aptl-installed-{provider_name}",
         implementation_version=version,
     )

--- a/src/aptl/validation/participant_readiness_reports.py
+++ b/src/aptl/validation/participant_readiness_reports.py
@@ -1,0 +1,59 @@
+"""Report construction and provenance helpers for participant readiness."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aptl.validation.participant_readiness_models import (
+    ParticipantReadinessReport,
+    ParticipantReadinessRequest,
+)
+
+if TYPE_CHECKING:
+    from aptl.core.runstore import RunStorageBackend
+
+
+def configured_readiness_model(
+    request: ParticipantReadinessRequest,
+) -> str | None:
+    """Return admitted non-secret model provenance without triggering launch."""
+
+    if request.provider_override is not None:
+        return request.provider_override.model
+    if request.provider_name == "deterministic":
+        return None
+    return getattr(
+        request.config.experiment.participant_models,
+        request.provider_name,
+        None,
+    )
+
+
+def persist_failed_readiness_report(
+    run_store: RunStorageBackend,
+    run_id: str,
+    provider: str,
+    model: str | None,
+    behavior: str,
+    participant_address: str,
+    *diagnostics: str,
+) -> ParticipantReadinessReport:
+    """Persist one failed bounded-participant readiness report."""
+
+    report = ParticipantReadinessReport(
+        passed=False,
+        run_id=run_id,
+        provider=provider,
+        model=model,
+        behavior=behavior,
+        participant_address=participant_address,
+        selected_actions=(),
+        completed_turns=0,
+        diagnostics=tuple(diagnostics),
+    )
+    run_store.write_json(
+        run_id,
+        "participant/readiness-report.json",
+        report.to_payload(),
+    )
+    return report

--- a/src/aptl/workbench/__init__.py
+++ b/src/aptl/workbench/__init__.py
@@ -22,6 +22,7 @@ from aptl.workbench.profiles import (
 )
 from aptl.workbench.runtime import (
     ProfileLaunch,
+    WorkbenchPaths,
     WorkbenchRuntime,
     WorkbenchStateError,
 )
@@ -36,6 +37,7 @@ __all__ = [
     "ProfileLaunch",
     "WorkbenchConfigurationError",
     "WorkbenchCredentialError",
+    "WorkbenchPaths",
     "WorkbenchRuntime",
     "WorkbenchStateError",
     "create_appliance_workbench_app",

--- a/src/aptl/workbench/agent.py
+++ b/src/aptl/workbench/agent.py
@@ -18,6 +18,7 @@ from mcp.client.stdio import stdio_client
 
 from aptl.utils.placeholders import contains_placeholder
 from aptl.core.config import validate_installed_participant_model_id
+from aptl.workbench.decision_schema import admit_decision_response_schema
 from aptl.workbench.process import (
     AgentExecutionError,
     BoundedProcessRunner,
@@ -183,7 +184,7 @@ class ClaudeCodeManagedAgentAdapter:
         if active.closed or not active.ready:
             raise AgentExecutionError("agent profile is not ready")
         _assert_config_unchanged(active)
-        schema_json = _admit_decision_response_schema(
+        schema_json = admit_decision_response_schema(
             active.launch,
             response_schema,
         )
@@ -261,48 +262,6 @@ class ClaudeCodeManagedAgentAdapter:
             str(handle.launch.client_config_path),
             "--strict-mcp-config",
         )
-
-
-def _admit_decision_response_schema(
-    launch: AgentLaunch,
-    response_schema: Mapping[str, object] | None,
-) -> str | None:
-    """Admit only the exact bounded candidate-index schema for decisions."""
-
-    if not isinstance(launch, DecisionAgentLaunch):
-        if response_schema is not None:
-            raise AgentExecutionError(
-                "agent response schema is limited to decision launches"
-            )
-        return None
-    if not isinstance(response_schema, Mapping) or set(response_schema) != {
-        "type",
-        "properties",
-        "required",
-        "additionalProperties",
-    }:
-        raise AgentExecutionError("agent response schema is invalid")
-    properties = response_schema.get("properties")
-    if (
-        response_schema.get("type") != "object"
-        or response_schema.get("required") != ["candidate"]
-        or response_schema.get("additionalProperties") is not False
-        or not isinstance(properties, Mapping)
-        or set(properties) != {"candidate"}
-    ):
-        raise AgentExecutionError("agent response schema is invalid")
-    candidate = properties.get("candidate")
-    if (
-        not isinstance(candidate, Mapping)
-        or set(candidate) != {"type", "minimum", "maximum"}
-        or candidate.get("type") != "integer"
-        or type(candidate.get("minimum")) is not int
-        or candidate.get("minimum") != 0
-        or type(candidate.get("maximum")) is not int
-        or candidate["maximum"] < 0
-    ):
-        raise AgentExecutionError("agent response schema is invalid")
-    return json.dumps(response_schema, separators=(",", ":"), sort_keys=True)
 
 
 def _admitted_executable(path: Path) -> Path:

--- a/src/aptl/workbench/agent.py
+++ b/src/aptl/workbench/agent.py
@@ -17,6 +17,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 from aptl.utils.placeholders import contains_placeholder
+from aptl.core.config import validate_installed_participant_model_id
 from aptl.workbench.process import (
     AgentExecutionError,
     BoundedProcessRunner,
@@ -45,8 +46,6 @@ _MAX_CONFIG_BYTES = 1_000_000
 _POSIX_OWNERSHIP_REQUIRED = (
     "installed agent execution requires POSIX ownership semantics"
 )
-
-
 InventoryProbe = Callable[[str, str, list[str], dict[str, str]], tuple[str, ...]]
 
 
@@ -123,6 +122,12 @@ class ClaudeCodeManagedAgentAdapter:
     @staticmethod
     def launch(launch: AgentLaunch, credentials: Mapping[str, str]) -> object:
         """Admit a generated strict config and create a minimal secret lease."""
+        if isinstance(launch, DecisionAgentLaunch) and launch.provider != "claude":
+            raise AgentExecutionError("agent launch provider does not match adapter")
+        try:
+            validate_installed_participant_model_id("claude", launch.model)
+        except ValueError as exc:
+            raise AgentExecutionError("agent model selection is invalid") from exc
         if isinstance(launch, DecisionAgentLaunch):
             servers: dict[str, dict[str, object]] = {}
             config_sha256 = ""
@@ -166,18 +171,28 @@ class ClaudeCodeManagedAgentAdapter:
         active.ready = True
         return inventory
 
-    def respond(self, handle: object, message: str) -> str:
+    def respond(
+        self,
+        handle: object,
+        message: str,
+        *,
+        response_schema: Mapping[str, object] | None = None,
+    ) -> str:
         """Run one bounded non-persistent agent request with prompt on stdin."""
         active = _require_handle(handle)
         if active.closed or not active.ready:
             raise AgentExecutionError("agent profile is not ready")
         _assert_config_unchanged(active)
+        schema_json = _admit_decision_response_schema(
+            active.launch,
+            response_schema,
+        )
         if not message or len(message) > self._max_prompt_chars:
             raise AgentExecutionError(
                 "participant message exceeds the configured limit"
             )
         result = self._runner.run(
-            self._argv(self._executable, active),
+            self._argv(self._executable, active, schema_json),
             env=dict(active.environment),
             cwd=self._work_dir,
             stdin=message.encode(),
@@ -198,7 +213,11 @@ class ClaudeCodeManagedAgentAdapter:
         active.closed = True
 
     @staticmethod
-    def _argv(executable: Path, handle: _ClaudeHandle) -> tuple[str, ...]:
+    def _argv(
+        executable: Path,
+        handle: _ClaudeHandle,
+        response_schema_json: str | None,
+    ) -> tuple[str, ...]:
         """Build the strict Claude Code invocation for an admitted profile."""
 
         base = (
@@ -218,7 +237,15 @@ class ClaudeCodeManagedAgentAdapter:
             "",
         )
         if isinstance(handle.launch, DecisionAgentLaunch):
-            return base
+            if response_schema_json is None:
+                raise AgentExecutionError("agent response schema is required")
+            return (
+                *base,
+                "--model",
+                handle.launch.model,
+                "--json-schema",
+                response_schema_json,
+            )
         allowed = ",".join(
             f"mcp__{server_id}__{tool}"
             for server_id, tools in handle.inventory.items()
@@ -226,12 +253,56 @@ class ClaudeCodeManagedAgentAdapter:
         )
         return (
             *base,
+            "--model",
+            handle.launch.model,
             "--allowedTools",
             allowed,
             "--mcp-config",
             str(handle.launch.client_config_path),
             "--strict-mcp-config",
         )
+
+
+def _admit_decision_response_schema(
+    launch: AgentLaunch,
+    response_schema: Mapping[str, object] | None,
+) -> str | None:
+    """Admit only the exact bounded candidate-index schema for decisions."""
+
+    if not isinstance(launch, DecisionAgentLaunch):
+        if response_schema is not None:
+            raise AgentExecutionError(
+                "agent response schema is limited to decision launches"
+            )
+        return None
+    if not isinstance(response_schema, Mapping) or set(response_schema) != {
+        "type",
+        "properties",
+        "required",
+        "additionalProperties",
+    }:
+        raise AgentExecutionError("agent response schema is invalid")
+    properties = response_schema.get("properties")
+    if (
+        response_schema.get("type") != "object"
+        or response_schema.get("required") != ["candidate"]
+        or response_schema.get("additionalProperties") is not False
+        or not isinstance(properties, Mapping)
+        or set(properties) != {"candidate"}
+    ):
+        raise AgentExecutionError("agent response schema is invalid")
+    candidate = properties.get("candidate")
+    if (
+        not isinstance(candidate, Mapping)
+        or set(candidate) != {"type", "minimum", "maximum"}
+        or candidate.get("type") != "integer"
+        or type(candidate.get("minimum")) is not int
+        or candidate.get("minimum") != 0
+        or type(candidate.get("maximum")) is not int
+        or candidate["maximum"] < 0
+    ):
+        raise AgentExecutionError("agent response schema is invalid")
+    return json.dumps(response_schema, separators=(",", ":"), sort_keys=True)
 
 
 def _admitted_executable(path: Path) -> Path:

--- a/src/aptl/workbench/bootstrap.py
+++ b/src/aptl/workbench/bootstrap.py
@@ -13,7 +13,7 @@ from aptl.core.session import ScenarioSession
 from aptl.workbench.agent import ClaudeCodeManagedAgentAdapter
 from aptl.workbench.app import ParticipantAuthorizer, create_participant_workbench_app
 from aptl.workbench.credentials import EphemeralCredentialBroker
-from aptl.workbench.runtime import WorkbenchRuntime
+from aptl.workbench.runtime import WorkbenchPaths, WorkbenchRuntime
 
 
 @dataclass(frozen=True)
@@ -44,10 +44,12 @@ def create_appliance_workbench_app(
         ScenarioSession(state_dir),
         adapter,
         LocalRunStore(state_dir / "runs"),
-        payload_root=settings.payload_root,
-        generated_config_dir=state_dir / "workbench" / "mcp-config",
+        paths=WorkbenchPaths(
+            payload_root=settings.payload_root,
+            generated_config_dir=state_dir / "workbench" / "mcp-config",
+            node_executable=settings.node_executable,
+        ),
         credential_broker=broker,
         model=settings.model,
-        node_executable=settings.node_executable,
     )
     return create_participant_workbench_app(runtime, authorizer)

--- a/src/aptl/workbench/bootstrap.py
+++ b/src/aptl/workbench/bootstrap.py
@@ -23,6 +23,7 @@ class ApplianceWorkbenchSettings:
     payload_root: Path
     state_dir: Path
     claude_executable: Path
+    model: str
     node_executable: Path = Path("/usr/bin/node")
 
 
@@ -46,6 +47,7 @@ def create_appliance_workbench_app(
         payload_root=settings.payload_root,
         generated_config_dir=state_dir / "workbench" / "mcp-config",
         credential_broker=broker,
+        model=settings.model,
         node_executable=settings.node_executable,
     )
     return create_participant_workbench_app(runtime, authorizer)

--- a/src/aptl/workbench/codex_agent.py
+++ b/src/aptl/workbench/codex_agent.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+from aptl.core.config import validate_installed_participant_model_id
+from aptl.utils.pathsafe import (
+    PathContainmentError,
+    create_exclusive_nofollow,
+    read_contained_nofollow,
+)
 from aptl.utils.placeholders import contains_placeholder
-from aptl.workbench.agent import _admitted_executable, _prepare_work_dir
+from aptl.workbench.agent import (
+    _admit_decision_response_schema,
+    _admitted_executable,
+    _prepare_work_dir,
+)
 from aptl.workbench.process import (
     AgentExecutionError,
     BoundedProcessRunner,
@@ -67,6 +79,12 @@ class CodexManagedAgentAdapter:
 
         if not isinstance(launch, DecisionAgentLaunch):
             raise AgentExecutionError("Codex adapter supports decision-only launches")
+        if launch.provider != "codex":
+            raise AgentExecutionError("agent launch provider does not match adapter")
+        try:
+            validate_installed_participant_model_id(launch.provider, launch.model)
+        except ValueError as exc:
+            raise AgentExecutionError("agent model selection is invalid") from exc
         credential = credentials.get(_MODEL_CREDENTIAL)
         if not credential or contains_placeholder(credential):
             raise AgentExecutionError("agent credential lease is incomplete")
@@ -89,18 +107,31 @@ class CodexManagedAgentAdapter:
         active.ready = True
         return {}
 
-    def respond(self, handle: object, message: str) -> str:
+    def respond(
+        self,
+        handle: object,
+        message: str,
+        *,
+        response_schema: Mapping[str, object] | None = None,
+    ) -> str:
         """Obtain one bounded structured decision from the installed provider."""
 
         active = _require_handle(handle)
         if active.closed or not active.ready:
             raise AgentExecutionError("agent profile is not ready")
+        schema_json = _admit_decision_response_schema(
+            active.launch,
+            response_schema,
+        )
+        if schema_json is None:
+            raise AgentExecutionError("agent response schema is required")
+        schema_path = self._sealed_output_schema(schema_json)
         if not message or len(message) > self._max_prompt_chars:
             raise AgentExecutionError(
                 "participant message exceeds the configured limit"
             )
         result = self._runner.run(
-            self._argv(self._executable),
+            self._argv(self._executable, active, schema_path),
             env=dict(active.environment),
             cwd=self._work_dir,
             stdin=message.encode(),
@@ -108,8 +139,37 @@ class CodexManagedAgentAdapter:
             max_output_bytes=self._max_output_bytes,
         )
         if result.returncode != 0:
-            raise AgentExecutionError("agent request failed")
+            raise AgentExecutionError(_classify_failed_request(result.stdout))
         return _parse_codex_result(result.stdout)
+
+    def _sealed_output_schema(self, schema_json: str) -> Path:
+        """Create or verify one private schema file keyed by its exact bytes."""
+
+        schema_bytes = (schema_json + "\n").encode()
+        schema_name = (
+            "participant-selection-"
+            f"{hashlib.sha256(schema_bytes).hexdigest()}.schema.json"
+        )
+        try:
+            create_exclusive_nofollow(
+                self._work_dir,
+                schema_name,
+                schema_bytes,
+            )
+        except FileExistsError:
+            try:
+                existing = read_contained_nofollow(self._work_dir, schema_name)
+            except PathContainmentError as exc:
+                raise AgentExecutionError(
+                    "agent output schema could not be sealed"
+                ) from exc
+            if not hmac.compare_digest(existing, schema_bytes):
+                raise AgentExecutionError("agent output schema could not be sealed")
+        except PathContainmentError as exc:
+            raise AgentExecutionError(
+                "agent output schema could not be sealed"
+            ) from exc
+        return self._work_dir / schema_name
 
     @staticmethod
     def close(handle: object) -> None:
@@ -121,12 +181,18 @@ class CodexManagedAgentAdapter:
         active.closed = True
 
     @staticmethod
-    def _argv(executable: Path) -> tuple[str, ...]:
+    def _argv(
+        executable: Path,
+        handle: _CodexHandle,
+        response_schema_path: Path,
+    ) -> tuple[str, ...]:
         """Build the tool-disabled Codex invocation."""
 
         return (
             str(executable),
             "exec",
+            "--model",
+            handle.launch.model,
             "--disable",
             "shell_tool",
             "--disable",
@@ -152,6 +218,8 @@ class CodexManagedAgentAdapter:
             "--ephemeral",
             "--color",
             "never",
+            "--output-schema",
+            str(response_schema_path),
             "--json",
             "-",
         )
@@ -185,6 +253,36 @@ def _parse_codex_result(stdout: bytes) -> str:
     if final_message is None:
         raise AgentExecutionError("agent returned an invalid result")
     return final_message
+
+
+def _classify_failed_request(stdout: bytes) -> str:
+    """Map known hostile provider failures to stable, secret-free diagnostics."""
+
+    try:
+        events = [
+            json.loads(raw_line)
+            for raw_line in stdout.decode("utf-8").splitlines()
+            if raw_line
+        ]
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return "agent request failed"
+    messages: list[str] = []
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        if isinstance(event.get("message"), str):
+            messages.append(event["message"])
+        item = event.get("item")
+        if isinstance(item, Mapping) and isinstance(item.get("message"), str):
+            messages.append(item["message"])
+    if any(
+        "does not have access to model" in message.lower()
+        or "model_not_found" in message.lower()
+        or "model not found" in message.lower()
+        for message in messages
+    ):
+        return "agent model is unavailable"
+    return "agent request failed"
 
 
 __all__ = ("CodexManagedAgentAdapter",)

--- a/src/aptl/workbench/codex_agent.py
+++ b/src/aptl/workbench/codex_agent.py
@@ -17,10 +17,10 @@ from aptl.utils.pathsafe import (
 )
 from aptl.utils.placeholders import contains_placeholder
 from aptl.workbench.agent import (
-    _admit_decision_response_schema,
     _admitted_executable,
     _prepare_work_dir,
 )
+from aptl.workbench.decision_schema import admit_decision_response_schema
 from aptl.workbench.process import (
     AgentExecutionError,
     BoundedProcessRunner,
@@ -33,6 +33,7 @@ _BASE_ENVIRONMENT = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
     "NO_COLOR": "1",
 }
+_SCHEMA_SEAL_ERROR = "agent output schema could not be sealed"
 
 
 @dataclass
@@ -119,7 +120,7 @@ class CodexManagedAgentAdapter:
         active = _require_handle(handle)
         if active.closed or not active.ready:
             raise AgentExecutionError("agent profile is not ready")
-        schema_json = _admit_decision_response_schema(
+        schema_json = admit_decision_response_schema(
             active.launch,
             response_schema,
         )
@@ -160,15 +161,11 @@ class CodexManagedAgentAdapter:
             try:
                 existing = read_contained_nofollow(self._work_dir, schema_name)
             except PathContainmentError as exc:
-                raise AgentExecutionError(
-                    "agent output schema could not be sealed"
-                ) from exc
+                raise AgentExecutionError(_SCHEMA_SEAL_ERROR) from exc
             if not hmac.compare_digest(existing, schema_bytes):
-                raise AgentExecutionError("agent output schema could not be sealed")
+                raise AgentExecutionError(_SCHEMA_SEAL_ERROR)
         except PathContainmentError as exc:
-            raise AgentExecutionError(
-                "agent output schema could not be sealed"
-            ) from exc
+            raise AgentExecutionError(_SCHEMA_SEAL_ERROR) from exc
         return self._work_dir / schema_name
 
     @staticmethod

--- a/src/aptl/workbench/decision_schema.py
+++ b/src/aptl/workbench/decision_schema.py
@@ -1,0 +1,63 @@
+"""Admission for the bounded participant decision response schema."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from aptl.workbench.process import AgentExecutionError
+from aptl.workbench.runtime import AgentLaunch, DecisionAgentLaunch
+
+_INVALID_RESPONSE_SCHEMA = "agent response schema is invalid"
+
+
+def admit_decision_response_schema(
+    launch: AgentLaunch,
+    response_schema: Mapping[str, object] | None,
+) -> str | None:
+    """Admit only the exact bounded candidate-index schema for decisions."""
+
+    if not isinstance(launch, DecisionAgentLaunch):
+        if response_schema is not None:
+            raise AgentExecutionError(
+                "agent response schema is limited to decision launches"
+            )
+        return None
+    properties = _candidate_properties(response_schema)
+    _validate_candidate(properties.get("candidate"))
+    return json.dumps(response_schema, separators=(",", ":"), sort_keys=True)
+
+
+def _candidate_properties(
+    response_schema: Mapping[str, object] | None,
+) -> Mapping[str, object]:
+    """Return the sole candidate property from an exact response envelope."""
+
+    if (
+        not isinstance(response_schema, Mapping)
+        or set(response_schema)
+        != {"type", "properties", "required", "additionalProperties"}
+        or response_schema.get("type") != "object"
+        or response_schema.get("required") != ["candidate"]
+        or response_schema.get("additionalProperties") is not False
+    ):
+        raise AgentExecutionError(_INVALID_RESPONSE_SCHEMA)
+    properties = response_schema.get("properties")
+    if not isinstance(properties, Mapping) or set(properties) != {"candidate"}:
+        raise AgentExecutionError(_INVALID_RESPONSE_SCHEMA)
+    return properties
+
+
+def _validate_candidate(candidate: object) -> None:
+    """Require one bounded, zero-based integer candidate index."""
+
+    if (
+        not isinstance(candidate, Mapping)
+        or set(candidate) != {"type", "minimum", "maximum"}
+        or candidate.get("type") != "integer"
+        or type(candidate.get("minimum")) is not int
+        or candidate.get("minimum") != 0
+        or type(candidate.get("maximum")) is not int
+        or candidate["maximum"] < 0
+    ):
+        raise AgentExecutionError(_INVALID_RESPONSE_SCHEMA)

--- a/src/aptl/workbench/runtime.py
+++ b/src/aptl/workbench/runtime.py
@@ -32,6 +32,7 @@ class ProfileLaunch:
     run_id: str
     client_config_path: Path
     policy_version: str
+    model: str
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,7 @@ class DecisionAgentLaunch:
 
     provider: str
     run_id: str
+    model: str
     policy_version: str = "aptl-participant-decision-provider/v1"
 
 
@@ -49,15 +51,19 @@ AgentLaunch = ProfileLaunch | DecisionAgentLaunch
 class ManagedAgentAdapter(Protocol):
     """Owns installed-agent and MCP process start/stop inside management."""
 
-    def launch(
-        self, launch: AgentLaunch, credentials: Mapping[str, str]
-    ) -> object: ...
+    def launch(self, launch: AgentLaunch, credentials: Mapping[str, str]) -> object: ...
 
     def close(self, handle: object) -> None: ...
 
     def list_tools(self, handle: object) -> Mapping[str, Collection[str]]: ...
 
-    def respond(self, handle: object, message: str) -> str: ...
+    def respond(
+        self,
+        handle: object,
+        message: str,
+        *,
+        response_schema: Mapping[str, object] | None = None,
+    ) -> str: ...
 
 
 class SessionCredentialBroker(Protocol):
@@ -93,6 +99,7 @@ class WorkbenchRuntime:
         payload_root: Path,
         generated_config_dir: Path,
         credential_broker: SessionCredentialBroker,
+        model: str,
         node_executable: Path = Path("/usr/bin/node"),
     ) -> None:
         self._session_manager = session_manager
@@ -102,6 +109,7 @@ class WorkbenchRuntime:
         self._generated_config_dir = generated_config_dir
         self._prepare_generated_config_parent()
         self._credential_broker = credential_broker
+        self._model = model
         self._node_executable = node_executable
         self._current: _ActiveProfile | None = None
         self._lock = RLock()
@@ -123,9 +131,7 @@ class WorkbenchRuntime:
             or stat.st_mode & 0o022
             or not os.access(parent, os.W_OK | os.X_OK)
         ):
-            raise WorkbenchStateError(
-                "managed configuration directory is unavailable"
-            )
+            raise WorkbenchStateError("managed configuration directory is unavailable")
 
     @property
     def current_launch(self) -> ProfileLaunch | None:
@@ -164,6 +170,7 @@ class WorkbenchRuntime:
             run_id=run_id,
             client_config_path=config_path,
             policy_version=selected.policy_version,
+            model=self._model,
         )
         try:
             handle = self._adapter.launch(launch, credentials)

--- a/src/aptl/workbench/runtime.py
+++ b/src/aptl/workbench/runtime.py
@@ -48,6 +48,15 @@ class DecisionAgentLaunch:
 AgentLaunch = ProfileLaunch | DecisionAgentLaunch
 
 
+@dataclass(frozen=True)
+class WorkbenchPaths:
+    """Trusted filesystem inputs for one workbench runtime."""
+
+    payload_root: Path
+    generated_config_dir: Path
+    node_executable: Path = Path("/usr/bin/node")
+
+
 class ManagedAgentAdapter(Protocol):
     """Owns installed-agent and MCP process start/stop inside management."""
 
@@ -96,21 +105,19 @@ class WorkbenchRuntime:
         adapter: ManagedAgentAdapter,
         run_store: RunStorageBackend,
         *,
-        payload_root: Path,
-        generated_config_dir: Path,
+        paths: WorkbenchPaths,
         credential_broker: SessionCredentialBroker,
         model: str,
-        node_executable: Path = Path("/usr/bin/node"),
     ) -> None:
         self._session_manager = session_manager
         self._adapter = adapter
         self._run_store = run_store
-        self._payload_root = payload_root
-        self._generated_config_dir = generated_config_dir
+        self._payload_root = paths.payload_root
+        self._generated_config_dir = paths.generated_config_dir
         self._prepare_generated_config_parent()
         self._credential_broker = credential_broker
         self._model = model
-        self._node_executable = node_executable
+        self._node_executable = paths.node_executable
         self._current: _ActiveProfile | None = None
         self._lock = RLock()
 

--- a/tests/test_bounded_participant_runtime.py
+++ b/tests/test_bounded_participant_runtime.py
@@ -1604,14 +1604,15 @@ def test_provider_executable_is_admitted_before_version_probe(
         unexpected_run,
     )
 
+    config = AptlConfig(
+        experiment={
+            "participant_models": {"claude": "claude-sonnet-4-5-20250929"}
+        }
+    )
     with pytest.raises(ValueError, match="untrusted provider executable"):
         participant_agency_readiness._selection_provider(
             "claude",
-            config=AptlConfig(
-                experiment={
-                    "participant_models": {"claude": "claude-sonnet-4-5-20250929"}
-                }
-            ),
+            config=config,
             project_dir=tmp_path,
             run_id="rejected-provider",
         )

--- a/tests/test_bounded_participant_runtime.py
+++ b/tests/test_bounded_participant_runtime.py
@@ -273,8 +273,32 @@ def _apparatus(participant_address: str):
         participant_address=participant_address,
         implementation_name="aptl-readiness-agent",
         implementation_version="1.0.0",
+        provider_name="deterministic",
+        model=None,
         run_id="readiness-run",
     )
+
+
+def test_installed_model_is_bound_as_raes_implementation_configuration() -> None:
+    apparatus = build_participant_apparatus(
+        participant_address="participant.behavior.security-assessor-agent",
+        implementation_name="aptl-installed-codex",
+        implementation_version="0.145.0",
+        provider_name="codex",
+        model="gpt-5-nano-2025-08-07",
+        run_id="explicit-model-run",
+    )
+
+    assert apparatus.provider == "codex"
+    assert apparatus.model == "gpt-5-nano-2025-08-07"
+    assert apparatus.selection.configuration_ref is not None
+    assert apparatus.selection.configuration_digest is not None
+    assert apparatus.selection.configuration_digest.startswith("sha256:")
+    assert apparatus.manifest.configuration_registry is not None
+    declaration = apparatus.manifest.configuration_registry.targets["model.identifier"]
+    assert declaration.value_type.value == "string"
+    assert declaration.allowed_value_kinds == ["literal"]
+    assert declaration.default is None
 
 
 def _run_selected_action(
@@ -310,11 +334,21 @@ def _run_selected_action(
 def _solicitation_for_behavior(
     tmp_path: Path,
     behavior_address: str,
+    *,
+    satisfy_for_action: str | None = None,
 ) -> ParticipantDecisionSolicitation:
     control, model, _, _ = _runtime(tmp_path)
     participant = _participant_for(model, behavior_address)
     episode_id = f"managed-{behavior_address.rsplit('.', 1)[-1]}"
     control.initialize_participant_episode(participant, episode_id=episode_id)
+    if satisfy_for_action is not None:
+        _satisfy_candidate_prerequisites(
+            control,
+            model,
+            behavior_address=behavior_address,
+            participant_address=participant,
+            action_address=f"participant.action-contract.{satisfy_for_action}",
+        )
     turn = project_participant_turn(
         runtime_model=model,
         runtime_snapshot=control.snapshot,
@@ -337,9 +371,17 @@ class _ManagedResponseAdapter:
     def __init__(self, response: str) -> None:
         self.response = response
         self.messages: list[str] = []
+        self.response_schemas: list[Mapping[str, object] | None] = []
 
-    def respond(self, _handle: object, message: str) -> str:
+    def respond(
+        self,
+        _handle: object,
+        message: str,
+        *,
+        response_schema: Mapping[str, object] | None = None,
+    ) -> str:
         self.messages.append(message)
+        self.response_schemas.append(response_schema)
         return self.response
 
     def close(self, _handle: object) -> None:
@@ -353,6 +395,8 @@ def _managed_provider(
     provider = ManagedAgentSelectionProvider(
         adapter=adapter,
         handle=object(),
+        provider_name="codex",
+        model="gpt-5-nano-2025-08-07",
         implementation_name="managed-test-provider",
         implementation_version="1.0.0",
     )
@@ -365,6 +409,7 @@ def test_managed_provider_compacts_large_surface_and_maps_exact_candidate(
     solicitation = _solicitation_for_behavior(
         tmp_path,
         "participant.behavior-specification.triage-authentication-event",
+        satisfy_for_action="classify-alert",
     )
     assert len(solicitation.candidate_selections) == 201
     provider, adapter = _managed_provider('{"candidate":200}')
@@ -383,16 +428,26 @@ def test_managed_provider_compacts_large_surface_and_maps_exact_candidate(
         "arguments",
     ]
     assert len(prompt["candidates"]) == len(solicitation.candidate_selections)
-    assert {
-        prompt["actions"][candidate[1]]
-        for candidate in prompt["candidates"]
-    } == {
-        item["action_contract_address"]
-        for item in solicitation.candidate_selections
+    assert {prompt["actions"][candidate[1]] for candidate in prompt["candidates"]} == {
+        item["action_contract_address"] for item in solicitation.candidate_selections
     }
-    assert {
-        candidate[0] for candidate in prompt["candidates"]
-    } == set(range(len(solicitation.candidate_selections)))
+    assert {candidate[0] for candidate in prompt["candidates"]} == set(
+        range(len(solicitation.candidate_selections))
+    )
+    assert adapter.response_schemas == [
+        {
+            "type": "object",
+            "properties": {
+                "candidate": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 200,
+                }
+            },
+            "required": ["candidate"],
+            "additionalProperties": False,
+        }
+    ]
 
 
 @pytest.mark.parametrize(
@@ -524,8 +579,8 @@ def test_all_nine_behaviors_project_the_exact_compiled_action_sets(
 
         assert turn.surface.surface_state == "delivered"
         assert {
-            candidate.action_contract_address.rsplit(".", 1)[-1]
-            for candidate in turn.candidates
+            entry.action_contract_address.rsplit(".", 1)[-1]
+            for entry in turn.surface.participant_view.action_entries
         } == set(expected_names)
         participant_payload = turn.surface.participant_view.model_dump_json()
         rendered_payload = json.dumps(turn.rendered_context)
@@ -539,6 +594,102 @@ def test_all_nine_behaviors_project_the_exact_compiled_action_sets(
         assert "BPA-HIDDEN-CANARY" not in rendered_payload
 
 
+def test_projected_candidates_require_successful_prior_observations(
+    tmp_path: Path,
+) -> None:
+    behavior = "participant.behavior-specification.triage-authentication-event"
+    control, model, _, _ = _runtime(tmp_path)
+    participant = _participant_for(model, behavior)
+    control.initialize_participant_episode(participant, episode_id="eligible-actions")
+
+    def available_actions() -> set[str]:
+        turn = project_participant_turn(
+            runtime_model=model,
+            runtime_snapshot=control.snapshot,
+            behavior_specification_address=behavior,
+            apparatus=_apparatus(participant),
+        )
+        return {
+            candidate.action_contract_address.rsplit(".", 1)[-1]
+            for candidate in turn.candidates
+        }
+
+    assert available_actions() == {"list-assigned-alerts"}
+
+    _run_selected_action(
+        control,
+        model,
+        behavior_address=behavior,
+        participant_address=participant,
+        action_name="list-assigned-alerts",
+    )
+    assert available_actions() == {
+        "list-assigned-alerts",
+        "inspect-assigned-alert",
+    }
+
+    _run_selected_action(
+        control,
+        model,
+        behavior_address=behavior,
+        participant_address=participant,
+        action_name="inspect-assigned-alert",
+    )
+    assert available_actions() == {
+        "list-assigned-alerts",
+        "inspect-assigned-alert",
+        "query-allowed-context",
+        "classify-alert",
+    }
+
+
+def test_projected_candidates_require_a_current_authenticated_session(
+    tmp_path: Path,
+) -> None:
+    behavior = "participant.behavior-specification.complete-normal-session"
+    control, model, _, _ = _runtime(tmp_path)
+    participant = _participant_for(model, behavior)
+    control.initialize_participant_episode(participant, episode_id="session-state")
+
+    def available_actions() -> set[str]:
+        turn = project_participant_turn(
+            runtime_model=model,
+            runtime_snapshot=control.snapshot,
+            behavior_specification_address=behavior,
+            apparatus=_apparatus(participant),
+        )
+        return {
+            candidate.action_contract_address.rsplit(".", 1)[-1]
+            for candidate in turn.candidates
+        }
+
+    assert "sign-out-session" not in available_actions()
+    _run_selected_action(
+        control,
+        model,
+        behavior_address=behavior,
+        participant_address=participant,
+        action_name="authenticate-synthetic-user",
+    )
+    assert "sign-out-session" in available_actions()
+    _run_selected_action(
+        control,
+        model,
+        behavior_address=behavior,
+        participant_address=participant,
+        action_name="sign-out-session",
+    )
+    assert "sign-out-session" not in available_actions()
+    _run_selected_action(
+        control,
+        model,
+        behavior_address=behavior,
+        participant_address=participant,
+        action_name="authenticate-synthetic-user",
+    )
+    assert "sign-out-session" in available_actions()
+
+
 def _projected_candidates_for_action(
     tmp_path: Path,
     behavior_address: str,
@@ -549,6 +700,13 @@ def _projected_candidates_for_action(
     control.initialize_participant_episode(
         participant,
         episode_id=f"variants-{action_name}",
+    )
+    _satisfy_candidate_prerequisites(
+        control,
+        model,
+        behavior_address=behavior_address,
+        participant_address=participant,
+        action_address=f"participant.action-contract.{action_name}",
     )
     turn = project_participant_turn(
         runtime_model=model,
@@ -561,6 +719,46 @@ def _projected_candidates_for_action(
         for candidate in turn.candidates
         if candidate.action_contract_address.endswith(f".{action_name}")
     )
+
+
+def _satisfy_candidate_prerequisites(
+    control: AptlParticipantControlPlane,
+    model: object,
+    *,
+    behavior_address: str,
+    participant_address: str,
+    action_address: str,
+) -> None:
+    """Create the successful episode observations required by one action."""
+
+    for prior_address in raes_participant_realizations.REQUIRED_PRIOR_ACTIONS.get(
+        action_address,
+        (),
+    ):
+        _satisfy_candidate_prerequisites(
+            control,
+            model,
+            behavior_address=behavior_address,
+            participant_address=participant_address,
+            action_address=prior_address,
+        )
+        completed = {
+            event["action_contract_address"]
+            for event in control.snapshot.participant_behavior_history.get(
+                participant_address,
+                [],
+            )
+            if event["event_type"] == "observation_emitted"
+            and event["action_result"]["status"] == "succeeded"
+        }
+        if prior_address not in completed:
+            _run_selected_action(
+                control,
+                model,
+                behavior_address=behavior_address,
+                participant_address=participant_address,
+                action_name=prior_address.rsplit(".", 1)[-1],
+            )
 
 
 def test_decision_surface_enumerates_every_finite_governed_choice(
@@ -690,6 +888,27 @@ def test_each_governed_variant_changes_the_verified_native_semantics(
         assert len(digests) == len(candidates)
 
 
+def test_head_endpoint_probe_uses_curl_head_semantics() -> None:
+    backend = _StatefulBackend()
+    address = "participant.action-contract.probe-permitted-endpoint"
+
+    operation = execute_verified_participant_operation(
+        backend=backend,
+        container_by_node={name: f"aptl-{name}" for name in NODES},
+        action_contract_address=address,
+        arguments={"endpoint": "/", "method": "HEAD"},
+        participant_address="participant.behavior.semantic-probe",
+        episode_id="head-semantics",
+        target_nodes=BPA_ACTION_REALIZATIONS[address].target_nodes,
+    )
+
+    assert operation.success is True
+    curl_calls = [command for _, command in backend.calls if command[0] == "curl"]
+    assert curl_calls
+    assert all("--head" in command for command in curl_calls)
+    assert all("-X" not in command for command in curl_calls)
+
+
 def test_participant_pipeline_accepts_only_declared_idempotent_stutters(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -721,16 +940,14 @@ def test_participant_pipeline_accepts_only_declared_idempotent_stutters(
         store.get_run_path("readiness-run")
         / "evaluator/participant-action-evidence.jsonl"
     )
-    evidence = [
-        json.loads(line) for line in evidence_path.read_text().splitlines()
-    ]
+    evidence = [json.loads(line) for line in evidence_path.read_text().splitlines()]
     assert [record["state_changed"] for record in evidence] == [True, False]
     assert evidence[-1]["allows_idempotent_stutter"] is True
     assert evidence[-1]["status"] == "succeeded"
     assert (
-        control.snapshot.participant_behavior_history[participant][-1][
-            "action_result"
-        ]["status"]
+        control.snapshot.participant_behavior_history[participant][-1]["action_result"][
+            "status"
+        ]
         == "succeeded"
     )
 
@@ -772,9 +989,7 @@ def test_participant_pipeline_accepts_only_declared_idempotent_stutters(
         store.get_run_path("readiness-run")
         / "evaluator/participant-action-evidence.jsonl"
     )
-    evidence = [
-        json.loads(line) for line in evidence_path.read_text().splitlines()
-    ]
+    evidence = [json.loads(line) for line in evidence_path.read_text().splitlines()]
     assert [record["state_changed"] for record in evidence] == [True, False]
     assert evidence[-1]["allows_idempotent_stutter"] is False
     assert evidence[-1]["status"] == "failed"
@@ -884,6 +1099,53 @@ def test_provider_invocation_is_a_raes_operation_and_admission_commits_history(
     )
     assert "pre_state_digest" not in json.dumps(next_turn.observation_history)
     assert "study-evaluator-evidence" not in json.dumps(next_turn.observation_history)
+
+
+def test_installed_provider_control_evidence_records_model_configuration(
+    tmp_path: Path,
+) -> None:
+    control, model, _, store = _runtime(tmp_path)
+    behavior = "participant.behavior-specification.complete-normal-session"
+    participant = _participant_for(model, behavior)
+    control.initialize_participant_episode(
+        participant,
+        episode_id="model-provenance",
+    )
+    provider, _ = _managed_provider('{"candidate":0}')
+    apparatus = build_participant_apparatus(
+        participant_address=participant,
+        implementation_name=provider.implementation_name,
+        implementation_version=provider.implementation_version,
+        provider_name=provider.provider_name,
+        model=provider.model,
+        run_id="readiness-run",
+    )
+
+    run_participant_turn(
+        control,
+        behavior_specification_address=behavior,
+        apparatus=apparatus,
+        provider=provider,
+    )
+
+    record = json.loads(
+        (
+            store.get_run_path("readiness-run")
+            / "evaluator/participant-control-evidence.jsonl"
+        ).read_text()
+    )
+    assert record["schema"] == "aptl.participant-control-evidence/v2"
+    assert record["provider"] == "codex"
+    assert record["model"] == "gpt-5-nano-2025-08-07"
+    assert (
+        record["implementation_configuration_ref"]
+        == apparatus.selection.configuration_ref
+    )
+    assert (
+        record["implementation_configuration_digest"]
+        == apparatus.selection.configuration_digest
+    )
+    assert record["official_capture_started"] is False
 
 
 class _MalformedProvider:
@@ -1345,6 +1607,11 @@ def test_provider_executable_is_admitted_before_version_probe(
     with pytest.raises(ValueError, match="untrusted provider executable"):
         participant_agency_readiness._selection_provider(
             "claude",
+            config=AptlConfig(
+                experiment={
+                    "participant_models": {"claude": "claude-sonnet-4-5-20250929"}
+                }
+            ),
             project_dir=tmp_path,
             run_id="rejected-provider",
         )
@@ -1417,10 +1684,70 @@ def test_readiness_runner_is_explicitly_pre_capture(
     assert report.participant_address.startswith("participant.behavior.")
     assert report.episode_terminal_reason
     assert report.official_capture_started is False
+    assert report.model is None
     assert (
         store.get_run_path("pre-capture-readiness")
         / "participant/readiness-report.json"
     ).exists()
+    payload = json.loads(
+        (
+            store.get_run_path("pre-capture-readiness")
+            / "participant/readiness-report.json"
+        ).read_text()
+    )
+    assert payload["schema"] == "aptl.participant-agency-readiness/v2"
+    assert payload["model"] is None
+
+
+def test_missing_installed_model_fails_before_provider_launch_with_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable_discovery_attempted = False
+
+    def unexpected_discovery(_name: str) -> str | None:
+        nonlocal executable_discovery_attempted
+        executable_discovery_attempted = True
+        return None
+
+    monkeypatch.setattr(
+        participant_readiness_provider.shutil,
+        "which",
+        unexpected_discovery,
+    )
+    store = LocalRunStore(tmp_path / "runs")
+
+    report = validate_participant_agency_readiness(
+        ParticipantReadinessRequest(
+            project_dir=PROJECT_ROOT,
+            config=AptlConfig(lab={"name": "test"}),
+            run_store=store,
+            provider_name="codex",
+            behavior_name="green-normal-session",
+            turns=1,
+            run_id="missing-installed-model",
+            backend=_StatefulBackend(),
+        )
+    )
+
+    assert report.passed is False
+    assert report.provider == "codex"
+    assert report.model is None
+    assert report.completed_turns == 0
+    assert report.diagnostics == (
+        "participant decision provider is unavailable: "
+        "installed participant model is not configured",
+    )
+    assert executable_discovery_attempted is False
+    payload = json.loads(
+        (
+            store.get_run_path("missing-installed-model")
+            / "participant/readiness-report.json"
+        ).read_text()
+    )
+    assert payload["schema"] == "aptl.participant-agency-readiness/v2"
+    assert payload["provider"] == "codex"
+    assert payload["model"] is None
 
 
 def test_positive_readiness_rejects_a_failed_native_terminal_outcome(
@@ -1486,7 +1813,16 @@ def test_full_qualification_covers_all_actions_and_boundary_challenges(
         check.check_id for check in report.checks if check.check_id.startswith("BC-")
     } == {f"BC-{index:02d}" for index in range(1, 11)}
     assert report.official_capture_started is False
+    assert report.installed_model is None
     assert (
         store.get_run_path("full-pre-capture-qualification")
         / "participant/readiness-suite-report.json"
     ).exists()
+    payload = json.loads(
+        (
+            store.get_run_path("full-pre-capture-qualification")
+            / "participant/readiness-suite-report.json"
+        ).read_text()
+    )
+    assert payload["schema"] == "aptl.participant-agency-qualification/v2"
+    assert payload["installed_model"] is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,8 +151,9 @@ class TestExperimentSettings:
         assert (
             settings.participant_models.model_for("codex") == "gpt-5-nano-2025-08-07"
         )
+        default_models = ExperimentSettings().participant_models
         with pytest.raises(ValueError, match="not configured"):
-            ExperimentSettings().participant_models.model_for("codex")
+            default_models.model_for("codex")
         with pytest.raises(ValueError, match="unknown installed participant provider"):
             settings.participant_models.model_for("other")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,6 +135,78 @@ class TestExperimentSettings:
         with pytest.raises(ValidationError):
             ExperimentSettings(participant_action_timeout_seconds=value)
 
+    def test_installed_participant_models_are_explicit_and_provider_closed(self):
+        from aptl.core.config import ExperimentSettings
+
+        settings = ExperimentSettings(
+            participant_models={
+                "claude": "claude-sonnet-4-5-20250929",
+                "codex": "gpt-5-nano-2025-08-07",
+            }
+        )
+
+        assert settings.participant_models.model_for("claude") == (
+            "claude-sonnet-4-5-20250929"
+        )
+        assert (
+            settings.participant_models.model_for("codex") == "gpt-5-nano-2025-08-07"
+        )
+        with pytest.raises(ValueError, match="not configured"):
+            ExperimentSettings().participant_models.model_for("codex")
+        with pytest.raises(ValueError, match="unknown installed participant provider"):
+            settings.participant_models.model_for("other")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            " ",
+            "latest",
+            "default",
+            "auto",
+            "sonnet",
+            "claude-sonnet-4-5",
+            "gpt-4o",
+            "gpt-5.2-codex",
+            "bad model",
+            "bad\nmodel",
+            "x" * 129,
+            7,
+            True,
+        ],
+    )
+    def test_rejects_ambiguous_or_malformed_participant_model(self, value):
+        from aptl.core.config import ExperimentSettings
+
+        with pytest.raises(ValidationError):
+            ExperimentSettings(participant_models={"codex": value})
+
+    def test_rejects_unknown_participant_model_provider_or_option(self):
+        from aptl.core.config import ExperimentSettings
+
+        with pytest.raises(ValidationError):
+            ExperimentSettings(participant_models={"other": "gpt-5-nano-2025-08-07"})
+        with pytest.raises(ValidationError):
+            ExperimentSettings(
+                participant_models={
+                    "codex": "gpt-5-nano-2025-08-07",
+                    "codex_options": {"fallback": "o1"},
+                }
+            )
+
+    @pytest.mark.parametrize(
+        ("provider", "model"),
+        [
+            ("claude", "gpt-5-nano-2025-08-07"),
+            ("codex", "claude-sonnet-4-5-20250929"),
+        ],
+    )
+    def test_rejects_model_identity_from_another_provider(self, provider, model):
+        from aptl.core.config import ExperimentSettings
+
+        with pytest.raises(ValidationError):
+            ExperimentSettings(participant_models={provider: model})
+
 
 class TestAptlConfig:
     """Tests for the top-level AptlConfig model."""
@@ -240,7 +312,10 @@ class TestConfigLoading:
         ],
     )
     def test_load_from_non_mapping_json_raises_valueerror(
-        self, tmp_config_dir, body, top_type,
+        self,
+        tmp_config_dir,
+        body,
+        top_type,
     ):
         """A JSON top-level that isn't an object must raise ``ValueError``.
 

--- a/tests/test_participant_workbench.py
+++ b/tests/test_participant_workbench.py
@@ -12,6 +12,17 @@ from fastapi.testclient import TestClient
 
 from aptl.core.session import ScenarioSession
 from aptl.core.runstore import LocalRunStore
+from aptl.workbench.runtime import WorkbenchPaths
+
+
+def _runtime_paths(payload_root: Path, generated_config_dir: Path) -> WorkbenchPaths:
+    """Build trusted runtime paths for one isolated workbench test."""
+
+    return WorkbenchPaths(
+        payload_root=payload_root,
+        generated_config_dir=generated_config_dir,
+        node_executable=Path(sys.executable),
+    )
 
 
 def test_profiles_expose_exactly_the_allowed_mcp_servers() -> None:
@@ -231,10 +242,8 @@ def test_profile_switch_closes_the_previous_runtime_and_records_the_active_trace
         session_manager,
         adapter,
         LocalRunStore(tmp_path / "runs"),
-        payload_root=payload_root,
-        generated_config_dir=tmp_path / "generated",
+        paths=_runtime_paths(payload_root, tmp_path / "generated"),
         credential_broker=credentials,
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
 
@@ -267,10 +276,11 @@ def test_profile_runtime_fails_closed_without_an_active_scenario(
         ScenarioSession(tmp_path / "state"),
         _FakeAdapter(),
         LocalRunStore(tmp_path / "runs"),
-        payload_root=_payload_with_all_artifacts(tmp_path / "payload"),
-        generated_config_dir=tmp_path / "generated",
+        paths=_runtime_paths(
+            _payload_with_all_artifacts(tmp_path / "payload"),
+            tmp_path / "generated",
+        ),
         credential_broker=_FakeCredentials(),
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
 
@@ -290,10 +300,11 @@ def test_runtime_creates_its_managed_config_parent_on_fresh_state(
         session_manager,
         _FakeAdapter(),
         LocalRunStore(tmp_path / "state" / "runs"),
-        payload_root=_payload_with_all_artifacts(tmp_path / "payload"),
-        generated_config_dir=generated,
+        paths=_runtime_paths(
+            _payload_with_all_artifacts(tmp_path / "payload"),
+            generated,
+        ),
         credential_broker=_FakeCredentials(),
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
 
@@ -315,10 +326,11 @@ def test_failed_agent_start_revokes_credentials_and_removes_generated_config(
         session_manager,
         _FailingAdapter(),
         LocalRunStore(tmp_path / "runs"),
-        payload_root=_payload_with_all_artifacts(tmp_path / "payload"),
-        generated_config_dir=tmp_path / "generated",
+        paths=_runtime_paths(
+            _payload_with_all_artifacts(tmp_path / "payload"),
+            tmp_path / "generated",
+        ),
         credential_broker=credentials,
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
 
@@ -342,10 +354,11 @@ def test_runtime_rejects_a_profile_with_an_unexpected_mcp_tool_inventory(
         session_manager,
         adapter,
         LocalRunStore(tmp_path / "runs"),
-        payload_root=_payload_with_all_artifacts(tmp_path / "payload"),
-        generated_config_dir=tmp_path / "generated",
+        paths=_runtime_paths(
+            _payload_with_all_artifacts(tmp_path / "payload"),
+            tmp_path / "generated",
+        ),
         credential_broker=credentials,
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
 
@@ -370,10 +383,11 @@ def test_runtime_keeps_a_rejected_agent_until_failed_cleanup_is_retried(
         session_manager,
         adapter,
         LocalRunStore(tmp_path / "runs"),
-        payload_root=_payload_with_all_artifacts(tmp_path / "payload"),
-        generated_config_dir=tmp_path / "generated",
+        paths=_runtime_paths(
+            _payload_with_all_artifacts(tmp_path / "payload"),
+            tmp_path / "generated",
+        ),
         credential_broker=credentials,
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
 
@@ -412,10 +426,11 @@ def test_runtime_validates_a_switch_target_before_closing_the_active_profile(
         session_manager,
         adapter,
         LocalRunStore(tmp_path / "runs"),
-        payload_root=_payload_with_all_artifacts(tmp_path / "payload"),
-        generated_config_dir=tmp_path / "generated",
+        paths=_runtime_paths(
+            _payload_with_all_artifacts(tmp_path / "payload"),
+            tmp_path / "generated",
+        ),
         credential_broker=credentials,
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
     red = runtime.start(ProfileId.RED)
@@ -441,10 +456,11 @@ def test_profile_switch_waits_for_an_active_agent_turn(tmp_path: Path) -> None:
         session_manager,
         adapter,
         LocalRunStore(tmp_path / "runs"),
-        payload_root=_payload_with_all_artifacts(tmp_path / "payload"),
-        generated_config_dir=tmp_path / "generated",
+        paths=_runtime_paths(
+            _payload_with_all_artifacts(tmp_path / "payload"),
+            tmp_path / "generated",
+        ),
         credential_broker=_FakeCredentials(),
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
     runtime.start(ProfileId.RED)
@@ -484,10 +500,11 @@ def test_browser_workbench_is_a_separate_authenticated_profile_surface(
         session_manager,
         _FakeAdapter(),
         LocalRunStore(tmp_path / "runs"),
-        payload_root=_payload_with_all_artifacts(tmp_path / "payload"),
-        generated_config_dir=tmp_path / "generated",
+        paths=_runtime_paths(
+            _payload_with_all_artifacts(tmp_path / "payload"),
+            tmp_path / "generated",
+        ),
         credential_broker=_FakeCredentials(),
-        node_executable=Path(sys.executable),
         model="claude-sonnet-4-5-20250929",
     )
     app = create_participant_workbench_app(

--- a/tests/test_participant_workbench.py
+++ b/tests/test_participant_workbench.py
@@ -235,6 +235,7 @@ def test_profile_switch_closes_the_previous_runtime_and_records_the_active_trace
         generated_config_dir=tmp_path / "generated",
         credential_broker=credentials,
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
 
     red = runtime.start(ProfileId.RED)
@@ -270,6 +271,7 @@ def test_profile_runtime_fails_closed_without_an_active_scenario(
         generated_config_dir=tmp_path / "generated",
         credential_broker=_FakeCredentials(),
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
 
     with pytest.raises(WorkbenchStateError, match="active scenario"):
@@ -292,6 +294,7 @@ def test_runtime_creates_its_managed_config_parent_on_fresh_state(
         generated_config_dir=generated,
         credential_broker=_FakeCredentials(),
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
 
     launch = runtime.start(ProfileId.RED)
@@ -316,6 +319,7 @@ def test_failed_agent_start_revokes_credentials_and_removes_generated_config(
         generated_config_dir=tmp_path / "generated",
         credential_broker=credentials,
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
 
     with pytest.raises(RuntimeError, match="agent launch failed"):
@@ -342,6 +346,7 @@ def test_runtime_rejects_a_profile_with_an_unexpected_mcp_tool_inventory(
         generated_config_dir=tmp_path / "generated",
         credential_broker=credentials,
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
 
     with pytest.raises(WorkbenchStateError, match="MCP tool inventory"):
@@ -369,6 +374,7 @@ def test_runtime_keeps_a_rejected_agent_until_failed_cleanup_is_retried(
         generated_config_dir=tmp_path / "generated",
         credential_broker=credentials,
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
 
     with pytest.raises(WorkbenchStateError, match="cleanup remains incomplete"):
@@ -410,6 +416,7 @@ def test_runtime_validates_a_switch_target_before_closing_the_active_profile(
         generated_config_dir=tmp_path / "generated",
         credential_broker=credentials,
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
     red = runtime.start(ProfileId.RED)
 
@@ -438,6 +445,7 @@ def test_profile_switch_waits_for_an_active_agent_turn(tmp_path: Path) -> None:
         generated_config_dir=tmp_path / "generated",
         credential_broker=_FakeCredentials(),
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
     runtime.start(ProfileId.RED)
     turn = threading.Thread(target=runtime.respond, args=("inspect",))
@@ -480,6 +488,7 @@ def test_browser_workbench_is_a_separate_authenticated_profile_surface(
         generated_config_dir=tmp_path / "generated",
         credential_broker=_FakeCredentials(),
         node_executable=Path(sys.executable),
+        model="claude-sonnet-4-5-20250929",
     )
     app = create_participant_workbench_app(
         runtime,
@@ -496,13 +505,13 @@ def test_browser_workbench_is_a_separate_authenticated_profile_surface(
         == 404
     )
     assert client.post("/workbench/profiles/red").status_code == 401
-    assert client.post("/workbench/messages", json={"message": "help"}).status_code == 401
+    assert (
+        client.post("/workbench/messages", json={"message": "help"}).status_code == 401
+    )
     assert client.delete("/workbench/profile").status_code == 401
     assert client.get("/openapi.json").status_code == 404
 
-    response = client.post(
-        "/workbench/profiles/red", headers=participant_headers
-    )
+    response = client.post("/workbench/profiles/red", headers=participant_headers)
     assert response.status_code == 200
     assert response.json() == {
         "profile": "red",
@@ -567,7 +576,9 @@ def test_browser_workbench_is_a_separate_authenticated_profile_surface(
     closed = client.delete("/workbench/profile", headers=participant_headers)
     assert closed.status_code == 200
     assert closed.json() == {"status": "closed"}
-    assert client.get("/workbench", headers=participant_headers).json()["profile"] is None
+    assert (
+        client.get("/workbench", headers=participant_headers).json()["profile"] is None
+    )
 
 
 class _FakeAdapter:

--- a/tests/test_participant_workbench_adapter.py
+++ b/tests/test_participant_workbench_adapter.py
@@ -436,11 +436,12 @@ def test_codex_decision_launch_is_ephemeral_read_only_and_config_isolated(
     } <= disabled
 
     output_schema.write_text("{}\n")
+    response_schema = _selection_schema(4)
     with pytest.raises(AgentExecutionError, match="sealed"):
         adapter.respond(
             handle,
             "choose",
-            response_schema=_selection_schema(4),
+            response_schema=response_schema,
         )
     assert len(runner.invocations) == 1
 
@@ -454,23 +455,25 @@ def test_decision_adapters_reject_cross_provider_launches(tmp_path: Path) -> Non
         codex_executable=_executable(tmp_path / "codex"),
         work_dir=tmp_path / "codex-work",
     )
+    codex_launch = DecisionAgentLaunch(
+        provider="codex",
+        run_id="a" * 32,
+        model="gpt-5-nano-2025-08-07",
+    )
+    claude_launch = DecisionAgentLaunch(
+        provider="claude",
+        run_id="a" * 32,
+        model="claude-sonnet-4-5-20250929",
+    )
 
     with pytest.raises(AgentExecutionError, match="provider"):
         claude.launch(
-            DecisionAgentLaunch(
-                provider="codex",
-                run_id="a" * 32,
-                model="gpt-5-nano-2025-08-07",
-            ),
+            codex_launch,
             {"ANTHROPIC_API_KEY": "model-secret"},
         )
     with pytest.raises(AgentExecutionError, match="provider"):
         codex.launch(
-            DecisionAgentLaunch(
-                provider="claude",
-                run_id="a" * 32,
-                model="claude-sonnet-4-5-20250929",
-            ),
+            claude_launch,
             {"CODEX_API_KEY": "model-secret"},
         )
 
@@ -504,12 +507,13 @@ def test_codex_model_access_failure_is_classified_without_raw_detail(
         {"CODEX_API_KEY": "model-secret"},
     )
     adapter.list_tools(handle)
+    response_schema = _selection_schema()
 
     with pytest.raises(AgentExecutionError, match="model is unavailable") as error:
         adapter.respond(
             handle,
             "choose",
-            response_schema=_selection_schema(),
+            response_schema=response_schema,
         )
     assert "secret-project" not in str(error.value)
     assert "secret-request-id" not in str(error.value)

--- a/tests/test_participant_workbench_adapter.py
+++ b/tests/test_participant_workbench_adapter.py
@@ -26,6 +26,21 @@ from aptl.workbench.profiles import ProfileId, profile_for, render_profile_confi
 from aptl.workbench.runtime import DecisionAgentLaunch, ProfileLaunch
 
 
+def _selection_schema(maximum: int = 0) -> dict[str, object]:
+    return {
+        "type": "object",
+        "properties": {
+            "candidate": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": maximum,
+            }
+        },
+        "required": ["candidate"],
+        "additionalProperties": False,
+    }
+
+
 def test_ephemeral_broker_returns_only_the_selected_profile_lease() -> None:
     broker = EphemeralCredentialBroker(
         {
@@ -172,6 +187,7 @@ def test_claude_adapter_uses_fixed_argv_minimal_env_and_stdin(
         run_id="a" * 32,
         client_config_path=config_path,
         policy_version="participant-workbench-profile/v1",
+        model="claude-sonnet-4-5-20250929",
     )
     handle = adapter.launch(
         launch,
@@ -197,6 +213,7 @@ def test_claude_adapter_uses_fixed_argv_minimal_env_and_stdin(
     assert _option_value(invocation.argv, "--max-budget-usd") == "1.00"
     assert _option_value(invocation.argv, "--tools") == ""
     assert _option_value(invocation.argv, "--permission-mode") == "dontAsk"
+    assert _option_value(invocation.argv, "--model") == ("claude-sonnet-4-5-20250929")
     assert _option_value(invocation.argv, "--mcp-config") == str(config_path)
     assert _option_value(invocation.argv, "--allowedTools") == (
         "mcp__aptl-red__kali_info"
@@ -223,6 +240,7 @@ def test_claude_adapter_rejects_oversized_prompts_and_failed_results(
             run_id="a" * 32,
             client_config_path=_single_server_config(tmp_path),
             policy_version="participant-workbench-profile/v1",
+            model="claude-sonnet-4-5-20250929",
         ),
         {"ANTHROPIC_API_KEY": "model-secret"},
     )
@@ -258,6 +276,7 @@ def test_claude_adapter_rejects_config_tampering_after_inventory(
             run_id="a" * 32,
             client_config_path=config_path,
             policy_version="participant-workbench-profile/v1",
+            model="claude-sonnet-4-5-20250929",
         ),
         {"ANTHROPIC_API_KEY": "model-secret"},
     )
@@ -288,7 +307,11 @@ def test_claude_decision_launch_has_no_mcp_or_action_tools(
         runner=runner,
     )
     handle = adapter.launch(
-        DecisionAgentLaunch(provider="claude", run_id="a" * 32),
+        DecisionAgentLaunch(
+            provider="claude",
+            run_id="a" * 32,
+            model="claude-sonnet-4-5-20250929",
+        ),
         {
             "ANTHROPIC_API_KEY": "model-secret",
             "OPENAI_API_KEY": "must-not-pass",
@@ -296,11 +319,34 @@ def test_claude_decision_launch_has_no_mcp_or_action_tools(
     )
 
     assert adapter.list_tools(handle) == {}
-    assert adapter.respond(handle, "choose") == '{"surface_id":"selected"}'
+    with pytest.raises(AgentExecutionError, match="response schema"):
+        adapter.respond(handle, "choose")
+    assert runner.invocations == []
+    assert (
+        adapter.respond(
+            handle,
+            "choose",
+            response_schema=_selection_schema(4),
+        )
+        == '{"surface_id":"selected"}'
+    )
     invocation = runner.invocations[0]
     assert invocation.env["ANTHROPIC_API_KEY"] == "model-secret"
     assert "OPENAI_API_KEY" not in invocation.env
     assert _option_value(invocation.argv, "--tools") == ""
+    assert _option_value(invocation.argv, "--model") == ("claude-sonnet-4-5-20250929")
+    assert json.loads(_option_value(invocation.argv, "--json-schema")) == {
+        "type": "object",
+        "properties": {
+            "candidate": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 4,
+            }
+        },
+        "required": ["candidate"],
+        "additionalProperties": False,
+    }
     assert "--mcp-config" not in invocation.argv
     assert "--allowedTools" not in invocation.argv
 
@@ -326,7 +372,11 @@ def test_codex_decision_launch_is_ephemeral_read_only_and_config_isolated(
         runner=runner,
     )
     handle = adapter.launch(
-        DecisionAgentLaunch(provider="codex", run_id="a" * 32),
+        DecisionAgentLaunch(
+            provider="codex",
+            run_id="a" * 32,
+            model="gpt-5-nano-2025-08-07",
+        ),
         {
             "CODEX_API_KEY": "model-secret",
             "ANTHROPIC_API_KEY": "must-not-pass",
@@ -335,13 +385,36 @@ def test_codex_decision_launch_is_ephemeral_read_only_and_config_isolated(
     )
 
     assert adapter.list_tools(handle) == {}
-    assert adapter.respond(handle, "choose") == '{"surface_id":"selected"}'
+    assert (
+        adapter.respond(
+            handle,
+            "choose",
+            response_schema=_selection_schema(4),
+        )
+        == '{"surface_id":"selected"}'
+    )
     invocation = runner.invocations[0]
     assert invocation.env["CODEX_API_KEY"] == "model-secret"
     assert "ANTHROPIC_API_KEY" not in invocation.env
     assert "OPENAI_API_KEY" not in invocation.env
     assert "CODEX_HOME" in invocation.env
     assert invocation.argv[-1] == "-"
+    assert _option_value(invocation.argv, "--model") == "gpt-5-nano-2025-08-07"
+    output_schema = Path(_option_value(invocation.argv, "--output-schema"))
+    assert output_schema.parent == tmp_path / "work"
+    assert json.loads(output_schema.read_text()) == {
+        "type": "object",
+        "properties": {
+            "candidate": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 4,
+            }
+        },
+        "required": ["candidate"],
+        "additionalProperties": False,
+    }
+    assert output_schema.stat().st_mode & 0o777 == 0o600
     assert _option_value(invocation.argv, "--sandbox") == "read-only"
     assert "--ignore-user-config" in invocation.argv
     assert "--ignore-rules" in invocation.argv
@@ -361,6 +434,85 @@ def test_codex_decision_launch_is_ephemeral_read_only_and_config_isolated(
         "multi_agent",
         "image_generation",
     } <= disabled
+
+    output_schema.write_text("{}\n")
+    with pytest.raises(AgentExecutionError, match="sealed"):
+        adapter.respond(
+            handle,
+            "choose",
+            response_schema=_selection_schema(4),
+        )
+    assert len(runner.invocations) == 1
+
+
+def test_decision_adapters_reject_cross_provider_launches(tmp_path: Path) -> None:
+    claude = ClaudeCodeManagedAgentAdapter(
+        claude_executable=_executable(tmp_path / "claude"),
+        work_dir=tmp_path / "claude-work",
+    )
+    codex = CodexManagedAgentAdapter(
+        codex_executable=_executable(tmp_path / "codex"),
+        work_dir=tmp_path / "codex-work",
+    )
+
+    with pytest.raises(AgentExecutionError, match="provider"):
+        claude.launch(
+            DecisionAgentLaunch(
+                provider="codex",
+                run_id="a" * 32,
+                model="gpt-5-nano-2025-08-07",
+            ),
+            {"ANTHROPIC_API_KEY": "model-secret"},
+        )
+    with pytest.raises(AgentExecutionError, match="provider"):
+        codex.launch(
+            DecisionAgentLaunch(
+                provider="claude",
+                run_id="a" * 32,
+                model="claude-sonnet-4-5-20250929",
+            ),
+            {"CODEX_API_KEY": "model-secret"},
+        )
+
+
+def test_codex_model_access_failure_is_classified_without_raw_detail(
+    tmp_path: Path,
+) -> None:
+    runner = _RecordingRunner(
+        ProcessResult(
+            returncode=1,
+            stdout=(
+                b'{"type":"error","message":"request failed"}\n'
+                b'{"type":"item.completed","item":{"type":"error",'
+                b'"message":"Project secret-project does not have access to '
+                b'model gpt-5-nano-2025-08-07"}}\n'
+            ),
+            stderr=b"request secret-request-id failed",
+        )
+    )
+    adapter = CodexManagedAgentAdapter(
+        codex_executable=_executable(tmp_path / "codex"),
+        work_dir=tmp_path / "work",
+        runner=runner,
+    )
+    handle = adapter.launch(
+        DecisionAgentLaunch(
+            provider="codex",
+            run_id="a" * 32,
+            model="gpt-5-nano-2025-08-07",
+        ),
+        {"CODEX_API_KEY": "model-secret"},
+    )
+    adapter.list_tools(handle)
+
+    with pytest.raises(AgentExecutionError, match="model is unavailable") as error:
+        adapter.respond(
+            handle,
+            "choose",
+            response_schema=_selection_schema(),
+        )
+    assert "secret-project" not in str(error.value)
+    assert "secret-request-id" not in str(error.value)
 
 
 def test_agent_executable_accepts_group_write_only_for_a_private_group(
@@ -439,6 +591,7 @@ def test_appliance_factory_wires_the_production_workbench_without_operator_route
             state_dir=tmp_path / "state",
             claude_executable=_executable(tmp_path / "claude"),
             node_executable=Path(sys.executable),
+            model="claude-sonnet-4-5-20250929",
         ),
         secret_source={"ANTHROPIC_API_KEY": "model-secret"},
         authorizer=lambda request: request.headers.get("X-Seat") == "seat",


### PR DESCRIPTION
## Summary

Make installed participant model selection explicit, immutable, and evidence-bound so readiness runs cannot inherit provider defaults or silently fall back. The change also closes the projection, realization, and structured-selection gaps found by exercising the exact RAES participant loop with both installed providers.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #862

## ADR Impact

- ADR-021
- ADR-025
- ADR-029
- ADR-032
- ADR-033
- ADR-044

## Changes

- Add strict provider-specific model configuration and bind its exact provider/model identity into RAES implementation manifests, selections, readiness reports, and control evidence.
- Launch Claude Code and Codex with explicit immutable models, isolated configuration, no action tools, and provider-native per-turn schemas bounded to the delivered candidate range.
- Filter projected choices by current-state prerequisites, preserve fresh-authentication semantics, and align native HEAD realization with the declared action.
- Update the bounded-participant runbook and architecture documentation for explicit model selection and reproducible pre-capture qualification.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Ground Control completion and policy gates passed. Live qualification `participant-qualification-codex-nano-862-v3` passed with pinned model `gpt-5-nano-2025-08-07`: 8/8 green, 8/8 red, 8/8 blue, 26/26 action coverage, BC-01 through BC-10, and official capture disabled. The corresponding installed Claude qualification had already passed.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #862 ← aptl.json, src/aptl/core/config.py, src/aptl/workbench/, src/aptl/backends/raes_participant_*.py, src/aptl/validation/participant_*.py
- TESTS: Issue #862 ← tests/test_config.py, tests/test_participant_workbench_adapter.py, tests/test_participant_workbench.py, tests/test_bounded_participant_runtime.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.