### PR TITLE
docs: cross-reference the OpenRAE env-pack companion repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ The scenario environment is whatever the SDL scenario defines. The default `tech
 
 Scenarios are [Reproducible Agentic Environments SDL](docs/sdl/index.md) documents under `scenarios/`. `aptl lab scenarios` lists the catalog; `aptl lab start --scenario <id>` (or `--scenario-path <file>`) selects one. The Compose profiles that come up are **realized from the nodes the SDL declares**—the topology follows the scenario's content, including dependency closure, rather than a preset keyed off its name.
 
+The SDL language and the reusable environment-pack format live in the RAES companion repositories—[OpenRAE/rae](https://github.com/OpenRAE/rae) (SDL and semantics) and [OpenRAE/env-packs](https://github.com/OpenRAE/env-packs) (pack definitions, templates, schemas, and authoring support). APTL consumes those definitions and realizes them as a running Docker lab; the lab lifecycle and runtime stay APTL-owned.
+
 The catalog ships the operational default plus four curated slices:
 
 | Scenario id | Boots | Omits |
@@ -186,7 +188,7 @@ Access at <http://localhost:5173> (dev) or <http://localhost:3000> (prod). The A
 
 **Components:** [Wazuh SIEM](docs/components/wazuh-siem.md) · [Kali Red Team](docs/components/kali-redteam.md) · [Victim Containers](docs/components/victim-containers.md) · [Reverse Engineering](docs/components/reverse-engineering-container.md) · [MCP Integration](docs/components/mcp-integration.md) · [Default Defensive Posture](docs/components/default-defensive-posture.md)
 
-**Scenarios & SDL:** [SDL Reference](docs/sdl/index.md) · [Curated TechVault Variants](docs/sdl/techvault-curated-variants.md) · [SOC Architecture Spec](docs/specs/soc-feature-spec.md)
+**Scenarios & SDL:** [SDL Reference](docs/sdl/index.md) · [Curated TechVault Variants](docs/sdl/techvault-curated-variants.md) · [Pack authoring (OpenRAE/env-packs)](https://github.com/OpenRAE/env-packs) · [SOC Architecture Spec](docs/specs/soc-feature-spec.md)
 
 **Reference:** [TechVault Scenario Overview](docs/reference/techvault-scenario-overview.md) · [TechVault Company Profile](docs/reference/techvault-company-profile.md) · [TechVault OSINT Readiness](docs/reference/techvault-osint-readiness.md) · [Container Template Guide](docs/containers/victim-template-guide.md)
 

--- a/docs/adrs/adr-051-component-level-raes-realization.md
+++ b/docs/adrs/adr-051-component-level-raes-realization.md
@@ -226,7 +226,7 @@ upstream work against `Brad-Edwards/aces`; until it lands, the ownership above i
 explicit rather than assumed.
 
 > **Update (2026-07-30, issue #876).** That upstream work has landed. raes 3.1.0
-> (RAESystem/rae#985) lowers `runtime.environment`, `runtime.mounts` (bind/tmpfs),
+> (OpenRAE/rae#985) lowers `runtime.environment`, `runtime.mounts` (bind/tmpfs),
 > `runtime.linux_capabilities`, `runtime.network.published_ports`,
 > `runtime.forwarding_agents`, and `runtime.service_listeners` into the SEM-218
 > realization concern registry, so RAES now owns their admission

--- a/docs/architecture/exp-005-safe-parameter-binding-provenance-preflight.md
+++ b/docs/architecture/exp-005-safe-parameter-binding-provenance-preflight.md
@@ -111,7 +111,7 @@ runtime and implementation-manifest boundary:
   the artifact identity and digest, and rejects duplicate owners. No package,
   environment, or ambient filesystem lookup supplies a manifest.
 - Provider and participant construction remain owned by #557 /
-  `RAESystem/rae#251`, not EXP-005.
+  `OpenRAE/rae#251`, not EXP-005.
 
 ### APTL apparatus configuration
 

--- a/docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md
+++ b/docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md
@@ -15,7 +15,7 @@ There are four distinct owners. Their contracts must not be conflated.
 | Concern | Owner | APTL boundary |
 | --- | --- | --- |
 | Portable attack-path, workflow, capture, evidence, and inventory semantics | RAES | APTL consumes the published RAES SDL, contract models, compiler, planner, diagnostics, and controlled vocabulary. It does not mirror them in an APTL schema or taxonomy. |
