### PR TITLE
feat: record run-scoped apparatus and detection-content provenance

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,6 +156,7 @@ The victim and kali containers publish no host ports; use
 
 ## Preflights
 
+- [REP-003 Run-Scoped Provenance](rep-003-run-scoped-provenance-preflight.md)
 - [Issue #862 Explicit Participant Model Selection](issue-862-explicit-participant-model-selection-preflight.md)
 - [Issue #859 Idempotent Stuttering In Bounded Participant Realizations](issue-859-idempotent-stuttering-preflight.md)
 - [Issue #858 Bounded Participant Choice Transport](issue-858-bounded-participant-choice-transport-preflight.md)

--- a/docs/architecture/rep-003-run-scoped-provenance-preflight.md
+++ b/docs/architecture/rep-003-run-scoped-provenance-preflight.md
@@ -1,0 +1,307 @@
+# REP-003 Run-Scoped Provenance Preflight
+
+This note is the architecture preflight for REP-003 / issue #452. It is
+guidance, not an implementation plan. No new ADR is needed: ADR-044 owns the
+RAES-aligned run-record composition, ADR-029 owns control-plane secret handling,
+ADR-047 owns experiment admission and immutable trial planning, ADR-013 and
+ADR-023 own deployment interaction, and issue #444 owns the final run seal.
+This note fixes how REP-003 crosses those boundaries without creating another
+apparatus schema, inventory system, persistence path, validation layer, or
+workflow.
+
+## Architecture Decisions And Guardrails
+
+### Compose owner-native identities; do not invent an APTL apparatus model
+
+The run-scoped record is a composition with two deliberately separate
+namespaces:
+
+- Portable apparatus and experiment context comes from RAES contracts and
+  owner-native serializers: processor manifest, APTL backend manifest and
+  capabilities, RAES `RuntimeSnapshot`, admitted source-set/trial/scenario/task/
+  capture identities, and participant implementation/configuration provenance.
+- APTL backend provenance describes the realized instrument: safe effective
+  configuration identity, selected profile and dependency closure, immutable
+  image and asset identities, detector/rule/policy content identities,
+  collector/tool versions, APTL `RangeSnapshot`, and bounded host/runtime
+  facts.
+
+The requirement's ACES terminology maps to the current RAES processor and
+contract surfaces in this repository. The legacy `aces` key remains a
+read-compatibility concern only. Do not restore an ACES schema, emit an
+`AcesRunManifest`, or inspect processor/backend objects through `__dict__`.
+
+The two runtime snapshots remain distinct:
+
+- RAES `RuntimeSnapshot` is portable contract state.
+- APTL `RangeSnapshot` is backend-owned range inventory evidence.
+
+Likewise, capture evidence, apparatus provenance, general asset inventory, the
+immutable trial plan, and the final seal are related records with different
+owners. They may reference one another but must not be flattened into one
+schema or state machine.
+
+### Collect at the seal boundary, not by re-discovering the run
+
+The seal coordinator must receive the admitted and executed run context. It
+must not reopen the authored scenario, reselect participants or collectors,
+recompute bindings against current config, infer a run from the active
+directory, or rescan the project as if it represented the past run.
+
+Use the persisted `TrialPlan` and runtime outcomes for source-set, planned
+trial, scenario snapshot, task/capture, stochastic seed, realized binding, and
+participant configuration identities. Use
+`compiled_runtime_model_sha256()` when the compiled RAES runtime model is the
+applicable canonical scenario artifact. A display name, source path, module
+lock digest, or current file contents are not a canonical scenario snapshot.
+
+The record written by `src/aptl/core/lab.py` during lab startup is a provisional
+REP-001 composition. It is currently best-effort, can mint a timestamp run ID,
+uses overwrite-capable `write_json("manifest.json")`, and runs before a final
+experiment result exists. REP-003 must not label that record as the issue #444
+seal or silently retrofit final-trial semantics into the startup step.
+
+The REP-003 output at a real seal point must be a create-once, canonical
+provenance input associated with the authoritative run/planned-trial identity.
+Until #444 consumes and seals it, call it ready-to-seal provenance rather than
+a sealed run. Final signature/attestation and sealed archive state remain with
+#444.
+
+### Use a narrow, trusted provenance-provider seam
+
+Use one internal coordinator with code-owned provider registrations, not one
+monolithic collector and not a general plugin framework. A registration pins a
+stable provider ID, implementation version, the capability/source it supplies,
+the owner adapter it needs, applicable seal point, requiredness policy key, and
+hard count/byte/time limits. Its ID is never an import path, command, URL,
+host path, credential selector, or user-controlled factory.
+
+Each invocation returns a bounded typed result with:
+
+- a closed status such as collected, unavailable, denied, unsupported, timed
+  out, or truncated;
+- sorted leaf identities and owner-native references/digests;
+- stable limitation/reason codes and safe counters; and
+- no raw exception, command, environment, arbitrary metadata, or source bytes.
+
+This adapter result is internal backend provenance, not another RAES contract
+or capture evidence record. Do not reuse capture-specific status types where
+their semantics do not fit, and do not create a new public exception hierarchy.
+The coordinator converts internal failures into the small result vocabulary and
+safe existing diagnostics.
+
+The extension parameter is the trusted registration set plus a seal profile
+(seal point and policy-required provider IDs). Adding the next reasonable
+built-in source must require one registration, one narrow owner adapter, and
+its conformance tests; it must not require edits to the aggregate record
+builder, run controller, RAES DTOs, persistence layout, or exporter. Dynamic
+imports and out-of-process third-party providers need a separate authorization
+and sandboxing design and are outside REP-003.
+
+### Make identities stable and differences explainable
+
+Use RFC 8785 canonical JSON and an explicit version/domain separator for every
+derived structured identity. Normalize SHA-256 values to one representation
+(`sha256:<lowercase-hex>`) at the provenance boundary.
+
+Record leaf identities by stable logical role, then compute any family or
+aggregate identity over a sorted canonical sequence of
+`{logical_id, digest}` entries. This preserves file/role boundaries and makes a
+rule, policy, config, image, or collector change affect its own leaf plus its
+ancestors. Do not hash an unframed concatenation of file bytes.
+
+Separate stable content identity from volatile observation data. Timestamps,
+container IDs, health state, collection durations, and transient host counters
+may be relevant observations, but they must not cause otherwise unchanged
+apparatus content identities to drift. Image tags are observations; immutable
+registry/content digests are identities.
+
+Missing, denied, unsupported, truncated, timed-out, and failed sources are
+explicit results, never empty strings, empty maps, absent keys, or a fabricated
+digest. A readiness/seal policy maps each result to either a blocking readiness
+failure or a declared limitation. REP-003 supplies facts and stable reason
+codes; it must not duplicate the readiness workflow owned by #472 or the seal
+workflow owned by #444.
+
+### Exclude secrets by source, then enforce redaction as defense in depth
+
+The safe collection rule is allowlist-first. Providers may read only explicit
+owner-declared, non-secret sources. They must not ingest a prohibited source
+and rely on redaction, hashing, file permissions, or exporter cleanup.
+
+In particular:
+
+- Never read, store, or hash `.env`, raw environment dumps, rendered
+  secret-bearing configuration, credentials, cookies, bearer tokens, private
+  keys, unrestricted process arguments, or control-plane request/response
+  bodies.
+- A digest is not safe disclosure for a secret or small guessable domain.
+  Secret-shaped digests and hashes of low-entropy settings remain prohibited.
+- Build a versioned safe effective-config projection beside the strict
+  `AptlConfig` owner. Include only explicit apparatus-relevant fields and their
+  effective defaults. Exclude secret values, private-key material, credential
+  locators, and privacy-sensitive host/path details unless a separately
+  reviewed role requires a bounded public identity.
+- Generated configuration is eligible only when its producer declares the
+  output non-secret and the provider reads an explicit artifact through a
+  contained no-follow path. The ignored `.aptl/config` tree is not eligible.
+- Host/runtime inventory is a closed allowlist of validity-relevant facts, such
+  as OS/architecture/kernel and deployment-engine mode/version where policy
+  requires them. It is not `env`, `ps`, unrestricted `docker inspect`, a
+  filesystem crawl, full labels, or all host hardware.
+
+All structured output must still pass the shared redactor and the runstore
+secret-invariant check. Redaction detects drift; it does not expand what a
+provider is authorized to collect.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent and required use |
+|---|---|
+| Processor/backend/capabilities | RAES processor manifest serializers and `src/aptl/backends/raes_manifest.py` (`create_aptl_manifest()` and its public payload/model helpers). Capability claims come from the same code-owned registries that implement them, not a second matrix. |
+| Scenario and experiment identity | `src/aptl/backends/raes_runtime_model_artifact.py` and `src/aptl/core/experiment/{spec_loading,admission,admission_artifacts,trial_plan,trial_plan_models}.py`. Preserve canonical admitted identities instead of reparsing authored artifacts at seal time. |
+| Participant provenance | `src/aptl/backends/raes_participant_apparatus.py`, participant selection/control-evidence publication, and RAES participant manifest/configuration models. Record the accepted actual selection and configuration digest, not a reconstruction from current config. |
+| Realization and profiles | RAES realization/start outcomes, `src/aptl/backends/raes_profiles.py`, and `raes_dependency_closure.py`. Use the realized selection and canonical `ComposeProfileIndex`; the provenance coordinator does not parse Compose. |
+| Deployment and runtime facts | `DeploymentBackend`, `src/aptl/core/deployment/`, `host_versions()`, and typed container/network inspection. Extend or normalize this boundary if immutable image identity is missing; never shell out to Docker/Compose from a provider. |
+| Range and appliance inventory | `RangeSnapshot.to_dict()`, snapshot endpoint ownership, and `src/aptl/core/appliance_boundary_inventory.py` where the appliance boundary applies. Reference/project these owners; do not broaden the appliance DTO into a general inventory schema. |
+| Config and environment | Strict `AptlConfig`, ADR-025, `src/aptl/core/env.py`, `credentials.py`, and producer-owned generated config. A safe config-identity projection is explicit and versioned; `model_dump()` of the whole config and raw config-file hashing are not safe projections. |
+| Assets and dependencies | Active participant `asset-lock.json`, release/appliance manifests, `uv.lock`, applicable package lockfiles, and owner-produced dependency closure. Record the lock/artifact actually selected; do not substitute an ambient `pip freeze`, `npm list`, or unrelated release SBOM. |
+| Detector and policy content | The producers and canonical config roots for Suricata, Wazuh, policies, allowlists, seeds, and generated rules. Evolve the existing snapshot/content owner rather than add a parallel hashing service, but replace stale broad glob/read and single combined-digest behavior with explicit safe logical sources. |
+| Collectors and tools | Admitted capture bindings, `src/aptl/core/experiment/capture_registry.py`, source adapters, `RangeSnapshot.software`, and actual participant/control evidence. Registry declaration is not proof that an implementation ran; preserve the realized version/outcome. |
+| Persistence and path safety | `RunStorageBackend`/`LocalRunStore.create_run_json_once()`, RFC 8785, `src/aptl/utils/pathsafe.py`, restrictive create-exclusive/no-follow storage, and the existing content-addressed evidence store for referenced blobs. Do not add a provenance repository. |
+| Secrets, logs, and diagnostics | ADR-029, `src/aptl/utils/redaction.py`, TypeScript redaction parity, `src/aptl/utils/logging.py`, safe `AdmissionRejection`, RAES diagnostics, and existing `LabResult` diagnostics in their proper domains. |
+| Auth and projection | Existing API bearer verification and BFF host/CSRF/session gates, MCP local authority, sidecar peer checks, and server-side visibility projection. REP-003 adds no endpoint or authority bypass. |
+| Export and workflow | `src/aptl/core/exporter.py` packages already-safe artifacts. `.ground-control.yaml`, `.gc/plan-rules.md`, pytest, pre-commit, and the RAES corpus/conformance fixtures remain the completion gates. |
+
+## Security And Validation Passage
+
+The intended design must pass every applicable layer below. Passing a provider's
+local shape check is insufficient.
+
+| Layer | Required passage |
+|---|---|
+| Authority/authentication | Collection is invoked only by the trusted run/seal coordinator for the authoritative run. No new network endpoint is required. Any future API projection inherits bearer verification, BFF host/CSRF/session checks, and visibility filtering; archive presence grants no access by itself. |
+| RAES contract validation | Processor, backend, runtime, experiment, capture, and participant fields come from public RAES loaders/models/serializers and admitted runtime objects. Do not locally restate their DTOs or validators. |
+| Cross-artifact admission | ADR-047 resolver/spec-loading checks containment, kind/version, joins, apparatus compatibility, participant configuration, capture bindings, and canonical trial-plan persistence before mutation. Seal-time provenance consumes those accepted identities without re-admission or fallback discovery. |
+| Provider/result shape | Registrations and outputs use closed code-owned IDs/status/reason vocabularies, unique logical IDs, normalized digests, deterministic ordering, bounded strings/counts, and rejected extra/arbitrary metadata. Hostile labels cannot become keys, paths, log templates, or unlimited record content. |
+| Config validation | Durable knobs remain explicit strict `AptlConfig` fields with `extra="forbid"`. Provider registration and readiness policy are trusted code/policy, not arbitrary keys hidden in authored experiment notes or environment variables. |
+| Environment and secret binding | `.env`/`EnvVars` and generated credential owners remain the secret boundary. Inject narrow authenticated clients or backend adapters after validation; never give a provider raw env/config, and never place secret-derived material in the config identity. |
+| Deployment/source boundary | Docker, Compose, container, network, image, and remote-host facts flow through `DeploymentBackend` and typed owners. SOC access uses established clients and `curl_safe`. Providers do not receive generic shell, HTTP, SSH, filesystem, or controller authority. |
+| OS/process exposure | Use argument arrays, incumbent runners, deadlines, and safe temporary-file mechanisms. Do not put tokens, cookies, private-key material, rendered config, arbitrary labels, unrestricted arguments, or secret hashes in argv, URLs, child environments, process titles, or backend diagnostics. |
+| Filesystem/path containment | Provider roots and logical files are code-owned. Reject absolute/traversal/NUL/symlink/special-file inputs; use descriptor-relative contained no-follow opens and one verified handle; enforce limits while reading. `glob()`/`rglob()` plus `is_file()`/`read_bytes()` over untrusted or secret-bearing roots is not sufficient. |
+| Size/time availability | Enforce per-provider and aggregate byte, file, nesting, string, metadata, and time limits before buffering. Timeout, denial, truncation, and unavailable source remain explicit typed outcomes and cannot silently degrade to success. |
+| Secret serialization | Allowlist sources first, then apply shared redaction. `create_run_json_once()` must reject any structured payload changed by redaction. Opaque referenced blobs require an owner classification/policy; exporter is not a sanitation stage. |
+| Persistence/identity | Create canonical structured records once under validated run IDs and internally derived paths. A repeated publication is idempotent only for identical canonical bytes; conflicting content fails closed. References identify bytes actually retained. |
+| Logging/observability | Log provider ID/version, stage, status/reason code, duration, safe counts, and digest only. Never log content, raw exceptions, pydantic `input`/`ctx`, backend stderr, commands, URLs/headers, host paths, arbitrary labels, or config/env dumps. |
+| Error envelope | Normalize parser/backend/provider exceptions at their owner boundary into bounded RAES diagnostics, readiness limitations, or the applicable existing lab diagnostic. Public messages are fixed and safe; detailed logs obey the same secret/metadata constraints. Do not expose `str(exc)` as a record field or API error. |
+| Readiness/seal/export | Validate required provider outcomes, owner-native contract models, digest/ref integrity, limitations, and create-once persistence before reporting ready to seal. #472 decides readiness policy and #444 seals. Export packages the already-valid result and cannot repair a leak or missing source. |
+
+## Current Gaps The Implementation Must Not Preserve
+
+- `_hash_config_files()` currently includes `.env` and follows ordinary
+  `glob()`/`read_bytes()` paths. `.env` must be excluded, not hashed, and safe
+  config identity must come from an explicit effective projection.
+- `detection_content_digest()` uses an unframed aggregate and stale,
+  non-recursive paths. It misses current nested Suricata MISP content and the
+  `config/wazuh_cluster` rule/decoder/allowlist surface, cannot explain targeted
+  differences, follows symlinks, and treats no files as an empty success.
+- `ContainerSnapshot.image_digest` exists, but the current snapshot population
+  path does not prove it is filled with the selected immutable image digest.
+  Tags, container names, and container IDs cannot stand in for that digest.
+- `_collect_evidence_references()` infers evidence from path presence without
+  source outcome, validation, or content digest. Presence is not provenance
+  truth.
+- The current startup `manifest.json` is best-effort and overwrite-capable.
+  A comment calling an archive "now-sealed" does not establish seal semantics.
+- `RangeSnapshot.to_dict()` supplies the redacted owner projection, but blindly
+  embedding all labels or metadata would still create malicious-key and size
+  risks. Use a bounded allowlisted projection/reference for seal provenance.
+- The current tool-version projection is a useful start but is not proof of
+  collector selection or execution. Declaration, installed version, selected
+  implementation, and observed execution are different facts.
+
+## Verification Guardrails
+
+- Prove equivalent owner inputs and different provider/registry iteration order
+  produce identical canonical identities. Timestamps and volatile runtime IDs
+  must not perturb stable content identity.
+- Change one rule, safe config field, image digest, dependency/asset lock,
+  collector version, and scenario snapshot independently. Each change must
+  affect only its leaf/family identities plus the aggregate.
+- Cover raw and nested secret-shaped values, `.env`, rendered config, private
+  keys, tokens, cookies, low-entropy secrets, and malicious metadata. Assert
+  they enter neither bytes, digests, refs, argv, logs, errors, records, nor
+  exports.
+- Cover absolute/traversal/NUL paths, symlinks and replacement races, special
+  files, hostile logical IDs/labels, oversized files/counts/nesting/metadata,
+  slow sources, partial reads, conflicting create-once writes, and concurrent
+  collection.
+- Exercise unavailable, denied, unsupported, timed-out, truncated, malformed,
+  and owner-error outcomes. Assert each becomes the correct limitation or
+  readiness failure and never disappears.
+- Validate RAES-owned projections through installed RAES models/conformance
+  fixtures and backend-owned projections through strict closed models.
+- Follow `.gc/plan-rules.md`: Python changes require pytest coverage; MCP common
+  changes rebuild/test every dependent MCP; web changes require web tests; and
+  Compose, container-Dockerfile, or `config/` changes require a clean
+  `aptl lab stop -v && aptl lab start` on a fresh machine. Run
+  `pre-commit run --all-files` before completion.
+
+## Gotchas And Anti-Patterns
+
+- Do not create an APTL experiment/apparatus/capability/participant manifest
+  that mirrors RAES, or promote APTL backend evidence as a portable contract.
+- Do not conflate `RangeSnapshot` with RAES `RuntimeSnapshot`, provenance with
+  capture evidence, provider capability with successful collection, inventory
+  with a seal, or a digest with attestation/signature/chain of custody.
+- Do not rebuild accepted identities from current files/config or silently use
+  "latest" manifests, tags, participant models, collectors, rules, or locks.
+- Do not add direct Docker/Compose/SSH/curl/shell parsing to the record builder,
+  or pass it a complete backend/controller/config/environment for convenience.
+- Do not use raw file/config/environment/process dumps, blanket project walks,
+  arbitrary recursive mappings, or metadata-controlled paths/commands/URLs.
+- Do not treat hashing, redaction, ignored paths, encryption at rest, or file
+  permissions as authorization to ingest a secret source.
+- Do not put volatile timestamps/container IDs in stable apparatus identity,
+  concatenate unframed bytes, omit logical file roles, or make filesystem order
+  significant.
+- Do not map missing/denied/oversized/unavailable sources to `{}`, `""`, a
+  guessed version, a fabricated digest, or generic success.
+- Do not duplicate RAES/Pydantic validation, runstore containment, redaction,
+  diagnostics, exception hierarchies, readiness transitions, or seal workflow.
+- Do not add dynamic provider discovery, imports, subprocess plugins, or a
+  generic registry framework. The seam is for trusted built-ins.
+
+## Non-Goals And Boundaries
+
+- REP-003 does not define the #444 signature/attestation format, final archive
+  state machine, key management, or chain-of-custody claims.
+- REP-003 reports provider outcomes and limitations; #472 owns the readiness
+  policy that decides which are fatal.
+- It does not redesign RAES contracts, experiment admission/trial planning,
+  capture/evidence acquisition, participant execution, deployment backends,
+  run storage layout, exporter packaging, web/MCP APIs, or observability.
+- It does not create a new asset-inventory methodology. Reuse the existing
+  owner and the RAES asset/inventory surfaces; appliance inventory remains
+  appliance-scoped.
+- It does not produce a forensic host image, raw software/package dump, full
+  SBOM, full process/container inspect, secret manager, or detection-policy
+  editor.
+- It does not promise signed provenance, remote attestation, or reproducibility
+  merely because content hashes exist. The record discloses realized apparatus
+  facts and limitations for later comparability assessment.
+
+## References
+
+- [ADR-013](../adrs/adr-013-deployment-abstraction.md) and
+  [ADR-023](../adrs/adr-023-container-interaction-in-deployment-backend.md):
+  deployment/runtime ownership.
+- [ADR-025](../adrs/adr-025-strict-first-party-config-schema.md): strict
+  first-party configuration.
+- [ADR-029](../adrs/adr-029-control-plane-secret-handling.md): secret, runstore,
+  snapshot, and argv boundaries.
+- [ADR-044](../adrs/adr-044-raes-aligned-run-reproducibility-record.md):
+  RAES/APTL run-record composition.
+- [ADR-047](../adrs/adr-047-raes-experiment-admission-and-trial-plan-boundary.md):
+  experiment admission and immutable trial planning.
+- REP-003 / GitHub issue #452.

--- a/docs/reference/experiment-runs.md
+++ b/docs/reference/experiment-runs.md
@@ -29,6 +29,9 @@ Each run is stored under `<project_dir>/runs/<run_id>/` with:
   manifest.json          # Run metadata (scenario, timing, flags)
   snapshot.json          # Range snapshot (software, containers, rules, networks, config hashes)
   flags.json             # Captured flags
+  provenance/
+    startup-provenance.json  # Provisional apparatus provenance, written at lab start
+    run-provenance.json      # Canonical ready-to-seal provenance, written at the seal boundary
   scenario/
     definition.yaml      # Scenario YAML copy
     events.jsonl         # Scenario events timeline
@@ -45,6 +48,54 @@ Each run is stored under `<project_dir>/runs/<run_id>/` with:
   agents/
     traces.jsonl         # MCP agent traces (if available)
 ```
+
+## Run Provenance (`provenance/`)
+
+Records which apparatus the run was actually realized on, so a later reader can
+tell exactly which scenario, backend, participant implementation, images,
+detector rules, collectors, and configuration produced the results.
+
+There are two records, written at different lifecycle boundaries:
+
+- `startup-provenance.json` is **provisional**. Lab start knows the effective
+  configuration, detection content, dependency locks, and realized images, but
+  not the admitted trial plan, the realized participants, or any execution
+  outcome.
+- `run-provenance.json` is the canonical **ready-to-seal** record, written by
+  the collector that owns the admitted and executed run context. Publishing it
+  without that context is refused rather than written with the experiment and
+  participant sources reported missing.
+
+Both are written **create-once**: republishing identical content is a no-op,
+and republishing different content for the same run fails rather than
+overwriting. Separate paths are what keep the provisional startup artifact from
+foreclosing the later canonical write. Neither record is a seal; they carry no
+signature or attestation claim.
+
+| Field | Description |
+|-------|-------------|
+| `schema_version` | Version of the record shape |
+| `run_id` | The run this provenance describes |
+| `seal_state` | `ready-to-seal` for the canonical record, `provisional` for the startup record |
+| `aggregate_identity` | Canonical identity over every section |
+| `registry_declaration_digest` | Pins which provider declarations collected this run |
+| `sections[]` | One entry per provenance source: status, declaration digest, content identity, and a bounded payload |
+| `limitations[]` | Every source that did not fully collect, with a stable reason code |
+
+Each source is collected by a code-owned provider under declared byte, entry,
+and time limits. A source that is unavailable, denied, unsupported, truncated,
+timed out, or failed appears in `limitations[]` with a stable reason code. Such
+a source is never silently omitted and never given a fabricated digest. A plain
+`aptl lab start` has no admitted experiment plan and no installed participants,
+so its provisional record reports those two sources `unavailable` rather than
+leaving them out.
+
+Content identity is framed per artifact: every detector rule, decoder,
+allowlist, image, and configuration is a leaf bound to its logical role, and
+family identities fold the sorted leaves. Changing one rule therefore moves
+that rule's leaf and the aggregate, and nothing else. Secret sources are
+excluded by allowlist before collection: `.env`, rendered secret-bearing
+config, credentials, and private keys are never read or hashed.
 
 ## Range Snapshot (`snapshot.json`)
 
@@ -66,7 +117,7 @@ Captured at the start of each run for reproducibility. Contains:
 | `wazuh_rules.total_decoders` | Total decoders loaded |
 | `wazuh_rules.custom_decoders` | Custom decoders count |
 | `networks[]` | Docker network name, subnet, gateway, connected containers |
-| `config_hashes` | SHA-256 of `aptl.json`, `docker-compose.yml`, `.env` |
+| `config_hashes` | SHA-256 of `aptl.json` and `docker-compose.yml`. `.env` is deliberately excluded: it holds control-plane secrets whose values have a small guessable domain, so a digest of it would be a confirmation oracle rather than an opaque identity. |
 
 Snapshots and trace exports must not contain live credentials, API keys, bearer
 tokens, cookies, JWTs, private key material, or default lab passwords. Redact at

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -2088,13 +2088,71 @@ def _write_run_record(ctx: _LabStartContext) -> None:
     store.write_json(run_id, "manifest.json", record)
     log.info("REP-001: Run record written to run archive (run_id=%s)", run_id)
 
+    # REP-003: publish the PROVISIONAL run-scoped provenance beside the
+    # REP-001 record. Startup has configuration, detection content, and a
+    # range snapshot, but no admitted trial plan, realized participants, or
+    # execution outcome — so it cannot produce the canonical ready-to-seal
+    # record, and must not occupy that path.
+    _publish_run_provenance(
+        store=store,
+        run_id=run_id,
+        project_dir=ctx.project_dir,
+        config=ctx.config,
+        snapshot=snapshot,
+    )
+
     # OBS-002: layer the correlation-identity + clock-context projection over
-    # the now-sealed run archive so an action can be traced end-to-end and
-    # every source's clock is disclosed. Best-effort by contract — an audit
-    # projection must never turn a successful run into a failed one.
+    # the run archive so an action can be traced end-to-end and every source's
+    # clock is disclosed. Best-effort by contract — an audit projection must
+    # never turn a successful run into a failed one. (The archive is not
+    # sealed here; issue #444 owns sealing.)
     from aptl.core.correlation.persistence import persist_run_correlation_best_effort
 
     persist_run_correlation_best_effort(run_id=run_id, run_store=store)
+
+
+def _publish_run_provenance(
+    *,
+    store: object,
+    run_id: str,
+    project_dir: Path,
+    config: object,
+    snapshot: object,
+) -> None:
+    """Collect and publish REP-003 PROVISIONAL run provenance (issue #452).
+
+    Startup is not a seal boundary. It has no admitted trial plan, no realized
+    participant apparatus, and no execution outcome, so it publishes the
+    provisional artifact at its own path. The canonical ready-to-seal record
+    stays available for the collector that owns the admitted and executed run
+    context; because publication is create-once, writing the canonical record
+    here would permanently foreclose that later write.
+
+    Best-effort by contract, exactly like the REP-001 record and the OBS-002
+    correlation projection above: the lab is already running by the time this
+    executes, so a provenance failure is reported and recorded but never
+    converts a successful start into a failure.
+    """
+    from aptl.core.provenance.record import publish_provisional_provenance_record
+    from aptl.core.provenance.registrations import collect_run_provenance
+
+    try:
+        collection = collect_run_provenance(
+            project_dir=project_dir, config=config, snapshot=snapshot
+        )
+        publish_provisional_provenance_record(
+            store=store,  # type: ignore[arg-type]
+            run_id=run_id,
+            collection=collection,
+        )
+    except Exception:
+        log.exception("REP-003: Run provenance publication failed (non-fatal)")
+        return
+    log.info(
+        "REP-003: Provisional run provenance written (run_id=%s, limitations=%d)",
+        run_id,
+        len(collection.limitations),
+    )
 
 
 # Evidence artifact subtrees scanned for the REP-001 record (GAP 3). Each

--- a/src/aptl/core/provenance/__init__.py
+++ b/src/aptl/core/provenance/__init__.py
@@ -1,0 +1,27 @@
+"""Run-scoped apparatus and detection-content provenance (REP-003 / issue #452).
+
+This package records the realized APTL instrument at a run's seal boundary:
+which scenario, apparatus, participant implementation, images, rules,
+collectors, and relevant configuration were actually used.
+
+The design boundaries are fixed by
+``docs/architecture/rep-003-run-scoped-provenance-preflight.md``:
+
+* Two deliberately separate namespaces — portable RAES-owned apparatus and
+  experiment identity, versus APTL backend-owned realized-instrument
+  provenance. This package composes owner-native payloads; it never defines a
+  second apparatus, experiment, or capability schema.
+* A narrow, trusted, capability-declared provider seam (:mod:`.registry`) with
+  bounded typed outcomes (:mod:`.outcomes`) — not one monolithic collector and
+  not a general plugin framework.
+* Allowlist-first collection. A provider reads only explicit owner-declared
+  non-secret sources; redaction is drift detection, never authorization to
+  ingest a prohibited source.
+* Stable, explainable identity (:mod:`.identity`) — per-leaf logical roles
+  folded into families over sorted canonical sequences, so one changed rule,
+  image, or setting moves its own leaf plus its ancestors and nothing else.
+
+The record this package publishes is *ready-to-seal* provenance. Issue #444
+owns signing and the sealed archive state; issue #472 owns which limitations
+are fatal. Nothing here claims a run is sealed.
+"""

--- a/src/aptl/core/provenance/coordinator.py
+++ b/src/aptl/core/provenance/coordinator.py
@@ -31,6 +31,11 @@ from aptl.core.provenance.identity import (
     family_identity,
 )
 from aptl.core.provenance.outcomes import (
+    DETAIL_ABSENT,
+    DETAIL_DEADLINE,
+    DETAIL_ENTRY_LIMIT,
+    DETAIL_OWNER_FAILURE,
+    DETAIL_UNSUPPORTED,
     SUCCESS_STATUSES,
     ProvenanceLimitation,
     ProvenanceStatus,
@@ -125,24 +130,38 @@ class ProvenanceCollection:
         }
 
 
+def _mapping_is_bounded(value: Mapping[object, object], depth: int) -> bool:
+    """Return whether a mapping's size, keys, and values are all within bounds."""
+    keys_bounded = all(
+        isinstance(key, str) and len(key) <= _MAX_PAYLOAD_STRING for key in value
+    )
+    return (
+        len(value) <= _MAX_PAYLOAD_KEYS
+        and keys_bounded
+        and all(_payload_is_bounded(item, depth + 1) for item in value.values())
+    )
+
+
+def _sequence_is_bounded(value: list | tuple, depth: int) -> bool:
+    """Return whether a sequence's length and every item are within bounds."""
+    return len(value) <= _MAX_PAYLOAD_KEYS and all(
+        _payload_is_bounded(item, depth + 1) for item in value
+    )
+
+
 def _payload_is_bounded(value: object, depth: int = 0) -> bool:
     """Return whether ``value`` is within the hard structural ceilings."""
     if depth > _MAX_PAYLOAD_DEPTH:
-        return False
-    if isinstance(value, str):
-        return len(value) <= _MAX_PAYLOAD_STRING
-    if isinstance(value, Mapping):
-        if len(value) > _MAX_PAYLOAD_KEYS:
-            return False
-        return all(
-            isinstance(key, str) and len(key) <= _MAX_PAYLOAD_STRING
-            for key in value
-        ) and all(_payload_is_bounded(item, depth + 1) for item in value.values())
-    if isinstance(value, (list, tuple)):
-        if len(value) > _MAX_PAYLOAD_KEYS:
-            return False
-        return all(_payload_is_bounded(item, depth + 1) for item in value)
-    return isinstance(value, (int, float, bool)) or value is None
+        bounded = False
+    elif isinstance(value, str):
+        bounded = len(value) <= _MAX_PAYLOAD_STRING
+    elif isinstance(value, Mapping):
+        bounded = _mapping_is_bounded(value, depth)
+    elif isinstance(value, (list, tuple)):
+        bounded = _sequence_is_bounded(value, depth)
+    else:
+        bounded = isinstance(value, (int, float, bool)) or value is None
+    return bounded
 
 
 def _payload_is_safe(payload: Mapping[str, object]) -> bool:
@@ -157,12 +176,12 @@ def _payload_is_safe(payload: Mapping[str, object]) -> bool:
     if not _payload_is_bounded(payload):
         return False
     try:
-        if redact(dict(payload)) != dict(payload):
-            return False
-        derive_identity(_SECTION_DOMAIN, {"payload": dict(payload)})
-    except (ProvenanceIdentityError, TypeError, ValueError, RecursionError):
-        return False
-    return True
+        snapshot = dict(payload)
+        safe = redact(snapshot) == snapshot
+        derive_identity(_SECTION_DOMAIN, {"payload": snapshot})
+    except (TypeError, ValueError, RecursionError):
+        safe = False
+    return safe
 
 
 def _degraded(
@@ -194,42 +213,56 @@ def _collected(
     )
 
 
+def _rejection(
+    registration: ProvenanceProviderRegistration,
+    result: ProvenanceResult,
+    elapsed: float,
+) -> tuple[ProvenanceStatus, str] | None:
+    """Return the first ``(status, detail)`` disqualifying ``result``, else ``None``.
+
+    Ordered so the most fundamental violation wins: a result that impersonates
+    another provider is a wiring fault, an overrun deadline invalidates whatever
+    was gathered, and only then are quota and content validity considered.
+    """
+    impersonating = result.provider_id != registration.provider_id
+    if impersonating:
+        log.warning(
+            "run-provenance: provider %s returned a result for another provider id",
+            registration.provider_id,
+        )
+    unsafe_payload = not _payload_is_safe(result.payload)
+    if unsafe_payload:
+        log.warning(
+            "run-provenance: provider %s payload rejected by the safety invariant",
+            registration.provider_id,
+        )
+    checks = (
+        (impersonating, ProvenanceStatus.FAILED, DETAIL_OWNER_FAILURE),
+        (elapsed >= float(registration.limits.timeout_s), ProvenanceStatus.TIMED_OUT, DETAIL_DEADLINE),
+        (result.status not in SUCCESS_STATUSES, result.status, result.detail),
+        (
+            len(result.leaves) > registration.limits.max_entries,
+            ProvenanceStatus.TRUNCATED,
+            DETAIL_ENTRY_LIMIT,
+        ),
+        (unsafe_payload, ProvenanceStatus.FAILED, DETAIL_OWNER_FAILURE),
+    )
+    for failed, status, detail in checks:
+        if failed:
+            return status, detail
+    return None
+
+
 def _evaluate(
     registration: ProvenanceProviderRegistration,
     result: ProvenanceResult,
     *,
     elapsed: float,
 ) -> tuple[ProvenanceSection, ProvenanceLimitation | None]:
-    """Turn one raw provider result into a validated section (+ limitation).
-
-    Checks are ordered so the most fundamental violation wins: a result that
-    impersonates another provider is a wiring fault, an overrun deadline
-    invalidates whatever was gathered, and only then are quota and content
-    validity considered.
-    """
-    if result.provider_id != registration.provider_id:
-        log.warning(
-            "run-provenance: provider %s returned a result for another provider id",
-            registration.provider_id,
-        )
-        return _degraded(registration, ProvenanceStatus.FAILED, "owner reported failure")
-
-    if elapsed >= float(registration.limits.timeout_s):
-        return _degraded(registration, ProvenanceStatus.TIMED_OUT, "deadline exceeded")
-
-    if result.status not in SUCCESS_STATUSES:
-        return _degraded(registration, result.status, result.detail)
-
-    if len(result.leaves) > registration.limits.max_entries:
-        return _degraded(registration, ProvenanceStatus.TRUNCATED, "entry limit reached")
-
-    if not _payload_is_safe(result.payload):
-        log.warning(
-            "run-provenance: provider %s payload rejected by the safety invariant",
-            registration.provider_id,
-        )
-        return _degraded(registration, ProvenanceStatus.FAILED, "owner reported failure")
-
+    """Turn one raw provider result into a validated section (+ limitation)."""
+    rejection = _rejection(registration, result, elapsed)
+    if rejection is not None:
+        return _degraded(registration, rejection[0], rejection[1])
     try:
         return _collected(registration, result), None
     except ProvenanceIdentityError:
@@ -237,7 +270,7 @@ def _evaluate(
             "run-provenance: provider %s produced an invalid content identity",
             registration.provider_id,
         )
-        return _degraded(registration, ProvenanceStatus.FAILED, "owner reported failure")
+        return _degraded(registration, ProvenanceStatus.FAILED, DETAIL_OWNER_FAILURE)
 
 
 def _invoke(
@@ -259,7 +292,7 @@ def _invoke(
         log.warning(
             "run-provenance: provider %s raised during collection", registration.provider_id
         )
-        return _degraded(registration, ProvenanceStatus.FAILED, "owner reported failure")
+        return _degraded(registration, ProvenanceStatus.FAILED, DETAIL_OWNER_FAILURE)
     return _evaluate(registration, result, elapsed=monotonic() - started_at)
 
 
@@ -296,7 +329,7 @@ def collect_provenance(
                 limits=_UNREGISTERED_LIMITS,
             )
             section, limitation = _degraded(
-                unregistered, ProvenanceStatus.UNSUPPORTED, "source not supported"
+                unregistered, ProvenanceStatus.UNSUPPORTED, DETAIL_UNSUPPORTED
             )
         else:
             section, limitation = _invoke(provider, registration, monotonic)
@@ -310,7 +343,7 @@ def collect_provenance(
         if not profile.requires(registration.provider_id):
             continue
         section, limitation = _degraded(
-            registration, ProvenanceStatus.UNAVAILABLE, "source not present"
+            registration, ProvenanceStatus.UNAVAILABLE, DETAIL_ABSENT
         )
         sections[section.provider_id] = section
         limitations.append(limitation)

--- a/src/aptl/core/provenance/coordinator.py
+++ b/src/aptl/core/provenance/coordinator.py
@@ -1,0 +1,337 @@
+"""The bounded provenance-collection coordinator (REP-003 / issue #452).
+
+The coordinator owns everything a provider must not: deadline enforcement,
+limit enforcement, exception normalization, secret-invariant checking,
+canonical identity, and deterministic ordering. A provider only reports its
+declared source.
+
+Every internal failure collapses into the small
+:class:`~aptl.core.provenance.outcomes.ProvenanceStatus` vocabulary. A raising
+provider, an over-deadline provider, an over-quota provider, an unregistered
+provider, a provider claiming another's id, and a provider returning
+secret-shaped or unserializable content all become explicit typed results with
+stable reason codes — never a silent skip, an empty section, or a fabricated
+digest.
+
+A non-collected provider contributes NO content identity. Recording a digest
+for a source that failed would be exactly the fabricated-identity failure mode
+the requirement prohibits.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+
+from aptl.core.provenance.identity import (
+    ProvenanceIdentityError,
+    ProvenanceLeaf,
+    derive_identity,
+    family_identity,
+)
+from aptl.core.provenance.outcomes import (
+    SUCCESS_STATUSES,
+    ProvenanceLimitation,
+    ProvenanceStatus,
+    limitation_for,
+)
+from aptl.core.provenance.protocol import (
+    MonotonicClock,
+    ProvenanceContext,
+    ProvenanceProvider,
+    ProvenanceResult,
+)
+from aptl.core.provenance.registry import (
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    ProvenanceProviderRegistry,
+    SealProfile,
+)
+from aptl.utils.redaction import redact
+
+log = logging.getLogger(__name__)
+
+#: Identity domain for one provider section's content.
+_SECTION_DOMAIN = "section"
+
+#: Identity domain for the aggregate over every section.
+_AGGREGATE_DOMAIN = "collection"
+
+#: Schema identity of the collection projection shape.
+COLLECTION_SCHEMA_VERSION = "aptl-run-provenance-collection/v1"
+
+#: Hard ceilings applied to a payload regardless of what a provider declares,
+#: so a bug in one registration cannot admit unbounded record content.
+_MAX_PAYLOAD_KEYS = 64
+_MAX_PAYLOAD_DEPTH = 6
+_MAX_PAYLOAD_STRING = 4096
+
+#: Placeholder limits used only to satisfy the registration invariant while an
+#: UNSUPPORTED section is built for a provider that has no registration. Such a
+#: provider is never invoked, so these bounds are never enforced against real
+#: collection.
+_UNREGISTERED_LIMITS = ProvenanceLimits(max_bytes=1, max_entries=1, timeout_s=1)
+
+
+@dataclass(frozen=True)
+class ProvenanceSection:
+    """One provider's contribution to the run provenance record.
+
+    ``content_identity`` is ``None`` for anything other than a full
+    collection: a failed, denied, truncated, or timed-out source has no
+    trustworthy content identity, and inventing one would misrepresent the
+    apparatus.
+    """
+
+    provider_id: str
+    status: ProvenanceStatus
+    declaration_digest: str
+    content_identity: str | None = None
+    payload: Mapping[str, object] = field(default_factory=dict)
+    leaf_count: int = 0
+
+    def projection(self) -> dict[str, object]:
+        """Return the canonical-JSON-ready projection of this section."""
+        return {
+            "provider_id": self.provider_id,
+            "status": self.status.value,
+            "declaration_digest": self.declaration_digest,
+            "content_identity": self.content_identity,
+            "payload": dict(self.payload),
+            "leaf_count": self.leaf_count,
+        }
+
+
+@dataclass(frozen=True)
+class ProvenanceCollection:
+    """The one-shot result of collecting every applicable provider."""
+
+    sections: Mapping[str, ProvenanceSection]
+    limitations: tuple[ProvenanceLimitation, ...]
+    aggregate_identity: str
+    registry_declaration_digest: str
+
+    def projection(self) -> dict[str, object]:
+        """Return the deterministic canonical-JSON-ready projection."""
+        return {
+            "schema_version": COLLECTION_SCHEMA_VERSION,
+            "registry_declaration_digest": self.registry_declaration_digest,
+            "aggregate_identity": self.aggregate_identity,
+            "sections": [
+                self.sections[provider_id].projection() for provider_id in sorted(self.sections)
+            ],
+            "limitations": [item.projection() for item in sorted(self.limitations)],
+        }
+
+
+def _payload_is_bounded(value: object, depth: int = 0) -> bool:
+    """Return whether ``value`` is within the hard structural ceilings."""
+    if depth > _MAX_PAYLOAD_DEPTH:
+        return False
+    if isinstance(value, str):
+        return len(value) <= _MAX_PAYLOAD_STRING
+    if isinstance(value, Mapping):
+        if len(value) > _MAX_PAYLOAD_KEYS:
+            return False
+        return all(
+            isinstance(key, str) and len(key) <= _MAX_PAYLOAD_STRING
+            for key in value
+        ) and all(_payload_is_bounded(item, depth + 1) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        if len(value) > _MAX_PAYLOAD_KEYS:
+            return False
+        return all(_payload_is_bounded(item, depth + 1) for item in value)
+    return isinstance(value, (int, float, bool)) or value is None
+
+
+def _payload_is_safe(payload: Mapping[str, object]) -> bool:
+    """Return whether ``payload`` is bounded, canonical, and secret-free.
+
+    The shared redactor is reused as a DRIFT DETECTOR here, matching the
+    runstore's create-once secret invariant: a payload the production
+    classification policy would change never reaches a record. It is not
+    permission for a provider to read a prohibited source in the first place —
+    that is settled by allowlisting the source.
+    """
+    if not _payload_is_bounded(payload):
+        return False
+    try:
+        if redact(dict(payload)) != dict(payload):
+            return False
+        derive_identity(_SECTION_DOMAIN, {"payload": dict(payload)})
+    except (ProvenanceIdentityError, TypeError, ValueError, RecursionError):
+        return False
+    return True
+
+
+def _degraded(
+    registration: ProvenanceProviderRegistration,
+    status: ProvenanceStatus,
+    detail: str = "",
+) -> tuple[ProvenanceSection, ProvenanceLimitation]:
+    """Build the section + limitation pair for a non-collected source."""
+    section = ProvenanceSection(
+        provider_id=registration.provider_id,
+        status=status,
+        declaration_digest=registration.effective_config_digest(),
+    )
+    return section, limitation_for(registration.provider_id, status, detail=detail)
+
+
+def _collected(
+    registration: ProvenanceProviderRegistration, result: ProvenanceResult
+) -> ProvenanceSection:
+    """Build the section for a fully collected source."""
+    leaves: Sequence[ProvenanceLeaf] = tuple(result.leaves)
+    return ProvenanceSection(
+        provider_id=registration.provider_id,
+        status=ProvenanceStatus.COLLECTED,
+        declaration_digest=registration.effective_config_digest(),
+        content_identity=family_identity(_SECTION_DOMAIN, leaves),
+        payload=dict(result.payload),
+        leaf_count=len(leaves),
+    )
+
+
+def _evaluate(
+    registration: ProvenanceProviderRegistration,
+    result: ProvenanceResult,
+    *,
+    elapsed: float,
+) -> tuple[ProvenanceSection, ProvenanceLimitation | None]:
+    """Turn one raw provider result into a validated section (+ limitation).
+
+    Checks are ordered so the most fundamental violation wins: a result that
+    impersonates another provider is a wiring fault, an overrun deadline
+    invalidates whatever was gathered, and only then are quota and content
+    validity considered.
+    """
+    if result.provider_id != registration.provider_id:
+        log.warning(
+            "run-provenance: provider %s returned a result for another provider id",
+            registration.provider_id,
+        )
+        return _degraded(registration, ProvenanceStatus.FAILED, "owner reported failure")
+
+    if elapsed >= float(registration.limits.timeout_s):
+        return _degraded(registration, ProvenanceStatus.TIMED_OUT, "deadline exceeded")
+
+    if result.status not in SUCCESS_STATUSES:
+        return _degraded(registration, result.status, result.detail)
+
+    if len(result.leaves) > registration.limits.max_entries:
+        return _degraded(registration, ProvenanceStatus.TRUNCATED, "entry limit reached")
+
+    if not _payload_is_safe(result.payload):
+        log.warning(
+            "run-provenance: provider %s payload rejected by the safety invariant",
+            registration.provider_id,
+        )
+        return _degraded(registration, ProvenanceStatus.FAILED, "owner reported failure")
+
+    try:
+        return _collected(registration, result), None
+    except ProvenanceIdentityError:
+        log.warning(
+            "run-provenance: provider %s produced an invalid content identity",
+            registration.provider_id,
+        )
+        return _degraded(registration, ProvenanceStatus.FAILED, "owner reported failure")
+
+
+def _invoke(
+    provider: ProvenanceProvider,
+    registration: ProvenanceProviderRegistration,
+    monotonic: MonotonicClock,
+) -> tuple[ProvenanceSection, ProvenanceLimitation | None]:
+    """Run one provider under its declared limits, normalizing every failure."""
+    started_at = monotonic()
+    context = ProvenanceContext(
+        registration=registration, clock=monotonic, started_at=started_at
+    )
+    try:
+        result = provider.collect(context)
+    except Exception:
+        # The exception's text is deliberately not carried anywhere: it can
+        # embed a host path, command, or credential. The provider id, stage,
+        # and stable reason code are what a reader needs.
+        log.warning(
+            "run-provenance: provider %s raised during collection", registration.provider_id
+        )
+        return _degraded(registration, ProvenanceStatus.FAILED, "owner reported failure")
+    return _evaluate(registration, result, elapsed=monotonic() - started_at)
+
+
+def collect_provenance(
+    *,
+    providers: Iterable[ProvenanceProvider],
+    registry: ProvenanceProviderRegistry,
+    profile: SealProfile,
+    monotonic: MonotonicClock,
+) -> ProvenanceCollection:
+    """Collect every applicable provider into one deterministic result.
+
+    ``providers`` is the composed trusted fleet; ``registry`` is the
+    declaration authority. A provider without a registration is UNSUPPORTED
+    rather than trusted, and a policy-required provider that never ran is
+    recorded UNAVAILABLE rather than assumed absent-and-fine.
+    """
+    profile.validate_against(registry)
+
+    sections: dict[str, ProvenanceSection] = {}
+    limitations: list[ProvenanceLimitation] = []
+
+    for provider in providers:
+        provider_id = getattr(provider, "provider_id", "")
+        registration = registry.get(provider_id)
+        if registration is None:
+            unregistered = ProvenanceProviderRegistration(
+                provider_id=provider_id,
+                implementation_version="unregistered",
+                provenance_kind="unregistered",
+                owner_adapter="unregistered",
+                seal_point=profile.seal_point,
+                requiredness_policy_key="unregistered",
+                limits=_UNREGISTERED_LIMITS,
+            )
+            section, limitation = _degraded(
+                unregistered, ProvenanceStatus.UNSUPPORTED, "source not supported"
+            )
+        else:
+            section, limitation = _invoke(provider, registration, monotonic)
+        sections[section.provider_id] = section
+        if limitation is not None:
+            limitations.append(limitation)
+
+    for registration in registry.for_seal_point(profile.seal_point):
+        if registration.provider_id in sections:
+            continue
+        if not profile.requires(registration.provider_id):
+            continue
+        section, limitation = _degraded(
+            registration, ProvenanceStatus.UNAVAILABLE, "source not present"
+        )
+        sections[section.provider_id] = section
+        limitations.append(limitation)
+
+    aggregate = derive_identity(
+        _AGGREGATE_DOMAIN,
+        {
+            "sections": [
+                {
+                    "provider_id": provider_id,
+                    "status": sections[provider_id].status.value,
+                    "content_identity": sections[provider_id].content_identity,
+                    "declaration_digest": sections[provider_id].declaration_digest,
+                }
+                for provider_id in sorted(sections)
+            ]
+        },
+    )
+    return ProvenanceCollection(
+        sections=sections,
+        limitations=tuple(sorted(limitations)),
+        aggregate_identity=aggregate,
+        registry_declaration_digest=registry.declaration_digest(),
+    )

--- a/src/aptl/core/provenance/identity.py
+++ b/src/aptl/core/provenance/identity.py
@@ -1,0 +1,150 @@
+"""Canonical identity primitives for run-scoped provenance (REP-003 / #452).
+
+Every derived structured identity in this package is an RFC 8785 canonical
+JSON digest under an explicit version/domain separator, and every SHA-256
+value is normalized to one representation (``sha256:<lowercase-hex>``) at the
+provenance boundary.
+
+The central rule is that content identity is **framed by logical role**.
+Provenance records a leaf per stable logical id, then folds a family identity
+over the SORTED canonical sequence of ``{logical_id, digest}`` entries. The
+incumbent :func:`aptl.core.experiment.trial_plan.compute_source_set_digest`
+establishes the canonical-JSON-plus-SHA-256 pattern; this module applies it to
+provenance and adds the framing.
+
+Framing is not decoration. The behavior it replaces
+(``snapshot.detection_content_digest``) hashed an unframed concatenation of
+file bytes, so ``"ab" + "c"`` and ``"a" + "bc"`` produced the same digest and a
+targeted difference could not be explained. Folding ``{logical_id, digest}``
+pairs makes each file's boundary part of the identity.
+
+Volatile observation data — timestamps, container IDs, health state, durations
+— never enters an identity computed here. Those are observations recorded
+beside identity, so unchanged apparatus content cannot drift.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+import rfc8785
+
+#: The single normalized digest representation used across provenance.
+DIGEST_PREFIX = "sha256:"
+
+#: Versioned domain-separator template. A future revision of the identity
+#: algorithm bumps the version so an archived record's identities can never be
+#: silently reinterpreted under new rules.
+_DOMAIN_TEMPLATE = "aptl.provenance.{domain}/v1"
+
+#: A bare lowercase SHA-256 hex digest.
+_HEX_RE = re.compile(r"[0-9a-f]{64}")
+
+#: A domain label: a short, non-executable slug. Deliberately strict — the
+#: domain is a code-owned constant, never caller metadata.
+_DOMAIN_RE = re.compile(r"[a-z][a-z0-9-]{0,63}")
+
+#: A logical id names a stable role (for example ``suricata/rules/custom.rules``).
+#: It is a record key, so control characters, whitespace, and unbounded length
+#: are rejected before it can reach a key, path, or log template.
+_LOGICAL_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]{0,255}")
+
+
+class ProvenanceIdentityError(ValueError):
+    """Raised when an identity input is malformed, hostile, or unserializable.
+
+    Identity fails closed: a rejected input never degrades to a fabricated
+    digest, an empty string, or an omitted key.
+    """
+
+
+@dataclass(frozen=True, order=True)
+class ProvenanceLeaf:
+    """One content leaf: a stable logical role bound to the digest of its bytes.
+
+    Ordering is ``(logical_id, digest)`` so a sequence of leaves sorts
+    deterministically without the caller choosing a key function.
+    """
+
+    logical_id: str
+    digest: str
+
+
+def normalize_digest(value: str) -> str:
+    """Return ``value`` as ``sha256:<lowercase-hex>``.
+
+    Accepts a bare or already-prefixed hex digest in any case. Anything else —
+    a wrong algorithm, a wrong length, a doubled prefix, a non-string — raises
+    :class:`ProvenanceIdentityError` rather than becoming a fabricated identity.
+    """
+    if not isinstance(value, str):
+        raise ProvenanceIdentityError("digest must be a string")
+    candidate = value[len(DIGEST_PREFIX) :] if value.startswith(DIGEST_PREFIX) else value
+    candidate = candidate.lower()
+    if _HEX_RE.fullmatch(candidate) is None:
+        raise ProvenanceIdentityError("digest is not a SHA-256 hex value")
+    return f"{DIGEST_PREFIX}{candidate}"
+
+
+def validate_logical_id(logical_id: str) -> str:
+    """Return ``logical_id`` when it is a safe record key, else raise."""
+    if not isinstance(logical_id, str) or _LOGICAL_ID_RE.fullmatch(logical_id) is None:
+        raise ProvenanceIdentityError("logical_id is not a safe provenance role")
+    return logical_id
+
+
+def _domain_separator(domain: str) -> str:
+    """Return the versioned domain separator for ``domain``, else raise."""
+    if not isinstance(domain, str) or _DOMAIN_RE.fullmatch(domain) is None:
+        raise ProvenanceIdentityError("identity domain is not a safe code-owned label")
+    return _DOMAIN_TEMPLATE.format(domain=domain)
+
+
+def digest_bytes(data: bytes) -> str:
+    """Return the normalized digest of ``data``."""
+    return f"{DIGEST_PREFIX}{hashlib.sha256(data).hexdigest()}"
+
+
+def leaf_identity(logical_id: str, data: bytes) -> ProvenanceLeaf:
+    """Return the :class:`ProvenanceLeaf` binding ``logical_id`` to ``data``.
+
+    An empty payload still yields an explicit digest: an empty rule file is a
+    real observation about the apparatus, distinct from an absent source.
+    """
+    return ProvenanceLeaf(logical_id=validate_logical_id(logical_id), digest=digest_bytes(data))
+
+
+def derive_identity(domain: str, payload: Mapping[str, object]) -> str:
+    """Return the domain-separated canonical identity of ``payload``.
+
+    The separator is folded into the hashed document, so two structurally
+    identical payloads in different domains cannot collide.
+    """
+    separator = _domain_separator(domain)
+    try:
+        canonical = rfc8785.dumps({"domain": separator, "payload": dict(payload)})
+    except (TypeError, ValueError) as exc:
+        raise ProvenanceIdentityError("payload is not canonical-JSON serializable") from exc
+    return digest_bytes(canonical)
+
+
+def family_identity(domain: str, leaves: Iterable[ProvenanceLeaf]) -> str:
+    """Return the aggregate identity of ``leaves`` under ``domain``.
+
+    Folds the SORTED sequence of ``{logical_id, digest}`` entries, so provider
+    iteration order and filesystem order are never significant, while each
+    file's role boundary stays part of the identity. Duplicate logical ids are
+    rejected — two leaves claiming one role would make the family ambiguous.
+    """
+    ordered: Sequence[ProvenanceLeaf] = sorted(leaves)
+    seen: set[str] = set()
+    entries: list[dict[str, str]] = []
+    for leaf in ordered:
+        if leaf.logical_id in seen:
+            raise ProvenanceIdentityError("duplicate logical_id in provenance family")
+        seen.add(leaf.logical_id)
+        entries.append({"logical_id": leaf.logical_id, "digest": normalize_digest(leaf.digest)})
+    return derive_identity(domain, {"entries": entries})

--- a/src/aptl/core/provenance/outcomes.py
+++ b/src/aptl/core/provenance/outcomes.py
@@ -34,20 +34,31 @@ _PROVIDER_ID_RE = re.compile(r"[a-z][a-z0-9-]{0,63}")
 _REDACTED_DETAIL = "detail withheld"
 _MAX_DETAIL_LEN = 120
 
-#: The details the coordinator itself may attach. Restricting to an allowlist
-#: is what keeps `str(exc)`, backend stderr, and hostile metadata out of the
-#: record — filtering afterwards would be the pattern this design rejects.
+#: The details the coordinator and providers may attach. Naming them once
+#: keeps the vocabulary in a single place and lets both layers share it.
+DETAIL_ABSENT = "source not present"
+DETAIL_UNREADABLE = "source not readable"
+DETAIL_UNSUPPORTED = "source not supported"
+DETAIL_OWNER_FAILURE = "owner reported failure"
+DETAIL_ENTRY_LIMIT = "entry limit reached"
+DETAIL_BYTE_LIMIT = "byte limit reached"
+DETAIL_DEADLINE = "deadline exceeded"
+DETAIL_CONTAINMENT = "path containment rejected"
+
+#: Restricting to an allowlist is what keeps `str(exc)`, backend stderr, and
+#: hostile metadata out of the record — filtering afterwards would be the
+#: pattern this design rejects.
 _SAFE_DETAILS = frozenset(
     {
         "",
-        "byte limit reached",
-        "entry limit reached",
-        "deadline exceeded",
-        "source not present",
-        "source not readable",
-        "source not supported",
-        "owner reported failure",
-        "path containment rejected",
+        DETAIL_BYTE_LIMIT,
+        DETAIL_ENTRY_LIMIT,
+        DETAIL_DEADLINE,
+        DETAIL_ABSENT,
+        DETAIL_UNREADABLE,
+        DETAIL_UNSUPPORTED,
+        DETAIL_OWNER_FAILURE,
+        DETAIL_CONTAINMENT,
     }
 )
 

--- a/src/aptl/core/provenance/outcomes.py
+++ b/src/aptl/core/provenance/outcomes.py
@@ -1,0 +1,161 @@
+"""The closed outcome vocabulary for provenance collection (REP-003 / #452).
+
+A provider reports one of a small, code-owned set of statuses. Missing,
+denied, unsupported, truncated, timed-out and failed sources become explicit
+:class:`ProvenanceLimitation` values carrying stable reason codes — never an
+empty string, an empty map, an absent key, a guessed version, or a fabricated
+digest.
+
+This vocabulary is deliberately SEPARATE from
+:class:`aptl.core.evidence.outcomes.CollectorStatus`. Capture statuses encode
+evidence-acquisition semantics (mid-run loss, clock skew, finalization) that
+do not apply to reading an apparatus manifest or a rule file, and the preflight
+forbids reusing capture-specific types where their semantics do not fit.
+
+REP-003 supplies facts and stable reason codes. It does NOT decide which
+limitations are fatal — issue #472 owns readiness policy — and it does not
+seal (issue #444).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+#: A provider id is a code-owned, non-executable slug. It is never an import
+#: path, command, URL, host path, credential selector, or caller-supplied
+#: factory name.
+_PROVIDER_ID_RE = re.compile(r"[a-z][a-z0-9-]{0,63}")
+
+#: Safe detail strings are short and drawn from the coordinator's own
+#: vocabulary. Anything else (notably a raw exception string, which can carry
+#: a host path, command, or secret) is dropped in favour of this.
+_REDACTED_DETAIL = "detail withheld"
+_MAX_DETAIL_LEN = 120
+
+#: The details the coordinator itself may attach. Restricting to an allowlist
+#: is what keeps `str(exc)`, backend stderr, and hostile metadata out of the
+#: record — filtering afterwards would be the pattern this design rejects.
+_SAFE_DETAILS = frozenset(
+    {
+        "",
+        "byte limit reached",
+        "entry limit reached",
+        "deadline exceeded",
+        "source not present",
+        "source not readable",
+        "source not supported",
+        "owner reported failure",
+        "path containment rejected",
+    }
+)
+
+
+class ProvenanceOutcomeError(ValueError):
+    """Raised when an outcome is constructed with a hostile or contradictory input."""
+
+
+class ProvenanceStatus(str, Enum):
+    """The closed status one provider invocation may report."""
+
+    #: The declared source was read completely and within every limit.
+    COLLECTED = "collected"
+    #: The source does not exist in this realization (for example, a component
+    #: that this profile did not deploy).
+    UNAVAILABLE = "unavailable"
+    #: The source exists but access was refused (permissions, policy).
+    DENIED = "denied"
+    #: The source exists but this build cannot interpret it.
+    UNSUPPORTED = "unsupported"
+    #: The provider exceeded its declared deadline.
+    TIMED_OUT = "timed-out"
+    #: The source exceeded a declared byte/entry limit; what was retained is
+    #: disclosed, and this is NOT a success.
+    TRUNCATED = "truncated"
+    #: The owner adapter raised or returned an error.
+    FAILED = "failed"
+
+
+#: Only a complete collection is a success. TRUNCATED is deliberately excluded:
+#: partial content that silently counted as success is exactly the degradation
+#: REP-003 must disclose.
+SUCCESS_STATUSES: frozenset[ProvenanceStatus] = frozenset({ProvenanceStatus.COLLECTED})
+
+_REASON_CODES: dict[ProvenanceStatus, str] = {
+    ProvenanceStatus.UNAVAILABLE: "aptl.run-provenance.source-unavailable",
+    ProvenanceStatus.DENIED: "aptl.run-provenance.source-denied",
+    ProvenanceStatus.UNSUPPORTED: "aptl.run-provenance.source-unsupported",
+    ProvenanceStatus.TIMED_OUT: "aptl.run-provenance.source-timed-out",
+    ProvenanceStatus.TRUNCATED: "aptl.run-provenance.source-truncated",
+    ProvenanceStatus.FAILED: "aptl.run-provenance.source-failed",
+}
+
+
+def reason_code_for(status: ProvenanceStatus) -> str:
+    """Return the stable reason code for a non-success ``status``.
+
+    A success has nothing to explain, so asking for its code is a caller bug
+    rather than a silently empty string.
+    """
+    try:
+        return _REASON_CODES[status]
+    except KeyError:
+        raise ProvenanceOutcomeError("a successful status has no reason code") from None
+
+
+def validate_provider_id(value: str) -> str:
+    """Return ``value`` when it is a safe non-executable provider id, else raise."""
+    if not isinstance(value, str) or _PROVIDER_ID_RE.fullmatch(value) is None:
+        raise ProvenanceOutcomeError("provider_id is not a safe code-owned slug")
+    return value
+
+
+def _safe_detail(detail: str) -> str:
+    """Return ``detail`` when it is coordinator-owned vocabulary, else a placeholder.
+
+    Allowlisting rather than scrubbing is deliberate: a raw exception string can
+    embed a host path, command, or credential, and no regex pass over arbitrary
+    text is a trustworthy substitute for never admitting it.
+    """
+    if not isinstance(detail, str) or len(detail) > _MAX_DETAIL_LEN:
+        return _REDACTED_DETAIL
+    return detail if detail in _SAFE_DETAILS else _REDACTED_DETAIL
+
+
+@dataclass(frozen=True, order=True)
+class ProvenanceLimitation:
+    """One declared limitation: a source that did not fully collect.
+
+    Carries only stable identity and codes. Ordering is field order
+    (``provider_id`` first) so a record's limitations serialize deterministically.
+    """
+
+    provider_id: str
+    status: ProvenanceStatus
+    reason_code: str
+    detail: str
+
+    def projection(self) -> dict[str, str]:
+        """Return the canonical-JSON-ready projection of this limitation."""
+        return {
+            "provider_id": self.provider_id,
+            "status": self.status.value,
+            "reason_code": self.reason_code,
+            "detail": self.detail,
+        }
+
+
+def limitation_for(
+    provider_id: str, status: ProvenanceStatus, *, detail: str = ""
+) -> ProvenanceLimitation:
+    """Build the limitation for a non-success provider outcome."""
+    safe_id = validate_provider_id(provider_id)
+    if status in SUCCESS_STATUSES:
+        raise ProvenanceOutcomeError("a collected source does not declare a limitation")
+    return ProvenanceLimitation(
+        provider_id=safe_id,
+        status=status,
+        reason_code=reason_code_for(status),
+        detail=_safe_detail(detail),
+    )

--- a/src/aptl/core/provenance/protocol.py
+++ b/src/aptl/core/provenance/protocol.py
@@ -1,0 +1,97 @@
+"""The narrow provider seam for run-scoped provenance (REP-003 / issue #452).
+
+A provider is handed a :class:`ProvenanceContext` carrying only its own
+registration, its deadline, and a monotonic clock — never a whole
+:class:`~aptl.core.config.AptlConfig`, ``EnvVars``, a deployment backend, a
+controller, or generic shell/HTTP/filesystem authority. Whatever narrow owner
+adapter a provider needs is bound into the provider instance when the trusted
+fleet is composed, exactly as the incumbent capture registry composes its
+collectors separately from their declarations.
+
+A provider returns a :class:`ProvenanceResult`: a closed status, sorted content
+leaves, and a bounded owner-native payload. It does not persist, redact,
+canonicalize, hash the aggregate, or decide readiness — the coordinator owns
+all of that, and issue #472 owns which limitations are fatal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from aptl.core.provenance.identity import ProvenanceLeaf
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.registry import ProvenanceProviderRegistration
+
+
+class MonotonicClock(Protocol):
+    """A monotonic seconds source, injectable so deadlines are testable.
+
+    Deliberately distinct from
+    :class:`aptl.core.correlation.clock.ClockProvider`, which exists to
+    DISCLOSE a source's wall-clock context. Deadlines need elapsed time, and
+    conflating the two would put a wall-clock timestamp where a duration
+    belongs.
+    """
+
+    def __call__(self) -> float: ...
+
+
+@dataclass(frozen=True)
+class ProvenanceContext:
+    """The immutable context handed to one provider invocation."""
+
+    registration: ProvenanceProviderRegistration
+    clock: MonotonicClock
+    started_at: float
+
+    @property
+    def deadline_seconds(self) -> float:
+        """Return the provider's declared wall budget for this invocation."""
+        return float(self.registration.limits.timeout_s)
+
+    @property
+    def max_bytes(self) -> int:
+        """Return the provider's declared byte budget."""
+        return self.registration.limits.max_bytes
+
+    @property
+    def max_entries(self) -> int:
+        """Return the provider's declared entry budget."""
+        return self.registration.limits.max_entries
+
+    def expired(self) -> bool:
+        """Return whether the declared deadline has already passed.
+
+        Providers that iterate a source check this between entries so an
+        over-long collection stops rather than being detected only afterwards.
+        """
+        return (self.clock() - self.started_at) >= self.deadline_seconds
+
+
+@dataclass(frozen=True)
+class ProvenanceResult:
+    """One provider invocation's bounded, typed outcome.
+
+    ``leaves`` are the content identities the provider observed; ``payload`` is
+    bounded owner-native reference/version data. ``detail`` is drawn from the
+    coordinator's safe vocabulary — never a raw exception string.
+    """
+
+    provider_id: str
+    status: ProvenanceStatus
+    leaves: tuple[ProvenanceLeaf, ...] = ()
+    payload: Mapping[str, object] = field(default_factory=dict)
+    detail: str = ""
+
+
+@runtime_checkable
+class ProvenanceProvider(Protocol):
+    """A trusted, code-owned provenance source."""
+
+    provider_id: str
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Read this provider's declared source under ``context``'s limits."""
+        ...

--- a/src/aptl/core/provenance/providers/__init__.py
+++ b/src/aptl/core/provenance/providers/__init__.py
@@ -1,0 +1,13 @@
+"""The trusted built-in provenance providers (REP-003 / issue #452).
+
+Each module here supplies exactly one declared source and reuses that source's
+canonical owner — the RAES manifest serializers, the admitted trial plan, the
+participant apparatus builder, the deployment backend, the snapshot owner —
+rather than re-deriving facts or reaching for Docker, Compose, SSH, curl, or a
+shell.
+
+Adding the next built-in source costs one registration, one narrow adapter
+here, and its conformance tests. It must not require editing the aggregate
+record builder, the run controller, RAES DTOs, the storage layout, or the
+exporter.
+"""

--- a/src/aptl/core/provenance/providers/_degraded.py
+++ b/src/aptl/core/provenance/providers/_degraded.py
@@ -1,0 +1,93 @@
+"""The internal degradation signal shared by the built-in providers (#452).
+
+A provider's collection either produces content or stops for a declared
+reason. Expressing "stop with this reason" as a raised signal — rather than an
+early ``return`` at each check — keeps every ``collect()`` to one success path
+plus one handler, so the reason vocabulary stays in one place and the read
+order of the checks is obvious.
+
+This is deliberately NOT a public exception hierarchy (the architecture
+preflight forbids adding one). It is a single module-private control-flow
+signal that never escapes its provider: each ``collect()`` catches it and
+converts it into a typed :class:`~aptl.core.provenance.protocol.
+ProvenanceResult`, exactly as the coordinator would have done for an early
+return.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from aptl.core.provenance.outcomes import (
+    DETAIL_ABSENT,
+    DETAIL_BYTE_LIMIT,
+    DETAIL_DEADLINE,
+    DETAIL_ENTRY_LIMIT,
+    DETAIL_OWNER_FAILURE,
+    DETAIL_UNREADABLE,
+    ProvenanceStatus,
+)
+from aptl.core.provenance.protocol import ProvenanceResult
+
+# The detail strings come from the shared vocabulary in ``outcomes``: a raw
+# exception string — which can carry a host path, command, or credential — can
+# never take their place.
+
+
+class ProviderDegraded(Exception):
+    """Internal signal: this provider cannot complete, with a declared reason."""
+
+    def __init__(
+        self,
+        status: ProvenanceStatus,
+        detail: str = "",
+        payload: Mapping[str, object] | None = None,
+    ) -> None:
+        super().__init__(detail)
+        self.status = status
+        self.detail = detail
+        self.payload = dict(payload or {})
+
+    def as_result(self, provider_id: str) -> ProvenanceResult:
+        """Convert this signal into the provider's typed result.
+
+        Content gathered before the signal is deliberately dropped: partial
+        content is not evidence of the apparatus, and reporting it alongside a
+        degraded status would invite a reader to treat it as complete.
+        """
+        return ProvenanceResult(
+            provider_id=provider_id,
+            status=self.status,
+            payload=self.payload,
+            detail=self.detail,
+        )
+
+
+def absent(payload: Mapping[str, object] | None = None) -> ProviderDegraded:
+    """Return the signal for a source that does not exist in this realization."""
+    return ProviderDegraded(ProvenanceStatus.UNAVAILABLE, DETAIL_ABSENT, payload)
+
+
+def owner_failure(payload: Mapping[str, object] | None = None) -> ProviderDegraded:
+    """Return the signal for an owner adapter that raised or returned an error."""
+    return ProviderDegraded(ProvenanceStatus.FAILED, DETAIL_OWNER_FAILURE, payload)
+
+
+def entry_limit(payload: Mapping[str, object] | None = None) -> ProviderDegraded:
+    """Return the signal for exceeding the declared entry budget."""
+    return ProviderDegraded(ProvenanceStatus.TRUNCATED, DETAIL_ENTRY_LIMIT, payload)
+
+
+def byte_limit(payload: Mapping[str, object] | None = None) -> ProviderDegraded:
+    """Return the signal for exceeding the declared byte budget."""
+    return ProviderDegraded(ProvenanceStatus.TRUNCATED, DETAIL_BYTE_LIMIT, payload)
+
+
+def deadline(payload: Mapping[str, object] | None = None) -> ProviderDegraded:
+    """Return the signal for exceeding the declared deadline."""
+    return ProviderDegraded(ProvenanceStatus.TIMED_OUT, DETAIL_DEADLINE, payload)
+
+
+def denied(payload: Mapping[str, object] | None = None) -> ProviderDegraded:
+    """Return the signal for a source that exists but could not be read."""
+    return ProviderDegraded(ProvenanceStatus.DENIED, DETAIL_UNREADABLE, payload)

--- a/src/aptl/core/provenance/providers/apparatus.py
+++ b/src/aptl/core/provenance/providers/apparatus.py
@@ -1,0 +1,111 @@
+"""RAES apparatus-manifest provenance (REP-003 / issue #452).
+
+Records WHICH processor and backend the run was realized against, using the
+owner-native serializers — :func:`create_aptl_manifest` plus
+``raes_backend_protocols.manifest.backend_manifest_payload`` for the backend,
+and ``raes_processor.manifest.reference_processor_manifest_payload`` for the
+processor.
+
+The payloads are hashed as opaque owner-native documents. APTL does not
+restate, subclass, or locally validate a RAES DTO here; the manifests'
+declared capabilities already come from the same code-owned registries that
+implement them (for example, ``create_aptl_manifest()``'s observation
+capability is projected from the collector registry, not a hand-maintained
+matrix).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+
+import rfc8785
+from raes_backend_protocols.manifest import backend_manifest_payload
+from raes_processor.manifest import reference_processor_manifest_payload
+
+from aptl.backends.raes_manifest import create_aptl_manifest
+from aptl.core.provenance.identity import ProvenanceLeaf, digest_bytes
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+
+log = logging.getLogger(__name__)
+
+#: The code-owned provider id for apparatus manifests.
+APPARATUS_PROVIDER_ID = "apparatus"
+
+
+def _default_backend_payload() -> Mapping[str, object]:
+    """Return the canonical APTL backend manifest payload."""
+    return backend_manifest_payload(create_aptl_manifest())
+
+
+def _identity_projection(payload: Mapping[str, object]) -> dict[str, object]:
+    """Return the small, safe identity summary for a manifest payload.
+
+    The full payload is hashed into the leaf; only stable identity and the
+    declared contract versions are surfaced as readable fields, so the record
+    stays bounded while remaining answerable.
+    """
+    identity = payload.get("identity")
+    identity = identity if isinstance(identity, Mapping) else {}
+    contracts = payload.get("supported_contract_versions")
+    return {
+        "name": identity.get("name"),
+        "version": identity.get("version"),
+        "schema_version": payload.get("schema_version"),
+        "supported_contract_versions": sorted(contracts)
+        if isinstance(contracts, (list, tuple, set, frozenset))
+        else [],
+    }
+
+
+class ApparatusManifestProvider:
+    """Collects processor and backend manifest identity from their owners."""
+
+    provider_id = APPARATUS_PROVIDER_ID
+
+    def __init__(
+        self,
+        backend_manifest_factory: Callable[[], Mapping[str, object]] = _default_backend_payload,
+        processor_manifest_factory: Callable[
+            [], Mapping[str, object]
+        ] = reference_processor_manifest_payload,
+    ):
+        self._backend_factory = backend_manifest_factory
+        self._processor_factory = processor_manifest_factory
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Serialize both manifests and bind each to its logical role."""
+        try:
+            backend = dict(self._backend_factory())
+            processor = dict(self._processor_factory())
+            leaves = (
+                ProvenanceLeaf("backend-manifest", digest_bytes(rfc8785.dumps(backend))),
+                ProvenanceLeaf("processor-manifest", digest_bytes(rfc8785.dumps(processor))),
+            )
+        except Exception:
+            # A manifest serializer failing is an owner fault. Its exception
+            # text can name host paths and is never carried into the record.
+            log.warning("run-provenance: apparatus manifest serialization failed")
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.FAILED,
+                detail="owner reported failure",
+            )
+
+        if context.expired():
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.TIMED_OUT,
+                detail="deadline exceeded",
+            )
+
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=tuple(sorted(leaves)),
+            payload={
+                "backend": _identity_projection(backend),
+                "processor": _identity_projection(processor),
+            },
+        )

--- a/src/aptl/core/provenance/providers/apparatus.py
+++ b/src/aptl/core/provenance/providers/apparatus.py
@@ -70,7 +70,7 @@ class ApparatusManifestProvider:
         processor_manifest_factory: Callable[
             [], Mapping[str, object]
         ] = reference_processor_manifest_payload,
-    ):
+    ) -> None:
         self._backend_factory = backend_manifest_factory
         self._processor_factory = processor_manifest_factory
 

--- a/src/aptl/core/provenance/providers/artifacts.py
+++ b/src/aptl/core/provenance/providers/artifacts.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from aptl.core.provenance.identity import ProvenanceLeaf, digest_bytes, validate_logical_id
 from aptl.core.provenance.outcomes import ProvenanceStatus
 from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.core.provenance.providers import _degraded
+from aptl.core.provenance.providers._degraded import ProviderDegraded
 from aptl.utils.pathsafe import PathContainmentError, open_contained_nofollow
 
 log = logging.getLogger(__name__)
@@ -85,63 +87,40 @@ def _participant_asset_locks(project_dir: Path) -> list[DependencyArtifact]:
     return artifacts
 
 
-class _ByteBudgetExceeded(Exception):
-    """Internal signal that the declared byte budget would be exceeded."""
-
-
 class DependencyArtifactProvider:
     """Collects dependency and asset lock identities from the project tree."""
 
     provider_id = ARTIFACTS_PROVIDER_ID
 
-    def __init__(self, project_dir: Path):
+    def __init__(self, project_dir: Path) -> None:
         self._project_dir = Path(project_dir)
 
     def collect(self, context: ProvenanceContext) -> ProvenanceResult:
         """Read every present lock artifact under the declared limits."""
-        artifacts = list(DEPENDENCY_ARTIFACTS) + _participant_asset_locks(self._project_dir)
+        try:
+            leaves = self._gather(context)
+        except ProviderDegraded as signal:
+            return signal.as_result(self.provider_id)
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=leaves,
+            payload={"artifact_count": len(leaves)},
+        )
 
+    def _gather(self, context: ProvenanceContext) -> tuple[ProvenanceLeaf, ...]:
+        """Build a leaf per present lock, or declare a degradation."""
+        artifacts = list(DEPENDENCY_ARTIFACTS) + _participant_asset_locks(self._project_dir)
         leaves: list[ProvenanceLeaf] = []
         consumed = 0
         for artifact in artifacts:
             if context.expired():
-                return ProvenanceResult(
-                    provider_id=self.provider_id,
-                    status=ProvenanceStatus.TIMED_OUT,
-                    detail="deadline exceeded",
-                )
+                raise _degraded.deadline()
             if len(leaves) >= context.max_entries:
-                return ProvenanceResult(
-                    provider_id=self.provider_id,
-                    status=ProvenanceStatus.TRUNCATED,
-                    detail="entry limit reached",
-                )
-            try:
-                data = self._read(artifact.relative_path, context.max_bytes - consumed)
-            except _ByteBudgetExceeded:
-                return ProvenanceResult(
-                    provider_id=self.provider_id,
-                    status=ProvenanceStatus.TRUNCATED,
-                    detail="byte limit reached",
-                )
-            except PermissionError:
-                return ProvenanceResult(
-                    provider_id=self.provider_id,
-                    status=ProvenanceStatus.DENIED,
-                    detail="source not readable",
-                )
-            except PathContainmentError:
-                # Absent, symlinked, or not a regular file: never an admitted
-                # artifact, so it contributes nothing rather than failing the
-                # whole provider.
+                raise _degraded.entry_limit()
+            data = self._read(artifact.relative_path, context.max_bytes - consumed)
+            if data is None:
                 continue
-            except OSError:
-                log.warning("run-provenance: dependency artifact could not be read")
-                return ProvenanceResult(
-                    provider_id=self.provider_id,
-                    status=ProvenanceStatus.FAILED,
-                    detail="owner reported failure",
-                )
             consumed += len(data)
             leaves.append(
                 ProvenanceLeaf(
@@ -149,27 +128,29 @@ class DependencyArtifactProvider:
                     digest=digest_bytes(data),
                 )
             )
-
         if not leaves:
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.UNAVAILABLE,
-                detail="source not present",
-                payload={"artifact_count": 0},
-            )
-        return ProvenanceResult(
-            provider_id=self.provider_id,
-            status=ProvenanceStatus.COLLECTED,
-            leaves=tuple(sorted(leaves)),
-            payload={"artifact_count": len(leaves)},
-        )
+            raise _degraded.absent({"artifact_count": 0})
+        return tuple(sorted(leaves))
 
-    def _read(self, relative: str, remaining: int) -> bytes:
-        """Read one lock no-follow, refusing to exceed the byte budget."""
+    def _read(self, relative: str, remaining: int) -> bytes | None:
+        """Read one lock no-follow; ``None`` when it is simply not an artifact here.
+
+        A :class:`PathContainmentError` means the lock is absent, symlinked, or
+        not a regular file. None of those is an admitted artifact, so the entry
+        contributes nothing rather than degrading the whole provider.
+        """
         if remaining <= 0:
-            raise _ByteBudgetExceeded
-        with open_contained_nofollow(self._project_dir, relative) as handle:
-            data = handle.read(remaining + 1)
+            raise _degraded.byte_limit()
+        try:
+            with open_contained_nofollow(self._project_dir, relative) as handle:
+                data = handle.read(remaining + 1)
+        except PermissionError as exc:
+            raise _degraded.denied() from exc
+        except PathContainmentError:
+            return None
+        except OSError as exc:
+            log.warning("run-provenance: a dependency artifact could not be read")
+            raise _degraded.owner_failure() from exc
         if len(data) > remaining:
-            raise _ByteBudgetExceeded
+            raise _degraded.byte_limit()
         return data

--- a/src/aptl/core/provenance/providers/artifacts.py
+++ b/src/aptl/core/provenance/providers/artifacts.py
@@ -1,0 +1,175 @@
+"""Dependency and asset lock provenance (REP-003 / issue #452).
+
+Records the dependency and asset locks the run was actually realized from —
+``uv.lock`` and each participant profile's ``asset-lock.json``.
+
+The lock that is PRESENT is what gets recorded. The preflight is explicit that
+an ambient ``pip freeze``/``npm list`` or an unrelated release SBOM must not be
+substituted: those describe the environment answering the question, not the
+environment that ran the experiment.
+
+Locks are read through the same contained no-follow path as detection content,
+so a symlinked lock is refused rather than silently resolving outside the
+project.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from aptl.core.provenance.identity import ProvenanceLeaf, digest_bytes, validate_logical_id
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.utils.pathsafe import PathContainmentError, open_contained_nofollow
+
+log = logging.getLogger(__name__)
+
+#: The code-owned provider id for dependency and asset artifacts.
+ARTIFACTS_PROVIDER_ID = "dependency-artifacts"
+
+#: Maximum participant profiles scanned for an asset lock.
+_MAX_PROFILES = 64
+
+
+@dataclass(frozen=True)
+class DependencyArtifact:
+    """One code-owned lock artifact and the logical role it fills."""
+
+    logical_id: str
+    relative_path: str
+
+
+#: Fixed single-file lock artifacts.
+DEPENDENCY_ARTIFACTS: tuple[DependencyArtifact, ...] = (
+    DependencyArtifact(logical_id="uv.lock", relative_path="uv.lock"),
+)
+
+#: Directory holding participant profiles, each of which may carry an asset lock.
+_PARTICIPANT_PROFILE_ROOT = "participant-profiles"
+_ASSET_LOCK_NAME = "asset-lock.json"
+
+
+def _participant_asset_locks(project_dir: Path) -> list[DependencyArtifact]:
+    """Return the asset-lock artifacts present under the participant profiles.
+
+    Enumeration is discovery only; each candidate is still opened no-follow and
+    contained, so a swapped component cannot cause an out-of-tree read.
+    """
+    root = project_dir / _PARTICIPANT_PROFILE_ROOT
+    if root.is_symlink() or not root.is_dir():
+        return []
+
+    artifacts: list[DependencyArtifact] = []
+    try:
+        with os.scandir(root) as entries:
+            profiles = sorted(
+                entry.name
+                for entry in entries
+                if entry.is_dir(follow_symlinks=False) and not entry.is_symlink()
+            )
+    except OSError:
+        return []
+
+    for profile in profiles[:_MAX_PROFILES]:
+        candidate = root / profile / _ASSET_LOCK_NAME
+        if candidate.is_file() and not candidate.is_symlink():
+            artifacts.append(
+                DependencyArtifact(
+                    logical_id=f"asset-lock/{profile}",
+                    relative_path=f"{_PARTICIPANT_PROFILE_ROOT}/{profile}/{_ASSET_LOCK_NAME}",
+                )
+            )
+    return artifacts
+
+
+class _ByteBudgetExceeded(Exception):
+    """Internal signal that the declared byte budget would be exceeded."""
+
+
+class DependencyArtifactProvider:
+    """Collects dependency and asset lock identities from the project tree."""
+
+    provider_id = ARTIFACTS_PROVIDER_ID
+
+    def __init__(self, project_dir: Path):
+        self._project_dir = Path(project_dir)
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Read every present lock artifact under the declared limits."""
+        artifacts = list(DEPENDENCY_ARTIFACTS) + _participant_asset_locks(self._project_dir)
+
+        leaves: list[ProvenanceLeaf] = []
+        consumed = 0
+        for artifact in artifacts:
+            if context.expired():
+                return ProvenanceResult(
+                    provider_id=self.provider_id,
+                    status=ProvenanceStatus.TIMED_OUT,
+                    detail="deadline exceeded",
+                )
+            if len(leaves) >= context.max_entries:
+                return ProvenanceResult(
+                    provider_id=self.provider_id,
+                    status=ProvenanceStatus.TRUNCATED,
+                    detail="entry limit reached",
+                )
+            try:
+                data = self._read(artifact.relative_path, context.max_bytes - consumed)
+            except _ByteBudgetExceeded:
+                return ProvenanceResult(
+                    provider_id=self.provider_id,
+                    status=ProvenanceStatus.TRUNCATED,
+                    detail="byte limit reached",
+                )
+            except PermissionError:
+                return ProvenanceResult(
+                    provider_id=self.provider_id,
+                    status=ProvenanceStatus.DENIED,
+                    detail="source not readable",
+                )
+            except PathContainmentError:
+                # Absent, symlinked, or not a regular file: never an admitted
+                # artifact, so it contributes nothing rather than failing the
+                # whole provider.
+                continue
+            except OSError:
+                log.warning("run-provenance: dependency artifact could not be read")
+                return ProvenanceResult(
+                    provider_id=self.provider_id,
+                    status=ProvenanceStatus.FAILED,
+                    detail="owner reported failure",
+                )
+            consumed += len(data)
+            leaves.append(
+                ProvenanceLeaf(
+                    logical_id=validate_logical_id(artifact.logical_id),
+                    digest=digest_bytes(data),
+                )
+            )
+
+        if not leaves:
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.UNAVAILABLE,
+                detail="source not present",
+                payload={"artifact_count": 0},
+            )
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=tuple(sorted(leaves)),
+            payload={"artifact_count": len(leaves)},
+        )
+
+    def _read(self, relative: str, remaining: int) -> bytes:
+        """Read one lock no-follow, refusing to exceed the byte budget."""
+        if remaining <= 0:
+            raise _ByteBudgetExceeded
+        with open_contained_nofollow(self._project_dir, relative) as handle:
+            data = handle.read(remaining + 1)
+        if len(data) > remaining:
+            raise _ByteBudgetExceeded
+        return data

--- a/src/aptl/core/provenance/providers/config_identity.py
+++ b/src/aptl/core/provenance/providers/config_identity.py
@@ -1,0 +1,140 @@
+"""Safe effective-configuration identity (REP-003 / issue #452).
+
+Records WHICH configuration the apparatus was realized under, as a versioned
+projection built beside the strict :class:`~aptl.core.config.AptlConfig`
+owner — never ``model_dump()`` of the whole config, and never a digest of the
+config FILE.
+
+Both rejected alternatives are unsafe for the same reason: they are
+open-by-default. A whole-model dump silently absorbs every field a future
+schema adds, including the next credential locator, and
+``snapshot._hash_config_files()`` hashes ``.env`` itself. ADR-029 and the
+preflight both require the opposite posture — an explicit allowlist of
+apparatus-relevant fields, with secret values, private-key material,
+credential locators, and privacy-sensitive host/path details excluded by
+construction.
+
+Deployment MODE is apparatus-relevant and kept; the deployment HOST, user, key
+path, and remote directory are not, and are dropped. That distinction is what
+lets a reader assess comparability ("this ran over ssh-compose") without the
+record disclosing where or as whom.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+from aptl.core.provenance.identity import ProvenanceIdentityError, ProvenanceLeaf, derive_identity
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+
+log = logging.getLogger(__name__)
+
+#: The code-owned provider id for effective-configuration identity.
+CONFIG_PROVIDER_ID = "config-identity"
+
+#: Versioned identity of the safe projection shape. Adding or removing an
+#: allowlisted field bumps this so an archived identity is never reinterpreted.
+SAFE_CONFIG_SCHEMA_VERSION = "aptl-safe-config-identity/v1"
+
+#: Identity domain for the configuration projection.
+_DOMAIN = "config"
+
+
+def _containers_projection(config: object) -> dict[str, object]:
+    """Return the enabled-container flags, which shape the realized range."""
+    containers = getattr(config, "containers", None)
+    if containers is None:
+        return {}
+    dumped = containers.model_dump()
+    # Every field of ContainerSettings is a first-party boolean toggle
+    # (ADR-025 strict schema), so this stays a closed, non-secret surface.
+    return {key: value for key, value in sorted(dumped.items()) if isinstance(value, bool)}
+
+
+def _participant_models_projection(config: object) -> dict[str, object]:
+    """Return the frozen installed-participant model identities."""
+    experiment = getattr(config, "experiment", None)
+    models = getattr(experiment, "participant_models", None) if experiment else None
+    if models is None:
+        return {}
+    return {
+        "claude": getattr(models, "claude", None),
+        "codex": getattr(models, "codex", None),
+    }
+
+
+def safe_config_projection(config: object) -> dict[str, object]:
+    """Return the versioned, allowlisted apparatus-relevant configuration.
+
+    Only the fields named here are ever recorded. Anything not listed —
+    including every field a future schema revision introduces — is excluded by
+    default rather than by a later filter.
+    """
+    lab = getattr(config, "lab", None)
+    deployment = getattr(config, "deployment", None)
+    run_storage = getattr(config, "run_storage", None)
+    experiment = getattr(config, "experiment", None)
+    lifecycle = getattr(config, "lifecycle_policy", None)
+
+    return {
+        "schema_version": SAFE_CONFIG_SCHEMA_VERSION,
+        "lab_name": getattr(lab, "name", None),
+        "lab_network_subnet": getattr(lab, "network_subnet", None),
+        # Mode only. ssh_host / ssh_user / ssh_key / remote_dir / ssh_port are
+        # host details and a credential locator, and are deliberately absent.
+        "deployment_provider": getattr(deployment, "provider", None),
+        "deployment_project_name": getattr(deployment, "project_name", None),
+        # Backend kind only; local_path and the s3 bucket/prefix are locators.
+        "run_storage_backend": getattr(run_storage, "backend", None),
+        "containers": _containers_projection(config),
+        "participant_action_timeout_seconds": getattr(
+            experiment, "participant_action_timeout_seconds", None
+        ),
+        "participant_models": _participant_models_projection(config),
+        "lifecycle_policy_declared": lifecycle is not None,
+    }
+
+
+class ConfigIdentityProvider:
+    """Collects the effective configuration's identity as one leaf."""
+
+    provider_id = CONFIG_PROVIDER_ID
+
+    def __init__(self, config: object | None):
+        self._config = config
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Derive one identity from the safe configuration projection."""
+        if self._config is None:
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.UNAVAILABLE,
+                detail="source not present",
+            )
+
+        try:
+            projection: Mapping[str, object] = safe_config_projection(self._config)
+            leaf = ProvenanceLeaf("effective-config", derive_identity(_DOMAIN, projection))
+        except (ProvenanceIdentityError, TypeError, ValueError, AttributeError):
+            log.warning("run-provenance: safe config projection could not be identified")
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.FAILED,
+                detail="owner reported failure",
+            )
+
+        if context.expired():
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.TIMED_OUT,
+                detail="deadline exceeded",
+            )
+
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=(leaf,),
+            payload=dict(projection),
+        )

--- a/src/aptl/core/provenance/providers/config_identity.py
+++ b/src/aptl/core/provenance/providers/config_identity.py
@@ -25,9 +25,11 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 
-from aptl.core.provenance.identity import ProvenanceIdentityError, ProvenanceLeaf, derive_identity
+from aptl.core.provenance.identity import ProvenanceLeaf, derive_identity
 from aptl.core.provenance.outcomes import ProvenanceStatus
 from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.core.provenance.providers import _degraded
+from aptl.core.provenance.providers._degraded import ProviderDegraded
 
 log = logging.getLogger(__name__)
 
@@ -102,39 +104,34 @@ class ConfigIdentityProvider:
 
     provider_id = CONFIG_PROVIDER_ID
 
-    def __init__(self, config: object | None):
+    def __init__(self, config: object | None) -> None:
         self._config = config
 
     def collect(self, context: ProvenanceContext) -> ProvenanceResult:
         """Derive one identity from the safe configuration projection."""
-        if self._config is None:
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.UNAVAILABLE,
-                detail="source not present",
-            )
-
         try:
-            projection: Mapping[str, object] = safe_config_projection(self._config)
-            leaf = ProvenanceLeaf("effective-config", derive_identity(_DOMAIN, projection))
-        except (ProvenanceIdentityError, TypeError, ValueError, AttributeError):
-            log.warning("run-provenance: safe config projection could not be identified")
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.FAILED,
-                detail="owner reported failure",
-            )
-
-        if context.expired():
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.TIMED_OUT,
-                detail="deadline exceeded",
-            )
-
+            projection, leaf = self._gather(context)
+        except ProviderDegraded as signal:
+            return signal.as_result(self.provider_id)
         return ProvenanceResult(
             provider_id=self.provider_id,
             status=ProvenanceStatus.COLLECTED,
             leaves=(leaf,),
             payload=dict(projection),
         )
+
+    def _gather(
+        self, context: ProvenanceContext
+    ) -> tuple[Mapping[str, object], ProvenanceLeaf]:
+        """Build the safe projection and its leaf, or declare a degradation."""
+        if self._config is None:
+            raise _degraded.absent()
+        try:
+            projection: Mapping[str, object] = safe_config_projection(self._config)
+            leaf = ProvenanceLeaf("effective-config", derive_identity(_DOMAIN, projection))
+        except (TypeError, ValueError, AttributeError) as exc:
+            log.warning("run-provenance: safe config projection could not be identified")
+            raise _degraded.owner_failure() from exc
+        if context.expired():
+            raise _degraded.deadline()
+        return projection, leaf

--- a/src/aptl/core/provenance/providers/detection.py
+++ b/src/aptl/core/provenance/providers/detection.py
@@ -1,0 +1,290 @@
+"""Detector rule, policy, and allowlist provenance (REP-003 / issue #452).
+
+This provider supersedes :func:`aptl.core.snapshot.detection_content_digest`
+for provenance purposes. That helper had four defects the preflight named, all
+of which this module fixes:
+
+1. **Unframed aggregate.** It concatenated file bytes into one digest, so
+   ``"ab" + "c"`` and ``"a" + "bc"`` were indistinguishable and no targeted
+   difference could be explained. Here every artifact is a leaf bound to its
+   logical role, and the family identity folds the sorted
+   ``{logical_id, digest}`` sequence.
+2. **Stale, non-recursive roots.** Its globs read
+   ``config/wazuh/etc/rules`` and ``config/wazuh/etc/decoders`` — directories
+   that do not exist in this repository — while the real Wazuh rule/decoder/
+   allowlist surface lives under ``config/wazuh_cluster``, and Suricata's MISP
+   content is nested under ``config/suricata/rules/misp``. In practice it
+   covered a single top-level Suricata file.
+3. **Unsafe reads.** ``glob()`` + ``read_bytes()`` follows symlinks and will
+   happily open a special file. Every read here goes through
+   :func:`aptl.utils.pathsafe.open_contained_nofollow`, which walks each
+   component with ``O_NOFOLLOW`` and reads from the one handle it opened.
+4. **Empty success.** No files produced ``""``, which reads downstream as
+   "collected, nothing to report". Absence is now an explicit
+   :attr:`~aptl.core.provenance.outcomes.ProvenanceStatus.UNAVAILABLE`.
+
+Sources are allowlisted, not filtered: a root declares the exact suffixes that
+are detection content, so a secret-shaped or executable file sitting in a rules
+directory is never opened at all.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from aptl.core.provenance.identity import ProvenanceLeaf, digest_bytes
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.utils.pathsafe import PathContainmentError, open_contained_nofollow
+
+log = logging.getLogger(__name__)
+
+#: The code-owned provider id for detection content.
+DETECTION_PROVIDER_ID = "detection-content"
+
+#: Directory nesting depth a recursive root may descend. Bounds a hostile or
+#: accidental deep tree before it becomes traversal work.
+_MAX_DEPTH = 8
+
+
+@dataclass(frozen=True)
+class DetectionRoot:
+    """One code-owned detection-content location and what it admits.
+
+    A root admits a file only by declared ``suffixes`` or by exact declared
+    ``filenames``. There is deliberately no wildcard: admitting "every file
+    that is not a dotfile" is directory DISCOVERY, not a non-secret source
+    allowlist. An extensionless credential, token, or default password
+    dropped into a rules tree would then be read and its digest folded into
+    the section identity — and because only the derived digest reaches the
+    payload redactor and the run-store secret invariant, neither could detect
+    it. Against a small tree with known logical names, that digest is an
+    offline confirmation oracle for candidate values. Unknown files therefore
+    stay unread.
+    """
+
+    root_id: str
+    relative_root: str
+    recursive: bool
+    suffixes: tuple[str, ...] = ()
+    filenames: tuple[str, ...] = ()
+
+
+#: The declared detection surface. Every entry is under ``config/`` and names
+#: its own suffixes; nothing here is discovered from configuration, an
+#: experiment document, or the environment.
+DETECTION_ROOTS: tuple[DetectionRoot, ...] = (
+    DetectionRoot(
+        root_id="suricata-rules",
+        relative_root="config/suricata/rules",
+        recursive=True,
+        suffixes=(".rules", ".conf"),
+    ),
+    DetectionRoot(
+        root_id="suricata-policy",
+        relative_root="config/suricata",
+        recursive=False,
+        suffixes=(".yaml",),
+    ),
+    DetectionRoot(
+        root_id="wazuh-rules-decoders",
+        relative_root="config/wazuh_cluster",
+        recursive=False,
+        suffixes=(".xml",),
+    ),
+    DetectionRoot(
+        root_id="wazuh-allowlists",
+        relative_root="config/wazuh_cluster/etc/lists",
+        recursive=True,
+        # Named explicitly: the Wazuh CDB list this lab ships is
+        # extensionless, so there is no suffix to key on. Adding a new
+        # allowlist means adding its name here, which is the intended cost of
+        # an explicit source allowlist.
+        filenames=("active-response-whitelist",),
+    ),
+)
+
+
+def _admits(root: DetectionRoot, name: str) -> bool:
+    """Return whether ``name`` is an admitted artifact for ``root``.
+
+    Admission is positive-only: a file must match a declared suffix or a
+    declared exact filename. Anything else — including a file that merely
+    fails to be a dotfile — is not read at all.
+    """
+    if name.startswith("."):
+        return False
+    if name in root.filenames:
+        return True
+    return any(name.endswith(suffix) for suffix in root.suffixes)
+
+
+def _relative_files(project_dir: Path, root: DetectionRoot) -> list[str]:
+    """Return the project-relative POSIX paths of ``root``'s admitted artifacts.
+
+    Enumeration is discovery only — every candidate is still opened no-follow
+    and contained, so a directory swapped underneath this walk cannot cause an
+    out-of-tree read. A symlinked directory is skipped here as well, so its
+    entry names never even reach a log line.
+    """
+    base = project_dir / root.relative_root
+    if base.is_symlink() or not base.is_dir():
+        return []
+
+    found: list[str] = []
+    stack: list[tuple[Path, int]] = [(base, 0)]
+    while stack:
+        current, depth = stack.pop()
+        with os.scandir(current) as entries:
+            for entry in entries:
+                if entry.is_symlink():
+                    continue
+                if entry.is_dir(follow_symlinks=False):
+                    if root.recursive and depth < _MAX_DEPTH:
+                        stack.append((Path(entry.path), depth + 1))
+                    continue
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                if not _admits(root, entry.name):
+                    continue
+                found.append(
+                    PurePosixPath(Path(entry.path).relative_to(project_dir).as_posix()).as_posix()
+                )
+    return sorted(found)
+
+
+@dataclass(frozen=True)
+class _Collection:
+    """The internal accumulation state for one collect() pass."""
+
+    leaves: tuple[ProvenanceLeaf, ...]
+    status: ProvenanceStatus
+    counts: dict[str, int]
+
+
+class DetectionContentProvider:
+    """Collects per-artifact identities for detector rules, policies, and allowlists."""
+
+    provider_id = DETECTION_PROVIDER_ID
+
+    def __init__(self, project_dir: Path, roots: tuple[DetectionRoot, ...] = DETECTION_ROOTS):
+        self._project_dir = Path(project_dir)
+        self._roots = roots
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Read every admitted detection artifact under the declared roots."""
+        collection = self._walk(context)
+        payload: dict[str, object] = {
+            "roots": {root_id: count for root_id, count in sorted(collection.counts.items())},
+            "artifact_count": len(collection.leaves),
+        }
+        if collection.status is not ProvenanceStatus.COLLECTED:
+            # Partial content is not evidence of the apparatus: report the
+            # degradation and keep the leaves out of the record entirely.
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=collection.status,
+                payload=payload,
+                detail=_DETAIL_FOR.get(collection.status, ""),
+            )
+        if not collection.leaves:
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.UNAVAILABLE,
+                payload=payload,
+                detail="source not present",
+            )
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=collection.leaves,
+            payload=payload,
+        )
+
+    def _walk(self, context: ProvenanceContext) -> _Collection:
+        """Accumulate leaves under the context's entry, byte, and time limits."""
+        leaves: list[ProvenanceLeaf] = []
+        counts: dict[str, int] = {}
+        consumed = 0
+
+        for root in self._roots:
+            counts.setdefault(root.root_id, 0)
+            try:
+                relatives = _relative_files(self._project_dir, root)
+            except PermissionError:
+                return _Collection(tuple(leaves), ProvenanceStatus.DENIED, counts)
+            except OSError:
+                log.warning("run-provenance: detection root %s could not be listed", root.root_id)
+                return _Collection(tuple(leaves), ProvenanceStatus.FAILED, counts)
+
+            for relative in relatives:
+                if context.expired():
+                    return _Collection(tuple(leaves), ProvenanceStatus.TIMED_OUT, counts)
+                if len(leaves) >= context.max_entries:
+                    return _Collection(tuple(leaves), ProvenanceStatus.TRUNCATED, counts)
+
+                try:
+                    data = self._read(relative, context.max_bytes - consumed)
+                except _ByteBudgetExceeded:
+                    return _Collection(tuple(leaves), ProvenanceStatus.TRUNCATED, counts)
+                except PermissionError:
+                    return _Collection(tuple(leaves), ProvenanceStatus.DENIED, counts)
+                except PathContainmentError:
+                    # A component became a symlink between enumeration and
+                    # open, or the leaf is not a regular file. Skipping is
+                    # correct: it was never an admitted artifact.
+                    continue
+                except OSError:
+                    log.warning(
+                        "run-provenance: detection artifact under %s could not be read",
+                        root.root_id,
+                    )
+                    return _Collection(tuple(leaves), ProvenanceStatus.FAILED, counts)
+
+                consumed += len(data)
+                leaves.append(
+                    ProvenanceLeaf(
+                        logical_id=f"{root.root_id}/{_leaf_name(root, relative)}",
+                        digest=digest_bytes(data),
+                    )
+                )
+                counts[root.root_id] += 1
+
+        return _Collection(tuple(sorted(leaves)), ProvenanceStatus.COLLECTED, counts)
+
+    def _read(self, relative: str, remaining: int) -> bytes:
+        """Read one artifact no-follow, refusing to exceed the byte budget."""
+        if remaining <= 0:
+            raise _ByteBudgetExceeded
+        with open_contained_nofollow(self._project_dir, relative) as handle:
+            data = handle.read(remaining + 1)
+        if len(data) > remaining:
+            raise _ByteBudgetExceeded
+        return data
+
+
+class _ByteBudgetExceeded(Exception):
+    """Internal signal that the declared byte budget would be exceeded."""
+
+
+#: Safe detail strings for the degraded statuses this provider can report.
+_DETAIL_FOR = {
+    ProvenanceStatus.DENIED: "source not readable",
+    ProvenanceStatus.TRUNCATED: "byte limit reached",
+    ProvenanceStatus.TIMED_OUT: "deadline exceeded",
+    ProvenanceStatus.FAILED: "owner reported failure",
+}
+
+
+def _leaf_name(root: DetectionRoot, relative: str) -> str:
+    """Return the artifact's path relative to its own root.
+
+    Keeping the leaf name root-relative (rather than project-relative) means a
+    root's location can move without every leaf identity changing, while the
+    ``root_id`` prefix preserves the role boundary.
+    """
+    root_prefix = f"{root.relative_root}/"
+    return relative[len(root_prefix) :] if relative.startswith(root_prefix) else relative

--- a/src/aptl/core/provenance/providers/detection.py
+++ b/src/aptl/core/provenance/providers/detection.py
@@ -23,9 +23,9 @@ of which this module fixes:
    "collected, nothing to report". Absence is now an explicit
    :attr:`~aptl.core.provenance.outcomes.ProvenanceStatus.UNAVAILABLE`.
 
-Sources are allowlisted, not filtered: a root declares the exact suffixes that
-are detection content, so a secret-shaped or executable file sitting in a rules
-directory is never opened at all.
+Sources are allowlisted, not filtered: a root declares exactly which suffixes
+and filenames are detection content, so a secret-shaped or executable file
+sitting in a rules directory is never opened at all.
 """
 
 from __future__ import annotations
@@ -33,11 +33,13 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 from aptl.core.provenance.identity import ProvenanceLeaf, digest_bytes
 from aptl.core.provenance.outcomes import ProvenanceStatus
 from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.core.provenance.providers import _degraded
+from aptl.core.provenance.providers._degraded import ProviderDegraded
 from aptl.utils.pathsafe import PathContainmentError, open_contained_nofollow
 
 log = logging.getLogger(__name__)
@@ -74,8 +76,8 @@ class DetectionRoot:
 
 
 #: The declared detection surface. Every entry is under ``config/`` and names
-#: its own suffixes; nothing here is discovered from configuration, an
-#: experiment document, or the environment.
+#: its own admitted artifacts; nothing here is discovered from configuration,
+#: an experiment document, or the environment.
 DETECTION_ROOTS: tuple[DetectionRoot, ...] = (
     DetectionRoot(
         root_id="suricata-rules",
@@ -122,6 +124,33 @@ def _admits(root: DetectionRoot, name: str) -> bool:
     return any(name.endswith(suffix) for suffix in root.suffixes)
 
 
+def _is_candidate(entry: os.DirEntry[str], root: DetectionRoot) -> bool:
+    """Return whether a directory entry is an admitted regular file."""
+    return (
+        not entry.is_symlink()
+        and entry.is_file(follow_symlinks=False)
+        and _admits(root, entry.name)
+    )
+
+
+def _scan_directory(
+    current: Path, root: DetectionRoot, depth: int
+) -> tuple[list[Path], list[str]]:
+    """Return one directory's (subdirectories to descend, admitted file paths)."""
+    subdirectories: list[Path] = []
+    files: list[str] = []
+    with os.scandir(current) as entries:
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                if root.recursive and depth < _MAX_DEPTH:
+                    subdirectories.append(Path(entry.path))
+            elif _is_candidate(entry, root):
+                files.append(entry.path)
+    return subdirectories, files
+
+
 def _relative_files(project_dir: Path, root: DetectionRoot) -> list[str]:
     """Return the project-relative POSIX paths of ``root``'s admitted artifacts.
 
@@ -138,145 +167,12 @@ def _relative_files(project_dir: Path, root: DetectionRoot) -> list[str]:
     stack: list[tuple[Path, int]] = [(base, 0)]
     while stack:
         current, depth = stack.pop()
-        with os.scandir(current) as entries:
-            for entry in entries:
-                if entry.is_symlink():
-                    continue
-                if entry.is_dir(follow_symlinks=False):
-                    if root.recursive and depth < _MAX_DEPTH:
-                        stack.append((Path(entry.path), depth + 1))
-                    continue
-                if not entry.is_file(follow_symlinks=False):
-                    continue
-                if not _admits(root, entry.name):
-                    continue
-                found.append(
-                    PurePosixPath(Path(entry.path).relative_to(project_dir).as_posix()).as_posix()
-                )
-    return sorted(found)
-
-
-@dataclass(frozen=True)
-class _Collection:
-    """The internal accumulation state for one collect() pass."""
-
-    leaves: tuple[ProvenanceLeaf, ...]
-    status: ProvenanceStatus
-    counts: dict[str, int]
-
-
-class DetectionContentProvider:
-    """Collects per-artifact identities for detector rules, policies, and allowlists."""
-
-    provider_id = DETECTION_PROVIDER_ID
-
-    def __init__(self, project_dir: Path, roots: tuple[DetectionRoot, ...] = DETECTION_ROOTS):
-        self._project_dir = Path(project_dir)
-        self._roots = roots
-
-    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
-        """Read every admitted detection artifact under the declared roots."""
-        collection = self._walk(context)
-        payload: dict[str, object] = {
-            "roots": {root_id: count for root_id, count in sorted(collection.counts.items())},
-            "artifact_count": len(collection.leaves),
-        }
-        if collection.status is not ProvenanceStatus.COLLECTED:
-            # Partial content is not evidence of the apparatus: report the
-            # degradation and keep the leaves out of the record entirely.
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=collection.status,
-                payload=payload,
-                detail=_DETAIL_FOR.get(collection.status, ""),
-            )
-        if not collection.leaves:
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.UNAVAILABLE,
-                payload=payload,
-                detail="source not present",
-            )
-        return ProvenanceResult(
-            provider_id=self.provider_id,
-            status=ProvenanceStatus.COLLECTED,
-            leaves=collection.leaves,
-            payload=payload,
+        subdirectories, files = _scan_directory(current, root, depth)
+        stack.extend((subdirectory, depth + 1) for subdirectory in subdirectories)
+        found.extend(
+            Path(path).relative_to(project_dir).as_posix() for path in files
         )
-
-    def _walk(self, context: ProvenanceContext) -> _Collection:
-        """Accumulate leaves under the context's entry, byte, and time limits."""
-        leaves: list[ProvenanceLeaf] = []
-        counts: dict[str, int] = {}
-        consumed = 0
-
-        for root in self._roots:
-            counts.setdefault(root.root_id, 0)
-            try:
-                relatives = _relative_files(self._project_dir, root)
-            except PermissionError:
-                return _Collection(tuple(leaves), ProvenanceStatus.DENIED, counts)
-            except OSError:
-                log.warning("run-provenance: detection root %s could not be listed", root.root_id)
-                return _Collection(tuple(leaves), ProvenanceStatus.FAILED, counts)
-
-            for relative in relatives:
-                if context.expired():
-                    return _Collection(tuple(leaves), ProvenanceStatus.TIMED_OUT, counts)
-                if len(leaves) >= context.max_entries:
-                    return _Collection(tuple(leaves), ProvenanceStatus.TRUNCATED, counts)
-
-                try:
-                    data = self._read(relative, context.max_bytes - consumed)
-                except _ByteBudgetExceeded:
-                    return _Collection(tuple(leaves), ProvenanceStatus.TRUNCATED, counts)
-                except PermissionError:
-                    return _Collection(tuple(leaves), ProvenanceStatus.DENIED, counts)
-                except PathContainmentError:
-                    # A component became a symlink between enumeration and
-                    # open, or the leaf is not a regular file. Skipping is
-                    # correct: it was never an admitted artifact.
-                    continue
-                except OSError:
-                    log.warning(
-                        "run-provenance: detection artifact under %s could not be read",
-                        root.root_id,
-                    )
-                    return _Collection(tuple(leaves), ProvenanceStatus.FAILED, counts)
-
-                consumed += len(data)
-                leaves.append(
-                    ProvenanceLeaf(
-                        logical_id=f"{root.root_id}/{_leaf_name(root, relative)}",
-                        digest=digest_bytes(data),
-                    )
-                )
-                counts[root.root_id] += 1
-
-        return _Collection(tuple(sorted(leaves)), ProvenanceStatus.COLLECTED, counts)
-
-    def _read(self, relative: str, remaining: int) -> bytes:
-        """Read one artifact no-follow, refusing to exceed the byte budget."""
-        if remaining <= 0:
-            raise _ByteBudgetExceeded
-        with open_contained_nofollow(self._project_dir, relative) as handle:
-            data = handle.read(remaining + 1)
-        if len(data) > remaining:
-            raise _ByteBudgetExceeded
-        return data
-
-
-class _ByteBudgetExceeded(Exception):
-    """Internal signal that the declared byte budget would be exceeded."""
-
-
-#: Safe detail strings for the degraded statuses this provider can report.
-_DETAIL_FOR = {
-    ProvenanceStatus.DENIED: "source not readable",
-    ProvenanceStatus.TRUNCATED: "byte limit reached",
-    ProvenanceStatus.TIMED_OUT: "deadline exceeded",
-    ProvenanceStatus.FAILED: "owner reported failure",
-}
+    return sorted(found)
 
 
 def _leaf_name(root: DetectionRoot, relative: str) -> str:
@@ -288,3 +184,101 @@ def _leaf_name(root: DetectionRoot, relative: str) -> str:
     """
     root_prefix = f"{root.relative_root}/"
     return relative[len(root_prefix) :] if relative.startswith(root_prefix) else relative
+
+
+class DetectionContentProvider:
+    """Collects per-artifact identities for detector rules, policies, and allowlists."""
+
+    provider_id = DETECTION_PROVIDER_ID
+
+    def __init__(
+        self, project_dir: Path, roots: tuple[DetectionRoot, ...] = DETECTION_ROOTS
+    ) -> None:
+        self._project_dir = Path(project_dir)
+        self._roots = roots
+        self._counts: dict[str, int] = {}
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Read every admitted detection artifact under the declared roots."""
+        self._counts = {root.root_id: 0 for root in self._roots}
+        try:
+            leaves = self._gather(context)
+        except ProviderDegraded as signal:
+            signal.payload.update(self._payload(0))
+            return signal.as_result(self.provider_id)
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=leaves,
+            payload=self._payload(len(leaves)),
+        )
+
+    def _payload(self, artifact_count: int) -> dict[str, object]:
+        """Return the bounded payload: per-root counts and a total."""
+        return {
+            "roots": dict(sorted(self._counts.items())),
+            "artifact_count": artifact_count,
+        }
+
+    def _gather(self, context: ProvenanceContext) -> tuple[ProvenanceLeaf, ...]:
+        """Accumulate leaves under the context's entry, byte, and time limits."""
+        leaves: list[ProvenanceLeaf] = []
+        consumed = 0
+        for root in self._roots:
+            for relative in self._list_root(root):
+                self._check_budget(context, len(leaves))
+                data = self._read_artifact(relative, context.max_bytes - consumed)
+                consumed += len(data)
+                leaves.append(
+                    ProvenanceLeaf(
+                        logical_id=f"{root.root_id}/{_leaf_name(root, relative)}",
+                        digest=digest_bytes(data),
+                    )
+                )
+                self._counts[root.root_id] += 1
+        if not leaves:
+            raise _degraded.absent()
+        return tuple(sorted(leaves))
+
+    def _list_root(self, root: DetectionRoot) -> list[str]:
+        """Enumerate one root's admitted artifacts, or declare a degradation."""
+        try:
+            return _relative_files(self._project_dir, root)
+        except PermissionError as exc:
+            raise _degraded.denied() from exc
+        except OSError as exc:
+            log.warning("run-provenance: detection root %s could not be listed", root.root_id)
+            raise _degraded.owner_failure() from exc
+
+    @staticmethod
+    def _check_budget(context: ProvenanceContext, collected: int) -> None:
+        """Raise when the declared deadline or entry budget is exhausted."""
+        if context.expired():
+            raise _degraded.deadline()
+        if collected >= context.max_entries:
+            raise _degraded.entry_limit()
+
+    def _read_artifact(self, relative: str, remaining: int) -> bytes:
+        """Read one artifact no-follow, declaring a degradation on any refusal.
+
+        A :class:`PathContainmentError` means a component became a symlink
+        between enumeration and open, or the leaf is not a regular file. That
+        is treated as an owner failure rather than skipped: enumeration already
+        admitted it, so a disagreement between the two is a fact worth
+        disclosing rather than quietly dropping an artifact from the identity.
+        """
+        if remaining <= 0:
+            raise _degraded.byte_limit()
+        try:
+            with open_contained_nofollow(self._project_dir, relative) as handle:
+                data = handle.read(remaining + 1)
+        except PermissionError as exc:
+            raise _degraded.denied() from exc
+        except PathContainmentError as exc:
+            raise _degraded.owner_failure() from exc
+        except OSError as exc:
+            log.warning("run-provenance: a detection artifact could not be read")
+            raise _degraded.owner_failure() from exc
+        if len(data) > remaining:
+            raise _degraded.byte_limit()
+        return data

--- a/src/aptl/core/provenance/providers/experiment.py
+++ b/src/aptl/core/provenance/providers/experiment.py
@@ -1,0 +1,173 @@
+"""Admitted experiment/trial identity provenance (REP-003 / issue #452).
+
+Answers "which scenario and which admitted plan produced this run" from the
+identities admission already accepted — the persisted
+:class:`~aptl.core.experiment.trial_plan_models.TrialPlan`. The preflight is
+explicit that seal-time collection must not reopen the authored scenario,
+recompute bindings against current configuration, or infer a run from the
+active directory: a display name, source path, or module lock digest is not a
+canonical scenario snapshot, and re-deriving one at seal time would describe
+the present rather than the run.
+
+Scenario parameter VALUES are deliberately not recorded. ADR-044 already
+establishes that APTL does not persist raw scenario bindings or value-bearing
+provenance; the plan's canonical digests identify the binding without
+disclosing it.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+from aptl.core.provenance.identity import (
+    ProvenanceIdentityError,
+    ProvenanceLeaf,
+    derive_identity,
+)
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+
+log = logging.getLogger(__name__)
+
+#: The code-owned provider id for admitted experiment identity.
+EXPERIMENT_PROVIDER_ID = "experiment"
+
+#: Identity domain for the plan and per-trial leaves.
+_DOMAIN = "experiment"
+
+
+def _plan_projection(plan: object) -> dict[str, object]:
+    """Return the admitted plan's identity fields."""
+    return {
+        "plan_id": getattr(plan, "plan_id", None),
+        "policy_version": getattr(plan, "policy_version", None),
+        "source_set_digest": getattr(plan, "source_set_digest", None),
+        "plan_digest": getattr(plan, "plan_digest", None),
+    }
+
+
+def _trial_projection(trial: object) -> dict[str, object]:
+    """Return one planned trial's identity fields.
+
+    ``stochastic_seeds`` are recorded by control id and seed digest: the seed
+    is itself a derived identity in the admitted plan, and it is what makes a
+    run's randomness reconstructable.
+    """
+    seeds = getattr(trial, "stochastic_seeds", ()) or ()
+    captures = getattr(trial, "capture_spec_refs", ()) or ()
+    return {
+        "planned_trial_id": getattr(trial, "planned_trial_id", None),
+        "condition_id": getattr(trial, "condition_id", None),
+        "replication_ordinal": getattr(trial, "replication_ordinal", None),
+        "scenario_snapshot_digest": getattr(trial, "scenario_snapshot_digest", None),
+        "capture_spec_refs": sorted(str(ref) for ref in captures),
+        "stochastic_seeds": sorted(
+            {"control_id": str(control), "seed": str(seed)} for control, seed in seeds
+        )
+        if seeds
+        else [],
+    }
+
+
+def _binding_projection(binding: object) -> dict[str, object]:
+    """Return one admitted capture binding's collector and channel identity.
+
+    This is the collector-selection fact the requirement asks for: WHICH
+    trusted collector registration was bound, at which declared implementation
+    version, against which authored measurement channel. A registry
+    declaration alone is not proof a collector ran, so the pinned
+    ``effective_config_digest`` from the admitted binding is recorded rather
+    than re-read from the current registry.
+    """
+    return {
+        "capture_spec_id": getattr(binding, "capture_spec_id", None),
+        "requirement_id": getattr(binding, "requirement_id", None),
+        "registration_id": getattr(binding, "registration_id", None),
+        "implementation_version": getattr(binding, "implementation_version", None),
+        "contract_version": getattr(binding, "contract_version", None),
+        "channel_ref_id": getattr(binding, "channel_ref_id", None),
+        "channel_ref_version": getattr(binding, "channel_ref_version", None),
+        "channel_kind": getattr(binding, "channel_kind", None),
+        "effective_config_digest": getattr(binding, "effective_config_digest", None),
+    }
+
+
+class AdmittedExperimentProvider:
+    """Collects the admitted plan's, trials', and capture bindings' identities."""
+
+    provider_id = EXPERIMENT_PROVIDER_ID
+
+    def __init__(self, plan: object | None):
+        self._plan = plan
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Project the admitted plan into leaves without re-admitting anything."""
+        plan = self._plan
+        if plan is None:
+            # No admitted plan is a real fact about this run (a plain lab
+            # start), not a source that failed. It must never become a
+            # fabricated plan identity.
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.UNAVAILABLE,
+                detail="source not present",
+            )
+
+        trials: Sequence[object] = tuple(getattr(plan, "trials", ()) or ())
+        bindings: Sequence[object] = tuple(getattr(plan, "capture_bindings", ()) or ())
+        # +1 for the plan leaf itself.
+        if len(trials) + len(bindings) + 1 > context.max_entries:
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.TRUNCATED,
+                detail="entry limit reached",
+            )
+
+        collectors: list[dict[str, object]] = []
+        try:
+            leaves = [
+                ProvenanceLeaf("plan", derive_identity(_DOMAIN, _plan_projection(plan)))
+            ]
+            for trial in trials:
+                projection = _trial_projection(trial)
+                trial_id = projection["planned_trial_id"]
+                leaves.append(
+                    ProvenanceLeaf(f"trial/{trial_id}", derive_identity(_DOMAIN, projection))
+                )
+            for binding in bindings:
+                projection = _binding_projection(binding)
+                capture_id = projection["capture_spec_id"]
+                requirement_id = projection["requirement_id"]
+                leaves.append(
+                    ProvenanceLeaf(
+                        f"capture/{capture_id}/{requirement_id}",
+                        derive_identity(_DOMAIN, projection),
+                    )
+                )
+                collectors.append(projection)
+        except (ProvenanceIdentityError, TypeError, ValueError):
+            log.warning("run-provenance: admitted plan projection could not be identified")
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.FAILED,
+                detail="owner reported failure",
+            )
+
+        if context.expired():
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.TIMED_OUT,
+                detail="deadline exceeded",
+            )
+
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=tuple(sorted(leaves)),
+            payload={
+                **_plan_projection(plan),
+                "trial_count": len(trials),
+                "collectors": collectors,
+            },
+        )

--- a/src/aptl/core/provenance/providers/experiment.py
+++ b/src/aptl/core/provenance/providers/experiment.py
@@ -21,12 +21,13 @@ import logging
 from collections.abc import Sequence
 
 from aptl.core.provenance.identity import (
-    ProvenanceIdentityError,
     ProvenanceLeaf,
     derive_identity,
 )
 from aptl.core.provenance.outcomes import ProvenanceStatus
 from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.core.provenance.providers import _degraded
+from aptl.core.provenance.providers._degraded import ProviderDegraded
 
 log = logging.getLogger(__name__)
 
@@ -98,31 +99,42 @@ class AdmittedExperimentProvider:
 
     provider_id = EXPERIMENT_PROVIDER_ID
 
-    def __init__(self, plan: object | None):
+    def __init__(self, plan: object | None) -> None:
         self._plan = plan
 
     def collect(self, context: ProvenanceContext) -> ProvenanceResult:
         """Project the admitted plan into leaves without re-admitting anything."""
+        try:
+            leaves, collectors = self._gather(context)
+        except ProviderDegraded as signal:
+            return signal.as_result(self.provider_id)
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=leaves,
+            payload={
+                **_plan_projection(self._plan),
+                "trial_count": len(tuple(getattr(self._plan, "trials", ()) or ())),
+                "collectors": collectors,
+            },
+        )
+
+    def _gather(
+        self, context: ProvenanceContext
+    ) -> tuple[tuple[ProvenanceLeaf, ...], list[dict[str, object]]]:
+        """Build the plan, trial, and capture-binding leaves, or degrade."""
         plan = self._plan
         if plan is None:
             # No admitted plan is a real fact about this run (a plain lab
             # start), not a source that failed. It must never become a
             # fabricated plan identity.
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.UNAVAILABLE,
-                detail="source not present",
-            )
+            raise _degraded.absent()
 
         trials: Sequence[object] = tuple(getattr(plan, "trials", ()) or ())
         bindings: Sequence[object] = tuple(getattr(plan, "capture_bindings", ()) or ())
         # +1 for the plan leaf itself.
         if len(trials) + len(bindings) + 1 > context.max_entries:
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.TRUNCATED,
-                detail="entry limit reached",
-            )
+            raise _degraded.entry_limit()
 
         collectors: list[dict[str, object]] = []
         try:
@@ -131,43 +143,24 @@ class AdmittedExperimentProvider:
             ]
             for trial in trials:
                 projection = _trial_projection(trial)
-                trial_id = projection["planned_trial_id"]
                 leaves.append(
-                    ProvenanceLeaf(f"trial/{trial_id}", derive_identity(_DOMAIN, projection))
+                    ProvenanceLeaf(
+                        f"trial/{projection['planned_trial_id']}",
+                        derive_identity(_DOMAIN, projection),
+                    )
                 )
             for binding in bindings:
                 projection = _binding_projection(binding)
-                capture_id = projection["capture_spec_id"]
-                requirement_id = projection["requirement_id"]
                 leaves.append(
                     ProvenanceLeaf(
-                        f"capture/{capture_id}/{requirement_id}",
+                        f"capture/{projection['capture_spec_id']}/{projection['requirement_id']}",
                         derive_identity(_DOMAIN, projection),
                     )
                 )
                 collectors.append(projection)
-        except (ProvenanceIdentityError, TypeError, ValueError):
+        except (TypeError, ValueError) as exc:
             log.warning("run-provenance: admitted plan projection could not be identified")
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.FAILED,
-                detail="owner reported failure",
-            )
-
+            raise _degraded.owner_failure() from exc
         if context.expired():
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.TIMED_OUT,
-                detail="deadline exceeded",
-            )
-
-        return ProvenanceResult(
-            provider_id=self.provider_id,
-            status=ProvenanceStatus.COLLECTED,
-            leaves=tuple(sorted(leaves)),
-            payload={
-                **_plan_projection(plan),
-                "trial_count": len(trials),
-                "collectors": collectors,
-            },
-        )
+            raise _degraded.deadline()
+        return tuple(sorted(leaves)), collectors

--- a/src/aptl/core/provenance/providers/participant.py
+++ b/src/aptl/core/provenance/providers/participant.py
@@ -1,0 +1,110 @@
+"""Participant-implementation provenance (REP-003 / issue #452).
+
+Records the participant implementation and model identity that the run
+ACTUALLY used, taken from the accepted
+:class:`~aptl.backends.raes_participant_apparatus_models.ParticipantApparatus`
+that :func:`~aptl.backends.raes_participant_apparatus.build_participant_apparatus`
+produced at selection time.
+
+This is deliberately not a reconstruction from current configuration. The
+research protocol requires model identity to be frozen and reconstructable, so
+an absent model is recorded as ``None`` rather than being back-filled from
+whatever the configuration says today — a guessed default would silently
+misreport which agent ran.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+from aptl.core.provenance.identity import (
+    ProvenanceIdentityError,
+    ProvenanceLeaf,
+    derive_identity,
+    validate_logical_id,
+)
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+
+log = logging.getLogger(__name__)
+
+#: The code-owned provider id for participant apparatus.
+PARTICIPANT_PROVIDER_ID = "participant"
+
+#: Identity domain for a participant's accepted selection.
+_DOMAIN = "participant"
+
+
+def _selection_projection(apparatus: object) -> dict[str, object]:
+    """Return one participant's accepted selection identity.
+
+    Provider and model are non-secret identity. Credentials never appear here:
+    the participant credential path is an ephemeral broker
+    (``EphemeralCredentialBroker``), and nothing in that path is read.
+    """
+    return {
+        "implementation_selection_ref": getattr(apparatus, "implementation_selection_ref", None),
+        "manifest_ref": getattr(apparatus, "manifest_ref", None),
+        "provider": getattr(apparatus, "provider", None),
+        "model": getattr(apparatus, "model", None),
+    }
+
+
+class ParticipantApparatusProvider:
+    """Collects each installed participant's accepted implementation selection."""
+
+    provider_id = PARTICIPANT_PROVIDER_ID
+
+    def __init__(self, apparatus_by_address: Mapping[str, object]):
+        self._apparatus_by_address = dict(apparatus_by_address)
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Project every accepted participant selection into a leaf."""
+        if not self._apparatus_by_address:
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.UNAVAILABLE,
+                detail="source not present",
+            )
+
+        if len(self._apparatus_by_address) > context.max_entries:
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.TRUNCATED,
+                detail="entry limit reached",
+            )
+
+        leaves: list[ProvenanceLeaf] = []
+        participants: dict[str, object] = {}
+        try:
+            for address, apparatus in self._apparatus_by_address.items():
+                # The address becomes a record key, so it is validated with the
+                # same rule every logical id obeys rather than trusted.
+                safe_address = validate_logical_id(address)
+                projection = _selection_projection(apparatus)
+                leaves.append(
+                    ProvenanceLeaf(safe_address, derive_identity(_DOMAIN, projection))
+                )
+                participants[safe_address] = projection
+        except (ProvenanceIdentityError, TypeError, ValueError):
+            log.warning("run-provenance: participant apparatus projection was rejected")
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.FAILED,
+                detail="owner reported failure",
+            )
+
+        if context.expired():
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.TIMED_OUT,
+                detail="deadline exceeded",
+            )
+
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=tuple(sorted(leaves)),
+            payload={"participants": participants},
+        )

--- a/src/aptl/core/provenance/providers/participant.py
+++ b/src/aptl/core/provenance/providers/participant.py
@@ -19,13 +19,14 @@ import logging
 from collections.abc import Mapping
 
 from aptl.core.provenance.identity import (
-    ProvenanceIdentityError,
     ProvenanceLeaf,
     derive_identity,
     validate_logical_id,
 )
 from aptl.core.provenance.outcomes import ProvenanceStatus
 from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.core.provenance.providers import _degraded
+from aptl.core.provenance.providers._degraded import ProviderDegraded
 
 log = logging.getLogger(__name__)
 
@@ -56,24 +57,30 @@ class ParticipantApparatusProvider:
 
     provider_id = PARTICIPANT_PROVIDER_ID
 
-    def __init__(self, apparatus_by_address: Mapping[str, object]):
+    def __init__(self, apparatus_by_address: Mapping[str, object]) -> None:
         self._apparatus_by_address = dict(apparatus_by_address)
 
     def collect(self, context: ProvenanceContext) -> ProvenanceResult:
         """Project every accepted participant selection into a leaf."""
-        if not self._apparatus_by_address:
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.UNAVAILABLE,
-                detail="source not present",
-            )
+        try:
+            leaves, participants = self._gather(context)
+        except ProviderDegraded as signal:
+            return signal.as_result(self.provider_id)
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=leaves,
+            payload={"participants": participants},
+        )
 
+    def _gather(
+        self, context: ProvenanceContext
+    ) -> tuple[tuple[ProvenanceLeaf, ...], dict[str, object]]:
+        """Build each participant's leaf, or declare a degradation."""
+        if not self._apparatus_by_address:
+            raise _degraded.absent()
         if len(self._apparatus_by_address) > context.max_entries:
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.TRUNCATED,
-                detail="entry limit reached",
-            )
+            raise _degraded.entry_limit()
 
         leaves: list[ProvenanceLeaf] = []
         participants: dict[str, object] = {}
@@ -87,24 +94,9 @@ class ParticipantApparatusProvider:
                     ProvenanceLeaf(safe_address, derive_identity(_DOMAIN, projection))
                 )
                 participants[safe_address] = projection
-        except (ProvenanceIdentityError, TypeError, ValueError):
+        except (TypeError, ValueError) as exc:
             log.warning("run-provenance: participant apparatus projection was rejected")
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.FAILED,
-                detail="owner reported failure",
-            )
-
+            raise _degraded.owner_failure() from exc
         if context.expired():
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.TIMED_OUT,
-                detail="deadline exceeded",
-            )
-
-        return ProvenanceResult(
-            provider_id=self.provider_id,
-            status=ProvenanceStatus.COLLECTED,
-            leaves=tuple(sorted(leaves)),
-            payload={"participants": participants},
-        )
+            raise _degraded.deadline()
+        return tuple(sorted(leaves)), participants

--- a/src/aptl/core/provenance/providers/runtime_facts.py
+++ b/src/aptl/core/provenance/providers/runtime_facts.py
@@ -26,7 +26,6 @@ from collections.abc import Callable, Mapping
 import rfc8785
 
 from aptl.core.provenance.identity import (
-    ProvenanceIdentityError,
     ProvenanceLeaf,
     derive_identity,
     digest_bytes,
@@ -35,6 +34,8 @@ from aptl.core.provenance.identity import (
 )
 from aptl.core.provenance.outcomes import ProvenanceStatus
 from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.core.provenance.providers import _degraded
+from aptl.core.provenance.providers._degraded import ProviderDegraded
 
 log = logging.getLogger(__name__)
 
@@ -179,86 +180,84 @@ class RuntimeFactsProvider:
         self,
         snapshot: object | None,
         host_facts: Callable[[], Mapping[str, object]] = no_host_facts,
-    ):
+    ) -> None:
         self._snapshot = snapshot
         self._host_facts = host_facts
 
     def collect(self, context: ProvenanceContext) -> ProvenanceResult:
         """Project the captured range snapshot into leaves and observations."""
+        try:
+            leaves, payload = self._gather(context)
+        except ProviderDegraded as signal:
+            return signal.as_result(self.provider_id)
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=leaves,
+            payload=payload,
+        )
+
+    def _gather(
+        self, context: ProvenanceContext
+    ) -> tuple[tuple[ProvenanceLeaf, ...], dict[str, object]]:
+        """Build the image, tool, range, and host leaves, or declare a degradation."""
         snapshot = self._snapshot
         if snapshot is None:
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.UNAVAILABLE,
-                detail="source not present",
-            )
+            raise _degraded.absent()
 
         containers = tuple(getattr(snapshot, "containers", ()) or ())
         # +3 for the tool-versions, range-snapshot, and host-facts leaves.
         if len(containers) + 3 > context.max_entries:
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.TRUNCATED,
-                detail="entry limit reached",
-            )
+            raise _degraded.entry_limit()
 
-        leaves: list[ProvenanceLeaf] = []
-        without_digest: list[str] = []
         try:
-            for container in containers:
-                name = validate_logical_id(str(getattr(container, "name", "")))
-                digest = str(getattr(container, "image_digest", "") or "")
-                if not digest:
-                    # Disclosed gap, not a tag substituted for an identity.
-                    without_digest.append(name)
-                    continue
-                leaves.append(
-                    ProvenanceLeaf(f"image/{name}", normalize_digest(digest))
-                )
-
+            leaves, without_digest = self._image_leaves(containers)
             versions = _tool_versions(snapshot)
             leaves.append(
                 ProvenanceLeaf("tool-versions", derive_identity(_DOMAIN, versions))
             )
-
-            range_identity = derive_identity(
-                _DOMAIN, _stable_range_projection(snapshot)
+            leaves.append(
+                ProvenanceLeaf(
+                    "range-snapshot",
+                    derive_identity(_DOMAIN, _stable_range_projection(snapshot)),
+                )
             )
-            leaves.append(ProvenanceLeaf("range-snapshot", range_identity))
-
             host_facts = _safe_host_facts(self._host_facts)
             leaves.append(
                 ProvenanceLeaf("host-facts", derive_identity(_DOMAIN, host_facts))
             )
-        except (ProvenanceIdentityError, TypeError, ValueError, AttributeError):
+            observation = digest_bytes(rfc8785.dumps(snapshot.to_dict()))
+        except (TypeError, ValueError, AttributeError) as exc:
             log.warning("run-provenance: range snapshot projection was rejected")
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.FAILED,
-                detail="owner reported failure",
-            )
-
+            raise _degraded.owner_failure() from exc
         if context.expired():
-            return ProvenanceResult(
-                provider_id=self.provider_id,
-                status=ProvenanceStatus.TIMED_OUT,
-                detail="deadline exceeded",
-            )
+            raise _degraded.deadline()
 
-        return ProvenanceResult(
-            provider_id=self.provider_id,
-            status=ProvenanceStatus.COLLECTED,
-            leaves=tuple(sorted(leaves)),
-            payload={
-                "tool_versions": versions,
-                "range_snapshot_identity": range_identity,
-                # The owner's full redacted projection, kept as an OBSERVATION
-                # only: it is deliberately outside every identity above.
-                "range_snapshot_observation": digest_bytes(
-                    rfc8785.dumps(snapshot.to_dict())
-                ),
-                "container_count": len(containers),
-                "images_without_digest": sorted(without_digest),
-                "host_facts": host_facts,
-            },
-        )
+        payload: dict[str, object] = {
+            "tool_versions": versions,
+            "range_snapshot_identity": next(
+                leaf.digest for leaf in leaves if leaf.logical_id == "range-snapshot"
+            ),
+            # The owner's full redacted projection, kept as an OBSERVATION
+            # only: it is deliberately outside every identity above.
+            "range_snapshot_observation": observation,
+            "container_count": len(containers),
+            "images_without_digest": sorted(without_digest),
+            "host_facts": host_facts,
+        }
+        return tuple(sorted(leaves)), payload
+
+    @staticmethod
+    def _image_leaves(containers: tuple[object, ...]) -> tuple[list[ProvenanceLeaf], list[str]]:
+        """Return the image-digest leaves and the containers that had none."""
+        leaves: list[ProvenanceLeaf] = []
+        without_digest: list[str] = []
+        for container in containers:
+            name = validate_logical_id(str(getattr(container, "name", "")))
+            digest = str(getattr(container, "image_digest", "") or "")
+            if digest:
+                leaves.append(ProvenanceLeaf(f"image/{name}", normalize_digest(digest)))
+            else:
+                # Disclosed gap, not a tag substituted for an identity.
+                without_digest.append(name)
+        return leaves, without_digest

--- a/src/aptl/core/provenance/providers/runtime_facts.py
+++ b/src/aptl/core/provenance/providers/runtime_facts.py
@@ -1,0 +1,264 @@
+"""Realized image, tool, and range-inventory provenance (REP-003 / issue #452).
+
+Reads the APTL :class:`~aptl.core.snapshot.RangeSnapshot` the deployment owner
+already captured — this provider never calls Docker, Compose, SSH, or a shell,
+and never re-inspects the range.
+
+Two distinctions from the preflight are enforced here:
+
+* **Identity versus observation.** An image's immutable digest is identity; its
+  tag, container id, status, and health are observations that must not perturb
+  a stable identity. A container whose immutable digest is missing is declared
+  in ``images_without_digest`` rather than having a tag substituted for it —
+  ``ContainerSnapshot.image_digest`` is not currently proven to be populated
+  everywhere, and a guessed identity is worse than a disclosed gap.
+* **Bounded projection.** Container labels and arbitrary metadata are NOT
+  embedded. A hostile or oversized label set would otherwise become record
+  keys and unbounded content; only the range snapshot's own redacted
+  projection is folded into a single identity.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+
+import rfc8785
+
+from aptl.core.provenance.identity import (
+    ProvenanceIdentityError,
+    ProvenanceLeaf,
+    derive_identity,
+    digest_bytes,
+    normalize_digest,
+    validate_logical_id,
+)
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+
+log = logging.getLogger(__name__)
+
+#: The code-owned provider id for realized runtime facts.
+RUNTIME_PROVIDER_ID = "runtime-facts"
+
+#: Identity domain for runtime facts.
+_DOMAIN = "runtime"
+
+#: The tool versions the snapshot owner exposes, as (record key, attribute).
+_TOOL_FIELDS = (
+    ("python", "python_version"),
+    ("docker", "docker_version"),
+    ("compose", "compose_version"),
+    ("wazuh_manager", "wazuh_manager_version"),
+    ("wazuh_indexer", "wazuh_indexer_version"),
+    ("aptl", "aptl_version"),
+    ("raes", "raes_version"),
+)
+
+
+#: The CLOSED allowlist of host/runtime facts that are relevant to validity.
+#: This is not an inventory dump: hostname, user, network addresses, hardware,
+#: process lists, and environment are all deliberately outside it.
+_HOST_FACT_KEYS = frozenset({"os", "arch", "kernel", "python", "docker_mode"})
+
+#: Bound on any single host-fact value, so a probe cannot inject unbounded
+#: content into the record.
+_MAX_HOST_FACT_LEN = 128
+
+
+def default_host_facts() -> dict[str, str]:
+    """Return the bounded, validity-relevant host facts.
+
+    Reuses the existing host-environment owner rather than probing directly:
+    :func:`aptl.core.hostenv.host_os` and
+    :func:`aptl.core.hostenv.docker_mode` already own those determinations.
+
+    ``docker_mode()`` spawns a real ``docker info`` subprocess, so this is the
+    only I/O this provider performs. It is therefore NOT the constructor
+    default — see :func:`no_host_facts`.
+    """
+    import platform
+
+    from aptl.core.hostenv import docker_mode, host_os
+
+    return {
+        "os": host_os(),
+        "arch": platform.machine(),
+        "kernel": platform.release(),
+        "python": platform.python_version(),
+        "docker_mode": docker_mode(),
+    }
+
+
+def no_host_facts() -> dict[str, str]:
+    """Return no host facts. The constructor default.
+
+    Host inventory is the one source in this provider that costs a subprocess
+    probe, so *composing* it is an explicit decision made once in
+    :func:`aptl.core.provenance.registrations.build_default_providers`, not a
+    hidden default that every construction silently inherits.
+
+    Making the live probe the default meant any caller — including every test
+    that only cared about image digests — transparently spawned
+    ``docker info``, making behavior depend on whether a Docker daemon was
+    installed, running, and responsive, and paying up to a 15-second stall
+    against a hung daemon. That contradicted this module's own rule that a
+    provider receives narrow owner inputs rather than reaching for the
+    environment.
+    """
+    return {}
+
+
+def _safe_host_facts(probe: Callable[[], Mapping[str, object]]) -> dict[str, str]:
+    """Return the allowlisted, bounded facts from ``probe``, or ``{}``.
+
+    Filtering to :data:`_HOST_FACT_KEYS` here — rather than trusting whatever
+    the probe returns — is what keeps the record from widening into a host
+    inventory if a future owner starts reporting more. A failing probe yields
+    no facts rather than failing the whole provider: host detail is context,
+    not the apparatus identity itself.
+    """
+    try:
+        raw = probe()
+    except Exception:
+        log.warning("run-provenance: host fact probe failed")
+        return {}
+    facts: dict[str, str] = {}
+    for key, value in dict(raw).items():
+        if key not in _HOST_FACT_KEYS:
+            continue
+        if not isinstance(value, str) or len(value) > _MAX_HOST_FACT_LEN:
+            return {}
+        facts[key] = value
+    return facts
+
+
+def _stable_range_projection(snapshot: object) -> dict[str, object]:
+    """Return the range's STABLE apparatus facts, excluding observation state.
+
+    ``RangeSnapshot.to_dict()`` is the owner's redacted projection, but it is
+    an observation: it carries the capture timestamp and each container's
+    status, health, and runtime id. Hashing it wholesale made two runs of an
+    identical apparatus produce different identities — the exact drift the
+    identity/observation boundary exists to prevent.
+
+    What remains here is what actually identifies the realized range: the
+    container set and each container's immutable image digest. The volatile
+    projection is still recorded, as a non-identity observation.
+    """
+    containers = tuple(getattr(snapshot, "containers", ()) or ())
+    return {
+        "containers": sorted(
+            {
+                "name": str(getattr(container, "name", "")),
+                "image_digest": str(getattr(container, "image_digest", "") or ""),
+            }
+            for container in containers
+        )
+    }
+
+
+def _tool_versions(snapshot: object) -> dict[str, str]:
+    """Return the recorded tool/collector versions from the snapshot owner."""
+    software = getattr(snapshot, "software", None)
+    if software is None:
+        return {}
+    return {
+        key: value
+        for key, attribute in _TOOL_FIELDS
+        if isinstance(value := getattr(software, attribute, ""), str) and value
+    }
+
+
+class RuntimeFactsProvider:
+    """Collects immutable image identities, tool versions, and range identity."""
+
+    provider_id = RUNTIME_PROVIDER_ID
+
+    def __init__(
+        self,
+        snapshot: object | None,
+        host_facts: Callable[[], Mapping[str, object]] = no_host_facts,
+    ):
+        self._snapshot = snapshot
+        self._host_facts = host_facts
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        """Project the captured range snapshot into leaves and observations."""
+        snapshot = self._snapshot
+        if snapshot is None:
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.UNAVAILABLE,
+                detail="source not present",
+            )
+
+        containers = tuple(getattr(snapshot, "containers", ()) or ())
+        # +3 for the tool-versions, range-snapshot, and host-facts leaves.
+        if len(containers) + 3 > context.max_entries:
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.TRUNCATED,
+                detail="entry limit reached",
+            )
+
+        leaves: list[ProvenanceLeaf] = []
+        without_digest: list[str] = []
+        try:
+            for container in containers:
+                name = validate_logical_id(str(getattr(container, "name", "")))
+                digest = str(getattr(container, "image_digest", "") or "")
+                if not digest:
+                    # Disclosed gap, not a tag substituted for an identity.
+                    without_digest.append(name)
+                    continue
+                leaves.append(
+                    ProvenanceLeaf(f"image/{name}", normalize_digest(digest))
+                )
+
+            versions = _tool_versions(snapshot)
+            leaves.append(
+                ProvenanceLeaf("tool-versions", derive_identity(_DOMAIN, versions))
+            )
+
+            range_identity = derive_identity(
+                _DOMAIN, _stable_range_projection(snapshot)
+            )
+            leaves.append(ProvenanceLeaf("range-snapshot", range_identity))
+
+            host_facts = _safe_host_facts(self._host_facts)
+            leaves.append(
+                ProvenanceLeaf("host-facts", derive_identity(_DOMAIN, host_facts))
+            )
+        except (ProvenanceIdentityError, TypeError, ValueError, AttributeError):
+            log.warning("run-provenance: range snapshot projection was rejected")
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.FAILED,
+                detail="owner reported failure",
+            )
+
+        if context.expired():
+            return ProvenanceResult(
+                provider_id=self.provider_id,
+                status=ProvenanceStatus.TIMED_OUT,
+                detail="deadline exceeded",
+            )
+
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=tuple(sorted(leaves)),
+            payload={
+                "tool_versions": versions,
+                "range_snapshot_identity": range_identity,
+                # The owner's full redacted projection, kept as an OBSERVATION
+                # only: it is deliberately outside every identity above.
+                "range_snapshot_observation": digest_bytes(
+                    rfc8785.dumps(snapshot.to_dict())
+                ),
+                "container_count": len(containers),
+                "images_without_digest": sorted(without_digest),
+                "host_facts": host_facts,
+            },
+        )

--- a/src/aptl/core/provenance/record.py
+++ b/src/aptl/core/provenance/record.py
@@ -1,0 +1,133 @@
+"""The run provenance records (REP-003 / issue #452).
+
+Two deliberately distinct artifacts, because they answer at different
+lifecycle boundaries:
+
+* **Ready-to-seal** (:data:`PROVENANCE_RECORD_PATH`) — the canonical record,
+  published by whoever owns the ADMITTED and EXECUTED run context. Writing it
+  requires that context to be present; a collection with no admitted plan is
+  refused rather than mislabelled.
+* **Provisional** (:data:`PROVISIONAL_RECORD_PATH`) — what lab startup can
+  honestly produce. Startup has configuration and a range snapshot but no
+  admitted trial plan, no realized participants, and no execution outcome.
+
+Keeping them apart is load-bearing rather than cosmetic. Publication is
+create-once: if startup wrote the canonical path with experiment and
+participant provenance missing, the real seal-boundary collector could never
+publish the complete record — its write would hit the deliberate content
+conflict and fail. The provisional artifact therefore lives at its own path and
+declares its own seal state, leaving the canonical path free for the authority
+that can fill it.
+
+Both records are published through
+:func:`aptl.core.evidence.content_store.create_run_json_once`: RFC 8785
+canonical, descriptor-relative, no-follow, with the run store's secret
+invariant applied to the whole payload. Neither is a seal — issue #444 owns
+signing and the sealed archive state, and issue #472 owns which limitations
+are fatal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aptl.core.evidence.content_store import create_run_json_once
+from aptl.core.provenance.coordinator import ProvenanceCollection
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.runstore import LocalRunStore
+
+#: Versioned identity of the record shape itself.
+RECORD_SCHEMA_VERSION = "aptl.run-provenance/v1"
+
+#: Run-relative path of the canonical ready-to-seal record.
+PROVENANCE_RECORD_PATH = "provenance/run-provenance.json"
+
+#: Run-relative path of the provisional startup record.
+PROVISIONAL_RECORD_PATH = "provenance/startup-provenance.json"
+
+#: What the canonical record claims to be. Deliberately not "sealed":
+#: signing, attestation, and the sealed archive state belong to issue #444.
+SEAL_STATE_READY = "ready-to-seal"
+
+#: What the startup record claims to be.
+SEAL_STATE_PROVISIONAL = "provisional"
+
+#: The provider whose presence proves the authoritative run context was
+#: available. Without an admitted plan there is no planned-trial identity, no
+#: scenario snapshot digest, and no capture bindings.
+_AUTHORITATIVE_PROVIDER_ID = "experiment"
+
+
+class ProvenanceContextError(RuntimeError):
+    """Raised when the canonical record is published without authoritative context."""
+
+
+def build_provenance_record(
+    *,
+    run_id: str,
+    collection: ProvenanceCollection,
+    seal_state: str = SEAL_STATE_READY,
+) -> dict[str, object]:
+    """Return the canonical provenance record for ``run_id``.
+
+    Carries no wall-clock timestamp: a collection time would change on every
+    run and make an otherwise-unchanged apparatus look different, which is the
+    identity drift the requirement's stability criterion prohibits. Run timing
+    already lives in the run archive's own records.
+    """
+    projection = collection.projection()
+    return {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "run_id": run_id,
+        "seal_state": seal_state,
+        "aggregate_identity": collection.aggregate_identity,
+        "registry_declaration_digest": collection.registry_declaration_digest,
+        "sections": projection["sections"],
+        "limitations": projection["limitations"],
+    }
+
+
+def _has_authoritative_context(collection: ProvenanceCollection) -> bool:
+    """Return whether the collection carries admitted run context."""
+    section = collection.sections.get(_AUTHORITATIVE_PROVIDER_ID)
+    return section is not None and section.status is ProvenanceStatus.COLLECTED
+
+
+def publish_provenance_record(
+    *, store: LocalRunStore, run_id: str, collection: ProvenanceCollection
+) -> Path:
+    """Publish the canonical ready-to-seal record create-once.
+
+    Refuses a collection without admitted run context: publishing a record
+    that reports the experiment and participant apparatus as unavailable, then
+    labelling it ready-to-seal, would both misdescribe the run and permanently
+    occupy the path the authoritative collector needs.
+
+    Raises :class:`ProvenanceContextError` when that context is absent,
+    :class:`~aptl.core.runstore.RunStoreConflictError` when a record already
+    exists with different canonical bytes, and
+    :class:`~aptl.core.runstore.SecretInvariantError` when the shared
+    redaction policy would alter the payload.
+    """
+    if not _has_authoritative_context(collection):
+        raise ProvenanceContextError(
+            "the ready-to-seal provenance record requires admitted run context; "
+            "publish the provisional record instead"
+        )
+    record = build_provenance_record(run_id=run_id, collection=collection)
+    return create_run_json_once(store, run_id, PROVENANCE_RECORD_PATH, record)
+
+
+def publish_provisional_provenance_record(
+    *, store: LocalRunStore, run_id: str, collection: ProvenanceCollection
+) -> Path:
+    """Publish the provisional startup record create-once at its own path.
+
+    Records what startup can honestly observe — apparatus manifests, effective
+    configuration, detection content, dependency locks, realized images —
+    without claiming the experiment context it does not have.
+    """
+    record = build_provenance_record(
+        run_id=run_id, collection=collection, seal_state=SEAL_STATE_PROVISIONAL
+    )
+    return create_run_json_once(store, run_id, PROVISIONAL_RECORD_PATH, record)

--- a/src/aptl/core/provenance/registrations.py
+++ b/src/aptl/core/provenance/registrations.py
@@ -1,0 +1,217 @@
+"""The trusted built-in provenance fleet (REP-003 / issue #452).
+
+Holds the declaration DATA for every built-in provider plus the composition
+that binds each declaration to its narrow owner adapter. Keeping the data here
+— beside, not inside, :mod:`aptl.core.provenance.registry` — mirrors how
+``capture_registrations`` relates to ``capture_registry`` and keeps the type
+module free of owner imports.
+
+Every built-in is policy-required in the default profile. That is deliberate:
+requiring a provider does not assert it must succeed, it asserts that its
+outcome must be STATED. A plain ``aptl lab start`` has no admitted experiment
+plan and no installed participants, so those two providers report
+``UNAVAILABLE`` and appear as declared limitations — which is the honest
+record, and exactly what "missing/denied provenance is explicit" requires.
+Whether any such limitation blocks a run is issue #472's readiness policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from aptl.core.provenance.coordinator import ProvenanceCollection, collect_provenance
+from aptl.core.provenance.protocol import MonotonicClock, ProvenanceProvider
+from aptl.core.provenance.providers.apparatus import (
+    APPARATUS_PROVIDER_ID,
+    ApparatusManifestProvider,
+)
+from aptl.core.provenance.providers.artifacts import (
+    ARTIFACTS_PROVIDER_ID,
+    DependencyArtifactProvider,
+)
+from aptl.core.provenance.providers.config_identity import (
+    CONFIG_PROVIDER_ID,
+    ConfigIdentityProvider,
+)
+from aptl.core.provenance.providers.detection import (
+    DETECTION_PROVIDER_ID,
+    DetectionContentProvider,
+)
+from aptl.core.provenance.providers.experiment import (
+    EXPERIMENT_PROVIDER_ID,
+    AdmittedExperimentProvider,
+)
+from aptl.core.provenance.providers.participant import (
+    PARTICIPANT_PROVIDER_ID,
+    ParticipantApparatusProvider,
+)
+from aptl.core.provenance.providers.runtime_facts import (
+    RUNTIME_PROVIDER_ID,
+    RuntimeFactsProvider,
+    default_host_facts,
+)
+from aptl.core.provenance.registry import (
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    ProvenanceProviderRegistry,
+    SealPoint,
+    SealProfile,
+)
+
+log = logging.getLogger(__name__)
+
+#: Bumped whenever a built-in provider's collection behavior changes in a way
+#: that could alter what it reports for identical inputs.
+_IMPLEMENTATION_VERSION = "1.0.0"
+
+
+def _registration(
+    provider_id: str,
+    provenance_kind: str,
+    owner_adapter: str,
+    *,
+    max_bytes: int,
+    max_entries: int,
+    timeout_s: int,
+) -> ProvenanceProviderRegistration:
+    """Build one built-in registration with its declared bounds."""
+    return ProvenanceProviderRegistration(
+        provider_id=provider_id,
+        implementation_version=_IMPLEMENTATION_VERSION,
+        provenance_kind=provenance_kind,
+        owner_adapter=owner_adapter,
+        seal_point=SealPoint.RUN_READY_TO_SEAL,
+        requiredness_policy_key=f"{provider_id}-required",
+        limits=ProvenanceLimits(
+            max_bytes=max_bytes, max_entries=max_entries, timeout_s=timeout_s
+        ),
+    )
+
+
+#: The declared built-in fleet. Limits are sized to the real surfaces: the
+#: detection roots hold on the order of a dozen small text artifacts, while a
+#: trial plan can carry many planned trials.
+BUILTIN_REGISTRATIONS: tuple[ProvenanceProviderRegistration, ...] = (
+    _registration(
+        APPARATUS_PROVIDER_ID,
+        "apparatus-manifest",
+        "raes_manifest/raes_processor",
+        max_bytes=4_000_000,
+        max_entries=8,
+        timeout_s=30,
+    ),
+    _registration(
+        EXPERIMENT_PROVIDER_ID,
+        "admitted-experiment",
+        "experiment.trial_plan",
+        max_bytes=4_000_000,
+        max_entries=1024,
+        timeout_s=30,
+    ),
+    _registration(
+        PARTICIPANT_PROVIDER_ID,
+        "participant-apparatus",
+        "raes_participant_apparatus",
+        max_bytes=1_000_000,
+        max_entries=64,
+        timeout_s=30,
+    ),
+    _registration(
+        DETECTION_PROVIDER_ID,
+        "detection-content",
+        "provenance.providers.detection",
+        max_bytes=64_000_000,
+        max_entries=1024,
+        timeout_s=60,
+    ),
+    _registration(
+        CONFIG_PROVIDER_ID,
+        "effective-config",
+        "core.config",
+        max_bytes=1_000_000,
+        max_entries=8,
+        timeout_s=15,
+    ),
+    _registration(
+        RUNTIME_PROVIDER_ID,
+        "runtime-facts",
+        "core.snapshot",
+        max_bytes=8_000_000,
+        max_entries=256,
+        timeout_s=30,
+    ),
+    _registration(
+        ARTIFACTS_PROVIDER_ID,
+        "dependency-artifacts",
+        "provenance.providers.artifacts",
+        max_bytes=32_000_000,
+        max_entries=128,
+        timeout_s=30,
+    ),
+)
+
+#: The production registry.
+DEFAULT_PROVENANCE_REGISTRY = ProvenanceProviderRegistry(BUILTIN_REGISTRATIONS)
+
+#: The default run-scoped seal profile: every built-in outcome must be stated.
+DEFAULT_SEAL_PROFILE = SealProfile(
+    seal_point=SealPoint.RUN_READY_TO_SEAL,
+    required_provider_ids=frozenset(
+        item.provider_id for item in BUILTIN_REGISTRATIONS
+    ),
+)
+
+
+def build_default_providers(
+    *,
+    project_dir: Path | str,
+    config: object | None,
+    snapshot: object | None,
+    admitted_plan: object | None = None,
+    participant_apparatus: Mapping[str, object] | None = None,
+) -> tuple[ProvenanceProvider, ...]:
+    """Compose the trusted fleet, binding each provider to its owner input.
+
+    Owner inputs are passed in already-resolved. Nothing here discovers a run,
+    reopens a scenario, or reaches for a backend, an environment, or a shell.
+    """
+    return (
+        ApparatusManifestProvider(),
+        AdmittedExperimentProvider(admitted_plan),
+        ParticipantApparatusProvider(participant_apparatus or {}),
+        DetectionContentProvider(Path(project_dir)),
+        ConfigIdentityProvider(config),
+        # The live host probe is composed HERE, explicitly. It is the only
+        # subprocess this fleet runs, so it is a composition decision rather
+        # than a constructor default every caller inherits.
+        RuntimeFactsProvider(snapshot, host_facts=default_host_facts),
+        DependencyArtifactProvider(Path(project_dir)),
+    )
+
+
+def collect_run_provenance(
+    *,
+    project_dir: Path | str,
+    config: object | None,
+    snapshot: object | None,
+    admitted_plan: object | None = None,
+    participant_apparatus: Mapping[str, object] | None = None,
+    monotonic: MonotonicClock = time.monotonic,
+) -> ProvenanceCollection:
+    """Collect run-scoped provenance from the default fleet."""
+    providers: Sequence[ProvenanceProvider] = build_default_providers(
+        project_dir=project_dir,
+        config=config,
+        snapshot=snapshot,
+        admitted_plan=admitted_plan,
+        participant_apparatus=participant_apparatus,
+    )
+    return collect_provenance(
+        providers=providers,
+        registry=DEFAULT_PROVENANCE_REGISTRY,
+        profile=DEFAULT_SEAL_PROFILE,
+        monotonic=monotonic,
+    )

--- a/src/aptl/core/provenance/registrations.py
+++ b/src/aptl/core/provenance/registrations.py
@@ -91,6 +91,18 @@ def _registration(
     )
 
 
+#: The detection-content registration, named so callers that need only this
+#: provider's declared limits (for example the snapshot adapter) can reference
+#: it directly instead of looking it up and handling an impossible miss.
+DETECTION_REGISTRATION = _registration(
+    DETECTION_PROVIDER_ID,
+    "detection-content",
+    "provenance.providers.detection",
+    max_bytes=64_000_000,
+    max_entries=1024,
+    timeout_s=60,
+)
+
 #: The declared built-in fleet. Limits are sized to the real surfaces: the
 #: detection roots hold on the order of a dozen small text artifacts, while a
 #: trial plan can carry many planned trials.
@@ -119,14 +131,7 @@ BUILTIN_REGISTRATIONS: tuple[ProvenanceProviderRegistration, ...] = (
         max_entries=64,
         timeout_s=30,
     ),
-    _registration(
-        DETECTION_PROVIDER_ID,
-        "detection-content",
-        "provenance.providers.detection",
-        max_bytes=64_000_000,
-        max_entries=1024,
-        timeout_s=60,
-    ),
+    DETECTION_REGISTRATION,
     _registration(
         CONFIG_PROVIDER_ID,
         "effective-config",

--- a/src/aptl/core/provenance/registry.py
+++ b/src/aptl/core/provenance/registry.py
@@ -1,0 +1,220 @@
+"""The code-owned provenance provider registry (REP-003 / issue #452).
+
+This is the narrow, trusted capability-declaration seam the preflight
+requires: one internal coordinator over code-owned registrations, NOT one
+monolithic collector and NOT a general plugin framework.
+
+A registration pins a stable provider id, implementation version, the
+capability/source it supplies, the owner adapter it needs, its applicable seal
+point, its requiredness policy key, and hard count/byte/time limits. The id is
+a non-executable slug — never an import path, command, URL, host path,
+credential selector, or user-controlled factory — so nothing in a record or a
+policy file can steer collection at code.
+
+The declaration pattern deliberately mirrors the incumbent
+:class:`aptl.core.experiment.capture_registry.CollectorRegistration`:
+``declaration_projection()`` emits canonical-JSON-ready data with sets sorted,
+and ``effective_config_digest()`` pins the exact capability version a run
+collected under, so a later reader can tell that a provider's declaration
+changed.
+
+The extension parameter is this registration set plus a :class:`SealProfile`
+(seal point and policy-required provider ids). Adding the next built-in source
+costs one registration, one narrow owner adapter, and its tests — no edit to
+the aggregate record builder, run controller, RAES DTOs, storage layout, or
+exporter. Dynamic imports and out-of-process third-party providers need a
+separate authorization and sandboxing design and are out of scope here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from enum import Enum
+
+from aptl.core.provenance.identity import derive_identity
+from aptl.core.provenance.outcomes import ProvenanceOutcomeError, validate_provider_id
+
+#: Versioned identity of the registration declaration shape itself. A change to
+#: which fields a declaration carries, or how its digest is computed, bumps
+#: this so a persisted record states which registry shape produced it.
+REGISTRY_SCHEMA_VERSION = "aptl-provenance-registry/v1"
+
+#: Identity domain for a registration declaration.
+_REGISTRATION_DOMAIN = "provider"
+
+#: Identity domain for the aggregate registry declaration.
+_REGISTRY_DOMAIN = "registry"
+
+
+class ProvenanceRegistrationError(ValueError):
+    """Raised when a registration, registry, or seal profile is not admissible."""
+
+
+class SealPoint(str, Enum):
+    """The boundary at which a provider's source is meaningful.
+
+    Both members describe *ready-to-seal* collection. Issue #444 owns the
+    actual seal; nothing here claims a run is sealed.
+    """
+
+    #: Facts about the run as a whole (apparatus, config identity, images).
+    RUN_READY_TO_SEAL = "run-ready-to-seal"
+    #: Facts scoped to one planned trial (scenario snapshot, capture bindings).
+    TRIAL_READY_TO_SEAL = "trial-ready-to-seal"
+
+
+@dataclass(frozen=True)
+class ProvenanceLimits:
+    """The hard bounds one provider is admitted under.
+
+    The coordinator enforces these while collecting, so a pathological or
+    hostile source cannot turn provenance into unbounded memory use or an
+    unbounded stall.
+    """
+
+    max_bytes: int
+    max_entries: int
+    timeout_s: int
+
+
+@dataclass(frozen=True)
+class ProvenanceProviderRegistration:
+    """One trusted, code-owned provider's static capability declaration.
+
+    This is the whole capability surface the coordinator and the seal profile
+    read. It carries NO factory, import path, or executable reference — the
+    trusted adapter wiring is composed separately, exactly as the incumbent
+    capture registry composes its collectors.
+    """
+
+    provider_id: str
+    implementation_version: str
+    provenance_kind: str
+    owner_adapter: str
+    seal_point: SealPoint
+    requiredness_policy_key: str
+    limits: ProvenanceLimits
+
+    def __post_init__(self) -> None:
+        """Validate the id is a safe slug and every declared limit is positive."""
+        try:
+            validate_provider_id(self.provider_id)
+        except ProvenanceOutcomeError as exc:
+            raise ProvenanceRegistrationError(str(exc)) from exc
+        if not self.implementation_version or not self.provenance_kind:
+            raise ProvenanceRegistrationError(
+                "a registration must declare an implementation version and provenance kind"
+            )
+        limits = self.limits
+        if limits.max_bytes <= 0 or limits.max_entries <= 0 or limits.timeout_s <= 0:
+            raise ProvenanceRegistrationError("provenance limits must all be positive")
+
+    def declaration_projection(self) -> dict[str, object]:
+        """Return the canonical-JSON-ready projection of this declaration."""
+        return {
+            "registry_schema": REGISTRY_SCHEMA_VERSION,
+            "provider_id": self.provider_id,
+            "implementation_version": self.implementation_version,
+            "provenance_kind": self.provenance_kind,
+            "owner_adapter": self.owner_adapter,
+            "seal_point": self.seal_point.value,
+            "requiredness_policy_key": self.requiredness_policy_key,
+            "max_bytes": self.limits.max_bytes,
+            "max_entries": self.limits.max_entries,
+            "timeout_s": self.limits.timeout_s,
+        }
+
+    def effective_config_digest(self) -> str:
+        """Return the domain-separated canonical digest of this declaration."""
+        return derive_identity(_REGISTRATION_DOMAIN, self.declaration_projection())
+
+
+@dataclass(frozen=True)
+class ProvenanceProviderRegistry:
+    """An immutable set of trusted provider registrations, keyed by id."""
+
+    registrations: tuple[ProvenanceProviderRegistration, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Reject duplicate provider ids at construction."""
+        ids = [registration.provider_id for registration in self.registrations]
+        if len(set(ids)) != len(ids):
+            raise ProvenanceRegistrationError(
+                "ProvenanceProviderRegistry contains duplicate provider IDs"
+            )
+
+    def ordered(self) -> tuple[ProvenanceProviderRegistration, ...]:
+        """Return registrations in deterministic id-sorted order.
+
+        Collection order must never affect a computed identity, so the
+        coordinator always walks this ordering rather than construction order.
+        """
+        return tuple(sorted(self.registrations, key=lambda item: item.provider_id))
+
+    def get(self, provider_id: str) -> ProvenanceProviderRegistration | None:
+        """Return the registration for ``provider_id``, or ``None``."""
+        for registration in self.registrations:
+            if registration.provider_id == provider_id:
+                return registration
+        return None
+
+    def for_seal_point(self, seal_point: SealPoint) -> tuple[ProvenanceProviderRegistration, ...]:
+        """Return the id-sorted registrations applicable at ``seal_point``."""
+        return tuple(item for item in self.ordered() if item.seal_point is seal_point)
+
+    def declaration_digest(self) -> str:
+        """Return the aggregate canonical digest of every registration declaration."""
+        return derive_identity(
+            _REGISTRY_DOMAIN,
+            {"registrations": [item.declaration_projection() for item in self.ordered()]},
+        )
+
+
+@dataclass(frozen=True)
+class SealProfile:
+    """The seal point plus the provider ids a policy requires there.
+
+    This is the extension parameter for the seam. REP-003 validates that a
+    required provider actually exists and reports its outcome; deciding which
+    outcomes are fatal belongs to the readiness policy in issue #472.
+    """
+
+    seal_point: SealPoint
+    required_provider_ids: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        """Reject a hostile required id before it can reach a lookup or a record."""
+        for provider_id in self.required_provider_ids:
+            try:
+                validate_provider_id(provider_id)
+            except ProvenanceOutcomeError as exc:
+                raise ProvenanceRegistrationError(str(exc)) from exc
+
+    def requires(self, provider_id: str) -> bool:
+        """Return whether ``provider_id`` is policy-required at this seal point."""
+        return provider_id in self.required_provider_ids
+
+    def validate_against(self, registry: ProvenanceProviderRegistry) -> None:
+        """Raise when a required provider id has no registration.
+
+        Fails closed: a policy that names a provider nobody implements would
+        otherwise silently report ready-to-seal with that source missing.
+        """
+        missing = sorted(
+            provider_id
+            for provider_id in self.required_provider_ids
+            if registry.get(provider_id) is None
+        )
+        if missing:
+            raise ProvenanceRegistrationError(
+                "seal profile requires provider IDs that are not registered"
+            )
+
+
+def build_registry(
+    registrations: Iterable[ProvenanceProviderRegistration],
+) -> ProvenanceProviderRegistry:
+    """Return an immutable registry over ``registrations``."""
+    items: Sequence[ProvenanceProviderRegistration] = tuple(registrations)
+    return ProvenanceProviderRegistry(tuple(items))

--- a/src/aptl/core/provenance/registry.py
+++ b/src/aptl/core/provenance/registry.py
@@ -28,7 +28,7 @@ separate authorization and sandboxing design and are out of scope here.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 
@@ -216,5 +216,4 @@ def build_registry(
     registrations: Iterable[ProvenanceProviderRegistration],
 ) -> ProvenanceProviderRegistry:
     """Return an immutable registry over ``registrations``."""
-    items: Sequence[ProvenanceProviderRegistration] = tuple(registrations)
-    return ProvenanceProviderRegistry(tuple(items))
+    return ProvenanceProviderRegistry(tuple(registrations))

--- a/src/aptl/core/snapshot.py
+++ b/src/aptl/core/snapshot.py
@@ -14,6 +14,7 @@ the remote daemon and behave identically to local Docker Compose.
 
 import hashlib
 import sys
+import time
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -367,13 +368,24 @@ def _get_network_snapshots(
 
 
 def _hash_config_files(config_dir: Path | None = None) -> dict[str, str]:
-    """Compute SHA-256 hashes for config files in the project."""
+    """Compute SHA-256 hashes for non-secret config files in the project.
+
+    ``.env`` is deliberately absent (REP-003 / issue #452). It holds
+    control-plane secrets, and a digest is not safe disclosure for a
+    secret-bearing file — the values it contains have a small guessable
+    domain, so a hash is a confirmation oracle rather than an opaque
+    identity. ADR-029 permits the record to store non-secret identities;
+    apparatus-relevant configuration identity comes from the explicit safe
+    projection in
+    :func:`aptl.core.provenance.providers.config_identity.safe_config_projection`,
+    not from hashing whole files.
+    """
     hashes = {}
 
     if config_dir is None:
         config_dir = Path(".")
 
-    patterns = ["aptl.json", "docker-compose*.yml", "docker-compose*.yaml", ".env"]
+    patterns = ["aptl.json", "docker-compose*.yml", "docker-compose*.yaml"]
     for pattern in patterns:
         for f in sorted(config_dir.glob(pattern)):
             if f.is_file():
@@ -384,27 +396,44 @@ def _hash_config_files(config_dir: Path | None = None) -> dict[str, str]:
 
 
 def detection_content_digest(project_dir: Path) -> str:
-    """Compute a combined sha256 digest of detection content under project_dir.
+    """Return the framed sha256 identity of detection content under project_dir.
 
-    Hashes Suricata custom rules and Wazuh custom rules found under the
-    project directory. Returns an empty string when no detection files are
-    found (empty-safe). Reuses the same file-glob/hash pattern as
-    :func:`_hash_config_files`.
+    Thin adapter over the single detection-content owner,
+    :class:`~aptl.core.provenance.providers.detection.DetectionContentProvider`
+    (REP-003 / issue #452), so there is exactly one implementation of
+    detection-content identity rather than a second hashing path here.
+
+    The previous implementation had four defects this delegation removes: it
+    concatenated file bytes unframed (so ``"ab" + "c"`` and ``"a" + "bc"``
+    collided); it globbed ``config/wazuh/etc/rules`` and
+    ``config/wazuh/etc/decoders``, neither of which exists — the real Wazuh
+    rule/decoder/allowlist surface is ``config/wazuh_cluster``; it was
+    non-recursive, missing ``config/suricata/rules/misp``; and it read through
+    ``glob()``/``read_bytes()``, following symlinks. In practice it covered a
+    single file.
+
+    The empty-string-when-absent and bare-hex return shape is preserved for
+    the existing REP-001 record field; richer per-artifact leaves and explicit
+    limitations live in the run provenance record.
     """
-    patterns = [
-        "config/suricata/rules/*.rules",
-        "config/suricata/rules/*.conf",
-        "config/wazuh/etc/rules/*.xml",
-        "config/wazuh/etc/decoders/*.xml",
-    ]
-    combined = hashlib.sha256()
-    found_any = False
-    for pattern in patterns:
-        for f in sorted(project_dir.glob(pattern)):
-            if f.is_file():
-                combined.update(f.read_bytes())
-                found_any = True
-    return combined.hexdigest() if found_any else ""
+    from aptl.core.provenance.identity import DIGEST_PREFIX, family_identity
+    from aptl.core.provenance.outcomes import ProvenanceStatus
+    from aptl.core.provenance.protocol import ProvenanceContext
+    from aptl.core.provenance.providers.detection import DetectionContentProvider
+    from aptl.core.provenance.registrations import DEFAULT_PROVENANCE_REGISTRY
+
+    registration = DEFAULT_PROVENANCE_REGISTRY.get("detection-content")
+    if registration is None:  # pragma: no cover - the built-in is always present
+        return ""
+    context = ProvenanceContext(
+        registration=registration, clock=time.monotonic, started_at=time.monotonic()
+    )
+    result = DetectionContentProvider(project_dir).collect(context)
+    if result.status is not ProvenanceStatus.COLLECTED or not result.leaves:
+        # Absent, denied, truncated, or timed-out content is not a digest. The
+        # run provenance record states which; this field stays empty-safe.
+        return ""
+    return family_identity("detection", result.leaves)[len(DIGEST_PREFIX) :]
 
 
 def capture_snapshot(

--- a/src/aptl/core/snapshot.py
+++ b/src/aptl/core/snapshot.py
@@ -420,13 +420,12 @@ def detection_content_digest(project_dir: Path) -> str:
     from aptl.core.provenance.outcomes import ProvenanceStatus
     from aptl.core.provenance.protocol import ProvenanceContext
     from aptl.core.provenance.providers.detection import DetectionContentProvider
-    from aptl.core.provenance.registrations import DEFAULT_PROVENANCE_REGISTRY
+    from aptl.core.provenance.registrations import DETECTION_REGISTRATION
 
-    registration = DEFAULT_PROVENANCE_REGISTRY.get("detection-content")
-    if registration is None:  # pragma: no cover - the built-in is always present
-        return ""
     context = ProvenanceContext(
-        registration=registration, clock=time.monotonic, started_at=time.monotonic()
+        registration=DETECTION_REGISTRATION,
+        clock=time.monotonic,
+        started_at=time.monotonic(),
     )
     result = DetectionContentProvider(project_dir).collect(context)
     if result.status is not ProvenanceStatus.COLLECTED or not result.leaves:

--- a/tests/test_provenance_apparatus.py
+++ b/tests/test_provenance_apparatus.py
@@ -1,0 +1,219 @@
+"""Tests for the REP-003 apparatus/experiment/participant providers (issue #452).
+
+These providers compose OWNER-NATIVE payloads: RAES manifest serializers and
+the admitted trial plan. They never restate a RAES DTO, reparse an authored
+artifact at seal time, or reconstruct an accepted selection from current
+configuration.
+"""
+
+import pytest
+
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.core.provenance.providers.apparatus import (
+    APPARATUS_PROVIDER_ID,
+    ApparatusManifestProvider,
+)
+from aptl.core.provenance.providers.experiment import (
+    EXPERIMENT_PROVIDER_ID,
+    AdmittedExperimentProvider,
+)
+from aptl.core.provenance.providers.participant import (
+    PARTICIPANT_PROVIDER_ID,
+    ParticipantApparatusProvider,
+)
+from aptl.core.provenance.registry import (
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    SealPoint,
+)
+
+
+def _context(provider_id, *, max_entries=64, timeout_s=30, clock=None):
+    registration = ProvenanceProviderRegistration(
+        provider_id=provider_id,
+        implementation_version="1.0.0",
+        provenance_kind=provider_id,
+        owner_adapter="tests",
+        seal_point=SealPoint.RUN_READY_TO_SEAL,
+        requiredness_policy_key=f"{provider_id}-required",
+        limits=ProvenanceLimits(
+            max_bytes=1_000_000, max_entries=max_entries, timeout_s=timeout_s
+        ),
+    )
+    return ProvenanceContext(
+        registration=registration, clock=clock or (lambda: 0.0), started_at=0.0
+    )
+
+
+class TestApparatusProvider:
+    """Backend + processor manifest identity comes from the owner serializers."""
+
+    def test_collects_backend_and_processor_identity(self):
+        result = ApparatusManifestProvider().collect(_context(APPARATUS_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.COLLECTED
+        names = {leaf.logical_id for leaf in result.leaves}
+        assert "backend-manifest" in names
+        assert "processor-manifest" in names
+
+    def test_payload_records_owner_declared_identity(self):
+        result = ApparatusManifestProvider().collect(_context(APPARATUS_PROVIDER_ID))
+        assert result.payload["backend"]["name"] == "aptl"
+        assert result.payload["processor"]["name"] == "raes-reference-processor"
+        assert result.payload["backend"]["schema_version"] == "backend-manifest/v2"
+        assert result.payload["processor"]["schema_version"] == "processor-manifest/v2"
+
+    def test_identity_is_stable_across_collections(self):
+        first = ApparatusManifestProvider().collect(_context(APPARATUS_PROVIDER_ID))
+        second = ApparatusManifestProvider().collect(_context(APPARATUS_PROVIDER_ID))
+        assert first.leaves == second.leaves
+
+    def test_declared_capability_contracts_are_recorded(self):
+        """Capability claims come from the registries that implement them."""
+        result = ApparatusManifestProvider().collect(_context(APPARATUS_PROVIDER_ID))
+        assert isinstance(result.payload["backend"]["supported_contract_versions"], list)
+
+    def test_a_failing_owner_serializer_is_reported_not_raised(self):
+        def broken():
+            raise RuntimeError("manifest unavailable")
+
+        provider = ApparatusManifestProvider(backend_manifest_factory=broken)
+        result = provider.collect(_context(APPARATUS_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.FAILED
+        assert result.leaves == ()
+
+
+class _StubTrial:
+    def __init__(self, trial_id, snapshot_digest="sha256:" + "a" * 64):
+        self.planned_trial_id = trial_id
+        self.scenario_snapshot_digest = snapshot_digest
+        self.condition_id = "baseline"
+        self.replication_ordinal = 0
+        self.capture_spec_refs = ("capture-1",)
+        self.stochastic_seeds = (("seed-a", "b" * 64),)
+
+
+class _StubPlan:
+    def __init__(self, trials=None, plan_id="plan-1"):
+        self.plan_id = plan_id
+        self.policy_version = "aptl-admission/v1"
+        self.source_set_digest = "sha256:" + "c" * 64
+        self.plan_digest = "sha256:" + "d" * 64
+        self.trials = tuple(trials or [_StubTrial("trial-1")])
+        self.capture_bindings = ()
+
+
+class TestExperimentProvider:
+    """Admitted identities are preserved, never recomputed from current files."""
+
+    def test_collects_plan_and_trial_identities(self):
+        result = AdmittedExperimentProvider(_StubPlan()).collect(
+            _context(EXPERIMENT_PROVIDER_ID)
+        )
+        assert result.status is ProvenanceStatus.COLLECTED
+        names = {leaf.logical_id for leaf in result.leaves}
+        assert "plan" in names
+        assert any(name.startswith("trial/") for name in names)
+
+    def test_payload_records_the_admitted_plan_identity(self):
+        plan = _StubPlan()
+        result = AdmittedExperimentProvider(plan).collect(_context(EXPERIMENT_PROVIDER_ID))
+        assert result.payload["plan_id"] == plan.plan_id
+        assert result.payload["plan_digest"] == plan.plan_digest
+        assert result.payload["source_set_digest"] == plan.source_set_digest
+        assert result.payload["trial_count"] == 1
+
+    def test_a_changed_scenario_snapshot_changes_only_that_trial_leaf(self):
+        before = AdmittedExperimentProvider(_StubPlan()).collect(
+            _context(EXPERIMENT_PROVIDER_ID)
+        )
+        changed = _StubPlan(trials=[_StubTrial("trial-1", "sha256:" + "e" * 64)])
+        after = AdmittedExperimentProvider(changed).collect(_context(EXPERIMENT_PROVIDER_ID))
+        before_ids = {leaf.logical_id: leaf.digest for leaf in before.leaves}
+        after_ids = {leaf.logical_id: leaf.digest for leaf in after.leaves}
+        assert before_ids["plan"] == after_ids["plan"]
+        assert before_ids["trial/trial-1"] != after_ids["trial/trial-1"]
+
+    def test_no_admitted_plan_is_unavailable_not_a_fabricated_identity(self):
+        result = AdmittedExperimentProvider(None).collect(_context(EXPERIMENT_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.UNAVAILABLE
+        assert result.leaves == ()
+
+    def test_more_trials_than_the_entry_budget_is_truncated(self):
+        plan = _StubPlan(trials=[_StubTrial(f"trial-{index}") for index in range(10)])
+        result = AdmittedExperimentProvider(plan).collect(
+            _context(EXPERIMENT_PROVIDER_ID, max_entries=4)
+        )
+        assert result.status is ProvenanceStatus.TRUNCATED
+
+    def test_parameter_bindings_are_not_recorded(self):
+        """Scenario parameter VALUES are not persisted (ADR-044 / REP-001)."""
+        result = AdmittedExperimentProvider(_StubPlan()).collect(
+            _context(EXPERIMENT_PROVIDER_ID)
+        )
+        assert "parameter_bindings" not in result.payload
+        assert "parameters" not in result.payload
+
+
+class _StubApparatus:
+    def __init__(self, model="claude-x", provider="claude"):
+        self.implementation_selection_ref = "selection-1"
+        self.manifest_ref = "manifest-1"
+        self.provider = provider
+        self.model = model
+
+
+class TestParticipantProvider:
+    """The accepted selection is recorded, not a reconstruction."""
+
+    def test_collects_participant_selection_identity(self):
+        result = ParticipantApparatusProvider({"red": _StubApparatus()}).collect(
+            _context(PARTICIPANT_PROVIDER_ID)
+        )
+        assert result.status is ProvenanceStatus.COLLECTED
+        assert {leaf.logical_id for leaf in result.leaves} == {"red"}
+
+    def test_payload_records_provider_and_model_identity(self):
+        """Model identity must be reconstructable from the record."""
+        result = ParticipantApparatusProvider({"red": _StubApparatus()}).collect(
+            _context(PARTICIPANT_PROVIDER_ID)
+        )
+        assert result.payload["participants"]["red"]["provider"] == "claude"
+        assert result.payload["participants"]["red"]["model"] == "claude-x"
+
+    def test_a_changed_model_changes_that_participants_leaf(self):
+        before = ParticipantApparatusProvider({"red": _StubApparatus()}).collect(
+            _context(PARTICIPANT_PROVIDER_ID)
+        )
+        after = ParticipantApparatusProvider({"red": _StubApparatus(model="other")}).collect(
+            _context(PARTICIPANT_PROVIDER_ID)
+        )
+        assert before.leaves != after.leaves
+
+    def test_no_participants_is_unavailable(self):
+        result = ParticipantApparatusProvider({}).collect(_context(PARTICIPANT_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.UNAVAILABLE
+
+    def test_a_participant_without_a_model_is_explicit_not_guessed(self):
+        """An absent model is null, never a fabricated default."""
+        result = ParticipantApparatusProvider({"red": _StubApparatus(model=None)}).collect(
+            _context(PARTICIPANT_PROVIDER_ID)
+        )
+        assert result.payload["participants"]["red"]["model"] is None
+
+    @pytest.mark.parametrize("address", ["", "bad address", "x" * 300])
+    def test_a_hostile_participant_address_is_rejected(self, address):
+        result = ParticipantApparatusProvider({address: _StubApparatus()}).collect(
+            _context(PARTICIPANT_PROVIDER_ID)
+        )
+        assert result.status is ProvenanceStatus.FAILED
+
+    def test_results_carry_the_declared_provider_id(self):
+        for provider, expected in (
+            (ApparatusManifestProvider(), APPARATUS_PROVIDER_ID),
+            (AdmittedExperimentProvider(_StubPlan()), EXPERIMENT_PROVIDER_ID),
+            (ParticipantApparatusProvider({"red": _StubApparatus()}), PARTICIPANT_PROVIDER_ID),
+        ):
+            result = provider.collect(_context(expected))
+            assert isinstance(result, ProvenanceResult)
+            assert result.provider_id == expected

--- a/tests/test_provenance_artifacts_host.py
+++ b/tests/test_provenance_artifacts_host.py
@@ -1,0 +1,231 @@
+"""Tests for REP-003 dependency/asset and host-fact provenance (issue #452).
+
+Closes the requirement's "image and dependency digests", "collector and tool
+versions ... measurement channels", and "relevant host/runtime inventory"
+clauses.
+"""
+
+import pytest
+
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext
+from aptl.core.provenance.providers.artifacts import (
+    ARTIFACTS_PROVIDER_ID,
+    DEPENDENCY_ARTIFACTS,
+    DependencyArtifactProvider,
+)
+from aptl.core.provenance.providers.experiment import AdmittedExperimentProvider
+from aptl.core.provenance.providers.runtime_facts import RuntimeFactsProvider
+from aptl.core.provenance.registry import (
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    SealPoint,
+)
+
+
+def _context(provider_id, *, max_bytes=10_000_000, max_entries=64, timeout_s=30, clock=None):
+    registration = ProvenanceProviderRegistration(
+        provider_id=provider_id,
+        implementation_version="1.0.0",
+        provenance_kind=provider_id,
+        owner_adapter="tests",
+        seal_point=SealPoint.RUN_READY_TO_SEAL,
+        requiredness_policy_key=f"{provider_id}-required",
+        limits=ProvenanceLimits(
+            max_bytes=max_bytes, max_entries=max_entries, timeout_s=timeout_s
+        ),
+    )
+    return ProvenanceContext(
+        registration=registration, clock=clock or (lambda: 0.0), started_at=0.0
+    )
+
+
+class TestDependencyArtifacts:
+    """Dependency and asset locks are recorded from the lock actually present."""
+
+    def test_declared_artifacts_are_project_relative_locks(self):
+        for artifact in DEPENDENCY_ARTIFACTS:
+            assert not artifact.relative_path.startswith("/")
+            assert ".." not in artifact.relative_path
+
+    def test_uv_lock_is_recorded(self, tmp_path):
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        result = DependencyArtifactProvider(tmp_path).collect(_context(ARTIFACTS_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.COLLECTED
+        assert any("uv.lock" in leaf.logical_id for leaf in result.leaves)
+
+    def test_participant_asset_locks_are_recorded(self, tmp_path):
+        profile = tmp_path / "participant-profiles" / "guided-purple-v1"
+        profile.mkdir(parents=True)
+        (profile / "asset-lock.json").write_text("{}")
+        result = DependencyArtifactProvider(tmp_path).collect(_context(ARTIFACTS_PROVIDER_ID))
+        assert any("asset-lock" in leaf.logical_id for leaf in result.leaves)
+
+    def test_a_changed_lock_changes_its_leaf(self, tmp_path):
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        before = DependencyArtifactProvider(tmp_path).collect(
+            _context(ARTIFACTS_PROVIDER_ID)
+        )
+        (tmp_path / "uv.lock").write_text("version = 2\n")
+        after = DependencyArtifactProvider(tmp_path).collect(_context(ARTIFACTS_PROVIDER_ID))
+        assert before.leaves != after.leaves
+
+    def test_absent_locks_are_unavailable_not_empty_success(self, tmp_path):
+        result = DependencyArtifactProvider(tmp_path).collect(_context(ARTIFACTS_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.UNAVAILABLE
+
+    def test_a_symlinked_lock_is_not_followed(self, tmp_path):
+        import os
+
+        secret = tmp_path / "outside.lock"
+        secret.write_text("SECRET")
+        os.symlink(secret, tmp_path / "uv.lock")
+        result = DependencyArtifactProvider(tmp_path).collect(_context(ARTIFACTS_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.UNAVAILABLE
+        assert "SECRET" not in repr(result)
+
+    def test_an_oversized_lock_is_truncated_not_partially_hashed(self, tmp_path):
+        (tmp_path / "uv.lock").write_text("x" * 5000)
+        result = DependencyArtifactProvider(tmp_path).collect(
+            _context(ARTIFACTS_PROVIDER_ID, max_bytes=1024)
+        )
+        assert result.status is ProvenanceStatus.TRUNCATED
+
+
+class _StubBinding:
+    def __init__(self, registration_id="pcap-collector", version="1.2.0"):
+        self.registration_id = registration_id
+        self.implementation_version = version
+        self.contract_version = "experiment-capture-spec-v1"
+        self.channel_ref_id = "channel-1"
+        self.channel_ref_version = "1"
+        self.channel_kind = "network-packet"
+        self.capture_spec_id = "capture-1"
+        self.requirement_id = "req-1"
+        self.effective_config_digest = "sha256:" + "7" * 64
+
+
+class _StubTrial:
+    planned_trial_id = "trial-1"
+    scenario_snapshot_digest = "sha256:" + "a" * 64
+    condition_id = "baseline"
+    replication_ordinal = 0
+    capture_spec_refs = ("capture-1",)
+    stochastic_seeds = ()
+
+
+class _StubPlan:
+    plan_id = "plan-1"
+    policy_version = "aptl-admission/v1"
+    source_set_digest = "sha256:" + "c" * 64
+    plan_digest = "sha256:" + "d" * 64
+
+    def __init__(self, bindings=()):
+        self.trials = (_StubTrial(),)
+        self.capture_bindings = tuple(bindings)
+
+
+class TestCollectorAndChannelProvenance:
+    """Collector selection and measurement channels come from admitted bindings."""
+
+    def test_capture_bindings_become_collector_leaves(self):
+        plan = _StubPlan(bindings=[_StubBinding()])
+        result = AdmittedExperimentProvider(plan).collect(_context("experiment"))
+        assert any(leaf.logical_id.startswith("capture/") for leaf in result.leaves)
+
+    def test_payload_records_collector_version_and_channel(self):
+        plan = _StubPlan(bindings=[_StubBinding()])
+        result = AdmittedExperimentProvider(plan).collect(_context("experiment"))
+        collectors = result.payload["collectors"]
+        assert collectors[0]["registration_id"] == "pcap-collector"
+        assert collectors[0]["implementation_version"] == "1.2.0"
+        assert collectors[0]["channel_kind"] == "network-packet"
+
+    def test_a_changed_collector_version_changes_only_its_leaf(self):
+        before = AdmittedExperimentProvider(_StubPlan([_StubBinding()])).collect(
+            _context("experiment")
+        )
+        after = AdmittedExperimentProvider(
+            _StubPlan([_StubBinding(version="1.3.0")])
+        ).collect(_context("experiment"))
+        before_ids = {leaf.logical_id: leaf.digest for leaf in before.leaves}
+        after_ids = {leaf.logical_id: leaf.digest for leaf in after.leaves}
+        assert before_ids["plan"] == after_ids["plan"]
+        changed = [k for k in before_ids if before_ids[k] != after_ids.get(k)]
+        assert all(name.startswith("capture/") for name in changed)
+
+    def test_no_bindings_records_no_collectors(self):
+        result = AdmittedExperimentProvider(_StubPlan()).collect(_context("experiment"))
+        assert result.payload["collectors"] == []
+
+
+class _StubSoftware:
+    python_version = "3.12.1"
+    docker_version = "27.0"
+    compose_version = "2.29"
+    wazuh_manager_version = ""
+    wazuh_indexer_version = ""
+    aptl_version = "0.2.0"
+    raes_version = "2.0.0"
+
+
+class _StubSnapshot:
+    timestamp = "2026-01-01T00:00:00Z"
+    containers: list = []
+    software = _StubSoftware()
+
+    def to_dict(self):
+        return {"timestamp": self.timestamp}
+
+
+class TestHostFacts:
+    """Host inventory is a closed allowlist of validity-relevant facts."""
+
+    def test_host_facts_leaf_is_recorded(self):
+        result = RuntimeFactsProvider(
+            _StubSnapshot(), host_facts=lambda: {"os": "linux", "arch": "x86_64"}
+        ).collect(_context("runtime-facts"))
+        assert any(leaf.logical_id == "host-facts" for leaf in result.leaves)
+
+    def test_host_facts_are_recorded_in_the_payload(self):
+        result = RuntimeFactsProvider(
+            _StubSnapshot(), host_facts=lambda: {"os": "linux", "arch": "x86_64"}
+        ).collect(_context("runtime-facts"))
+        assert result.payload["host_facts"]["os"] == "linux"
+
+    def test_host_facts_are_restricted_to_the_allowlist(self):
+        """A rogue owner cannot widen the record into a host inventory dump."""
+        result = RuntimeFactsProvider(
+            _StubSnapshot(),
+            host_facts=lambda: {"os": "linux", "hostname": "secret-box", "user": "root"},
+        ).collect(_context("runtime-facts"))
+        rendered = repr(result.payload)
+        assert "secret-box" not in rendered
+        assert "root" not in rendered
+
+    def test_default_host_facts_are_bounded_and_safe(self):
+        result = RuntimeFactsProvider(_StubSnapshot()).collect(_context("runtime-facts"))
+        assert set(result.payload["host_facts"]) <= {
+            "os",
+            "arch",
+            "kernel",
+            "python",
+            "docker_mode",
+        }
+
+    def test_a_failing_host_probe_does_not_fail_the_provider(self):
+        def broken():
+            raise RuntimeError("probe failed")
+
+        result = RuntimeFactsProvider(_StubSnapshot(), host_facts=broken).collect(
+            _context("runtime-facts")
+        )
+        assert result.status is ProvenanceStatus.COLLECTED
+        assert result.payload["host_facts"] == {}
+
+    @pytest.mark.parametrize("value", [{"os": "x" * 5000}, {"os": object()}])
+    def test_hostile_host_fact_values_are_rejected(self, value):
+        result = RuntimeFactsProvider(_StubSnapshot(), host_facts=lambda: value).collect(
+            _context("runtime-facts")
+        )
+        assert result.payload["host_facts"] == {}

--- a/tests/test_provenance_builtin_fleet.py
+++ b/tests/test_provenance_builtin_fleet.py
@@ -12,6 +12,7 @@ import pytest
 from aptl.core.config import AptlConfig
 from aptl.core.provenance.outcomes import ProvenanceStatus
 from aptl.core.provenance.record import PROVENANCE_RECORD_PATH, PROVISIONAL_RECORD_PATH
+from aptl.core.provenance.registry import ProvenanceProviderRegistry
 from aptl.core.provenance.registrations import (
     BUILTIN_REGISTRATIONS,
     DEFAULT_PROVENANCE_REGISTRY,
@@ -94,10 +95,9 @@ class TestBuiltinRegistrations:
         DEFAULT_SEAL_PROFILE.validate_against(DEFAULT_PROVENANCE_REGISTRY)
 
     def test_the_registry_declaration_digest_is_stable(self):
-        assert (
-            DEFAULT_PROVENANCE_REGISTRY.declaration_digest()
-            == DEFAULT_PROVENANCE_REGISTRY.declaration_digest()
-        )
+        first = DEFAULT_PROVENANCE_REGISTRY.declaration_digest()
+        second = ProvenanceProviderRegistry(tuple(reversed(BUILTIN_REGISTRATIONS))).declaration_digest()
+        assert first == second
 
     def test_adding_a_provider_requires_only_a_registration(self):
         """The extension seam: a new source is one registration, not a rewrite."""

--- a/tests/test_provenance_builtin_fleet.py
+++ b/tests/test_provenance_builtin_fleet.py
@@ -1,0 +1,278 @@
+"""Tests for the REP-003 built-in provider fleet and run wiring (issue #452).
+
+Covers the composed default registry, the seal profile, and the end-to-end
+collect-and-publish path — including the honest posture when a source genuinely
+does not exist for a plain lab start (no admitted plan, no participants).
+"""
+
+import json
+
+import pytest
+
+from aptl.core.config import AptlConfig
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.record import PROVENANCE_RECORD_PATH, PROVISIONAL_RECORD_PATH
+from aptl.core.provenance.registrations import (
+    BUILTIN_REGISTRATIONS,
+    DEFAULT_PROVENANCE_REGISTRY,
+    DEFAULT_SEAL_PROFILE,
+    build_default_providers,
+    collect_run_provenance,
+)
+from aptl.core.runstore import LocalRunStore
+
+_RUN_ID = "run_20260101T000000Z"
+
+
+class _StubSoftware:
+    python_version = "3.12.1"
+    docker_version = "27.0"
+    compose_version = "2.29"
+    wazuh_manager_version = ""
+    wazuh_indexer_version = ""
+    aptl_version = "0.2.0"
+    raes_version = "2.0.0"
+
+
+class _StubContainer:
+    def __init__(self, name):
+        self.name = name
+        self.image = "img:tag"
+        self.image_id = "volatile"
+        self.image_digest = "sha256:" + "f" * 64
+        self.status = "running"
+        self.health = "healthy"
+
+
+class _StubSnapshot:
+    def __init__(self):
+        self.timestamp = "2026-01-01T00:00:00Z"
+        self.software = _StubSoftware()
+        self.containers = [_StubContainer("aptl-victim")]
+
+    def to_dict(self):
+        return {"timestamp": self.timestamp, "containers": ["aptl-victim"]}
+
+
+class _StubPlan:
+    """Minimal admitted plan: the canonical record requires this context."""
+
+    plan_id = "plan-1"
+    policy_version = "aptl-admission/v1"
+    source_set_digest = "sha256:" + "c" * 64
+    plan_digest = "sha256:" + "d" * 64
+    trials = ()
+    capture_bindings = ()
+
+
+class TestBuiltinRegistrations:
+    """Every built-in provider is declared exactly once, with real bounds."""
+
+    def test_every_builtin_id_is_unique(self):
+        ids = [item.provider_id for item in BUILTIN_REGISTRATIONS]
+        assert len(ids) == len(set(ids))
+
+    def test_the_declared_families_cover_the_requirement(self):
+        ids = {item.provider_id for item in BUILTIN_REGISTRATIONS}
+        assert ids == {
+            "apparatus",
+            "experiment",
+            "participant",
+            "detection-content",
+            "dependency-artifacts",
+            "config-identity",
+            "runtime-facts",
+        }
+
+    def test_every_registration_declares_positive_limits(self):
+        for item in BUILTIN_REGISTRATIONS:
+            assert item.limits.max_bytes > 0
+            assert item.limits.max_entries > 0
+            assert item.limits.timeout_s > 0
+
+    def test_the_default_profile_validates_against_the_default_registry(self):
+        DEFAULT_SEAL_PROFILE.validate_against(DEFAULT_PROVENANCE_REGISTRY)
+
+    def test_the_registry_declaration_digest_is_stable(self):
+        assert (
+            DEFAULT_PROVENANCE_REGISTRY.declaration_digest()
+            == DEFAULT_PROVENANCE_REGISTRY.declaration_digest()
+        )
+
+    def test_adding_a_provider_requires_only_a_registration(self):
+        """The extension seam: a new source is one registration, not a rewrite."""
+        from aptl.core.provenance.registry import (
+            ProvenanceLimits,
+            ProvenanceProviderRegistration,
+            ProvenanceProviderRegistry,
+            SealPoint,
+        )
+
+        extra = ProvenanceProviderRegistration(
+            provider_id="future-source",
+            implementation_version="1.0.0",
+            provenance_kind="future",
+            owner_adapter="tests",
+            seal_point=SealPoint.RUN_READY_TO_SEAL,
+            requiredness_policy_key="future-required",
+            limits=ProvenanceLimits(max_bytes=1, max_entries=1, timeout_s=1),
+        )
+        extended = ProvenanceProviderRegistry(BUILTIN_REGISTRATIONS + (extra,))
+        assert extended.get("future-source") is not None
+
+
+class TestDefaultFleet:
+    """The composed fleet reports honestly about sources that do not exist."""
+
+    def test_fleet_covers_every_registered_provider(self):
+        providers = build_default_providers(
+            project_dir=".", config=AptlConfig(), snapshot=_StubSnapshot()
+        )
+        assert {p.provider_id for p in providers} == {
+            item.provider_id for item in BUILTIN_REGISTRATIONS
+        }
+
+    def test_absent_plan_and_participants_are_unavailable_not_missing(self, tmp_path):
+        """A plain lab start has no admitted plan; that is disclosed, not hidden."""
+        collection = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_StubSnapshot()
+        )
+        assert collection.sections["experiment"].status is ProvenanceStatus.UNAVAILABLE
+        assert collection.sections["participant"].status is ProvenanceStatus.UNAVAILABLE
+        declared = {item.provider_id for item in collection.limitations}
+        assert {"experiment", "participant"} <= declared
+
+    def test_present_sources_are_collected(self, tmp_path):
+        collection = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_StubSnapshot()
+        )
+        assert collection.sections["apparatus"].status is ProvenanceStatus.COLLECTED
+        assert collection.sections["config-identity"].status is ProvenanceStatus.COLLECTED
+        assert collection.sections["runtime-facts"].status is ProvenanceStatus.COLLECTED
+
+    def test_detection_content_is_collected_when_rules_exist(self, tmp_path):
+        rules = tmp_path / "config" / "suricata" / "rules"
+        rules.mkdir(parents=True)
+        (rules / "local.rules").write_text("alert tcp any any -> any any (sid:1;)")
+        collection = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_StubSnapshot()
+        )
+        assert collection.sections["detection-content"].status is ProvenanceStatus.COLLECTED
+
+    def test_collection_is_deterministic(self, tmp_path):
+        first = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_StubSnapshot()
+        )
+        second = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_StubSnapshot()
+        )
+        assert first.projection() == second.projection()
+
+    def test_the_whole_collection_survives_the_store_secret_invariant(self, tmp_path):
+        """Real providers against a real config must publish without redaction drift."""
+        from aptl.core.provenance.record import publish_provenance_record
+
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        collection = collect_run_provenance(
+            project_dir=tmp_path,
+            config=AptlConfig(),
+            snapshot=_StubSnapshot(),
+            admitted_plan=_StubPlan(),
+        )
+        path = publish_provenance_record(
+            store=store, run_id=_RUN_ID, collection=collection
+        )
+        loaded = json.loads(path.read_bytes())
+        assert loaded["seal_state"] == "ready-to-seal"
+        assert loaded["run_id"] == _RUN_ID
+
+    def test_published_record_lands_at_the_declared_run_relative_path(self, tmp_path):
+        from aptl.core.provenance.record import publish_provenance_record
+
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        collection = collect_run_provenance(
+            project_dir=tmp_path,
+            config=AptlConfig(),
+            snapshot=_StubSnapshot(),
+            admitted_plan=_StubPlan(),
+        )
+        publish_provenance_record(store=store, run_id=_RUN_ID, collection=collection)
+        assert (store.get_run_path(_RUN_ID) / PROVENANCE_RECORD_PATH).exists()
+
+    def test_no_host_path_leaks_into_the_record(self, tmp_path):
+        collection = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_StubSnapshot()
+        )
+        assert str(tmp_path) not in json.dumps(collection.projection())
+
+
+class TestLabWiring:
+    """The lab-start step publishes provenance without becoming a seal."""
+
+    def test_step_publishes_a_record(self, tmp_path):
+        from aptl.core.lab import _publish_run_provenance
+
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        _publish_run_provenance(
+            store=store,
+            run_id=_RUN_ID,
+            project_dir=tmp_path,
+            config=AptlConfig(),
+            snapshot=_StubSnapshot(),
+        )
+        assert (store.get_run_path(_RUN_ID) / PROVISIONAL_RECORD_PATH).exists()
+
+    def test_step_is_best_effort_and_never_raises(self, tmp_path):
+        """A provenance failure must not turn a running lab into a failed start."""
+        from aptl.core.lab import _publish_run_provenance
+
+        store = LocalRunStore(tmp_path / "runs")
+        # No create_run: publication will fail internally.
+        _publish_run_provenance(
+            store=store,
+            run_id="../escape",
+            project_dir=tmp_path,
+            config=AptlConfig(),
+            snapshot=_StubSnapshot(),
+        )
+
+    def test_republishing_the_same_run_is_idempotent(self, tmp_path):
+        from aptl.core.lab import _publish_run_provenance
+
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        for _ in range(2):
+            _publish_run_provenance(
+                store=store,
+                run_id=_RUN_ID,
+                project_dir=tmp_path,
+                config=AptlConfig(),
+                snapshot=_StubSnapshot(),
+            )
+        assert (store.get_run_path(_RUN_ID) / PROVISIONAL_RECORD_PATH).exists()
+
+
+@pytest.mark.fuzz
+class TestFleetFuzz:
+    """The fleet stays typed under hostile project trees."""
+
+    def test_hostile_detection_tree_never_escapes_a_typed_outcome(self, tmp_path):
+        import os
+
+        rules = tmp_path / "config" / "suricata" / "rules"
+        rules.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.rules").write_text("SECRET")
+        os.symlink(outside / "secret.rules", rules / "link.rules")
+        (rules / "deep").mkdir()
+        (rules / "deep" / "a.rules").write_text("x")
+
+        collection = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_StubSnapshot()
+        )
+        assert collection.sections["detection-content"].status in set(ProvenanceStatus)
+        assert "SECRET" not in json.dumps(collection.projection())

--- a/tests/test_provenance_config_runtime.py
+++ b/tests/test_provenance_config_runtime.py
@@ -1,0 +1,286 @@
+"""Tests for the REP-003 config-identity and runtime-facts providers (#452).
+
+The config provider is the preflight's "versioned safe effective-config
+projection beside the strict AptlConfig owner": an explicit allowlist of
+apparatus-relevant fields, never ``model_dump()`` of the whole config and
+never a raw hash of the config file (which would fold ``.env`` and credential
+locators into an identity).
+"""
+
+import pytest
+
+from pydantic import BaseModel
+
+from aptl.core.config import AptlConfig, DeploymentConfig, LabSettings
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext
+from aptl.core.provenance.providers.config_identity import (
+    CONFIG_PROVIDER_ID,
+    SAFE_CONFIG_SCHEMA_VERSION,
+    ConfigIdentityProvider,
+    safe_config_projection,
+)
+from aptl.core.provenance.providers.runtime_facts import (
+    RUNTIME_PROVIDER_ID,
+    RuntimeFactsProvider,
+)
+from aptl.core.provenance.registry import (
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    SealPoint,
+)
+
+
+def _context(provider_id, *, max_entries=64, timeout_s=30, clock=None):
+    registration = ProvenanceProviderRegistration(
+        provider_id=provider_id,
+        implementation_version="1.0.0",
+        provenance_kind=provider_id,
+        owner_adapter="tests",
+        seal_point=SealPoint.RUN_READY_TO_SEAL,
+        requiredness_policy_key=f"{provider_id}-required",
+        limits=ProvenanceLimits(
+            max_bytes=1_000_000, max_entries=max_entries, timeout_s=timeout_s
+        ),
+    )
+    return ProvenanceContext(
+        registration=registration, clock=clock or (lambda: 0.0), started_at=0.0
+    )
+
+
+class TestSafeConfigProjection:
+    """The projection is an explicit allowlist, versioned, and secret-free."""
+
+    def test_projection_is_versioned(self):
+        projection = safe_config_projection(AptlConfig())
+        assert projection["schema_version"] == SAFE_CONFIG_SCHEMA_VERSION
+
+    def test_apparatus_relevant_fields_are_included(self):
+        projection = safe_config_projection(AptlConfig())
+        assert projection["deployment_provider"] == "docker-compose"
+        assert projection["run_storage_backend"] == "local"
+        assert "containers" in projection
+        assert "participant_models" in projection
+
+    def test_ssh_credential_locators_are_excluded(self):
+        """ssh_key is a credential locator; ssh_host/user are host details."""
+        config = AptlConfig(
+            deployment=DeploymentConfig(
+                provider="ssh-compose",
+                ssh_host="10.1.2.3",
+                ssh_user="operator",
+                ssh_key="/home/operator/.ssh/id_ed25519",
+                remote_dir="/srv/aptl",
+            )
+        )
+        rendered = repr(safe_config_projection(config))
+        assert "10.1.2.3" not in rendered
+        assert "operator" not in rendered
+        assert "id_ed25519" not in rendered
+        assert "/srv/aptl" not in rendered
+
+    def test_deployment_mode_survives_even_when_host_details_do_not(self):
+        """Validity needs the mode; it does not need the host."""
+        config = AptlConfig(
+            deployment=DeploymentConfig(provider="ssh-compose", ssh_host="10.1.2.3")
+        )
+        assert safe_config_projection(config)["deployment_provider"] == "ssh-compose"
+
+    def test_local_run_storage_path_is_excluded(self):
+        projection = safe_config_projection(AptlConfig())
+        assert "local_path" not in repr(projection)
+
+    def test_participant_model_identity_is_included(self):
+        """Model identity must be reconstructable from the record."""
+        config = AptlConfig()
+        config.experiment.participant_models.claude = "claude-opus-4-5-20251101"
+        projection = safe_config_projection(config)
+        assert projection["participant_models"]["claude"] == "claude-opus-4-5-20251101"
+
+    def test_projection_never_contains_a_secret_shaped_value(self):
+        from aptl.utils.redaction import redact
+
+        projection = safe_config_projection(AptlConfig())
+        assert redact(projection) == projection
+
+    def test_projection_is_not_a_whole_config_dump(self):
+        """A model_dump() would sweep in every future field, secret or not.
+
+        Asserted against what must be ABSENT: the raw nested config objects.
+        A set-cardinality comparison would pass for almost any return value,
+        including an empty dict.
+        """
+        projection = safe_config_projection(AptlConfig())
+        # A dump would surface the raw nested section names. ``containers`` is
+        # excluded from this list deliberately: the projection legitimately
+        # owns that key, but it holds flat boolean toggles rather than the model.
+        for raw_section in ("lab", "deployment", "run_storage", "experiment", "lifecycle_policy"):
+            assert raw_section not in projection
+        for value in projection.values():
+            assert not isinstance(value, BaseModel)
+        assert all(
+            isinstance(flag, bool) for flag in projection["containers"].values()
+        )
+
+    def test_projection_still_carries_the_fields_it_promises(self):
+        """Guards the exclusion test above from passing on an empty projection."""
+        projection = safe_config_projection(AptlConfig())
+        for expected in (
+            "schema_version",
+            "lab_name",
+            "deployment_provider",
+            "run_storage_backend",
+            "containers",
+            "participant_models",
+        ):
+            assert expected in projection
+
+
+class TestConfigIdentityProvider:
+    """Config identity is one leaf derived from the safe projection."""
+
+    def test_collects_a_single_config_identity_leaf(self):
+        result = ConfigIdentityProvider(AptlConfig()).collect(_context(CONFIG_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.COLLECTED
+        assert [leaf.logical_id for leaf in result.leaves] == ["effective-config"]
+
+    def test_changing_one_safe_field_changes_the_identity(self):
+        base = ConfigIdentityProvider(AptlConfig()).collect(_context(CONFIG_PROVIDER_ID))
+        changed = ConfigIdentityProvider(
+            AptlConfig(lab=LabSettings(name="other-lab"))
+        ).collect(_context(CONFIG_PROVIDER_ID))
+        assert base.leaves != changed.leaves
+
+    def test_changing_an_excluded_field_does_not_change_the_identity(self):
+        """An ssh host is not apparatus content; it must not perturb identity."""
+        base = ConfigIdentityProvider(
+            AptlConfig(deployment=DeploymentConfig(provider="ssh-compose"))
+        ).collect(_context(CONFIG_PROVIDER_ID))
+        with_host = ConfigIdentityProvider(
+            AptlConfig(
+                deployment=DeploymentConfig(provider="ssh-compose", ssh_host="10.9.9.9")
+            )
+        ).collect(_context(CONFIG_PROVIDER_ID))
+        assert base.leaves == with_host.leaves
+
+    def test_absent_config_is_unavailable(self):
+        result = ConfigIdentityProvider(None).collect(_context(CONFIG_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.UNAVAILABLE
+
+    def test_identity_is_stable_across_collections(self):
+        first = ConfigIdentityProvider(AptlConfig()).collect(_context(CONFIG_PROVIDER_ID))
+        second = ConfigIdentityProvider(AptlConfig()).collect(_context(CONFIG_PROVIDER_ID))
+        assert first.leaves == second.leaves
+
+
+class _StubContainer:
+    def __init__(self, name, image_digest="sha256:" + "f" * 64, image="img:tag"):
+        self.name = name
+        self.image = image
+        self.image_id = "container-id-volatile"
+        self.image_digest = image_digest
+        self.status = "running"
+        self.health = "healthy"
+        self.labels = {"com.example": "x"}
+        self.networks = {}
+        self.ports = []
+
+
+class _StubSoftware:
+    python_version = "3.12.1"
+    docker_version = "27.0"
+    compose_version = "2.29"
+    wazuh_manager_version = "4.9"
+    wazuh_indexer_version = "2.16"
+    aptl_version = "0.2.0"
+    raes_version = "2.0.0"
+
+
+class _StubSnapshot:
+    def __init__(self, containers=None):
+        self.timestamp = "2026-01-01T00:00:00Z"
+        self.software = _StubSoftware()
+        self.containers = containers or [_StubContainer("aptl-victim")]
+
+    def to_dict(self):
+        return {"timestamp": self.timestamp, "containers": [c.name for c in self.containers]}
+
+
+class TestRuntimeFactsProvider:
+    """Image identities and tool versions, with volatile data kept out."""
+
+    def test_collects_image_digest_and_tool_version_leaves(self):
+        result = RuntimeFactsProvider(_StubSnapshot()).collect(_context(RUNTIME_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.COLLECTED
+        names = {leaf.logical_id for leaf in result.leaves}
+        assert "image/aptl-victim" in names
+        assert "tool-versions" in names
+
+    def test_a_changed_image_digest_changes_only_that_leaf(self):
+        before = RuntimeFactsProvider(_StubSnapshot()).collect(_context(RUNTIME_PROVIDER_ID))
+        after = RuntimeFactsProvider(
+            _StubSnapshot(containers=[_StubContainer("aptl-victim", "sha256:" + "0" * 64)])
+        ).collect(_context(RUNTIME_PROVIDER_ID))
+        before_ids = {leaf.logical_id: leaf.digest for leaf in before.leaves}
+        after_ids = {leaf.logical_id: leaf.digest for leaf in after.leaves}
+        assert before_ids["tool-versions"] == after_ids["tool-versions"]
+        assert before_ids["image/aptl-victim"] != after_ids["image/aptl-victim"]
+
+    def test_volatile_state_does_not_perturb_identity(self):
+        """Health, status, and container id are observations, not identity."""
+        stable = _StubContainer("aptl-victim")
+        volatile = _StubContainer("aptl-victim")
+        volatile.status = "restarting"
+        volatile.health = "unhealthy"
+        volatile.image_id = "different-volatile-id"
+        before = RuntimeFactsProvider(_StubSnapshot([stable])).collect(
+            _context(RUNTIME_PROVIDER_ID)
+        )
+        after = RuntimeFactsProvider(_StubSnapshot([volatile])).collect(
+            _context(RUNTIME_PROVIDER_ID)
+        )
+        assert before.leaves == after.leaves
+
+    def test_a_container_without_an_immutable_digest_is_declared_not_guessed(self):
+        """A tag can never stand in for the selected immutable digest."""
+        result = RuntimeFactsProvider(
+            _StubSnapshot([_StubContainer("aptl-victim", image_digest="")])
+        ).collect(_context(RUNTIME_PROVIDER_ID))
+        assert "aptl-victim" in result.payload["images_without_digest"]
+        assert not any("image/aptl-victim" == leaf.logical_id for leaf in result.leaves)
+
+    def test_container_labels_are_not_embedded(self):
+        """Hostile labels must not become record keys or unbounded content."""
+        container = _StubContainer("aptl-victim")
+        container.labels = {"evil" * 500: "x" * 5000}
+        result = RuntimeFactsProvider(_StubSnapshot([container])).collect(
+            _context(RUNTIME_PROVIDER_ID)
+        )
+        assert "evilevil" not in repr(result.payload)
+
+    def test_absent_snapshot_is_unavailable(self):
+        result = RuntimeFactsProvider(None).collect(_context(RUNTIME_PROVIDER_ID))
+        assert result.status is ProvenanceStatus.UNAVAILABLE
+
+    def test_more_containers_than_the_budget_is_truncated(self):
+        containers = [_StubContainer(f"aptl-node-{index}") for index in range(20)]
+        result = RuntimeFactsProvider(_StubSnapshot(containers)).collect(
+            _context(RUNTIME_PROVIDER_ID, max_entries=5)
+        )
+        assert result.status is ProvenanceStatus.TRUNCATED
+
+    def test_payload_records_the_range_snapshot_identity(self):
+        result = RuntimeFactsProvider(_StubSnapshot()).collect(_context(RUNTIME_PROVIDER_ID))
+        assert result.payload["range_snapshot_identity"].startswith("sha256:")
+
+    def test_tool_versions_are_recorded(self):
+        result = RuntimeFactsProvider(_StubSnapshot()).collect(_context(RUNTIME_PROVIDER_ID))
+        assert result.payload["tool_versions"]["aptl"] == "0.2.0"
+        assert result.payload["tool_versions"]["raes"] == "2.0.0"
+
+    @pytest.mark.parametrize("name", ["", "bad name", "x" * 300])
+    def test_a_hostile_container_name_is_rejected(self, name):
+        result = RuntimeFactsProvider(_StubSnapshot([_StubContainer(name)])).collect(
+            _context(RUNTIME_PROVIDER_ID)
+        )
+        assert result.status is ProvenanceStatus.FAILED

--- a/tests/test_provenance_coordinator.py
+++ b/tests/test_provenance_coordinator.py
@@ -257,12 +257,11 @@ class TestRequiredProviders:
             seal_point=SealPoint.RUN_READY_TO_SEAL,
             required_provider_ids=frozenset({"nonexistent"}),
         )
+        providers = [_StubProvider("apparatus")]
+        clock = _FakeClock()
         with pytest.raises(ProvenanceRegistrationError):
             collect_provenance(
-                providers=[_StubProvider("apparatus")],
-                registry=registry,
-                profile=profile,
-                monotonic=_FakeClock(),
+                providers=providers, registry=registry, profile=profile, monotonic=clock
             )
 
 

--- a/tests/test_provenance_coordinator.py
+++ b/tests/test_provenance_coordinator.py
@@ -1,0 +1,370 @@
+"""Tests for the REP-003 provenance coordinator (issue #452).
+
+Covers the preflight's bounded-collection contract: every internal failure
+becomes one of the small typed statuses, limits are enforced, ordering never
+perturbs identity, and no source silently degrades to success.
+"""
+
+import pytest
+
+from aptl.core.provenance.coordinator import collect_provenance
+from aptl.core.provenance.identity import leaf_identity
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext, ProvenanceResult
+from aptl.core.provenance.registry import (
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    ProvenanceProviderRegistry,
+    SealPoint,
+    SealProfile,
+)
+
+_PROFILE = SealProfile(seal_point=SealPoint.RUN_READY_TO_SEAL)
+
+
+def _registration(provider_id: str, *, max_bytes=1024, max_entries=8, timeout_s=5):
+    return ProvenanceProviderRegistration(
+        provider_id=provider_id,
+        implementation_version="1.0.0",
+        provenance_kind=provider_id,
+        owner_adapter="tests",
+        seal_point=SealPoint.RUN_READY_TO_SEAL,
+        requiredness_policy_key=f"{provider_id}-required",
+        limits=ProvenanceLimits(
+            max_bytes=max_bytes, max_entries=max_entries, timeout_s=timeout_s
+        ),
+    )
+
+
+class _StubProvider:
+    """A provider whose behavior each test dictates."""
+
+    def __init__(self, provider_id, *, result=None, raises=None, elapsed=0.0):
+        self.provider_id = provider_id
+        self._result = result
+        self._raises = raises
+        self._elapsed = elapsed
+        self.calls = 0
+
+    def collect(self, context: ProvenanceContext) -> ProvenanceResult:
+        self.calls += 1
+        context.clock.advance(self._elapsed)
+        if self._raises is not None:
+            raise self._raises
+        if self._result is not None:
+            return self._result
+        return ProvenanceResult(
+            provider_id=self.provider_id,
+            status=ProvenanceStatus.COLLECTED,
+            leaves=(leaf_identity("a", b"1"),),
+            payload={"kind": self.provider_id},
+        )
+
+
+class _FakeClock:
+    """A monotonic clock the test advances explicitly."""
+
+    def __init__(self):
+        self._now = 0.0
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+def _collect(providers, registrations=None, profile=_PROFILE, clock=None):
+    registry = ProvenanceProviderRegistry(
+        tuple(registrations or [_registration(p.provider_id) for p in providers])
+    )
+    return collect_provenance(
+        providers=providers,
+        registry=registry,
+        profile=profile,
+        monotonic=clock or _FakeClock(),
+    )
+
+
+class TestSuccessfulCollection:
+    """A collected provider contributes a section with a framed identity."""
+
+    def test_section_carries_status_identity_and_payload(self):
+        collection = _collect([_StubProvider("apparatus")])
+        section = collection.sections["apparatus"]
+        assert section.status is ProvenanceStatus.COLLECTED
+        assert section.content_identity.startswith("sha256:")
+        assert section.payload["kind"] == "apparatus"
+
+    def test_section_records_the_pinned_declaration_digest(self):
+        """A reader can tell the provider's declared capability changed."""
+        collection = _collect([_StubProvider("apparatus")])
+        registration = _registration("apparatus")
+        assert (
+            collection.sections["apparatus"].declaration_digest
+            == registration.effective_config_digest()
+        )
+
+    def test_no_limitation_for_a_collected_source(self):
+        collection = _collect([_StubProvider("apparatus")])
+        assert collection.limitations == ()
+
+    def test_aggregate_identity_is_provider_order_independent(self):
+        forward = _collect([_StubProvider("apparatus"), _StubProvider("detection-content")])
+        backward = _collect([_StubProvider("detection-content"), _StubProvider("apparatus")])
+        assert forward.aggregate_identity == backward.aggregate_identity
+
+    def test_a_changed_leaf_changes_only_its_section_and_the_aggregate(self):
+        stable = _StubProvider("apparatus")
+        changed = _StubProvider(
+            "detection-content",
+            result=ProvenanceResult(
+                provider_id="detection-content",
+                status=ProvenanceStatus.COLLECTED,
+                leaves=(leaf_identity("a", b"changed"),),
+                payload={"kind": "detection-content"},
+            ),
+        )
+        before = _collect([_StubProvider("apparatus"), _StubProvider("detection-content")])
+        after = _collect([stable, changed])
+        assert (
+            before.sections["apparatus"].content_identity
+            == after.sections["apparatus"].content_identity
+        )
+        assert (
+            before.sections["detection-content"].content_identity
+            != after.sections["detection-content"].content_identity
+        )
+        assert before.aggregate_identity != after.aggregate_identity
+
+
+class TestFailureBecomesAnExplicitLimitation:
+    """No source silently disappears or degrades to success."""
+
+    def test_a_raising_provider_becomes_failed_not_an_exception(self):
+        collection = _collect([_StubProvider("apparatus", raises=RuntimeError("boom"))])
+        assert collection.sections["apparatus"].status is ProvenanceStatus.FAILED
+        assert [item.provider_id for item in collection.limitations] == ["apparatus"]
+
+    def test_a_raising_provider_never_leaks_its_exception_text(self):
+        secret = "token=abc123 /home/user/.env"
+        collection = _collect([_StubProvider("apparatus", raises=RuntimeError(secret))])
+        rendered = repr(collection.projection())
+        assert "abc123" not in rendered
+        assert ".env" not in rendered
+
+    def test_a_failed_provider_contributes_no_content_identity(self):
+        """A failure must not produce a fabricated digest."""
+        collection = _collect([_StubProvider("apparatus", raises=RuntimeError())])
+        assert collection.sections["apparatus"].content_identity is None
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            ProvenanceStatus.UNAVAILABLE,
+            ProvenanceStatus.DENIED,
+            ProvenanceStatus.UNSUPPORTED,
+            ProvenanceStatus.TRUNCATED,
+        ],
+    )
+    def test_every_reported_non_success_becomes_a_limitation(self, status):
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(provider_id="apparatus", status=status),
+        )
+        collection = _collect([provider])
+        assert [item.status for item in collection.limitations] == [status]
+
+    def test_overrunning_the_declared_deadline_is_timed_out(self):
+        clock = _FakeClock()
+        provider = _StubProvider("apparatus", elapsed=9.0)
+        collection = _collect(
+            [provider], registrations=[_registration("apparatus", timeout_s=5)], clock=clock
+        )
+        assert collection.sections["apparatus"].status is ProvenanceStatus.TIMED_OUT
+        assert collection.limitations[0].status is ProvenanceStatus.TIMED_OUT
+
+    def test_a_timed_out_provider_discards_its_partial_content(self):
+        clock = _FakeClock()
+        provider = _StubProvider("apparatus", elapsed=9.0)
+        collection = _collect(
+            [provider], registrations=[_registration("apparatus", timeout_s=5)], clock=clock
+        )
+        assert collection.sections["apparatus"].content_identity is None
+
+    def test_exceeding_the_declared_entry_limit_is_truncated(self):
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(
+                provider_id="apparatus",
+                status=ProvenanceStatus.COLLECTED,
+                leaves=tuple(leaf_identity(f"leaf-{index}", b"x") for index in range(9)),
+            ),
+        )
+        collection = _collect(
+            [provider], registrations=[_registration("apparatus", max_entries=8)]
+        )
+        assert collection.sections["apparatus"].status is ProvenanceStatus.TRUNCATED
+
+    def test_a_provider_with_no_registration_is_unsupported(self):
+        """An unregistered provider is never trusted into the record."""
+        registry = ProvenanceProviderRegistry((_registration("apparatus"),))
+        collection = collect_provenance(
+            providers=[_StubProvider("rogue")],
+            registry=registry,
+            profile=_PROFILE,
+            monotonic=_FakeClock(),
+        )
+        assert collection.sections["rogue"].status is ProvenanceStatus.UNSUPPORTED
+
+    def test_a_result_claiming_another_providers_id_is_rejected(self):
+        """A provider cannot write into a sibling's section."""
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(
+                provider_id="detection-content", status=ProvenanceStatus.COLLECTED
+            ),
+        )
+        collection = _collect([provider])
+        assert collection.sections["apparatus"].status is ProvenanceStatus.FAILED
+
+
+class TestRequiredProviders:
+    """A policy-required provider that never ran is reported, not assumed."""
+
+    def test_a_missing_required_provider_is_recorded_as_unavailable(self):
+        registry = ProvenanceProviderRegistry(
+            (_registration("apparatus"), _registration("detection-content"))
+        )
+        profile = SealProfile(
+            seal_point=SealPoint.RUN_READY_TO_SEAL,
+            required_provider_ids=frozenset({"detection-content"}),
+        )
+        collection = collect_provenance(
+            providers=[_StubProvider("apparatus")],
+            registry=registry,
+            profile=profile,
+            monotonic=_FakeClock(),
+        )
+        assert collection.sections["detection-content"].status is ProvenanceStatus.UNAVAILABLE
+        assert "detection-content" in {item.provider_id for item in collection.limitations}
+
+    def test_required_provider_ids_are_validated_against_the_registry(self):
+        from aptl.core.provenance.registry import ProvenanceRegistrationError
+
+        registry = ProvenanceProviderRegistry((_registration("apparatus"),))
+        profile = SealProfile(
+            seal_point=SealPoint.RUN_READY_TO_SEAL,
+            required_provider_ids=frozenset({"nonexistent"}),
+        )
+        with pytest.raises(ProvenanceRegistrationError):
+            collect_provenance(
+                providers=[_StubProvider("apparatus")],
+                registry=registry,
+                profile=profile,
+                monotonic=_FakeClock(),
+            )
+
+
+class TestPayloadSafety:
+    """Provider payloads are bounded and secret-free before they reach a record."""
+
+    def test_a_secret_shaped_payload_is_rejected_not_redacted_into_the_record(self):
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(
+                provider_id="apparatus",
+                status=ProvenanceStatus.COLLECTED,
+                payload={"api_key": "AKIAIOSFODNN7EXAMPLE"},
+            ),
+        )
+        collection = _collect([provider])
+        assert collection.sections["apparatus"].status is ProvenanceStatus.FAILED
+        assert "AKIAIOSFODNN7EXAMPLE" not in repr(collection.projection())
+
+    def test_an_unserializable_payload_fails_closed(self):
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(
+                provider_id="apparatus",
+                status=ProvenanceStatus.COLLECTED,
+                payload={"handle": object()},
+            ),
+        )
+        collection = _collect([provider])
+        assert collection.sections["apparatus"].status is ProvenanceStatus.FAILED
+
+    def test_a_payload_exceeding_the_key_ceiling_is_rejected(self):
+        """The coordinator's hard ceilings must be enforced, not just documented."""
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(
+                provider_id="apparatus",
+                status=ProvenanceStatus.COLLECTED,
+                payload={f"key-{index}": index for index in range(65)},
+            ),
+        )
+        assert _collect([provider]).sections["apparatus"].status is ProvenanceStatus.FAILED
+
+    def test_a_payload_exceeding_the_depth_ceiling_is_rejected(self):
+        nested: dict = {"leaf": 1}
+        for _ in range(8):
+            nested = {"next": nested}
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(
+                provider_id="apparatus",
+                status=ProvenanceStatus.COLLECTED,
+                payload=nested,
+            ),
+        )
+        assert _collect([provider]).sections["apparatus"].status is ProvenanceStatus.FAILED
+
+    def test_a_payload_exceeding_the_string_ceiling_is_rejected(self):
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(
+                provider_id="apparatus",
+                status=ProvenanceStatus.COLLECTED,
+                payload={"note": "x" * 4097},
+            ),
+        )
+        assert _collect([provider]).sections["apparatus"].status is ProvenanceStatus.FAILED
+
+    def test_a_payload_within_every_ceiling_is_accepted(self):
+        """The ceilings must not reject ordinary provider output."""
+        provider = _StubProvider(
+            "apparatus",
+            result=ProvenanceResult(
+                provider_id="apparatus",
+                status=ProvenanceStatus.COLLECTED,
+                leaves=(leaf_identity("a", b"1"),),
+                payload={"note": "x" * 4096, "nested": {"a": {"b": {"c": 1}}}},
+            ),
+        )
+        assert _collect([provider]).sections["apparatus"].status is ProvenanceStatus.COLLECTED
+
+    def test_projection_is_deterministic(self):
+        first = _collect([_StubProvider("apparatus"), _StubProvider("detection-content")])
+        second = _collect([_StubProvider("detection-content"), _StubProvider("apparatus")])
+        assert first.projection() == second.projection()
+
+    def test_projection_lists_limitations_in_a_stable_order(self):
+        collection = _collect(
+            [
+                _StubProvider(
+                    "detection-content",
+                    result=ProvenanceResult(
+                        provider_id="detection-content", status=ProvenanceStatus.DENIED
+                    ),
+                ),
+                _StubProvider(
+                    "apparatus",
+                    result=ProvenanceResult(
+                        provider_id="apparatus", status=ProvenanceStatus.DENIED
+                    ),
+                ),
+            ]
+        )
+        ordered = [item["provider_id"] for item in collection.projection()["limitations"]]
+        assert ordered == sorted(ordered)

--- a/tests/test_provenance_detection.py
+++ b/tests/test_provenance_detection.py
@@ -1,0 +1,270 @@
+"""Tests for the REP-003 detection-content provenance provider (issue #452).
+
+The behavior this replaces (``snapshot.detection_content_digest``) hashed an
+unframed concatenation over four non-recursive globs, two of which
+(``config/wazuh/etc/rules``, ``config/wazuh/etc/decoders``) do not exist in
+this repository at all — the real Wazuh rule/decoder surface is
+``config/wazuh_cluster`` and Suricata's MISP content is nested under
+``config/suricata/rules/misp``. These tests pin the corrected surface, the
+per-leaf framing, and the safe reading path.
+"""
+
+import os
+
+import pytest
+
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext
+from aptl.core.provenance.providers.detection import (
+    DETECTION_PROVIDER_ID,
+    DETECTION_ROOTS,
+    DetectionContentProvider,
+)
+from aptl.core.provenance.registry import (
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    SealPoint,
+)
+
+
+def _context(*, max_bytes=65536, max_entries=64, timeout_s=30, clock=None):
+    registration = ProvenanceProviderRegistration(
+        provider_id=DETECTION_PROVIDER_ID,
+        implementation_version="1.0.0",
+        provenance_kind="detection-content",
+        owner_adapter="aptl.core.provenance.providers.detection",
+        seal_point=SealPoint.RUN_READY_TO_SEAL,
+        requiredness_policy_key="detection-content-required",
+        limits=ProvenanceLimits(
+            max_bytes=max_bytes, max_entries=max_entries, timeout_s=timeout_s
+        ),
+    )
+    ticker = clock or (lambda: 0.0)
+    return ProvenanceContext(registration=registration, clock=ticker, started_at=0.0)
+
+
+def _write(root, relative, content=b"rule"):
+    target = root / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+def _leaf_ids(result):
+    return {leaf.logical_id for leaf in result.leaves}
+
+
+class TestSurfaceCoverage:
+    """The corrected surface covers what the previous globs missed."""
+
+    def test_nested_suricata_misp_content_is_covered(self, tmp_path):
+        """The old non-recursive glob missed config/suricata/rules/misp/."""
+        _write(tmp_path, "config/suricata/rules/misp/misp-iocs.rules")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert result.status is ProvenanceStatus.COLLECTED
+        assert any("misp-iocs.rules" in name for name in _leaf_ids(result))
+
+    def test_wazuh_cluster_rules_and_decoders_are_covered(self, tmp_path):
+        """The old globs pointed at config/wazuh/etc/, which does not exist."""
+        _write(tmp_path, "config/wazuh_cluster/suricata_rules.xml")
+        _write(tmp_path, "config/wazuh_cluster/samba_decoders.xml")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        names = _leaf_ids(result)
+        assert any("suricata_rules.xml" in name for name in names)
+        assert any("samba_decoders.xml" in name for name in names)
+
+    def test_allowlists_are_covered(self, tmp_path):
+        _write(tmp_path, "config/wazuh_cluster/etc/lists/active-response-whitelist")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert any("active-response-whitelist" in name for name in _leaf_ids(result))
+
+    def test_top_level_suricata_rules_are_still_covered(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/local.rules")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert any("local.rules" in name for name in _leaf_ids(result))
+
+    def test_unrelated_files_are_not_ingested(self, tmp_path):
+        """Roots carry explicit suffix allowlists; a script is not detection content."""
+        _write(tmp_path, "config/wazuh_cluster/patch-rule-path.py", b"import os")
+        _write(tmp_path, "config/wazuh_cluster/suricata_rules.xml")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert not any("patch-rule-path" in name for name in _leaf_ids(result))
+
+    def test_every_declared_root_is_under_config(self, tmp_path):
+        """No root may reach outside the project's detection content."""
+        for root in DETECTION_ROOTS:
+            assert root.relative_root.startswith("config/")
+            assert ".." not in root.relative_root
+
+
+class TestTargetedDifferences:
+    """Changing one artifact moves its own leaf and the family, nothing else."""
+
+    def test_changing_one_rule_changes_only_its_leaf(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/local.rules", b"v1")
+        _write(tmp_path, "config/wazuh_cluster/suricata_rules.xml", b"stable")
+        before = DetectionContentProvider(tmp_path).collect(_context())
+
+        _write(tmp_path, "config/suricata/rules/local.rules", b"v2")
+        after = DetectionContentProvider(tmp_path).collect(_context())
+
+        before_by_id = {leaf.logical_id: leaf.digest for leaf in before.leaves}
+        after_by_id = {leaf.logical_id: leaf.digest for leaf in after.leaves}
+        changed = [
+            name for name in before_by_id if before_by_id[name] != after_by_id.get(name)
+        ]
+        assert len(changed) == 1
+        assert "local.rules" in changed[0]
+
+    def test_identical_content_is_stable_across_collections(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/local.rules", b"v1")
+        first = DetectionContentProvider(tmp_path).collect(_context())
+        second = DetectionContentProvider(tmp_path).collect(_context())
+        assert first.leaves == second.leaves
+
+    def test_content_split_across_files_is_not_ambiguous(self, tmp_path):
+        """The concatenation collision the previous implementation had."""
+        _write(tmp_path, "config/suricata/rules/a.rules", b"ab")
+        _write(tmp_path, "config/suricata/rules/b.rules", b"c")
+        first = DetectionContentProvider(tmp_path).collect(_context())
+
+        _write(tmp_path, "config/suricata/rules/a.rules", b"a")
+        _write(tmp_path, "config/suricata/rules/b.rules", b"bc")
+        second = DetectionContentProvider(tmp_path).collect(_context())
+        assert first.leaves != second.leaves
+
+    def test_leaves_are_sorted_regardless_of_filesystem_order(self, tmp_path):
+        for name in ("z.rules", "a.rules", "m.rules"):
+            _write(tmp_path, f"config/suricata/rules/{name}")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert list(result.leaves) == sorted(result.leaves)
+
+
+class TestAbsentAndDegradedSources:
+    """Absence and degradation are explicit, never an empty success."""
+
+    def test_no_detection_content_is_unavailable_not_empty_success(self, tmp_path):
+        """The previous helper returned '' here, which read as 'nothing changed'."""
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert result.status is ProvenanceStatus.UNAVAILABLE
+        assert result.leaves == ()
+
+    def test_exceeding_the_entry_limit_is_truncated(self, tmp_path):
+        for index in range(6):
+            _write(tmp_path, f"config/suricata/rules/rule-{index}.rules")
+        result = DetectionContentProvider(tmp_path).collect(_context(max_entries=3))
+        assert result.status is ProvenanceStatus.TRUNCATED
+
+    def test_exceeding_the_byte_limit_is_truncated(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/big.rules", b"x" * 4096)
+        result = DetectionContentProvider(tmp_path).collect(_context(max_bytes=1024))
+        assert result.status is ProvenanceStatus.TRUNCATED
+
+    def test_a_truncated_collection_reports_no_partial_content_as_complete(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/big.rules", b"x" * 4096)
+        result = DetectionContentProvider(tmp_path).collect(_context(max_bytes=1024))
+        assert result.status is not ProvenanceStatus.COLLECTED
+
+    def test_expired_deadline_is_timed_out(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/local.rules")
+        # The provider checks its deadline before each artifact, so a clock
+        # already past the budget must stop it before the first read.
+        result = DetectionContentProvider(tmp_path).collect(
+            _context(timeout_s=5, clock=lambda: 99.0)
+        )
+        assert result.status is ProvenanceStatus.TIMED_OUT
+        assert result.leaves == ()
+
+    def test_unreadable_root_is_denied_not_silently_skipped(self, tmp_path):
+        rules = tmp_path / "config" / "suricata" / "rules"
+        rules.mkdir(parents=True)
+        (rules / "local.rules").write_bytes(b"rule")
+        os.chmod(rules, 0o000)
+        try:
+            result = DetectionContentProvider(tmp_path).collect(_context())
+            assert result.status in {ProvenanceStatus.DENIED, ProvenanceStatus.COLLECTED}
+            if result.status is ProvenanceStatus.DENIED:
+                assert result.leaves == ()
+        finally:
+            os.chmod(rules, 0o755)
+
+
+class TestSafeReading:
+    """Reading is path-contained and no-follow; hostile entries never ingest."""
+
+    def test_a_symlinked_rule_file_is_not_followed(self, tmp_path):
+        secret = tmp_path / "outside-secret.txt"
+        secret.write_bytes(b"SECRET-CONTENT")
+        rules = tmp_path / "config" / "suricata" / "rules"
+        rules.mkdir(parents=True)
+        os.symlink(secret, rules / "link.rules")
+        _write(tmp_path, "config/suricata/rules/real.rules", b"rule")
+
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert not any("link.rules" in name for name in _leaf_ids(result))
+        assert "SECRET-CONTENT" not in repr(result.payload)
+
+    def test_a_symlinked_root_directory_is_not_followed(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "evil.rules").write_bytes(b"SECRET-CONTENT")
+        suricata = tmp_path / "config" / "suricata"
+        suricata.mkdir(parents=True)
+        os.symlink(outside, suricata / "rules")
+
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert not any("evil.rules" in name for name in _leaf_ids(result))
+
+    def test_a_special_file_is_not_ingested(self, tmp_path):
+        rules = tmp_path / "config" / "suricata" / "rules"
+        rules.mkdir(parents=True)
+        os.mkfifo(rules / "pipe.rules")
+        _write(tmp_path, "config/suricata/rules/real.rules")
+
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert not any("pipe.rules" in name for name in _leaf_ids(result))
+
+    def test_env_is_never_read_even_if_placed_under_a_root(self, tmp_path):
+        """Secret sources are excluded by suffix allowlist, not by later scrubbing."""
+        _write(tmp_path, "config/suricata/rules/.env", b"WAZUH_PASSWORD=hunter2")
+        _write(tmp_path, "config/suricata/rules/real.rules")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert not any(".env" in name for name in _leaf_ids(result))
+        assert "hunter2" not in repr(result)
+
+    def test_payload_carries_counts_and_root_ids_only(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/local.rules")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert set(result.payload) == {"roots", "artifact_count"}
+        assert isinstance(result.payload["artifact_count"], int)
+
+    def test_no_host_path_appears_in_the_result(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/local.rules")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert str(tmp_path) not in repr(result)
+
+    def test_logical_ids_are_project_relative(self, tmp_path):
+        _write(tmp_path, "config/suricata/rules/local.rules")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        for name in _leaf_ids(result):
+            assert not name.startswith("/")
+            assert ".." not in name
+
+
+@pytest.mark.fuzz
+class TestDetectionFuzz:
+    """Property-based coverage for hostile names and sizes."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "a" * 200 + ".rules",
+            "weird name.rules",
+            "nested/deep/deeper/file.rules",
+            ".hidden.rules",
+        ],
+    )
+    def test_unusual_names_never_raise(self, tmp_path, name):
+        _write(tmp_path, f"config/suricata/rules/{name}")
+        result = DetectionContentProvider(tmp_path).collect(_context())
+        assert result.status in set(ProvenanceStatus)

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -1,0 +1,160 @@
+"""Tests for the REP-003 provenance identity primitives (issue #452).
+
+These cover the preflight's "Make identities stable and differences
+explainable" guardrail: domain-separated RFC 8785 canonical identity, one
+normalized digest representation, per-leaf logical roles, and a family
+identity folded over a SORTED canonical sequence — never an unframed
+concatenation of file bytes.
+"""
+
+import hashlib
+
+import pytest
+
+from aptl.core.provenance.identity import (
+    DIGEST_PREFIX,
+    ProvenanceIdentityError,
+    derive_identity,
+    family_identity,
+    leaf_identity,
+    normalize_digest,
+)
+
+
+class TestNormalizeDigest:
+    """One representation for every SHA-256 value at the provenance boundary."""
+
+    def test_bare_hex_gains_the_prefix(self):
+        bare = "a" * 64
+        assert normalize_digest(bare) == f"{DIGEST_PREFIX}{bare}"
+
+    def test_prefixed_digest_is_idempotent(self):
+        value = f"{DIGEST_PREFIX}{'b' * 64}"
+        assert normalize_digest(value) == value
+
+    def test_uppercase_hex_is_lowercased(self):
+        assert normalize_digest("A" * 64) == f"{DIGEST_PREFIX}{'a' * 64}"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "sha256:",
+            "z" * 64,
+            "a" * 63,
+            "a" * 65,
+            "md5:" + "a" * 32,
+            "sha256:sha256:" + "a" * 64,
+        ],
+    )
+    def test_malformed_digest_is_rejected(self, value):
+        """A malformed digest fails closed rather than becoming a fabricated identity."""
+        with pytest.raises(ProvenanceIdentityError):
+            normalize_digest(value)
+
+    def test_non_string_is_rejected(self):
+        with pytest.raises(ProvenanceIdentityError):
+            normalize_digest(None)  # type: ignore[arg-type]
+
+
+class TestLeafIdentity:
+    """A leaf binds a stable logical role to the digest of its bytes."""
+
+    def test_leaf_binds_logical_id_and_digest(self):
+        leaf = leaf_identity("suricata/rules/custom.rules", b"alert tcp any any;")
+        assert leaf.logical_id == "suricata/rules/custom.rules"
+        assert leaf.digest == normalize_digest(
+            hashlib.sha256(b"alert tcp any any;").hexdigest()
+        )
+
+    def test_same_bytes_under_different_roles_are_different_leaves(self):
+        """Role is part of identity, so a file moving roles is a real difference."""
+        first = leaf_identity("wazuh/rules/local.xml", b"<group/>")
+        second = leaf_identity("wazuh/decoders/local.xml", b"<group/>")
+        assert first.digest == second.digest
+        assert first != second
+
+    def test_empty_bytes_still_produce_an_explicit_digest(self):
+        """An empty file is a real observation, not a missing source."""
+        leaf = leaf_identity("suricata/rules/empty.rules", b"")
+        assert leaf.digest == normalize_digest(hashlib.sha256(b"").hexdigest())
+
+    @pytest.mark.parametrize("logical_id", ["", " ", "a" * 513, "x\x00y", "x\ny"])
+    def test_hostile_logical_id_is_rejected(self, logical_id):
+        """Hostile metadata can never become a record key."""
+        with pytest.raises(ProvenanceIdentityError):
+            leaf_identity(logical_id, b"data")
+
+
+class TestFamilyIdentity:
+    """A family folds a sorted canonical sequence of {logical_id, digest}."""
+
+    def test_family_is_order_independent(self):
+        one = leaf_identity("a", b"1")
+        two = leaf_identity("b", b"2")
+        assert family_identity("detection", [one, two]) == family_identity(
+            "detection", [two, one]
+        )
+
+    def test_concatenation_ambiguity_is_defeated(self):
+        """The defect this replaces: unframed concatenation collides.
+
+        ``"ab" + "c"`` and ``"a" + "bc"`` hash identically under the old
+        combined-digest approach. Framing by logical role must separate them.
+        """
+        split_one = [leaf_identity("first", b"ab"), leaf_identity("second", b"c")]
+        split_two = [leaf_identity("first", b"a"), leaf_identity("second", b"bc")]
+        assert family_identity("detection", split_one) != family_identity(
+            "detection", split_two
+        )
+
+    def test_one_changed_leaf_changes_the_family(self):
+        before = [leaf_identity("a", b"1"), leaf_identity("b", b"2")]
+        after = [leaf_identity("a", b"1"), leaf_identity("b", b"changed")]
+        assert family_identity("detection", before) != family_identity("detection", after)
+
+    def test_unchanged_leaf_keeps_its_own_identity_when_a_sibling_changes(self):
+        """Targeted differences: a sibling's change never perturbs this leaf."""
+        stable = leaf_identity("a", b"1")
+        assert stable == leaf_identity("a", b"1")
+
+    def test_different_families_of_the_same_leaves_differ(self):
+        leaves = [leaf_identity("a", b"1")]
+        assert family_identity("detection", leaves) != family_identity("config", leaves)
+
+    def test_empty_family_is_explicit_not_an_empty_string(self):
+        """No leaves is a real, stable identity — never '' masquerading as success."""
+        empty = family_identity("detection", [])
+        assert empty.startswith(DIGEST_PREFIX)
+        assert empty == family_identity("detection", [])
+        assert empty != family_identity("detection", [leaf_identity("a", b"")])
+
+    def test_duplicate_logical_ids_are_rejected(self):
+        duplicated = [leaf_identity("a", b"1"), leaf_identity("a", b"2")]
+        with pytest.raises(ProvenanceIdentityError):
+            family_identity("detection", duplicated)
+
+
+class TestDeriveIdentity:
+    """Structured identities are domain-separated and canonical."""
+
+    def test_identity_is_stable_across_mapping_insertion_order(self):
+        first = derive_identity("record", {"a": 1, "b": 2})
+        second = derive_identity("record", {"b": 2, "a": 1})
+        assert first == second
+
+    def test_domain_separation_prevents_cross_domain_collision(self):
+        payload = {"a": 1}
+        assert derive_identity("record", payload) != derive_identity("provider", payload)
+
+    def test_identity_is_a_normalized_digest(self):
+        assert derive_identity("record", {"a": 1}).startswith(DIGEST_PREFIX)
+
+    def test_unserializable_payload_fails_closed(self):
+        with pytest.raises(ProvenanceIdentityError):
+            derive_identity("record", {"a": object()})
+
+    @pytest.mark.parametrize("domain", ["", "not a domain", "x" * 129])
+    def test_hostile_domain_is_rejected(self, domain):
+        with pytest.raises(ProvenanceIdentityError):
+            derive_identity(domain, {"a": 1})

--- a/tests/test_provenance_outcomes.py
+++ b/tests/test_provenance_outcomes.py
@@ -1,0 +1,108 @@
+"""Tests for the REP-003 provenance outcome vocabulary (issue #452).
+
+Covers the preflight rule that missing, denied, unsupported, truncated,
+timed-out and failed sources are EXPLICIT results — never empty strings,
+empty maps, absent keys, or a fabricated digest.
+"""
+
+import pytest
+
+from aptl.core.provenance.outcomes import (
+    SUCCESS_STATUSES,
+    ProvenanceLimitation,
+    ProvenanceOutcomeError,
+    ProvenanceStatus,
+    limitation_for,
+    reason_code_for,
+)
+
+
+class TestStatusVocabulary:
+    """The status set is closed and covers every REP-003 failure mode."""
+
+    def test_every_required_status_exists(self):
+        assert {status.value for status in ProvenanceStatus} == {
+            "collected",
+            "unavailable",
+            "denied",
+            "unsupported",
+            "timed-out",
+            "truncated",
+            "failed",
+        }
+
+    def test_only_collected_is_a_full_success(self):
+        assert SUCCESS_STATUSES == frozenset({ProvenanceStatus.COLLECTED})
+
+    def test_truncated_is_not_a_success(self):
+        """Truncation is disclosed degradation, never silent success."""
+        assert ProvenanceStatus.TRUNCATED not in SUCCESS_STATUSES
+
+    def test_every_non_success_status_has_a_stable_reason_code(self):
+        for status in ProvenanceStatus:
+            if status in SUCCESS_STATUSES:
+                continue
+            code = reason_code_for(status)
+            assert code.startswith("aptl.run-provenance.")
+            assert code == reason_code_for(status), "reason codes must be stable"
+
+    def test_collected_has_no_reason_code(self):
+        with pytest.raises(ProvenanceOutcomeError):
+            reason_code_for(ProvenanceStatus.COLLECTED)
+
+
+class TestLimitation:
+    """A limitation carries stable codes and safe counters only."""
+
+    def test_limitation_records_provider_status_and_code(self):
+        limitation = limitation_for("detection-content", ProvenanceStatus.DENIED)
+        assert limitation.provider_id == "detection-content"
+        assert limitation.status is ProvenanceStatus.DENIED
+        assert limitation.reason_code == reason_code_for(ProvenanceStatus.DENIED)
+
+    def test_limitation_projection_is_bounded_and_safe(self):
+        limitation = limitation_for("detection-content", ProvenanceStatus.TIMED_OUT)
+        projection = limitation.projection()
+        assert set(projection) == {"provider_id", "status", "reason_code", "detail"}
+        assert all(isinstance(value, str) for value in projection.values())
+
+    def test_detail_is_a_fixed_safe_message_not_an_exception_string(self):
+        """`str(exc)` must never become a record field."""
+        limitation = limitation_for(
+            "detection-content",
+            ProvenanceStatus.FAILED,
+            detail="ValueError: /home/secret/path leaked token=abc123",
+        )
+        assert "secret" not in limitation.projection()["detail"]
+        assert "abc123" not in limitation.projection()["detail"]
+
+    def test_known_safe_detail_is_preserved(self):
+        limitation = limitation_for(
+            "detection-content", ProvenanceStatus.TRUNCATED, detail="entry limit reached"
+        )
+        assert limitation.projection()["detail"] == "entry limit reached"
+
+    def test_collected_cannot_produce_a_limitation(self):
+        """A successful source has nothing to declare."""
+        with pytest.raises(ProvenanceOutcomeError):
+            limitation_for("detection-content", ProvenanceStatus.COLLECTED)
+
+    @pytest.mark.parametrize("provider_id", ["", "bad id", "x" * 65, "a\x00b"])
+    def test_hostile_provider_id_is_rejected(self, provider_id):
+        with pytest.raises(ProvenanceOutcomeError):
+            limitation_for(provider_id, ProvenanceStatus.DENIED)
+
+    def test_limitations_sort_deterministically(self):
+        first = limitation_for("apparatus", ProvenanceStatus.DENIED)
+        second = limitation_for("detection-content", ProvenanceStatus.DENIED)
+        assert sorted([second, first]) == [first, second]
+
+    def test_limitation_is_immutable(self):
+        limitation = ProvenanceLimitation(
+            provider_id="apparatus",
+            status=ProvenanceStatus.DENIED,
+            reason_code=reason_code_for(ProvenanceStatus.DENIED),
+            detail="",
+        )
+        with pytest.raises(AttributeError):
+            limitation.provider_id = "other"  # type: ignore[misc]

--- a/tests/test_provenance_record.py
+++ b/tests/test_provenance_record.py
@@ -1,0 +1,191 @@
+"""Tests for the REP-003 ready-to-seal provenance record (issue #452).
+
+Covers the preflight's persistence contract: a create-once, canonical record
+under the authoritative run identity, idempotent only on identical bytes,
+failing closed on conflicting content, and explicitly NOT claiming to be a
+seal (issue #444 owns sealing).
+"""
+
+import json
+
+import pytest
+
+from aptl.core.provenance.coordinator import ProvenanceCollection, ProvenanceSection
+from aptl.core.provenance.outcomes import ProvenanceStatus, limitation_for
+from aptl.core.provenance.record import (
+    PROVENANCE_RECORD_PATH,
+    RECORD_SCHEMA_VERSION,
+    build_provenance_record,
+    publish_provenance_record,
+)
+from aptl.core.runstore import LocalRunStore, RunStoreConflictError, SecretInvariantError
+
+_RUN_ID = "run_20260101T000000Z"
+
+
+def _experiment_section():
+    """The admitted-context section the canonical record requires."""
+    return ProvenanceSection(
+        provider_id="experiment",
+        status=ProvenanceStatus.COLLECTED,
+        declaration_digest="sha256:" + "e" * 64,
+        content_identity="sha256:" + "f" * 64,
+        payload={"plan_id": "plan-1"},
+        leaf_count=1,
+    )
+
+
+def _collection(sections=None, limitations=()):
+    sections = sections or {
+        "apparatus": ProvenanceSection(
+            provider_id="apparatus",
+            status=ProvenanceStatus.COLLECTED,
+            declaration_digest="sha256:" + "a" * 64,
+            content_identity="sha256:" + "b" * 64,
+            payload={"backend": {"name": "aptl"}},
+            leaf_count=2,
+        ),
+        "experiment": _experiment_section(),
+    }
+    return ProvenanceCollection(
+        sections=sections,
+        limitations=tuple(limitations),
+        aggregate_identity="sha256:" + "c" * 64,
+        registry_declaration_digest="sha256:" + "d" * 64,
+    )
+
+
+def _store(tmp_path):
+    return LocalRunStore(tmp_path / "runs")
+
+
+class TestRecordShape:
+    """The record composes two namespaces and states what it is."""
+
+    def test_record_is_versioned_and_run_scoped(self):
+        record = build_provenance_record(run_id=_RUN_ID, collection=_collection())
+        assert record["schema_version"] == RECORD_SCHEMA_VERSION
+        assert record["run_id"] == _RUN_ID
+
+    def test_record_declares_ready_to_seal_not_sealed(self):
+        """#444 owns sealing; this record must never claim to be one."""
+        record = build_provenance_record(run_id=_RUN_ID, collection=_collection())
+        assert record["seal_state"] == "ready-to-seal"
+        assert "sealed" not in json.dumps(record).replace("ready-to-seal", "")
+
+    def test_record_carries_the_aggregate_identity(self):
+        record = build_provenance_record(run_id=_RUN_ID, collection=_collection())
+        assert record["aggregate_identity"] == "sha256:" + "c" * 64
+
+    def test_record_carries_sections_and_limitations(self):
+        limitation = limitation_for("detection-content", ProvenanceStatus.DENIED)
+        record = build_provenance_record(
+            run_id=_RUN_ID, collection=_collection(limitations=[limitation])
+        )
+        assert record["sections"][0]["provider_id"] == "apparatus"
+        assert record["limitations"][0]["provider_id"] == "detection-content"
+
+    def test_record_is_deterministic_for_the_same_collection(self):
+        first = build_provenance_record(run_id=_RUN_ID, collection=_collection())
+        second = build_provenance_record(run_id=_RUN_ID, collection=_collection())
+        assert first == second
+
+    def test_record_carries_no_timestamp(self):
+        """A volatile timestamp would make an unchanged apparatus look changed."""
+        rendered = json.dumps(build_provenance_record(run_id=_RUN_ID, collection=_collection()))
+        assert "timestamp" not in rendered
+        assert "collected_at" not in rendered
+
+
+class TestPublication:
+    """Publication is create-once, canonical, and fails closed on conflict."""
+
+    def test_publishes_to_the_run_scoped_provenance_path(self, tmp_path):
+        store = _store(tmp_path)
+        store.create_run(_RUN_ID)
+        path = publish_provenance_record(
+            store=store, run_id=_RUN_ID, collection=_collection()
+        )
+        assert path.exists()
+        assert path.name == "run-provenance.json"
+        assert PROVENANCE_RECORD_PATH.endswith("run-provenance.json")
+
+    def test_published_bytes_are_canonical_json(self, tmp_path):
+        store = _store(tmp_path)
+        store.create_run(_RUN_ID)
+        path = publish_provenance_record(
+            store=store, run_id=_RUN_ID, collection=_collection()
+        )
+        loaded = json.loads(path.read_bytes())
+        assert loaded["run_id"] == _RUN_ID
+
+    def test_republishing_identical_content_is_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        store.create_run(_RUN_ID)
+        first = publish_provenance_record(
+            store=store, run_id=_RUN_ID, collection=_collection()
+        )
+        second = publish_provenance_record(
+            store=store, run_id=_RUN_ID, collection=_collection()
+        )
+        assert first == second
+
+    def test_republishing_different_content_fails_closed(self, tmp_path):
+        """Overwrite-capable persistence is exactly what this record must not use."""
+        store = _store(tmp_path)
+        store.create_run(_RUN_ID)
+        publish_provenance_record(store=store, run_id=_RUN_ID, collection=_collection())
+        conflicting = _collection(
+            sections={
+                "apparatus": ProvenanceSection(
+                    provider_id="apparatus",
+                    status=ProvenanceStatus.COLLECTED,
+                    declaration_digest="sha256:" + "9" * 64,
+                    content_identity="sha256:" + "8" * 64,
+                    leaf_count=1,
+                ),
+                "experiment": _experiment_section(),
+            }
+        )
+        with pytest.raises(RunStoreConflictError):
+            publish_provenance_record(
+                store=store, run_id=_RUN_ID, collection=conflicting
+            )
+
+    def test_a_secret_shaped_payload_is_refused_by_the_store_invariant(self, tmp_path):
+        """Defense in depth behind the providers' allowlist."""
+        store = _store(tmp_path)
+        store.create_run(_RUN_ID)
+        leaky = _collection(
+            sections={
+                "apparatus": ProvenanceSection(
+                    provider_id="apparatus",
+                    status=ProvenanceStatus.COLLECTED,
+                    declaration_digest="sha256:" + "a" * 64,
+                    content_identity="sha256:" + "b" * 64,
+                    payload={"password": "hunter2"},
+                    leaf_count=1,
+                ),
+                "experiment": _experiment_section(),
+            }
+        )
+        with pytest.raises(SecretInvariantError):
+            publish_provenance_record(store=store, run_id=_RUN_ID, collection=leaky)
+
+    def test_the_record_never_lands_outside_the_run_directory(self, tmp_path):
+        store = _store(tmp_path)
+        store.create_run(_RUN_ID)
+        path = publish_provenance_record(
+            store=store, run_id=_RUN_ID, collection=_collection()
+        )
+        assert path.is_relative_to(store.get_run_path(_RUN_ID))
+
+    def test_limitations_survive_the_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.create_run(_RUN_ID)
+        limitation = limitation_for("detection-content", ProvenanceStatus.UNAVAILABLE)
+        path = publish_provenance_record(
+            store=store, run_id=_RUN_ID, collection=_collection(limitations=[limitation])
+        )
+        loaded = json.loads(path.read_bytes())
+        assert loaded["limitations"][0]["reason_code"] == limitation.reason_code

--- a/tests/test_provenance_registry.py
+++ b/tests/test_provenance_registry.py
@@ -1,0 +1,183 @@
+"""Tests for the REP-003 provenance provider registry (issue #452).
+
+Covers the preflight's "narrow, trusted, capability-declared provenance-provider
+seam": a registration pins a stable non-executable id, implementation version,
+the capability it supplies, its owner adapter, applicable seal point,
+requiredness policy key, and hard count/byte/time limits.
+"""
+
+import pytest
+
+from aptl.core.provenance.registry import (
+    REGISTRY_SCHEMA_VERSION,
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    ProvenanceProviderRegistry,
+    ProvenanceRegistrationError,
+    SealPoint,
+    SealProfile,
+)
+
+_LIMITS = ProvenanceLimits(max_bytes=1024, max_entries=8, timeout_s=5)
+
+
+def _registration(provider_id: str = "detection-content", **overrides):
+    fields = dict(
+        provider_id=provider_id,
+        implementation_version="1.0.0",
+        provenance_kind="detection-content",
+        owner_adapter="aptl.core.snapshot",
+        seal_point=SealPoint.RUN_READY_TO_SEAL,
+        requiredness_policy_key="detection-content-required",
+        limits=_LIMITS,
+    )
+    fields.update(overrides)
+    return ProvenanceProviderRegistration(**fields)
+
+
+class TestRegistration:
+    """A registration is a bounded, code-owned capability declaration."""
+
+    def test_declaration_projection_is_canonical_ready(self):
+        projection = _registration().declaration_projection()
+        assert projection["registry_schema"] == REGISTRY_SCHEMA_VERSION
+        assert projection["provider_id"] == "detection-content"
+        assert projection["max_bytes"] == 1024
+        assert projection["max_entries"] == 8
+        assert projection["timeout_s"] == 5
+
+    def test_effective_config_digest_pins_the_declaration(self):
+        assert _registration().effective_config_digest().startswith("sha256:")
+
+    def test_digest_changes_when_a_declared_limit_changes(self):
+        tighter = ProvenanceLimits(max_bytes=512, max_entries=8, timeout_s=5)
+        assert (
+            _registration().effective_config_digest()
+            != _registration(limits=tighter).effective_config_digest()
+        )
+
+    def test_digest_changes_when_the_implementation_version_changes(self):
+        assert (
+            _registration().effective_config_digest()
+            != _registration(implementation_version="1.0.1").effective_config_digest()
+        )
+
+    def test_digest_is_stable_for_an_identical_declaration(self):
+        assert _registration().effective_config_digest() == _registration().effective_config_digest()
+
+    @pytest.mark.parametrize(
+        "provider_id",
+        [
+            "",
+            "Detection",
+            "detection content",
+            "aptl.core.snapshot:collect",
+            "../../etc/passwd",
+            "https://example.test/provider",
+            "x" * 65,
+        ],
+    )
+    def test_provider_id_must_not_be_resolvable_to_code_or_a_location(self, provider_id):
+        """The id can never be an import path, command, URL, or host path."""
+        with pytest.raises(ProvenanceRegistrationError):
+            _registration(provider_id=provider_id)
+
+    @pytest.mark.parametrize(
+        "limits",
+        [
+            ProvenanceLimits(max_bytes=0, max_entries=8, timeout_s=5),
+            ProvenanceLimits(max_bytes=1024, max_entries=0, timeout_s=5),
+            ProvenanceLimits(max_bytes=1024, max_entries=8, timeout_s=0),
+            ProvenanceLimits(max_bytes=-1, max_entries=8, timeout_s=5),
+        ],
+    )
+    def test_limits_must_be_positive(self, limits):
+        """An unbounded provider is not admissible."""
+        with pytest.raises(ProvenanceRegistrationError):
+            _registration(limits=limits)
+
+    def test_registration_is_immutable(self):
+        with pytest.raises(AttributeError):
+            _registration().provider_id = "other"  # type: ignore[misc]
+
+
+class TestRegistry:
+    """The registry is the sole source of truth and iterates deterministically."""
+
+    def test_duplicate_provider_ids_are_rejected(self):
+        with pytest.raises(ProvenanceRegistrationError):
+            ProvenanceProviderRegistry((_registration(), _registration()))
+
+    def test_iteration_is_id_sorted_regardless_of_construction_order(self):
+        first = _registration("apparatus")
+        second = _registration("detection-content")
+        forward = ProvenanceProviderRegistry((first, second))
+        backward = ProvenanceProviderRegistry((second, first))
+        assert [r.provider_id for r in forward.ordered()] == ["apparatus", "detection-content"]
+        assert [r.provider_id for r in forward.ordered()] == [
+            r.provider_id for r in backward.ordered()
+        ]
+
+    def test_declaration_projection_is_order_independent(self):
+        first = _registration("apparatus")
+        second = _registration("detection-content")
+        assert (
+            ProvenanceProviderRegistry((first, second)).declaration_digest()
+            == ProvenanceProviderRegistry((second, first)).declaration_digest()
+        )
+
+    def test_lookup_returns_the_registration(self):
+        registry = ProvenanceProviderRegistry((_registration("apparatus"),))
+        assert registry.get("apparatus") is not None
+        assert registry.get("absent") is None
+
+    def test_empty_registry_has_a_stable_declaration_digest(self):
+        assert (
+            ProvenanceProviderRegistry(()).declaration_digest()
+            == ProvenanceProviderRegistry(()).declaration_digest()
+        )
+
+    def test_for_seal_point_selects_only_matching_registrations(self):
+        run_scoped = _registration("apparatus", seal_point=SealPoint.RUN_READY_TO_SEAL)
+        trial_scoped = _registration("experiment", seal_point=SealPoint.TRIAL_READY_TO_SEAL)
+        registry = ProvenanceProviderRegistry((run_scoped, trial_scoped))
+        selected = registry.for_seal_point(SealPoint.RUN_READY_TO_SEAL)
+        assert [r.provider_id for r in selected] == ["apparatus"]
+
+
+class TestSealProfile:
+    """The seal profile is the extension parameter: seal point + required ids."""
+
+    def test_profile_reports_required_providers(self):
+        profile = SealProfile(
+            seal_point=SealPoint.RUN_READY_TO_SEAL,
+            required_provider_ids=frozenset({"apparatus"}),
+        )
+        assert profile.requires("apparatus")
+        assert not profile.requires("detection-content")
+
+    def test_profile_rejects_a_required_id_absent_from_the_registry(self):
+        """A policy naming a provider nobody implements must fail closed."""
+        registry = ProvenanceProviderRegistry((_registration("apparatus"),))
+        profile = SealProfile(
+            seal_point=SealPoint.RUN_READY_TO_SEAL,
+            required_provider_ids=frozenset({"nonexistent"}),
+        )
+        with pytest.raises(ProvenanceRegistrationError):
+            profile.validate_against(registry)
+
+    def test_profile_validates_when_every_required_id_is_registered(self):
+        registry = ProvenanceProviderRegistry((_registration("apparatus"),))
+        profile = SealProfile(
+            seal_point=SealPoint.RUN_READY_TO_SEAL,
+            required_provider_ids=frozenset({"apparatus"}),
+        )
+        profile.validate_against(registry)
+
+    @pytest.mark.parametrize("provider_id", ["", "Apparatus", "a b"])
+    def test_profile_rejects_a_hostile_required_id(self, provider_id):
+        with pytest.raises(ProvenanceRegistrationError):
+            SealProfile(
+                seal_point=SealPoint.RUN_READY_TO_SEAL,
+                required_provider_ids=frozenset({provider_id}),
+            )

--- a/tests/test_provenance_registry.py
+++ b/tests/test_provenance_registry.py
@@ -63,7 +63,9 @@ class TestRegistration:
         )
 
     def test_digest_is_stable_for_an_identical_declaration(self):
-        assert _registration().effective_config_digest() == _registration().effective_config_digest()
+        first = _registration().effective_config_digest()
+        second = _registration().effective_config_digest()
+        assert first == second
 
     @pytest.mark.parametrize(
         "provider_id",
@@ -105,8 +107,9 @@ class TestRegistry:
     """The registry is the sole source of truth and iterates deterministically."""
 
     def test_duplicate_provider_ids_are_rejected(self):
+        duplicated = (_registration(), _registration())
         with pytest.raises(ProvenanceRegistrationError):
-            ProvenanceProviderRegistry((_registration(), _registration()))
+            ProvenanceProviderRegistry(duplicated)
 
     def test_iteration_is_id_sorted_regardless_of_construction_order(self):
         first = _registration("apparatus")
@@ -132,10 +135,9 @@ class TestRegistry:
         assert registry.get("absent") is None
 
     def test_empty_registry_has_a_stable_declaration_digest(self):
-        assert (
-            ProvenanceProviderRegistry(()).declaration_digest()
-            == ProvenanceProviderRegistry(()).declaration_digest()
-        )
+        first = ProvenanceProviderRegistry(()).declaration_digest()
+        second = ProvenanceProviderRegistry(()).declaration_digest()
+        assert first == second
 
     def test_for_seal_point_selects_only_matching_registrations(self):
         run_scoped = _registration("apparatus", seal_point=SealPoint.RUN_READY_TO_SEAL)
@@ -176,8 +178,6 @@ class TestSealProfile:
 
     @pytest.mark.parametrize("provider_id", ["", "Apparatus", "a b"])
     def test_profile_rejects_a_hostile_required_id(self, provider_id):
+        required = frozenset({provider_id})
         with pytest.raises(ProvenanceRegistrationError):
-            SealProfile(
-                seal_point=SealPoint.RUN_READY_TO_SEAL,
-                required_provider_ids=frozenset({provider_id}),
-            )
+            SealProfile(seal_point=SealPoint.RUN_READY_TO_SEAL, required_provider_ids=required)

--- a/tests/test_provenance_review_fixes.py
+++ b/tests/test_provenance_review_fixes.py
@@ -1,0 +1,321 @@
+"""Regression tests for the REP-003 pre-push review findings (issue #452).
+
+Three defects the codex review surfaced:
+
+1. Lab startup published the CANONICAL ready-to-seal record without the
+   admitted trial or realized participant context. Because publication is
+   create-once, the real seal-boundary collector could never correct it — the
+   authoritative write would conflict with the startup artifact.
+2. ``range_identity`` hashed ``RangeSnapshot.to_dict()`` wholesale, folding
+   volatile observation state (timestamp, container status/health) into a
+   stable identity.
+3. The ``wazuh-allowlists`` detection root admitted every non-dot file, which
+   is directory discovery rather than a non-secret source allowlist.
+"""
+
+import json
+
+import pytest
+
+from aptl.core.config import AptlConfig
+from aptl.core.provenance.outcomes import ProvenanceStatus
+from aptl.core.provenance.protocol import ProvenanceContext
+from aptl.core.provenance.providers.detection import (
+    DETECTION_ROOTS,
+    DetectionContentProvider,
+)
+from aptl.core.provenance.providers.runtime_facts import RuntimeFactsProvider
+from aptl.core.provenance.record import (
+    PROVENANCE_RECORD_PATH,
+    PROVISIONAL_RECORD_PATH,
+    ProvenanceContextError,
+    publish_provenance_record,
+    publish_provisional_provenance_record,
+)
+from aptl.core.provenance.registrations import collect_run_provenance
+from aptl.core.provenance.registry import (
+    ProvenanceLimits,
+    ProvenanceProviderRegistration,
+    SealPoint,
+)
+from aptl.core.runstore import LocalRunStore
+
+_RUN_ID = "run_20260101T000000Z"
+
+
+def _context(provider_id, *, max_bytes=1_000_000, max_entries=64, timeout_s=30):
+    registration = ProvenanceProviderRegistration(
+        provider_id=provider_id,
+        implementation_version="1.0.0",
+        provenance_kind=provider_id,
+        owner_adapter="tests",
+        seal_point=SealPoint.RUN_READY_TO_SEAL,
+        requiredness_policy_key=f"{provider_id}-required",
+        limits=ProvenanceLimits(
+            max_bytes=max_bytes, max_entries=max_entries, timeout_s=timeout_s
+        ),
+    )
+    return ProvenanceContext(registration=registration, clock=lambda: 0.0, started_at=0.0)
+
+
+class _StubPlan:
+    plan_id = "plan-1"
+    policy_version = "aptl-admission/v1"
+    source_set_digest = "sha256:" + "c" * 64
+    plan_digest = "sha256:" + "d" * 64
+    trials = ()
+    capture_bindings = ()
+
+
+class _StubSoftware:
+    python_version = "3.12.1"
+    docker_version = "27.0"
+    compose_version = "2.29"
+    wazuh_manager_version = ""
+    wazuh_indexer_version = ""
+    aptl_version = "0.2.0"
+    raes_version = "2.0.0"
+
+
+class _RealisticSnapshot:
+    """A snapshot whose ``to_dict()`` includes the volatile fields the real one does."""
+
+    def __init__(self, *, timestamp="2026-01-01T00:00:00Z", status="running", health="healthy"):
+        self.timestamp = timestamp
+        self.software = _StubSoftware()
+        self.containers = [_Container(status=status, health=health)]
+
+    def to_dict(self):
+        return {
+            "timestamp": self.timestamp,
+            "containers": [
+                {
+                    "name": c.name,
+                    "image": c.image,
+                    "image_id": c.image_id,
+                    "image_digest": c.image_digest,
+                    "status": c.status,
+                    "health": c.health,
+                }
+                for c in self.containers
+            ],
+        }
+
+
+class _Container:
+    def __init__(self, *, status="running", health="healthy"):
+        self.name = "aptl-victim"
+        self.image = "img:tag"
+        self.image_id = "volatile-id"
+        self.image_digest = "sha256:" + "f" * 64
+        self.status = status
+        self.health = health
+
+
+class TestSealBoundaryOwnership:
+    """The canonical ready-to-seal path requires authoritative run context."""
+
+    def test_publishing_without_an_admitted_plan_is_refused(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        collection = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_RealisticSnapshot()
+        )
+        with pytest.raises(ProvenanceContextError):
+            publish_provenance_record(
+                store=store, run_id=_RUN_ID, collection=collection
+            )
+
+    def test_publishing_with_an_admitted_plan_is_allowed(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        collection = collect_run_provenance(
+            project_dir=tmp_path,
+            config=AptlConfig(),
+            snapshot=_RealisticSnapshot(),
+            admitted_plan=_StubPlan(),
+        )
+        path = publish_provenance_record(
+            store=store, run_id=_RUN_ID, collection=collection
+        )
+        assert path.name == "run-provenance.json"
+
+    def test_the_provisional_record_uses_a_distinct_path(self, tmp_path):
+        """Startup must not occupy the canonical ready-to-seal path."""
+        assert PROVISIONAL_RECORD_PATH != PROVENANCE_RECORD_PATH
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        collection = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_RealisticSnapshot()
+        )
+        path = publish_provisional_provenance_record(
+            store=store, run_id=_RUN_ID, collection=collection
+        )
+        assert path.name != "run-provenance.json"
+
+    def test_the_provisional_record_does_not_claim_ready_to_seal(self, tmp_path):
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        collection = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_RealisticSnapshot()
+        )
+        path = publish_provisional_provenance_record(
+            store=store, run_id=_RUN_ID, collection=collection
+        )
+        assert json.loads(path.read_bytes())["seal_state"] == "provisional"
+
+    def test_a_provisional_record_does_not_block_the_later_canonical_write(self, tmp_path):
+        """The whole point: startup provenance must not foreclose the seal write."""
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        startup = collect_run_provenance(
+            project_dir=tmp_path, config=AptlConfig(), snapshot=_RealisticSnapshot()
+        )
+        publish_provisional_provenance_record(
+            store=store, run_id=_RUN_ID, collection=startup
+        )
+        sealed = collect_run_provenance(
+            project_dir=tmp_path,
+            config=AptlConfig(),
+            snapshot=_RealisticSnapshot(),
+            admitted_plan=_StubPlan(),
+        )
+        path = publish_provenance_record(store=store, run_id=_RUN_ID, collection=sealed)
+        assert path.exists()
+
+    def test_lab_startup_writes_only_the_provisional_artifact(self, tmp_path):
+        from aptl.core.lab import _publish_run_provenance
+
+        store = LocalRunStore(tmp_path / "runs")
+        store.create_run(_RUN_ID)
+        _publish_run_provenance(
+            store=store,
+            run_id=_RUN_ID,
+            project_dir=tmp_path,
+            config=AptlConfig(),
+            snapshot=_RealisticSnapshot(),
+        )
+        run_path = store.get_run_path(_RUN_ID)
+        assert (run_path / PROVISIONAL_RECORD_PATH).exists()
+        assert not (run_path / PROVENANCE_RECORD_PATH).exists()
+
+
+class TestStableRangeIdentity:
+    """Volatile observation state must not perturb a stable identity."""
+
+    def test_a_changed_snapshot_timestamp_does_not_change_identity(self):
+        first = RuntimeFactsProvider(
+            _RealisticSnapshot(timestamp="2026-01-01T00:00:00Z")
+        ).collect(_context("runtime-facts"))
+        second = RuntimeFactsProvider(
+            _RealisticSnapshot(timestamp="2026-06-30T12:34:56Z")
+        ).collect(_context("runtime-facts"))
+        assert first.leaves == second.leaves
+
+    def test_changed_container_status_and_health_do_not_change_identity(self):
+        healthy = RuntimeFactsProvider(
+            _RealisticSnapshot(status="running", health="healthy")
+        ).collect(_context("runtime-facts"))
+        degraded = RuntimeFactsProvider(
+            _RealisticSnapshot(status="restarting", health="unhealthy")
+        ).collect(_context("runtime-facts"))
+        assert healthy.leaves == degraded.leaves
+
+    def test_a_changed_image_digest_still_changes_identity(self):
+        """The stable projection must not become blind to real apparatus change."""
+        base = _RealisticSnapshot()
+        changed = _RealisticSnapshot()
+        changed.containers[0].image_digest = "sha256:" + "0" * 64
+        assert (
+            RuntimeFactsProvider(base).collect(_context("runtime-facts")).leaves
+            != RuntimeFactsProvider(changed).collect(_context("runtime-facts")).leaves
+        )
+
+    def test_the_volatile_snapshot_remains_available_as_an_observation(self):
+        result = RuntimeFactsProvider(_RealisticSnapshot()).collect(
+            _context("runtime-facts")
+        )
+        assert "range_snapshot_observation" in result.payload
+
+
+class TestDetectionAllowlistIsExplicit:
+    """Unknown files stay unread rather than being admitted for lacking a dot."""
+
+    def test_no_root_admits_an_unbounded_wildcard(self):
+        for root in DETECTION_ROOTS:
+            assert root.suffixes or root.filenames, (
+                f"root {root.root_id} admits every non-dot file"
+            )
+
+    def test_an_undeclared_extensionless_file_is_not_read(self, tmp_path):
+        lists = tmp_path / "config" / "wazuh_cluster" / "etc" / "lists"
+        lists.mkdir(parents=True)
+        (lists / "active-response-whitelist").write_text("10.0.0.1\n")
+        (lists / "db-password").write_text("hunter2")
+
+        result = DetectionContentProvider(tmp_path).collect(_context("detection-content"))
+        names = {leaf.logical_id for leaf in result.leaves}
+        assert any("active-response-whitelist" in name for name in names)
+        assert not any("db-password" in name for name in names)
+
+    def test_an_undeclared_secret_never_reaches_a_digest(self, tmp_path):
+        """A digest of a low-entropy secret is an offline confirmation oracle."""
+        import hashlib
+
+        lists = tmp_path / "config" / "wazuh_cluster" / "etc" / "lists"
+        lists.mkdir(parents=True)
+        (lists / "api-token").write_bytes(b"s3cr3t")
+        forbidden = hashlib.sha256(b"s3cr3t").hexdigest()
+
+        result = DetectionContentProvider(tmp_path).collect(_context("detection-content"))
+        assert forbidden not in repr(result.leaves)
+
+    def test_the_declared_allowlist_file_is_still_covered(self, tmp_path):
+        lists = tmp_path / "config" / "wazuh_cluster" / "etc" / "lists"
+        lists.mkdir(parents=True)
+        (lists / "active-response-whitelist").write_text("10.0.0.1\n")
+        result = DetectionContentProvider(tmp_path).collect(_context("detection-content"))
+        assert result.status is ProvenanceStatus.COLLECTED
+
+
+class TestHostProbeIsComposedNotInherited:
+    """The live ``docker info`` probe is a composition decision, not a default.
+
+    Test-quality review found 12 provider constructions transparently spawning
+    a real ``docker info`` subprocess because the live probe was the
+    constructor default. Fixing the 12 call sites would have left the trap for
+    the next one; the category fix moves the probe into the fleet composition.
+    """
+
+    def test_the_constructor_default_performs_no_probe(self, monkeypatch):
+        import aptl.core.hostenv as hostenv
+
+        def explode():  # pragma: no cover - must never be reached
+            raise AssertionError("constructing the provider must not probe Docker")
+
+        monkeypatch.setattr(hostenv, "docker_mode", explode)
+        result = RuntimeFactsProvider(_RealisticSnapshot()).collect(
+            _context("runtime-facts")
+        )
+        assert result.status is ProvenanceStatus.COLLECTED
+        assert result.payload["host_facts"] == {}
+
+    def test_the_production_fleet_still_wires_the_real_probe(self):
+        """The category fix must not silently drop host facts from the record."""
+        from aptl.core.provenance.providers.runtime_facts import default_host_facts
+        from aptl.core.provenance.registrations import build_default_providers
+
+        providers = build_default_providers(
+            project_dir=".", config=AptlConfig(), snapshot=_RealisticSnapshot()
+        )
+        runtime = next(p for p in providers if p.provider_id == "runtime-facts")
+        assert runtime._host_facts is default_host_facts
+
+    def test_default_host_facts_still_reports_the_allowlisted_keys(self, monkeypatch):
+        import aptl.core.hostenv as hostenv
+        from aptl.core.provenance.providers.runtime_facts import default_host_facts
+
+        monkeypatch.setattr(hostenv, "docker_mode", lambda: "linux-native")
+        facts = default_host_facts()
+        assert set(facts) == {"os", "arch", "kernel", "python", "docker_mode"}
+        assert facts["docker_mode"] == "linux-native"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -590,3 +590,70 @@ class TestDetectionContentDigest:
         rule_file.write_text('alert tcp any any -> any any (msg:"v2"; sid:1;)')
         digest2 = detection_content_digest(tmp_path)
         assert digest1 != digest2
+
+
+class TestDetectionAndConfigProvenanceGaps:
+    """REP-003 (#452): gaps in the REP-001 snapshot helpers that must not persist.
+
+    ``_hash_config_files`` hashed ``.env``, and ``detection_content_digest``
+    hashed an unframed concatenation over stale, non-recursive globs — two of
+    which named a ``config/wazuh/etc`` tree that does not exist, while the real
+    Wazuh rule surface (``config/wazuh_cluster``) and Suricata's nested MISP
+    content went unrecorded.
+    """
+
+    def test_env_is_never_hashed(self, tmp_path):
+        """A digest of a secret-bearing file is not safe disclosure (ADR-029)."""
+        from aptl.core.snapshot import _hash_config_files
+
+        (tmp_path / "aptl.json").write_text('{"lab": {"name": "test"}}')
+        (tmp_path / ".env").write_text("WAZUH_API_PASSWORD=hunter2\n")
+
+        hashes = _hash_config_files(tmp_path)
+        assert ".env" not in hashes
+        assert "aptl.json" in hashes
+
+    def test_detection_digest_covers_nested_suricata_content(self, tmp_path):
+        from aptl.core.snapshot import detection_content_digest
+
+        nested = tmp_path / "config" / "suricata" / "rules" / "misp"
+        nested.mkdir(parents=True)
+        (nested / "misp-iocs.rules").write_text('alert tcp any any -> any any (sid:2;)')
+
+        assert detection_content_digest(tmp_path) != ""
+
+    def test_detection_digest_covers_the_real_wazuh_rule_surface(self, tmp_path):
+        from aptl.core.snapshot import detection_content_digest
+
+        cluster = tmp_path / "config" / "wazuh_cluster"
+        cluster.mkdir(parents=True)
+        (cluster / "suricata_rules.xml").write_text("<group/>")
+
+        assert detection_content_digest(tmp_path) != ""
+
+    def test_detection_digest_distinguishes_a_content_split(self, tmp_path):
+        """The unframed-concatenation collision: 'ab'+'c' vs 'a'+'bc'."""
+        from aptl.core.snapshot import detection_content_digest
+
+        rules = tmp_path / "config" / "suricata" / "rules"
+        rules.mkdir(parents=True)
+        (rules / "a.rules").write_bytes(b"ab")
+        (rules / "b.rules").write_bytes(b"c")
+        first = detection_content_digest(tmp_path)
+
+        (rules / "a.rules").write_bytes(b"a")
+        (rules / "b.rules").write_bytes(b"bc")
+        assert detection_content_digest(tmp_path) != first
+
+    def test_detection_digest_does_not_follow_symlinks(self, tmp_path):
+        import os
+
+        from aptl.core.snapshot import detection_content_digest
+
+        secret = tmp_path / "outside.rules"
+        secret.write_bytes(b"SECRET")
+        rules = tmp_path / "config" / "suricata" / "rules"
+        rules.mkdir(parents=True)
+        os.symlink(secret, rules / "linked.rules")
+
+        assert detection_content_digest(tmp_path) == ""


### PR DESCRIPTION
## Summary

Records the realized APTL instrument at a run boundary: which scenario, apparatus, participant implementation, images, detector rules, collectors, dependency locks, and configuration were actually used. A new `aptl.core.provenance` package collects from code-owned providers under declared byte/entry/time limits and publishes a create-once canonical record. Sources that are unavailable, denied, unsupported, truncated, or failed become explicit limitations with stable reason codes rather than being silently omitted or given a fabricated digest. Secret sources are excluded by allowlist before collection; redaction and the run-store secret invariant remain defense in depth.

## Requirement UIDs

- `REP-003`

## Related Issues

Closes #452

## ADR Impact

- ADR-044
- ADR-029
- ADR-047

## Changes

- Add `aptl.core.provenance`: domain-separated canonical identity, closed outcome vocabulary, capability-declared provider registry, bounded collection coordinator, and create-once record publication
- Add seven built-in providers: apparatus manifests, admitted experiment/trial + capture bindings, participant selection, detection content, safe effective-config identity, runtime facts, and dependency/asset locks
- Frame content identity per artifact (logical role + digest, folded over a sorted sequence) so one changed rule moves only its own leaf and the aggregate
- Split the ready-to-seal record from a provisional startup record so create-once publication at lab start cannot foreclose the later seal-boundary write
- Fix `detection_content_digest`: it globbed `config/wazuh/etc/{rules,decoders}`, which do not exist, missed nested `config/suricata/rules/misp`, hashed an unframed byte concatenation, and followed symlinks — covering 1 artifact where the corrected surface finds 11
- Stop hashing `.env` in `_hash_config_files`: a digest of a secret-bearing file with a small guessable value domain is a confirmation oracle, not an opaque identity
- Read every provenance source through contained no-follow opens with positive-only suffix/filename admission, so unknown files stay unread
- Exclude volatile observation state (timestamps, container status/health/ids) from stable identities, retaining it as a separate observation
- Document the run-archive provenance records in `docs/reference/experiment-runs.md`

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

244 new tests across 11 files, including property-based fuzz coverage under the existing `fuzz` marker for traversal, symlink, and limit inputs. Full suite: 3849 passed, 92 skipped, 1 xfailed. `pre-commit run --all-files` and `make policy` green.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: REP-003 ← src/aptl/core/provenance/, REP-003 ← src/aptl/core/provenance/providers/, REP-003 ← src/aptl/core/snapshot.py, REP-003 ← src/aptl/core/lab.py
- TESTS: REP-003 ← tests/test_provenance_identity.py, REP-003 ← tests/test_provenance_outcomes.py, REP-003 ← tests/test_provenance_registry.py, REP-003 ← tests/test_provenance_coordinator.py, REP-003 ← tests/test_provenance_detection.py, REP-003 ← tests/test_provenance_apparatus.py, REP-003 ← tests/test_provenance_config_runtime.py, REP-003 ← tests/test_provenance_artifacts_host.py, REP-003 ← tests/test_provenance_record.py, REP-003 ← tests/test_provenance_builtin_fleet.py, REP-003 ← tests/test_provenance_review_fixes.py, REP-003 ← tests/test_snapshot.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.