-| Environment-pack format, templates, schemas, validation, release tooling, and adoption guidance | `RAESystem/env-packs` | The companion repository defines how a RAES environment pack is shaped and validated. It does not own the particular experiment, scenario, or execution a downstream user creates with that format. |
+| Environment-pack format, templates, schemas, validation, release tooling, and adoption guidance | `OpenRAE/env-packs` | The companion repository defines how a RAES environment pack is shaped and validated. It does not own the particular experiment, scenario, or execution a downstream user creates with that format. |
 | Particular scenario content, experiment design, and execution choices | Downstream scenario or experiment owner | The downstream owner chooses and authors the specific RAES scenario or experiment within the published format and capability constraints. It cannot use that choice to select APTL container names, Compose fragments, host paths, `.env` keys, credentials, shell commands, collector implementations, or backend-specific persistence paths. |
 | Runtime realization, lab lifecycle, source acquisition, backend observation, and APTL-local evidence persistence | APTL | APTL lowers an admitted RAES execution plan through the existing runtime target and `DeploymentBackend`, then records backend evidence through the existing snapshot/run-store boundaries. |
 
@@ -27,7 +27,7 @@ Specifically:
   participant execution, and observed runtime effects through its declared
   backend capabilities. APTL must not recreate a pack-specific attack-path
   executor, static scenario branch, or local semantic model.
-- **Environment-pack format:** `RAESystem/env-packs` owns the reusable pack
+- **Environment-pack format:** `OpenRAE/env-packs` owns the reusable pack
   format, templates, schemas, validation, release tooling, and adoption
   guidance. It does not select a particular scenario, experiment, participant,
   or execution for a downstream user.
@@ -54,9 +54,9 @@ Specifically:
 
 This note is the APTL reference follow-up for issue #589. The cross-repository
 follow-ups already named by the issue remain the authorities for their scopes:
-[RAES #629](https://github.com/RAESystem/rae/issues/629) for semantic
+[RAES #629](https://github.com/OpenRAE/rae/issues/629) for semantic
 capture/inventory ownership and
-[env-packs #138](https://github.com/RAESystem/env-packs/issues/138) for the
+[env-packs #138](https://github.com/OpenRAE/env-packs/issues/138) for the
 environment-pack format reference. There is no APTL asset migration to create:
 the former APTL capture/parity surfaces were intentionally removed under
 #690/#757.

--- a/docs/architecture/issue-876-dynamic-composition-readback-preflight.md
+++ b/docs/architecture/issue-876-dynamic-composition-readback-preflight.md
@@ -8,7 +8,7 @@ second SEM-218 disclosure gate.
 > **Update (2026-07-30).** The preflight below was written against raes 2.0.0,
 > where the six runtime dimensions were not RAES-lowered concerns and the
 > boundary anticipated a backend-owned attestation feeding artifact satisfaction.
-> raes 3.1.0 (RAESystem/rae#985) instead lowers those dimensions into the
+> raes 3.1.0 (OpenRAE/rae#985) instead lowers those dimensions into the
 > realization concern registry, so the delivered design is a plain observe-and-
 > disclose: the "provider-owned runtime observation adapter" described here is
 > `aptl.backends.raes_runtime_observation`, and it discloses each observed concern

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,8 @@ run from source instead, use a virtualenv editable install
 
 ### Scenario Authoring
 - [Authoring Boundary](sdl/index.md): Current RAES-owned scenario handoff
+- [RAES SDL & runtime (OpenRAE/rae)](https://github.com/OpenRAE/rae): Companion repo owning SDL shape and semantics
+- [Pack definitions & authoring (OpenRAE/env-packs)](https://github.com/OpenRAE/env-packs): Companion repo for the environment-pack format, templates, schemas, and authoring support
 - [Curated RAES Variants](sdl/techvault-curated-variants.md): Supported startup catalog variants
 - [TechVault Static Validation Gate](raes/techvault-static-validation-gate.md): Current static scenario gate
 - [TechVault Live Validation Gate](raes/techvault-live-validation-gate.md): Current runtime realization gate

--- a/docs/sdl/index.md
+++ b/docs/sdl/index.md
@@ -3,6 +3,23 @@
 APTL no longer maintains a local scenario language or parser. ADR-035 moved
 scenario authoring and runtime handoff to RAES SDL.
 
+## Companion repositories
+
+Scenario authoring and the reusable environment-pack format are defined in the
+RAES companion repositories, not in APTL:
+
+- [OpenRAE/rae](https://github.com/OpenRAE/rae): the RAES SDL, tools, runtime,
+  and reference backend. It owns SDL shape and semantics.
+- [OpenRAE/env-packs](https://github.com/OpenRAE/env-packs): the RAES companion
+  repository for environment-pack definitions, formats, templates, schemas,
+  validation, tooling, and authoring/adoption guidance. Use it to author and
+  validate environment packs.
+
+These are authoring and reference links, not runtime source URLs or trust roots.
+APTL consumes published RAES SDL and packs. How a scenario *runs* as a lab (the
+Compose topology, container realization, lab lifecycle, credentials, and
+captured evidence) stays APTL-owned and is documented in APTL's own pages.
+
 Current operator-facing startup selection uses:
 
 - `scenarios/catalog.json` for curated scenario IDs

--- a/src/aptl/backends/raes_artifact_mechanisms.py
+++ b/src/aptl/backends/raes_artifact_mechanisms.py
@@ -118,7 +118,7 @@ _ENV_PACK_COPY_PROFILE_BODY: dict[str, Any] = {
 }
 
 
-# Generic runtime composition (ADR-051 route 3, RAESystem/rae#985). APTL composes
+# Generic runtime composition (ADR-051 route 3, OpenRAE/rae#985). APTL composes
 # a node's declared runtime shape onto a pinned generic OS substrate and proves
 # the composition by independently reading every declared runtime realization
 # concern back off the realized container. raes 3.1.0 lowers runtime-environment,
@@ -446,7 +446,7 @@ def aptl_artifact_mechanisms() -> tuple[ArtifactMechanismCapability, ...]:
     """Return every artifact mechanism APTL can materialize and verify.
 
     ``dynamic-composition`` is advertised now that raes 3.1.0 lowers the runtime
-    realization concerns (RAESystem/rae#985) and APTL composes a node onto a
+    realization concerns (OpenRAE/rae#985) and APTL composes a node onto a
     generic substrate and reads every declared runtime concern back by
     read-after-write (issue #876) — so the SEM-218 I4 precondition
     "materialize *and* independently read back" holds for it.

--- a/src/aptl/backends/raes_manifest.py
+++ b/src/aptl/backends/raes_manifest.py
@@ -290,7 +290,7 @@ _REALIZATION_ENVELOPE = build_aptl_realization_envelope(_PROVISIONER)
 # (SEM-218 I4). ``support_mode`` is OPEN_REALIZATION because APTL now supports the
 # generic ``dynamic-composition`` route (issue #876): it composes a node's runtime
 # onto a pinned substrate and reads every declared runtime concern back off the
-# realized container (raes 3.1.0 lowers those concerns, RAESystem/rae#985). The
+# realized container (raes 3.1.0 lowers those concerns, OpenRAE/rae#985). The
 # mode is the most-open posture for the domain; the exact and constrained branches
 # still apply independently through the per-kind support sets below.
 #

--- a/tests/test_raes_artifact_mechanisms.py
+++ b/tests/test_raes_artifact_mechanisms.py
@@ -135,7 +135,7 @@ def test_manifest_declares_only_mechanisms_backed_by_readback():
         "dynamic-composition",
     }
     # dynamic-composition is backed now: raes 3.1.0 lowers the runtime concerns
-    # (RAESystem/rae#985) and APTL reads each declared dimension back off the
+    # (OpenRAE/rae#985) and APTL reads each declared dimension back off the
     # realized container (issue #876), satisfying the I4 precondition.
     assert "dynamic-composition" in declared
 

--- a/tests/test_scenario_pack_ownership_contract.py
+++ b/tests/test_scenario_pack_ownership_contract.py
@@ -3,10 +3,14 @@
 from pathlib import Path
 
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 _OWNERSHIP_NOTE = (
-    Path(__file__).resolve().parents[1]
-    / "docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md"
+    _REPO_ROOT / "docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md"
 )
+_README = _REPO_ROOT / "README.md"
+_SDL_BOUNDARY = _REPO_ROOT / "docs/sdl/index.md"
+
+_ENV_PACKS_REPO = "https://github.com/OpenRAE/env-packs"
 
 
 def _decision_rows(note: str) -> dict[str, str]:
@@ -30,14 +34,43 @@ def test_scenario_pack_ownership_remains_four_way_and_current() -> None:
 
     assert set(owners) == {
         "RAES",
-        "RAESystem/env-packs",
+        "OpenRAE/env-packs",
         "Downstream scenario or experiment owner",
         "APTL",
     }
     assert "semantic" in owners["RAES"].lower()
-    assert "format" in owners["RAESystem/env-packs"].lower()
+    assert "format" in owners["OpenRAE/env-packs"].lower()
     assert "scenario" in owners["Downstream scenario or experiment owner"].lower()
     assert "realization" in owners["APTL"].lower()
-    assert "https://github.com/RAESystem/rae/issues/629" in note
-    assert "https://github.com/RAESystem/env-packs/issues/138" in note
+    assert "https://github.com/OpenRAE/rae/issues/629" in note
+    assert "https://github.com/OpenRAE/env-packs/issues/138" in note
     assert "Brad-Edwards/aces" not in note
+    # The RAESystem org was renamed to OpenRAE; the stale name must not return.
+    assert "RAESystem" not in note
+
+
+def test_user_docs_cross_reference_env_pack_companion_repo() -> None:
+    """Issue #590: README and the authoring boundary link the pack-definition repo.
+
+    The companion repo is described as pack-definition and authoring support
+    (AC2), and the authoring boundary keeps APTL runtime guidance APTL-owned
+    (AC3).
+    """
+    readme = _README.read_text(encoding="utf-8")
+    boundary = _SDL_BOUNDARY.read_text(encoding="utf-8")
+
+    # AC2: both user-facing surfaces cross-reference the companion repo.
+    assert _ENV_PACKS_REPO in readme
+    assert _ENV_PACKS_REPO in boundary
+
+    # AC2: the boundary page frames it as pack-definition / authoring support.
+    lowered = boundary.lower()
+    assert "environment-pack" in lowered
+    assert "authoring" in lowered
+
+    # AC3: APTL runtime realization stays explicitly APTL-owned.
+    assert "APTL-owned" in boundary
+
+    # The stale org name must not appear in either user-facing surface.
+    assert "RAESystem" not in readme
+    assert "RAESystem" not in boundary


### PR DESCRIPTION
## Summary

Adds APTL cross-references to the RAES env-pack companion repo (OpenRAE/env-packs), now that the ownership decision the acceptance criteria wait on is recorded (issue #589 preflight). Links describe the companion repo as pack-definition and authoring support and keep APTL runtime/lab guidance clearly APTL-owned. Also corrects the stale RAESystem org name to OpenRAE repo-wide (the org was renamed; old URLs only redirect).

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #590

## ADR Impact

- ADR-021

## Changes

- docs/sdl/index.md: new "Companion repositories" section linking OpenRAE/rae (SDL/semantics) and OpenRAE/env-packs (pack definitions, format, templates, schemas, validation, authoring), framed as authoring/reference links (not runtime source URLs or trust roots), with an explicit APTL-owned runtime boundary
- README.md: companion-repo sentence in the Scenarios section and a Pack authoring (OpenRAE/env-packs) link on the Scenarios & SDL docs line
- docs/index.md: companion-repo pointers in the Scenario Authoring section
- Corrected stale RAESystem -> OpenRAE org name in docs (issue-589/issue-876/exp-005 preflights, adr-051) and in comment shorthand under src/aptl/backends/ and tests/
- tests/test_scenario_pack_ownership_contract.py: updated to the canonical OpenRAE owner key + issue URLs, added a RAESystem regression guard, and added semantic link coverage asserting README and the authoring boundary cross-reference OpenRAE/env-packs with pack-definition/authoring wording while keeping runtime guidance APTL-owned

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Documentation cross-references plus a stale org-name correction; no runtime behavior changed. The source .py edits are comment-only. New coverage is the contract-test extension (2 tests pass). Full completion suite + make policy (Vale) + pre-commit are green; companion link targets verified to resolve under OpenRAE.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: issue #590 acceptance criteria ← tests/test_scenario_pack_ownership_contract.py

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.