### PR TITLE
fix: harden lab lifecycle recovery

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,6 +156,7 @@ The victim and kali containers publish no host ports; use
 
 ## Preflights
 
+- [Issue #905 Lab Lifecycle Robustness](issue-905-lab-lifecycle-robustness-preflight.md)
 - [Issue #874 Scenario-Bundle Realization Roots](issue-874-scenario-bundle-realization-roots-preflight.md)
 - [Issue #878 Scenario Verification Plugin Seam](issue-878-scenario-verification-plugin-seam-preflight.md)
 - [Issue #866 TechVault Component Realization](issue-866-techvault-realization-contract-preflight.md)

--- a/docs/architecture/issue-905-lab-lifecycle-robustness-preflight.md
+++ b/docs/architecture/issue-905-lab-lifecycle-robustness-preflight.md
@@ -1,0 +1,191 @@
+# Issue #905 Lab Lifecycle Robustness Preflight
+
+This note fixes the architecture boundary for interrupted and overlapping lab
+lifecycle operations. It is guidance, not an implementation plan. No new ADR
+is needed: ADR-045 already defines the lifecycle owner and ADR-046 already
+requires every project lifecycle mutation to reuse
+`.aptl/lifecycle/.lock`. Issue #905 requires the start, stop, clean-boot,
+kill, monitor, retry, and API paths to honor that accepted contract.
+
+## Decisions And Ownership Boundaries
+
+Treat lifecycle ownership and residual runtime state as different facts:
+
+| Fact | Required behavior |
+| --- | --- |
+| The shared lifecycle lock is held | Another owner is still mutating this project range. Fail before Docker or generated-state mutation with a stable, actionable busy result. Do not remove resources from under that owner. |
+| The lock is free and project-owned containers or networks exist | A complete or partial range already exists without a current lifecycle owner. Normal start fails before RAES apply and SEM-218 evaluation, and directs the operator to the explicit stop or clean-boot workflow. |
+| The lock is free and no project-owned runtime artifacts exist | Normal start may proceed through the existing RAES realization and readiness contract. |
+| Presence cannot be determined | Fail closed as an observation error. An empty result caused by a Docker, transport, or parse failure is not proof that the range is absent. |
+
+Normal start must not silently reconcile, stop, replace, or delete an existing
+range. The safe default is a clear collision result. `aptl lab stop` remains
+the non-volume reset, while `aptl lab stop -v` and `aptl lab start --clean`
+remain the explicit destructive volume-reset surfaces. Persistent project
+volumes alone are valid state for a stopped range and must not block normal
+start.
+
+Acquire the single project lifecycle mutation lock before `.env` hydration or
+any other project-state or Docker mutation. Hold it through authoritative RAES
+realization, readiness, and the late finalization steps. An OS lock, not lock
+file existence or a stored PID, establishes ownership. Process death must
+release ownership so that a subsequent stop can recover the abandoned range.
+The lock must work across processes and threads on supported POSIX and Windows
+hosts; ADR-045's current Windows in-process fallback is not sufficient for this
+contract.
+
+Clean boot and lifecycle enforcement are composite operations. They acquire
+one outer owner and invoke stop/start through an explicit already-owned or
+reentrant internal seam. They must not deadlock by acquiring the same lock
+twice, release it between stop and start, or create a second lock namespace.
+Read-only status may observe a transition without taking the exclusive lock,
+but `LabStatus.running` must not be redefined to mean ownership, residue, or
+realization success.
+
+Teardown is idempotent and best effort to completion within one admitted
+project identity. It removes directly materialized, project-labeled containers
+before network removal can be attempted; requests Compose project teardown;
+continues bounded project-scoped residual container and network cleanup even
+when Compose reports an error; and verifies that project-owned runtime
+artifacts are absent before reporting success. Default teardown preserves
+volumes. The `-v` path uses the existing project-scoped volume inventory and
+also reports aggregate failures. A current Compose file is not authoritative
+for resources created by an interrupted or older realization.
+
+The 900-second Compose health proof and authenticated stateful-service
+readiness feed the SEM-218 realization contract. `docker compose up -d` or an
+`Up` container state is not realization success. Issue #905 must not shorten,
+detach, or bypass those checks merely to make the process exit sooner. Proven
+duplicate waits may be removed only after showing that the same typed evidence
+is already available. Asynchronous start would require durable job ownership,
+cancellation, result retrieval, and API semantics and is outside this issue.
+
+## Required Reuse And Cross-Cutting Passage
+
+| Layer | Canonical incumbent and required passage |
+| --- | --- |
+| Public lifecycle boundary | `core.lab.orchestrate_lab_start()`, `stop_lab()`, `clean_boot_lab()`, `core.kill`, `cli.lab`, `cli.kill`, and the API lab router stay projections of one core lifecycle contract. Do not add CLI-, API-, or web-only collision logic. |
+| Lifecycle ownership | Promote the `.aptl/lifecycle/.lock` convention from `lifecycle_enforce._single_owner_lock()` as required by ADR-045 and ADR-046. Reuse `LifecycleBusyError` semantics and the reentrant ownership pattern in `runstore`; add portable cross-process behavior and path-safe file creation rather than another lock or PID schema. |
+| Configuration and identity | `AptlConfig` and `DeploymentConfig` remain the strict, `extra="forbid"` durable shapes. Validate `DeploymentConfig.project_name` once as a bounded Docker Compose project token because it scopes `-p`, label queries, and destructive volume-prefix cleanup. Profiles may use their existing stop fallback, but an invalid present config must not silently change destructive project identity to the default. Use the last admitted non-secret lifecycle/realization identity where the accepted ADR permits it, otherwise fail closed. |
+| Environment and secrets | Keep `.env` admission in `load_dotenv()`, `env_vars_from_dict()`, and placeholder validation. This change needs no new environment variable or credential. ADR-029 redaction, `redact()`, owner-only generated files, and `curl_safe` remain mandatory. The lifecycle lock and presence probe must not parse or persist secrets. |
+| Backend authority | `DeploymentBackend`, `DockerComposeBackend`, and `SshComposeBackend` own runtime inspection and mutation. Remote Docker keeps its admitted `DOCKER_HOST` and SSH identity environment. Core, CLI, and API code must not issue a second set of Docker commands or assume a local daemon. |
+| Runtime identity and queries | Standard Compose resources use `com.docker.compose.project`; directly materialized containers also use `aptl.lifecycle.project`; realized networks use the project and realization labels. Build checked presence and cleanup on these admitted identities and generated realization metadata. Existing query helpers that return `[]` on command or parse failure cannot be used as proof of absence without preserving an error channel. Names and broad prefixes are not lifecycle authority. |
+| Cleanup | Reuse `_compose_stop`, `_compose_lifecycle`, `_compose_base_substrate`, `_compose_network_realization`, and `_compose_volume_cleanup`. Preserve the label-bounded generic-container cleanup and volume inventory. Extend their orchestration instead of adding a shell cleanup script or daemon-wide prune. |
+| Realization and readiness | Keep `start_lab_with_raes()`, generated RAES lifecycle artifacts, `wait_for_services_healthy()`, authenticated readiness, `_raes_stateful_observation`, `ReadinessPolling`, and `core.services.wait_for_service()`. Presence is an admission check, not a new realization verdict or a parsed SEM-218 message. |
+| Results and errors | Keep `LabResult`, `StartupOutcome`, and `StartupDiagnostic` as the canonical core envelope, with existing CLI rendering and `LabActionResponse` projection. Busy, pre-existing, observation-failed, and cleanup-incomplete states need stable bounded diagnostics; they do not require a duplicate DTO or public exception hierarchy. Raw commands, Docker stderr, environment, credentials, host paths, or tracebacks must not cross the CLI/API/log envelope. |
+| Authentication and web/API | The existing `verify_token`, BFF Host/CSRF/session gates, strict response model, loopback defaults, and web single-flight UI remain authoritative. An API `asyncio.wait_for()` timeout does not cancel its worker thread; the worker retains the lifecycle owner until it actually exits, and the response must continue to describe the outcome as unknown rather than success or cleanup authority. |
+| Logging and observability | Use `get_logger()`, redaction, existing progress callbacks, and bounded structured fields. Record lifecycle stage, owner-busy versus residue-present classification, duration, resource counts, and cleanup verification. Do not log secret-bearing config, commands, raw backend output, process argv, or a PID as an authority token. No new OTel or persistence schema is needed. |
+| Workflow and verification | Python changes require focused pytest coverage, `pytest`, the Ruff complexity gate, `pre-commit run --all-files`, and CI/Sonar checks from `.ground-control.yaml`. Changes to Compose, Dockerfiles, or `config/` also require the clean-lab gate on a fresh machine; the architecture does not require those artifact changes. |
+
+## Security And Host-Layer Guardrails
+
+- **Lock-file surface:** create and open the fixed project-local lock through
+  the repository's no-follow, contained path helpers. The lifecycle directory
+  and file must use owner-only permissions. Do not truncate or follow an
+  operator-controlled symlink, and do not put secrets, argv, or authoritative
+  owner metadata in the file.
+- **Destructive identity:** validate the Compose project token before it
+  reaches command argv, label filters, logs, or the `<project>_` volume-prefix
+  query. A malformed or unknown identity blocks cleanup. It never falls back
+  to a broader name match, current working directory guess, or daemon-wide
+  prune.
+- **Command and remote-host surface:** retain list-form subprocess arguments,
+  explicit Compose project selection, scenario-root environment-file control,
+  bounded timeouts/output, and the SSH backend's validated host, user, port,
+  and key path. Do not interpolate a shell command or expose credentials in
+  argv.
+- **Runtime observation:** distinguish no resources from observation failure.
+  Inspect all container states, including created and exited resources, and
+  project-owned networks. A running-container-only query misses exactly the
+  interrupted ranges in this issue.
+- **Error envelope:** normalize and redact backend errors before placing them
+  in `LabResult`, logs, API JSON, or CLI output. Operator guidance may name the
+  safe APTL command to run, but it must not echo raw Docker output, environment
+  values, filesystem paths, or secrets.
+- **Mutation race:** every path that can start, stop, kill, retry, enforce, or
+  clean a range uses the same owner. An emergency label does not authorize
+  force-removing containers from under a live start.
+
+## Extensibility Seam And Whole-Repository Scope
+
+The required seam is one fixed mutation guard per admitted project directory.
+That guard protects the selected deployment provider and validated project
+name rather than creating a lock namespace for either value. Pair it with a
+backend-owned checked observation of project runtime presence. The observation
+keeps `present`, `absent`, and `observation failed` distinct and can later
+support an explicit invocation-time collision policy such as `fail` or a
+separately designed `reconcile`. The default for this issue remains `fail`.
+Do not add an untyped option map or durable config flag.
+
+Readiness duration remains parameterized through the existing polling/deadline
+seams (`ReadinessPolling` and `wait_for_service()`), not hard-coded in a new
+CLI/API branch. That preserves the next reasonable extension: a request-scoped
+readiness or finalization budget that still produces the same authoritative
+evidence. It does not authorize returning success before the proof completes.
+
+The implementation must audit these repository and host surfaces together:
+
+- `src/aptl/core/config.py`, `env.py`, `lab.py`, `lab_types.py`,
+  `lifecycle_enforce.py`, `lifecycle_policy.py`, `kill.py`, `runstore.py`, and
+  `utils/pathsafe.py`;
+- the deployment protocol, Docker and SSH backends, checked queries, Compose
+  stop/kill orchestration, base-substrate cleanup, network realization,
+  volume inventory, service health, and stateful readiness;
+- RAES start orchestration, generated lifecycle artifacts, stateful
+  observation, and SEM-218 diagnostics;
+- CLI lab/kill rendering, API dependencies/router/schemas, BFF and token
+  gates, and the web lab client/types/single-flight behavior;
+- `.aptl/lifecycle/.lock`, narrow lifecycle state, `.aptl/realization`, Docker
+  containers/networks/volumes and labels, the local or remote Docker daemon,
+  and native POSIX/Windows file-lock behavior;
+- focused lifecycle/backend/API/CLI tests and the repository-wide workflow
+  gates in `.ground-control.yaml` and `.gc/plan-rules.md`.
+
+## Proof Obligations
+
+Coverage must demonstrate the contract, not merely a happy-path command:
+
+- a second start fails busy before RAES while the first owner is alive;
+- stop and kill do not remove containers while start owns the project, but
+  process death releases the lock and stop can reset the range;
+- a free lock plus running, created, or exited project containers, or a
+  project network, gives the clear pre-existing-range result without entering
+  SEM-218 evaluation;
+- a Docker, SSH transport, or parse failure during detection fails closed;
+- cleanup handles mixed Compose and directly materialized resources, continues
+  after a Compose error, removes networks only after attached project
+  containers, verifies absence, and is idempotent;
+- default teardown preserves volumes, `-v` removes only the validated
+  project's volumes, and another project's resources remain untouched;
+- CLI and API receive the same normalized `LabResult`, an API timeout does not
+  free a still-running worker's owner, and remote Docker retains its backend
+  environment;
+- cross-process exclusion is exercised on POSIX and Windows, including
+  composite clean-boot/enforcement ownership without nested-lock deadlock.
+
+## Non-Goals And Anti-Patterns
+
+This issue does not add arbitrary partial-RAES resume, implicit reconciliation,
+a background start daemon, a durable job/cancellation API, new readiness or
+SEM-218 semantics, multi-range tenancy, a new API/web/config schema, or a new
+exception hierarchy. It does not change scenario models, profiles, secret or
+certificate ownership, seed behavior, MCP setup, or volume persistence.
+
+Avoid these anti-patterns:
+
+- treating `containers are Up`, `LabStatus.running`, lock-file existence, or a
+  PID file as proof of realization or ownership;
+- parsing SEM-218 prose to discover a lifecycle collision;
+- interpreting an empty unchecked Docker query as absence;
+- auto-stopping or force-removing a range from normal start;
+- releasing the owner between clean-boot stop and start, or before late
+  mutating finalization finishes;
+- returning immediately from teardown after the first Compose error;
+- identifying resources only by `aptl-` names, current Compose membership, or
+  broad prefixes; using `docker system prune` or an equivalent global cleanup;
+- deleting `.env`, keys, `.mcp.json`, configuration, run archives, images, or
+  volumes without the existing explicit destructive surface;
+- shortening or backgrounding authoritative health/readiness checks under the
+  guise of teardown robustness;
+- duplicating lifecycle checks, DTOs, validators, polling loops, logging, or
+  exception handling in CLI, API, web, RAES, or shell scripts.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -144,6 +144,22 @@ docker compose --profile wazuh --profile victim --profile kali stop
 docker compose --profile wazuh --profile victim --profile kali down -v
 ```
 
+Lifecycle mutations are single-owner per project. If a start, stop, clean boot,
+policy tick, or container kill is already running, another mutating command
+fails with `lifecycle-owner-busy` and does not remove resources from under the
+active operation. Wait for the first command to finish, or stop it and then run
+`aptl lab stop` to reset any abandoned range.
+
+Normal `aptl lab start` also refuses a free-lock project that still has labelled
+containers (including created or exited containers) or networks. Run `aptl lab
+stop` for a volume-preserving reset, or `aptl lab start --clean` for the
+explicit volume-destroying reset. Detection failures are fail-closed; repair
+the local or SSH Docker connection instead of assuming an empty range.
+
+`aptl lab start` remains in the foreground until Compose health and authenticated
+service readiness finish. Containers showing `Up` is not a successful lab
+realization and does not make it safe to start another lifecycle operation.
+
 ## Lifecycle Policy
 
 The lab can auto-teardown on a TTL or idle timeout and provision on a schedule
@@ -185,8 +201,9 @@ aptl lab monitor --interval 60
 aptl lab policy show
 ```
 
-The tick holds a per-project lock, so a manual `enforce` and a running
-`monitor` never act at once. See
+The tick uses the same per-project lock as manual/API start, stop, clean boot,
+and container kill, so policy automation cannot interleave with another lab
+mutation. See
 [ADR-045](adrs/adr-045-ephemeral-lifecycle-policy-enforcement.md) for the
 design.
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -216,18 +216,21 @@ Lab start failed: RAES runtime handoff failed: ...
   label org.aptl.realization.network expected 'true', found ''.
 ```
 
-The stale networks were created without the label the current version
-expects. `aptl lab stop` (graceful) does not always remove them. Remove
-by name and retry:
+The stale networks were created without the realization label the current
+version expects. Current APTL teardown removes all networks carrying the
+validated Compose project label, including older networks without the newer
+realization label. Use the project-scoped reset and retry:
 
 ```bash
 aptl lab stop
-docker network ls --filter name=aptl \
-  --format '{{.Name}}\t{{.Labels}}' \
-  | awk '/org\.aptl\.realization\.network=true/{next} $1 ~ /^aptl_aptl-/ {print $1}' \
-  | xargs -r docker network rm
 aptl lab start
 ```
+
+If stop reports `lifecycle-owner-busy`, another start/stop/clean/kill or policy
+operation still owns the project; wait for it to exit before retrying. If stop
+reports a cleanup-verification or observation failure, restore the configured
+local/SSH Docker connection and run stop again. Do not use a daemon-wide prune:
+APTL cleanup is deliberately bounded by the validated project labels.
 
 Tracked in [#722](https://github.com/Brad-Edwards/aptl/issues/722).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - "Issue #866 TechVault Component Realization Preflight": architecture/issue-866-techvault-realization-contract-preflight.md
     - "Issue #874 Scenario-Bundle Realization Roots Preflight": architecture/issue-874-scenario-bundle-realization-roots-preflight.md
     - "Issue #878 Scenario Verification Plugin Seam Preflight": architecture/issue-878-scenario-verification-plugin-seam-preflight.md
+    - "Issue #905 Lab Lifecycle Robustness Preflight": architecture/issue-905-lab-lifecycle-robustness-preflight.md
   - Deployment: deployment.md
   - Components:
     - Wazuh SIEM: components/wazuh-siem.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,8 +170,12 @@ show_missing = true
 # ``# pragma: no cover`` still works.
 exclude_also = [
     "if os.name != \"posix\":",
+    "if os.name == \"nt\":",
     "except metadata.PackageNotFoundError:",
     "if TYPE_CHECKING:",
+    # Low-level Windows handle bindings are exercised by Windows CI only;
+    # Linux CI covers the platform-neutral orchestration around them.
+    "def _windows_",
 ]
 
 [tool.coverage.xml]

--- a/src/aptl/cli/lifecycle.py
+++ b/src/aptl/cli/lifecycle.py
@@ -51,7 +51,8 @@ def enforce(
     or provision a due scheduled range. Designed to be driven by a systemd
     timer or cron entry. A no-op when no ``lifecycle_policy`` is configured.
     """
-    from aptl.core.lifecycle_enforce import LifecycleBusyError, enforce_once
+    from aptl.core.lifecycle_enforce import enforce_once
+    from aptl.core.lifecycle_policy import LifecycleBusyError
 
     try:
         result = enforce_once(project_dir, grace_minutes=grace_minutes)
@@ -84,7 +85,8 @@ def monitor(
     systemd timer / cron. Holds the project lifecycle lock for its whole run,
     so a second monitor (or a one-shot ``enforce``) cannot act concurrently.
     """
-    from aptl.core.lifecycle_enforce import LifecycleBusyError, run_monitor
+    from aptl.core.lifecycle_enforce import run_monitor
+    from aptl.core.lifecycle_policy import LifecycleBusyError
 
     try:
         results = run_monitor(

--- a/src/aptl/core/config.py
+++ b/src/aptl/core/config.py
@@ -16,6 +16,7 @@ from aptl.utils.logging import get_logger
 log = get_logger("config")
 
 _NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+_COMPOSE_PROJECT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 _PARTICIPANT_MODEL_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,127}$")
 _CREDENTIAL_SOURCE_VARIABLE_PATTERN = re.compile(r"^[A-Z_][A-Z0-9_]{0,127}$")
 _IMMUTABLE_PARTICIPANT_MODEL_PATTERNS = {
@@ -27,6 +28,17 @@ _IMMUTABLE_PARTICIPANT_MODEL_PATTERNS = {
     ),
 }
 _CONFIG_FILENAMES = ["aptl.json"]
+
+
+def validate_compose_project_name(value: str) -> str:
+    """Return a bounded Compose project token or raise ``ValueError``."""
+
+    if not _COMPOSE_PROJECT_NAME_PATTERN.fullmatch(value):
+        raise ValueError(
+            "deployment.project_name must be 1-63 lowercase letters, "
+            "digits, hyphens, or underscores and start with a letter or digit"
+        )
+    return value
 
 
 class LabSettings(BaseModel):
@@ -180,6 +192,13 @@ class DeploymentConfig(BaseModel):
                 f"Supported: {', '.join(sorted(allowed))}"
             )
         return v
+
+    @field_validator("project_name")
+    @classmethod
+    def validate_project_name(cls, value: str) -> str:
+        """Validate the identity used by Compose and destructive label queries."""
+
+        return validate_compose_project_name(value)
 
 
 _TIME_PATTERN = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")

--- a/src/aptl/core/deployment/_compose_base_substrate.py
+++ b/src/aptl/core/deployment/_compose_base_substrate.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 from aptl.core.deployment._compose_realization_networks import (
     _match_managed_network,
 )
-from aptl.core.deployment.errors import BackendSeedError, BackendTimeoutError
+from aptl.core.deployment.errors import BackendSeedError
 from aptl.core.deployment.realization import DeploymentNetworkAttachment
 
 if TYPE_CHECKING:
@@ -403,75 +403,6 @@ class ComposeBaseSubstrateMixin(object):
             raise BackendSeedError(
                 f"failed to copy project content into container {container}"
             )
-
-    def remove_generic_materializer_containers(self) -> list[str]:
-        """Force-remove every container the generic materializer started (ADR-048).
-
-        `docker compose down` only tears down containers Compose itself
-        started; a node the generic materializer realized directly (a plain
-        `docker run`) is invisible to it, so stopping the lab would otherwise
-        leave those containers running - attached to the very networks/
-        volumes the rest of cleanup needs to remove, failing that cleanup
-        outright. Discovered by ``aptl.lifecycle.project``, the label
-        ``start_base_container`` sets on every one of its containers, never
-        by name pattern. Returns one failure message per container that
-        could not be removed, empty when clean.
-        """
-
-        try:
-            list_result = self._run(
-                [
-                    "docker",
-                    "ps",
-                    "-aq",
-                    "--filter",
-                    f"label=aptl.lifecycle.project={self._project_name}",
-                ],
-                timeout=30,
-            )
-            if list_result.returncode != 0:
-                return ["failed to list generic-materializer containers"]
-            names = [line for line in list_result.stdout.splitlines() if line.strip()]
-            if not names:
-                return []
-            result = self._run(["docker", "rm", "-f", *names], timeout=60)
-        except (BackendTimeoutError, OSError):
-            return ["failed to remove generic-materializer containers"]
-        return (
-            []
-            if result.returncode == 0
-            else ["failed to remove generic-materializer containers"]
-        )
-
-    def remove_project_containers(self) -> list[str]:
-        """Force-remove residual containers carrying this project identity."""
-
-        try:
-            list_result = self._run(
-                [
-                    "docker",
-                    "ps",
-                    "-aq",
-                    "--filter",
-                    f"label=com.docker.compose.project={self._project_name}",
-                ],
-                timeout=30,
-            )
-            if list_result.returncode != 0:
-                return ["failed to list residual project containers"]
-            identifiers = [
-                line.strip() for line in list_result.stdout.splitlines() if line.strip()
-            ]
-            if not identifiers:
-                return []
-            result = self._run(["docker", "rm", "-f", *identifiers], timeout=60)
-        except (BackendTimeoutError, OSError):
-            return ["failed to remove residual project containers"]
-        return (
-            []
-            if result.returncode == 0
-            else ["failed to remove residual project containers"]
-        )
 
     def configure_base_container_networks(self, nodes: tuple[object, ...]) -> None:
         """Bind image-free nodes to admitted networks before they are created."""

--- a/src/aptl/core/deployment/_compose_base_substrate.py
+++ b/src/aptl/core/deployment/_compose_base_substrate.py
@@ -139,7 +139,9 @@ class ComposeBaseSubstrateMixin(object):
             # materialization ops run against it idempotently.
             return
         self._run(["docker", "rm", "-f", spec.container_name])
-        argv = self._base_container_create_command(spec, network_bindings, run_image_ref)
+        argv = self._base_container_create_command(
+            spec, network_bindings, run_image_ref
+        )
         result = self._run(argv, timeout=180)
         self._complete_base_container_start(spec, network_bindings, result)
 
@@ -427,18 +429,48 @@ class ComposeBaseSubstrateMixin(object):
                 ],
                 timeout=30,
             )
+            if list_result.returncode != 0:
+                return ["failed to list generic-materializer containers"]
             names = [line for line in list_result.stdout.splitlines() if line.strip()]
             if not names:
                 return []
             result = self._run(["docker", "rm", "-f", *names], timeout=60)
-        except (BackendTimeoutError, OSError) as exc:
-            return [f"failed to remove generic-materializer containers: {exc}"]
+        except (BackendTimeoutError, OSError):
+            return ["failed to remove generic-materializer containers"]
         return (
             []
             if result.returncode == 0
-            else [
-                f"failed to remove generic-materializer containers: {result.stderr.strip()}"
+            else ["failed to remove generic-materializer containers"]
+        )
+
+    def remove_project_containers(self) -> list[str]:
+        """Force-remove residual containers carrying this project identity."""
+
+        try:
+            list_result = self._run(
+                [
+                    "docker",
+                    "ps",
+                    "-aq",
+                    "--filter",
+                    f"label=com.docker.compose.project={self._project_name}",
+                ],
+                timeout=30,
+            )
+            if list_result.returncode != 0:
+                return ["failed to list residual project containers"]
+            identifiers = [
+                line.strip() for line in list_result.stdout.splitlines() if line.strip()
             ]
+            if not identifiers:
+                return []
+            result = self._run(["docker", "rm", "-f", *identifiers], timeout=60)
+        except (BackendTimeoutError, OSError):
+            return ["failed to remove residual project containers"]
+        return (
+            []
+            if result.returncode == 0
+            else ["failed to remove residual project containers"]
         )
 
     def configure_base_container_networks(self, nodes: tuple[object, ...]) -> None:

--- a/src/aptl/core/deployment/_compose_lifecycle.py
+++ b/src/aptl/core/deployment/_compose_lifecycle.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Protocol
 
 from aptl.core.deployment.errors import BackendTimeoutError
+from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
 from aptl.utils.logging import get_logger
 
 log = get_logger("deployment.docker_compose")
@@ -39,6 +40,12 @@ class _ComposeLifecycleBackend(Protocol):
     def remove_generic_materializer_containers(self) -> list[str]:
         """Force-remove containers the generic materializer started directly."""
 
+    def remove_project_containers(self) -> list[str]:
+        """Force-remove residual project-labelled containers."""
+
+    def observe_project_runtime(self) -> ProjectRuntimePresence:
+        """Return checked residual project container/network presence."""
+
 
 def kill_compose_lab(
     backend: _ComposeLifecycleBackend,
@@ -61,6 +68,7 @@ def kill_compose_lab(
     )
     _run_compose_down(backend, profiles, timeout=timeout)
     container_failures = backend.remove_generic_materializer_containers()
+    container_failures += backend.remove_project_containers()
     if container_failures:
         log.warning(
             "generic-materializer container cleanup failed: %s",
@@ -73,7 +81,12 @@ def kill_compose_lab(
             "; ".join(network_failures[:5]),
         )
 
-    error = _kill_error(kill_error, container_failures + network_failures, kill_ok)
+    verification_failures = _kill_verification_failures(backend)
+    error = _kill_error(
+        kill_error,
+        container_failures + network_failures + verification_failures,
+        kill_ok,
+    )
     success = not error
     if success:
         log.info("All lab containers stopped")
@@ -88,10 +101,7 @@ def _run_compose_kill(
 ) -> tuple[bool, str]:
     """Run docker compose kill and return its success state and hard error."""
 
-    kill_cmd = ["docker", "compose"]
-    for profile in profiles:
-        kill_cmd.extend(["--profile", profile])
-    kill_cmd.append("kill")
+    kill_cmd = backend._build_command("kill", profiles)
 
     log.info("Running: %s", " ".join(kill_cmd))
     kill_ok = False
@@ -100,11 +110,11 @@ def _run_compose_kill(
         result = backend._run(kill_cmd, timeout=timeout)
         kill_ok = result.returncode == 0
         if not kill_ok:
-            log.warning("docker compose kill stderr: %s", result.stderr.strip())
+            log.warning("docker compose kill returned non-zero")
     except BackendTimeoutError:
         log.warning("docker compose kill timed out after %ds", timeout)
-    except OSError as exc:
-        error = f"docker compose kill failed: {exc}"
+    except OSError:
+        error = "docker compose kill failed"
         log.error(error)
     return kill_ok, error
 
@@ -122,11 +132,11 @@ def _run_compose_down(
     try:
         result = backend._run(down_cmd, timeout=timeout)
         if result.returncode != 0:
-            log.warning("docker compose down stderr: %s", result.stderr.strip())
+            log.warning("docker compose down returned non-zero")
     except BackendTimeoutError:
         log.warning("docker compose down timed out after %ds", timeout)
-    except OSError as exc:
-        log.warning("docker compose down failed: %s", exc)
+    except OSError:
+        log.warning("docker compose down failed")
 
 
 def _kill_error(
@@ -139,6 +149,25 @@ def _kill_error(
     error = kill_error
     if not error and network_failures:
         error = "; ".join(network_failures[:5])
+    # A non-zero Compose kill is recoverable when the bounded down/residual
+    # cleanup path proves the project runtime absent. The terminal runtime fact
+    # is authoritative; raw Compose stderr is not exposed.
     if not error and not kill_ok:
-        error = "docker compose kill returned non-zero"
+        log.info("Compose kill returned non-zero but cleanup verified absence")
     return error
+
+
+def _kill_verification_failures(
+    backend: _ComposeLifecycleBackend,
+) -> list[str]:
+    """Require checked proof that emergency cleanup removed project runtime."""
+
+    presence = backend.observe_project_runtime()
+    if presence.error:
+        return ["failed to verify emergency project cleanup"]
+    if presence.present:
+        return [
+            "project runtime artifacts remain after emergency cleanup "
+            f"(containers={presence.container_count}, networks={presence.network_count})"
+        ]
+    return []

--- a/src/aptl/core/deployment/_compose_network_realization.py
+++ b/src/aptl/core/deployment/_compose_network_realization.py
@@ -97,8 +97,7 @@ class ComposeRealizationNetworkMixin:
                 )
             else:
                 failures.append(
-                    result.error
-                    or f"Failed to create realized network {network.name}."
+                    result.error or f"Failed to create realized network {network.name}."
                 )
         return failures
 
@@ -439,25 +438,15 @@ class ComposeRealizationNetworkMixin:
                     "ls",
                     "--filter",
                     f"label={_COMPOSE_PROJECT_LABEL}={self._project_name}",
-                    "--filter",
-                    (
-                        f"label={_REALIZATION_NETWORK_LABEL}="
-                        f"{_REALIZATION_NETWORK_LABEL_VALUE}"
-                    ),
-                    "--filter",
-                    f"name={self._project_name}",
                     "--format",
                     "{{.Name}}",
                 ],
                 timeout=_REALIZATION_TIMEOUT,
             )
-        except (BackendTimeoutError, OSError) as exc:
-            return [f"Failed to list project networks for cleanup: {exc}"]
+        except (BackendTimeoutError, OSError):
+            return ["Failed to list project networks for cleanup"]
         if result.returncode != 0:
-            return [
-                "Failed to list project networks for cleanup: "
-                f"{result.stderr.strip()}"
-            ]
+            return ["Failed to list project networks for cleanup"]
         network_names = [
             line.strip() for line in result.stdout.splitlines() if line.strip()
         ]
@@ -467,14 +456,9 @@ class ComposeRealizationNetworkMixin:
                     ["docker", "network", "rm", network_name],
                     timeout=_REALIZATION_TIMEOUT,
                 )
-            except (BackendTimeoutError, OSError) as exc:
-                failures.append(
-                    f"Failed to remove project network {network_name}: {exc}"
-                )
+            except (BackendTimeoutError, OSError):
+                failures.append("Failed to remove a project network")
                 continue
             if result.returncode != 0:
-                failures.append(
-                    f"Failed to remove project network {network_name}: "
-                    f"{result.stderr.strip()}"
-                )
+                failures.append("Failed to remove a project network")
         return failures

--- a/src/aptl/core/deployment/_compose_project_cleanup.py
+++ b/src/aptl/core/deployment/_compose_project_cleanup.py
@@ -1,0 +1,70 @@
+"""Project-scoped residual container cleanup for Compose backends."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aptl.core.deployment.errors import BackendTimeoutError
+
+
+class _CleanupBackend(Protocol):
+    """Backend surface required by the project-container cleanup helper."""
+
+    _project_name: str
+
+    def _run(self, cmd: list[str], *, timeout: int): ...
+
+
+def _remove_labelled_containers(
+    backend: _CleanupBackend,
+    *,
+    label: str,
+    list_failure: str,
+    remove_failure: str,
+) -> list[str]:
+    """Remove every container carrying ``label`` and return bounded failures."""
+
+    failure = ""
+    try:
+        list_result = backend._run(
+            ["docker", "ps", "-aq", "--filter", f"label={label}"], timeout=30
+        )
+        if list_result.returncode != 0:
+            failure = list_failure
+        else:
+            identifiers = [
+                line.strip() for line in list_result.stdout.splitlines() if line.strip()
+            ]
+            if identifiers:
+                remove_result = backend._run(
+                    ["docker", "rm", "-f", *identifiers], timeout=60
+                )
+                if remove_result.returncode != 0:
+                    failure = remove_failure
+    except (BackendTimeoutError, OSError):
+        failure = remove_failure
+    return [failure] if failure else []
+
+
+class ComposeProjectCleanupMixin(object):
+    """Remove project-owned containers that Compose may leave behind."""
+
+    def remove_generic_materializer_containers(self) -> list[str]:
+        """Force-remove containers realized directly by the generic materializer."""
+
+        return _remove_labelled_containers(
+            self,
+            label=f"aptl.lifecycle.project={self._project_name}",
+            list_failure="failed to list generic-materializer containers",
+            remove_failure="failed to remove generic-materializer containers",
+        )
+
+    def remove_project_containers(self) -> list[str]:
+        """Force-remove residual containers carrying the Compose project identity."""
+
+        return _remove_labelled_containers(
+            self,
+            label=f"com.docker.compose.project={self._project_name}",
+            list_failure="failed to list residual project containers",
+            remove_failure="failed to remove residual project containers",
+        )

--- a/src/aptl/core/deployment/_compose_project_cleanup.py
+++ b/src/aptl/core/deployment/_compose_project_cleanup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import Protocol
 
 from aptl.core.deployment.errors import BackendTimeoutError
@@ -12,7 +13,10 @@ class _CleanupBackend(Protocol):
 
     _project_name: str
 
-    def _run(self, cmd: list[str], *, timeout: int): ...
+    def _run(self, cmd: list[str], *, timeout: int) -> subprocess.CompletedProcess:
+        """Run one backend-scoped command."""
+
+        ...
 
 
 def _remove_labelled_containers(

--- a/src/aptl/core/deployment/_compose_queries.py
+++ b/src/aptl/core/deployment/_compose_queries.py
@@ -15,6 +15,8 @@ from aptl.core.deployment._proc_net_listeners import (
     ContainerListeners,
     parse_proc_net_listeners,
 )
+from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+from aptl.core.deployment.errors import BackendTimeoutError
 from aptl.utils.logging import get_logger
 
 log = get_logger("deployment.docker_compose")
@@ -66,6 +68,18 @@ def _parse_ports(ports_str: str) -> list[str]:
     if not ports_str:
         return []
     return [p.strip() for p in ports_str.split(",") if p.strip()]
+
+
+def _nonempty_lines(output: str) -> set[str]:
+    """Return the distinct identifiers from bounded line-oriented output."""
+
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+def _nonempty_line_count(output: str) -> int:
+    """Count bounded line-oriented Docker identifiers."""
+
+    return len(_nonempty_lines(output))
 
 
 def _parse_lab_row(line: str) -> dict[str, Any] | None:
@@ -171,6 +185,49 @@ class ComposeQueryMixin(object):
     """
 
     # Host inventory (CLI-004 / ADR-023) ----------------------------------
+
+    def observe_project_runtime(self) -> ProjectRuntimePresence:
+        """Observe all project containers and networks without conflating errors."""
+
+        try:
+            container_ids: set[str] = set()
+            for project_label in (
+                "com.docker.compose.project",
+                "aptl.lifecycle.project",
+            ):
+                containers = self._run(
+                    [
+                        "docker",
+                        "ps",
+                        "-aq",
+                        "--filter",
+                        f"label={project_label}={self._project_name}",
+                    ],
+                    timeout=_HOST_INVENTORY_TIMEOUT,
+                )
+                if containers.returncode != 0:
+                    return ProjectRuntimePresence(error="container observation failed")
+                container_ids.update(_nonempty_lines(containers.stdout))
+            networks = self._run(
+                [
+                    "docker",
+                    "network",
+                    "ls",
+                    "--filter",
+                    f"label=com.docker.compose.project={self._project_name}",
+                    "--format",
+                    "{{.ID}}",
+                ],
+                timeout=_HOST_INVENTORY_TIMEOUT,
+            )
+            if networks.returncode != 0:
+                return ProjectRuntimePresence(error="network observation failed")
+        except (BackendTimeoutError, OSError):
+            return ProjectRuntimePresence(error="runtime observation failed")
+        return ProjectRuntimePresence(
+            container_count=len(container_ids),
+            network_count=_nonempty_line_count(networks.stdout),
+        )
 
     def host_versions(self) -> dict[str, str]:
         result = {"docker": "", "compose": ""}
@@ -462,8 +519,6 @@ class ComposeQueryMixin(object):
             timeout=_LISTENER_SIDECAR_TIMEOUT,
         )
         if result.returncode != 0:
-            log.debug(
-                "listener sidecar failed for %s: %s", name, result.stderr.strip()
-            )
+            log.debug("listener sidecar failed for %s: %s", name, result.stderr.strip())
             return None
         return parse_proc_net_listeners(result.stdout)

--- a/src/aptl/core/deployment/_compose_queries.py
+++ b/src/aptl/core/deployment/_compose_queries.py
@@ -15,8 +15,6 @@ from aptl.core.deployment._proc_net_listeners import (
     ContainerListeners,
     parse_proc_net_listeners,
 )
-from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
-from aptl.core.deployment.errors import BackendTimeoutError
 from aptl.utils.logging import get_logger
 
 log = get_logger("deployment.docker_compose")
@@ -68,18 +66,6 @@ def _parse_ports(ports_str: str) -> list[str]:
     if not ports_str:
         return []
     return [p.strip() for p in ports_str.split(",") if p.strip()]
-
-
-def _nonempty_lines(output: str) -> set[str]:
-    """Return the distinct identifiers from bounded line-oriented output."""
-
-    return {line.strip() for line in output.splitlines() if line.strip()}
-
-
-def _nonempty_line_count(output: str) -> int:
-    """Count bounded line-oriented Docker identifiers."""
-
-    return len(_nonempty_lines(output))
 
 
 def _parse_lab_row(line: str) -> dict[str, Any] | None:
@@ -185,49 +171,6 @@ class ComposeQueryMixin(object):
     """
 
     # Host inventory (CLI-004 / ADR-023) ----------------------------------
-
-    def observe_project_runtime(self) -> ProjectRuntimePresence:
-        """Observe all project containers and networks without conflating errors."""
-
-        try:
-            container_ids: set[str] = set()
-            for project_label in (
-                "com.docker.compose.project",
-                "aptl.lifecycle.project",
-            ):
-                containers = self._run(
-                    [
-                        "docker",
-                        "ps",
-                        "-aq",
-                        "--filter",
-                        f"label={project_label}={self._project_name}",
-                    ],
-                    timeout=_HOST_INVENTORY_TIMEOUT,
-                )
-                if containers.returncode != 0:
-                    return ProjectRuntimePresence(error="container observation failed")
-                container_ids.update(_nonempty_lines(containers.stdout))
-            networks = self._run(
-                [
-                    "docker",
-                    "network",
-                    "ls",
-                    "--filter",
-                    f"label=com.docker.compose.project={self._project_name}",
-                    "--format",
-                    "{{.ID}}",
-                ],
-                timeout=_HOST_INVENTORY_TIMEOUT,
-            )
-            if networks.returncode != 0:
-                return ProjectRuntimePresence(error="network observation failed")
-        except (BackendTimeoutError, OSError):
-            return ProjectRuntimePresence(error="runtime observation failed")
-        return ProjectRuntimePresence(
-            container_count=len(container_ids),
-            network_count=_nonempty_line_count(networks.stdout),
-        )
 
     def host_versions(self) -> dict[str, str]:
         result = {"docker": "", "compose": ""}

--- a/src/aptl/core/deployment/_compose_runtime_inventory.py
+++ b/src/aptl/core/deployment/_compose_runtime_inventory.py
@@ -1,0 +1,78 @@
+"""Checked project-runtime presence observation for Compose backends."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+from aptl.core.deployment.errors import BackendTimeoutError
+
+_HOST_INVENTORY_TIMEOUT = 90
+
+
+class _InventoryBackend(Protocol):
+    """Backend surface required by checked runtime inventory."""
+
+    _project_name: str
+
+    def _run(self, cmd: list[str], *, timeout: int): ...
+
+
+def _nonempty_lines(output: str) -> set[str]:
+    """Return the distinct identifiers from bounded line-oriented output."""
+
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+class ComposeRuntimeInventoryMixin(object):
+    """Observe project-owned containers and networks without conflating errors."""
+
+    def observe_project_runtime(self) -> ProjectRuntimePresence:
+        """Return checked runtime presence across both admitted container labels."""
+
+        container_ids: set[str] = set()
+        network_count = 0
+        error = ""
+        try:
+            for project_label in (
+                "com.docker.compose.project",
+                "aptl.lifecycle.project",
+            ):
+                containers = self._run(
+                    [
+                        "docker",
+                        "ps",
+                        "-aq",
+                        "--filter",
+                        f"label={project_label}={self._project_name}",
+                    ],
+                    timeout=_HOST_INVENTORY_TIMEOUT,
+                )
+                if containers.returncode != 0:
+                    error = "container observation failed"
+                    break
+                container_ids.update(_nonempty_lines(containers.stdout))
+            if not error:
+                networks = self._run(
+                    [
+                        "docker",
+                        "network",
+                        "ls",
+                        "--filter",
+                        f"label=com.docker.compose.project={self._project_name}",
+                        "--format",
+                        "{{.ID}}",
+                    ],
+                    timeout=_HOST_INVENTORY_TIMEOUT,
+                )
+                if networks.returncode != 0:
+                    error = "network observation failed"
+                else:
+                    network_count = len(_nonempty_lines(networks.stdout))
+        except (BackendTimeoutError, OSError):
+            error = "runtime observation failed"
+        if error:
+            return ProjectRuntimePresence(error=error)
+        return ProjectRuntimePresence(
+            container_count=len(container_ids), network_count=network_count
+        )

--- a/src/aptl/core/deployment/_compose_runtime_inventory.py
+++ b/src/aptl/core/deployment/_compose_runtime_inventory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import Protocol
 
 from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
@@ -15,7 +16,10 @@ class _InventoryBackend(Protocol):
 
     _project_name: str
 
-    def _run(self, cmd: list[str], *, timeout: int): ...
+    def _run(self, cmd: list[str], *, timeout: int) -> subprocess.CompletedProcess:
+        """Run one backend-scoped command."""
+
+        ...
 
 
 def _nonempty_lines(output: str) -> set[str]:

--- a/src/aptl/core/deployment/_compose_stop.py
+++ b/src/aptl/core/deployment/_compose_stop.py
@@ -11,6 +11,8 @@ from aptl.core.deployment._compose_volume_cleanup import (
     project_scoped_volume_names,
     remove_leftover_project_volumes,
 )
+from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+from aptl.core.deployment.errors import BackendTimeoutError
 from aptl.core.lab_types import LabResult
 from aptl.utils.logging import get_logger
 
@@ -48,6 +50,16 @@ class _ComposeStopBackend(Protocol):
 
     def remove_generic_materializer_containers(self) -> list[str]:
         """Force-remove containers the generic materializer started directly."""
+
+        ...
+
+    def remove_project_containers(self) -> list[str]:
+        """Force-remove residual containers scoped to the Compose project."""
+
+        ...
+
+    def observe_project_runtime(self) -> ProjectRuntimePresence:
+        """Return checked residual project container/network presence."""
 
         ...
 
@@ -99,20 +111,51 @@ def _run_stop(
     discovery_error: str,
     timeout: int,
 ) -> LabResult:
-    """Run Compose down and return its cleanup result."""
+    """Run bounded project cleanup and verify the runtime is absent."""
 
+    failures = backend.remove_generic_materializer_containers()
     cmd = backend._build_command("down", profiles, compose_files=compose_files)
     if remove_volumes:
         cmd.append("-v")
     log.info("Stopping lab (remove_volumes=%s)", remove_volumes)
-    result = backend._run(cmd)
-    if result.returncode != 0:
-        log.error("Lab stop failed: %s", result.stderr)
-        return LabResult(success=False, error=result.stderr)
-    failures = _cleanup_failures(
-        backend, remove_volumes, volume_names, discovery_error, timeout
+    compose_recovered = _run_compose_down(backend, cmd, timeout)
+    failures.extend(
+        _cleanup_failures(
+            backend, remove_volumes, volume_names, discovery_error, timeout
+        )
     )
-    return _cleanup_result(failures)
+    failures.extend(_verification_failures(backend))
+    return _cleanup_result(failures, compose_recovered=compose_recovered)
+
+
+def _run_compose_down(
+    backend: _ComposeStopBackend, cmd: list[str], timeout: int
+) -> bool:
+    """Attempt Compose teardown and report whether fallback cleanup is needed."""
+
+    try:
+        result = backend._run(cmd, timeout=timeout)
+    except (BackendTimeoutError, OSError):
+        log.warning("Compose teardown did not complete; continuing project cleanup")
+        return True
+    if result.returncode != 0:
+        log.warning("Compose teardown returned non-zero; continuing project cleanup")
+        return True
+    return False
+
+
+def _verification_failures(backend: _ComposeStopBackend) -> list[str]:
+    """Return a failure unless checked observation proves runtime absence."""
+
+    presence = backend.observe_project_runtime()
+    if presence.error:
+        return ["Failed to verify project runtime cleanup"]
+    if presence.present:
+        return [
+            "Project runtime artifacts remain after cleanup "
+            f"(containers={presence.container_count}, networks={presence.network_count})"
+        ]
+    return []
 
 
 def _cleanup_failures(
@@ -130,7 +173,7 @@ def _cleanup_failures(
     removal outright with "network has active endpoints".
     """
 
-    failures = backend.remove_generic_materializer_containers()
+    failures = backend.remove_project_containers()
     failures += backend.remove_project_networks()
     if not remove_volumes:
         return failures
@@ -143,12 +186,17 @@ def _cleanup_failures(
     return failures
 
 
-def _cleanup_result(failures: list[str]) -> LabResult:
+def _cleanup_result(
+    failures: list[str], *, compose_recovered: bool = False
+) -> LabResult:
     """Translate cleanup failures into the public lab result."""
 
     if failures:
         error = "; ".join(failures[:5])
         log.error("Lab cleanup failed: %s", error)
         return LabResult(success=False, error=error)
+    if compose_recovered:
+        log.info("Lab stopped successfully through residual project cleanup")
+        return LabResult(success=True, message="Lab stopped after recovery cleanup")
     log.info("Lab stopped successfully")
     return LabResult(success=True, message="Lab stopped")

--- a/src/aptl/core/deployment/_compose_volume_cleanup.py
+++ b/src/aptl/core/deployment/_compose_volume_cleanup.py
@@ -6,7 +6,6 @@ import subprocess
 from collections.abc import Callable
 
 from aptl.core.deployment.errors import BackendTimeoutError
-from aptl.utils.redaction import redact
 
 DockerRun = Callable[..., subprocess.CompletedProcess[str]]
 
@@ -50,10 +49,10 @@ def _run_volume_command(
     """Run one Docker volume command and normalize its failure."""
     try:
         result = run(command, timeout=timeout)
-    except (BackendTimeoutError, OSError) as exc:
-        return None, [f"{failure_message}: {exc}"]
+    except (BackendTimeoutError, OSError):
+        return None, [failure_message]
     if result.returncode != 0:
-        return None, [f"{failure_message}: {redact(result.stderr.strip())}"]
+        return None, [failure_message]
     return result, []
 
 

--- a/src/aptl/core/deployment/backend_host_inventory.py
+++ b/src/aptl/core/deployment/backend_host_inventory.py
@@ -12,7 +12,23 @@ today both backends back them with the docker CLI but the Protocol stays
 Docker-shape-agnostic.
 """
 
+from dataclasses import dataclass
 from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class ProjectRuntimePresence:
+    """Checked project-owned runtime inventory used by lifecycle admission."""
+
+    container_count: int = 0
+    network_count: int = 0
+    error: str = ""
+
+    @property
+    def present(self) -> bool:
+        """Whether at least one project container or network exists."""
+
+        return self.container_count > 0 or self.network_count > 0
 
 
 class HostInventoryBackend(Protocol):
@@ -26,6 +42,15 @@ class HostInventoryBackend(Protocol):
             version string as reported by the daemon, or empty string
             on probe failure (missing binary, daemon down, etc.).
         """
+        ...
+
+    def observe_project_runtime(self) -> ProjectRuntimePresence:
+        """Return checked project container/network presence.
+
+        ``error`` is non-empty when absence could not be proved. Implementations
+        must include stopped/created containers and project-owned networks.
+        """
+
         ...
 
     def host_list_lab_containers(self) -> list[dict[str, Any]]:

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -30,6 +30,7 @@ from aptl.core.appliance_boundary import (
     ApplianceBoundaryBinding,
     ApplianceBoundaryPolicy,
 )
+from aptl.core.config import validate_compose_project_name
 from aptl.core.deployment.errors import BackendTimeoutError
 from aptl.core.lab_types import LabResult, LabStatus
 from aptl.utils.logging import get_logger
@@ -62,7 +63,7 @@ class DockerComposeBackend(
         offline_staged: bool = False,
     ) -> None:
         self._project_dir = project_dir
-        self._project_name = project_name
+        self._project_name = validate_compose_project_name(project_name)
         self._offline_staged = offline_staged
         self._appliance_boundary: (
             tuple[

--- a/src/aptl/core/deployment/docker_compose.py
+++ b/src/aptl/core/deployment/docker_compose.py
@@ -16,8 +16,12 @@ from aptl.core.deployment._compose_build_dedupe import (
 )
 from aptl.core.deployment._compose_image_fetch import ComposeImageFetchMixin
 from aptl.core.deployment._compose_lifecycle import kill_compose_lab
+from aptl.core.deployment._compose_project_cleanup import ComposeProjectCleanupMixin
 from aptl.core.deployment._compose_queries import ComposeQueryMixin
 from aptl.core.deployment._compose_realization import ComposeRealizationMixin
+from aptl.core.deployment._compose_runtime_inventory import (
+    ComposeRuntimeInventoryMixin,
+)
 from aptl.core.deployment._compose_seed_attribution import (
     ComposeSeedAttributionMixin,
 )
@@ -40,11 +44,13 @@ _DOCKER_TIMEOUT = 30
 
 
 class DockerComposeBackend(
+    ComposeRuntimeInventoryMixin,
     ComposeQueryMixin,
     ComposeRealizationMixin,
     ComposeSeedAttributionMixin,
     ComposeSeedExecutionMixin,
     ComposeBaseSubstrateMixin,
+    ComposeProjectCleanupMixin,
     ComposeImageFetchMixin,
 ):
     """Docker Compose deployment backend.
@@ -273,7 +279,9 @@ class DockerComposeBackend(
             LabResult indicating success or failure.
         """
         build = build and not self._offline_staged
-        compose_files = self._start_compose_files(build=build, scenario_root=scenario_root)
+        compose_files = self._start_compose_files(
+            build=build, scenario_root=scenario_root
+        )
         cmd = self._build_command(
             "up", profiles, compose_files=compose_files, scenario_root=scenario_root
         )
@@ -312,11 +320,7 @@ class DockerComposeBackend(
 
         root = scenario_root if scenario_root is not None else self._project_dir
         override = write_duplicate_build_override(root) if build else None
-        return (
-            (root / "docker-compose.yml", override)
-            if override is not None
-            else None
-        )
+        return (root / "docker-compose.yml", override) if override is not None else None
 
     def stop(self, profiles: list[str], *, remove_volumes: bool = False) -> LabResult:
         """Stop lab services via docker compose down.

--- a/src/aptl/core/kill.py
+++ b/src/aptl/core/kill.py
@@ -16,10 +16,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, TypedDict
 
-from aptl.core.deployment.docker_compose import (
-    _DOCKER_TIMEOUT,
+from aptl.core.config import find_config, load_config
+from aptl.core.lab import ALL_KNOWN_PROFILES
+from aptl.core.lifecycle_guard import (
+    LifecycleLockUnavailableError,
+    lifecycle_mutation_lock,
 )
-from aptl.core.lab import ALL_KNOWN_PROFILES, build_compose_command
+from aptl.core.lifecycle_policy import LifecycleBusyError
 from aptl.core.session import ScenarioSession
 from aptl.utils.logging import get_logger
 
@@ -41,6 +44,7 @@ class McpProcess(TypedDict):
     pid: int
     cmdline: str
     name: str
+
 
 MCP_SERVER_NAMES = [
     "mcp-wazuh",
@@ -250,8 +254,11 @@ def kill_mcp_processes(
         log.info("No MCP server processes found")
         return 0, []
 
-    log.info("Found %d MCP server process(es): %s", len(processes),
-             ", ".join(f"{p['name']}(pid={p['pid']})" for p in processes))
+    log.info(
+        "Found %d MCP server process(es): %s",
+        len(processes),
+        ", ".join(f"{p['name']}(pid={p['pid']})" for p in processes),
+    )
 
     pids_to_track, errors = _sigterm_processes(processes)
     survivors = _await_graceful_exit(pids_to_track, timeout, time_source, sleep)
@@ -268,9 +275,9 @@ def kill_lab_containers(
 ) -> tuple[bool, str]:
     """Emergency-stop all lab containers.
 
-    Uses the deployment backend's kill method for immediate shutdown.
-    Falls back to direct Docker Compose subprocess calls if no backend
-    is provided.
+    Uses the configured deployment backend's kill method for immediate
+    shutdown. A missing config uses the bounded default Compose backend;
+    an invalid present config fails closed rather than guessing identity.
 
     Args:
         project_dir: Working directory for Docker Compose.
@@ -279,67 +286,51 @@ def kill_lab_containers(
     Returns:
         Tuple of (success, error_message).
     """
-    profiles = list(ALL_KNOWN_PROFILES)
+    resolved_dir = Path(project_dir) if project_dir is not None else Path(".")
+    try:
+        with lifecycle_mutation_lock(resolved_dir) as project_root:
+            resolved_backend, error = _kill_backend(project_root, backend)
+            if error:
+                return False, error
+            assert resolved_backend is not None
+            return resolved_backend.kill(list(ALL_KNOWN_PROFILES))
+    except LifecycleBusyError:
+        return (
+            False,
+            "[lifecycle-owner-busy] Another lab lifecycle operation is active; "
+            "wait for it to finish before retrying container kill.",
+        )
+    except LifecycleLockUnavailableError:
+        return (
+            False,
+            "[lifecycle-lock-unavailable] Container kill blocked because safe "
+            "project lifecycle ownership could not be established.",
+        )
+
+
+def _kill_backend(
+    project_dir: Path,
+    backend: Optional["DeploymentBackend"],
+) -> tuple[Optional["DeploymentBackend"], str]:
+    """Resolve the configured backend without guessing an invalid identity."""
 
     if backend is not None:
-        return backend.kill(profiles)
+        return backend, ""
+    from aptl.core.deployment import get_backend
+    from aptl.core.deployment.docker_compose import DockerComposeBackend
 
-    # Fallback: direct Docker Compose calls (for backward compat and
-    # cases where config is unavailable)
-    return _kill_via_compose(project_dir, profiles)
-
-
-def _kill_via_compose(
-    project_dir: Optional[Path],
-    profiles: list[str],
-) -> tuple[bool, str]:
-    """Emergency-stop lab containers via direct ``docker compose`` calls."""
-    kwargs: dict[str, object] = {
-        "capture_output": True,
-        "text": True,
-        "timeout": _DOCKER_TIMEOUT,
-    }
-    if project_dir is not None:
-        kwargs["cwd"] = project_dir
-
-    # Phase 1: docker compose kill (immediate SIGKILL)
-    kill_cmd = ["docker", "compose"]
-    for profile in profiles:
-        kill_cmd.extend(["--profile", profile])
-    kill_cmd.append("kill")
-
-    log.info("Running: %s", " ".join(kill_cmd))
-    kill_ok = False
+    config_path = find_config(project_dir)
+    if config_path is None:
+        return DockerComposeBackend(project_dir=project_dir), ""
     try:
-        result = subprocess.run(kill_cmd, **kwargs)
-        kill_ok = result.returncode == 0
-        if not kill_ok:
-            log.warning("docker compose kill stderr: %s", result.stderr.strip())
-    except subprocess.TimeoutExpired:
-        log.warning("docker compose kill timed out after %ds", _DOCKER_TIMEOUT)
-    except OSError as exc:
-        msg = f"docker compose kill failed: {exc}"
-        log.error(msg)
-        return False, msg
-
-    # Phase 2: docker compose down (cleanup).  Treat non-zero exit as
-    # a warning — the important work (SIGKILL) already happened above.
-    down_cmd = build_compose_command("down", profiles=profiles)
-    log.info("Running: %s", " ".join(down_cmd))
-    try:
-        result = subprocess.run(down_cmd, **kwargs)
-        if result.returncode != 0:
-            log.warning("docker compose down stderr: %s", result.stderr.strip())
-    except subprocess.TimeoutExpired:
-        log.warning("docker compose down timed out after %ds", _DOCKER_TIMEOUT)
-    except OSError as exc:
-        log.warning("docker compose down failed: %s", exc)
-
-    if not kill_ok:
-        return False, "docker compose kill returned non-zero"
-
-    log.info("All lab containers stopped")
-    return True, ""
+        config = load_config(config_path)
+    except (FileNotFoundError, ValueError):
+        return (
+            None,
+            "[lifecycle-invalid-configuration] Container kill blocked: invalid "
+            "configuration; refusing to guess the deployment project identity.",
+        )
+    return get_backend(config, project_dir), ""
 
 
 def clear_session(state_dir: Path) -> bool:
@@ -384,6 +375,31 @@ def execute_kill(
     containers: bool = False,
     project_dir: Optional[Path] = None,
 ) -> KillResult:
+    """Execute the full kill switch under the shared project mutation owner."""
+
+    resolved_dir = Path(project_dir) if project_dir else Path(".")
+    try:
+        with lifecycle_mutation_lock(resolved_dir) as project_root:
+            return _execute_kill_owned(containers, project_root)
+    except LifecycleBusyError:
+        return KillResult(
+            success=False,
+            errors=[
+                "[lifecycle-owner-busy] Another lab lifecycle operation is active; "
+                "the kill switch did not mutate project state."
+            ],
+        )
+    except LifecycleLockUnavailableError:
+        return KillResult(
+            success=False,
+            errors=[
+                "[lifecycle-lock-unavailable] The kill switch could not establish "
+                "safe project lifecycle ownership."
+            ],
+        )
+
+
+def _execute_kill_owned(containers: bool, resolved_dir: Path) -> KillResult:
     """Execute the emergency kill switch.
 
     Runs each step independently so that a failure in one does not
@@ -396,7 +412,6 @@ def execute_kill(
     Returns:
         KillResult with details of what was done.
     """
-    resolved_dir = Path(project_dir) if project_dir else Path(".")
     state_dir = resolved_dir / ".aptl"
     errors: list[str] = []
 
@@ -444,7 +459,9 @@ def execute_kill(
 
     # Success if any step accomplished something, or if there was simply
     # nothing to kill (no errors).
-    any_action = mcp_killed > 0 or containers_stopped or session_cleared or trace_cleaned
+    any_action = (
+        mcp_killed > 0 or containers_stopped or session_cleared or trace_cleaned
+    )
     success = any_action or len(errors) == 0
 
     result = KillResult(
@@ -458,6 +475,10 @@ def execute_kill(
 
     log.info(
         "Kill switch complete: mcp=%d containers=%s session=%s trace=%s errors=%d",
-        mcp_killed, containers_stopped, session_cleared, trace_cleaned, len(errors),
+        mcp_killed,
+        containers_stopped,
+        session_cleared,
+        trace_cleaned,
+        len(errors),
     )
     return result

--- a/src/aptl/core/kill.py
+++ b/src/aptl/core/kill.py
@@ -289,23 +289,33 @@ def kill_lab_containers(
     resolved_dir = Path(project_dir) if project_dir is not None else Path(".")
     try:
         with lifecycle_mutation_lock(resolved_dir) as project_root:
-            resolved_backend, error = _kill_backend(project_root, backend)
-            if error:
-                return False, error
-            assert resolved_backend is not None
-            return resolved_backend.kill(list(ALL_KNOWN_PROFILES))
+            result = _kill_lab_containers_owned(project_root, backend)
     except LifecycleBusyError:
-        return (
+        result = (
             False,
             "[lifecycle-owner-busy] Another lab lifecycle operation is active; "
             "wait for it to finish before retrying container kill.",
         )
     except LifecycleLockUnavailableError:
-        return (
+        result = (
             False,
             "[lifecycle-lock-unavailable] Container kill blocked because safe "
             "project lifecycle ownership could not be established.",
         )
+    return result
+
+
+def _kill_lab_containers_owned(
+    project_dir: Path,
+    backend: Optional["DeploymentBackend"],
+) -> tuple[bool, str]:
+    """Kill project containers while the caller owns the lifecycle lock."""
+
+    resolved_backend, error = _kill_backend(project_dir, backend)
+    if error:
+        return False, error
+    assert resolved_backend is not None
+    return resolved_backend.kill(list(ALL_KNOWN_PROFILES))
 
 
 def _kill_backend(
@@ -314,23 +324,27 @@ def _kill_backend(
 ) -> tuple[Optional["DeploymentBackend"], str]:
     """Resolve the configured backend without guessing an invalid identity."""
 
-    if backend is not None:
-        return backend, ""
-    from aptl.core.deployment import get_backend
-    from aptl.core.deployment.docker_compose import DockerComposeBackend
+    resolved_backend = backend
+    error = ""
+    if resolved_backend is None:
+        from aptl.core.deployment import get_backend
+        from aptl.core.deployment.docker_compose import DockerComposeBackend
 
-    config_path = find_config(project_dir)
-    if config_path is None:
-        return DockerComposeBackend(project_dir=project_dir), ""
-    try:
-        config = load_config(config_path)
-    except (FileNotFoundError, ValueError):
-        return (
-            None,
-            "[lifecycle-invalid-configuration] Container kill blocked: invalid "
-            "configuration; refusing to guess the deployment project identity.",
-        )
-    return get_backend(config, project_dir), ""
+        config_path = find_config(project_dir)
+        if config_path is None:
+            resolved_backend = DockerComposeBackend(project_dir=project_dir)
+        else:
+            try:
+                config = load_config(config_path)
+            except (FileNotFoundError, ValueError):
+                error = (
+                    "[lifecycle-invalid-configuration] Container kill blocked: "
+                    "invalid configuration; refusing to guess the deployment "
+                    "project identity."
+                )
+            else:
+                resolved_backend = get_backend(config, project_dir)
+    return resolved_backend, error
 
 
 def clear_session(state_dir: Path) -> bool:

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -523,35 +523,57 @@ def clean_boot_lab(
     """
     try:
         with lifecycle_mutation_lock(project_dir) as project_root:
-            if progress is not None:
-                progress("Stopping the existing lab before clean boot.")
-            stop_result = stop_lab(
-                remove_volumes=remove_volumes,
-                project_dir=project_root,
-                backend=backend,
-            )
-            if not stop_result.success:
-                return LabResult(
-                    success=False,
-                    error=redact(
-                        "clean-state cleanup failed; lab not booted: "
-                        f"{stop_result.error}"
-                    ),
-                    outcome=StartupOutcome.FAILED,
-                )
-
-            appliance_kwargs = {"appliance": appliance} if appliance is not None else {}
-            return orchestrate_lab_start(
+            result = _clean_boot_lab_owned(
                 project_root,
+                remove_volumes=remove_volumes,
                 skip_seed=skip_seed,
                 scenario_path=scenario_path,
+                backend=backend,
                 progress=progress,
-                **appliance_kwargs,
+                appliance=appliance,
             )
     except LifecycleBusyError:
-        return _lifecycle_busy_result("start --clean")
+        result = _lifecycle_busy_result("start --clean")
     except LifecycleLockUnavailableError:
-        return _lifecycle_lock_unavailable_result()
+        result = _lifecycle_lock_unavailable_result()
+    return result
+
+
+def _clean_boot_lab_owned(
+    project_root: Path,
+    *,
+    remove_volumes: bool,
+    skip_seed: bool,
+    scenario_path: Optional[Path],
+    backend: Optional["DeploymentBackend"],
+    progress: ProgressCallback | None,
+    appliance: ApplianceStartOptions | None,
+) -> LabResult:
+    """Clean and restart the lab while the caller owns lifecycle mutation."""
+
+    if progress is not None:
+        progress("Stopping the existing lab before clean boot.")
+    stop_result = stop_lab(
+        remove_volumes=remove_volumes,
+        project_dir=project_root,
+        backend=backend,
+    )
+    if not stop_result.success:
+        return LabResult(
+            success=False,
+            error=redact(
+                f"clean-state cleanup failed; lab not booted: {stop_result.error}"
+            ),
+            outcome=StartupOutcome.FAILED,
+        )
+    appliance_kwargs = {"appliance": appliance} if appliance is not None else {}
+    return orchestrate_lab_start(
+        project_root,
+        skip_seed=skip_seed,
+        scenario_path=scenario_path,
+        progress=progress,
+        **appliance_kwargs,
+    )
 
 
 def lab_status(

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -53,6 +53,11 @@ from aptl.core.lab_types import (
     StartupDiagnostic as StartupDiagnostic,
     StartupOutcome as StartupOutcome,
 )
+from aptl.core.lifecycle_guard import (
+    LifecycleLockUnavailableError,
+    lifecycle_mutation_lock,
+)
+from aptl.core.lifecycle_policy import LifecycleBusyError
 from aptl.core.services import (
     ServiceResult,
     check_indexer_ready,
@@ -252,7 +257,9 @@ def admitted_stateful_artifact_ownership(
 ) -> frozenset[tuple[str, str, str, str]]:
     """Lazy RAES import for exact pre-mutation artifact ownership."""
 
-    from aptl.backends._raes_scenario_queries import admitted_stateful_artifact_ownership as _load
+    from aptl.backends._raes_scenario_queries import (
+        admitted_stateful_artifact_ownership as _load,
+    )
 
     return _load(project_dir, config, backend, scenario_path=scenario_path)
 
@@ -376,9 +383,9 @@ def stop_lab(
 ) -> LabResult:
     """Stop the lab environment.
 
-    Loads the config to determine which profiles to include in the
-    down command. If config loading fails, falls back to all known
-    profiles to ensure containers are stopped.
+    Loads the config to determine the admitted project identity and profiles.
+    A missing config falls back to the default project and known profiles for
+    recovery; an invalid present config fails closed.
 
     Args:
         remove_volumes: If True, also remove Docker volumes (-v flag).
@@ -388,9 +395,27 @@ def stop_lab(
     Returns:
         LabResult indicating success or failure.
     """
-    # Load config to get active profiles; fall back to all profiles
-    profiles: list[str] = []
     search_dir = project_dir or Path(".")
+    try:
+        with lifecycle_mutation_lock(search_dir) as project_root:
+            return _stop_lab_owned(remove_volumes, project_root, backend)
+    except LifecycleBusyError:
+        return _lifecycle_busy_result("stop")
+    except LifecycleLockUnavailableError:
+        return _lifecycle_lock_unavailable_result()
+
+
+def _stop_lab_owned(
+    remove_volumes: bool,
+    search_dir: Path,
+    backend: Optional["DeploymentBackend"],
+) -> LabResult:
+    """Run teardown while the caller owns the project lifecycle lock."""
+
+    # Load config to get active profiles; fall back to all profiles only when
+    # there is no config. An invalid present config cannot safely identify the
+    # deployment project for destructive label and volume queries.
+    profiles: list[str] = []
     config_path = find_config(search_dir)
     config: AptlConfig | None = None
     if config_path is not None:
@@ -399,6 +424,15 @@ def stop_lab(
             profiles = config.containers.enabled_profiles()
         except (FileNotFoundError, ValueError) as exc:
             log.warning("Could not load config for profiles: %s", exc)
+            if backend is None:
+                return LabResult(
+                    success=False,
+                    error=(
+                        "[lifecycle-invalid-configuration] Lab stop blocked: "
+                        "invalid configuration; refusing to guess the deployment "
+                        "project identity. Repair aptl.json and retry."
+                    ),
+                )
     if not profiles:
         profiles = list(ALL_KNOWN_PROFILES)
     # OTel stack (Collector + Tempo + Grafana) is core infrastructure the
@@ -413,6 +447,32 @@ def stop_lab(
         backend = _get_backend(search_dir, config)
 
     return backend.stop(profiles, remove_volumes=remove_volumes)
+
+
+def _lifecycle_busy_result(action: str) -> LabResult:
+    """Return the bounded public result for an overlapping mutation."""
+
+    return LabResult(
+        success=False,
+        error=(
+            "[lifecycle-owner-busy] Another lab lifecycle operation is active. "
+            f"Wait for it to finish before retrying `aptl lab {action}`."
+        ),
+        outcome=StartupOutcome.FAILED,
+    )
+
+
+def _lifecycle_lock_unavailable_result() -> LabResult:
+    """Return a bounded failure when safe lifecycle ownership is unavailable."""
+
+    return LabResult(
+        success=False,
+        error=(
+            "[lifecycle-lock-unavailable] Lab lifecycle ownership could not be "
+            "established safely. Repair the project .aptl state path and retry."
+        ),
+        outcome=StartupOutcome.FAILED,
+    )
 
 
 def clean_boot_lab(
@@ -461,30 +521,37 @@ def clean_boot_lab(
         LabResult — the boot outcome on success, or a fatal ``FAILED``
         result carrying the redacted cleanup error when teardown fails.
     """
-    if progress is not None:
-        progress("Stopping the existing lab before clean boot.")
-    stop_result = stop_lab(
-        remove_volumes=remove_volumes,
-        project_dir=project_dir,
-        backend=backend,
-    )
-    if not stop_result.success:
-        return LabResult(
-            success=False,
-            error=redact(
-                f"clean-state cleanup failed; lab not booted: {stop_result.error}"
-            ),
-            outcome=StartupOutcome.FAILED,
-        )
+    try:
+        with lifecycle_mutation_lock(project_dir) as project_root:
+            if progress is not None:
+                progress("Stopping the existing lab before clean boot.")
+            stop_result = stop_lab(
+                remove_volumes=remove_volumes,
+                project_dir=project_root,
+                backend=backend,
+            )
+            if not stop_result.success:
+                return LabResult(
+                    success=False,
+                    error=redact(
+                        "clean-state cleanup failed; lab not booted: "
+                        f"{stop_result.error}"
+                    ),
+                    outcome=StartupOutcome.FAILED,
+                )
 
-    appliance_kwargs = {"appliance": appliance} if appliance is not None else {}
-    return orchestrate_lab_start(
-        project_dir,
-        skip_seed=skip_seed,
-        scenario_path=scenario_path,
-        progress=progress,
-        **appliance_kwargs,
-    )
+            appliance_kwargs = {"appliance": appliance} if appliance is not None else {}
+            return orchestrate_lab_start(
+                project_root,
+                skip_seed=skip_seed,
+                scenario_path=scenario_path,
+                progress=progress,
+                **appliance_kwargs,
+            )
+    except LifecycleBusyError:
+        return _lifecycle_busy_result("start --clean")
+    except LifecycleLockUnavailableError:
+        return _lifecycle_lock_unavailable_result()
 
 
 def lab_status(
@@ -960,6 +1027,43 @@ def _step_load_config(ctx: _LabStartContext) -> LabResult | None:
     return result
 
 
+def _step_reject_preexisting_range(ctx: _LabStartContext) -> LabResult | None:
+    """Fail normal start when project runtime residue already exists.
+
+    Presence is an admission fact, not a realization verdict. A checked
+    backend observation keeps an unavailable daemon or malformed transport
+    response distinct from a genuinely empty project.
+    """
+
+    assert ctx.backend is not None
+    presence = ctx.backend.observe_project_runtime()
+    if presence.error:
+        log.error("Lab runtime presence observation failed")
+        return LabResult(
+            success=False,
+            error=(
+                "[lifecycle-observation-failed] Lab start blocked because "
+                "existing project runtime state could not be determined. "
+                "Check the deployment backend connection and retry."
+            ),
+        )
+    if not presence.present:
+        return None
+    log.warning(
+        "Lab start blocked by project runtime residue (containers=%d networks=%d)",
+        presence.container_count,
+        presence.network_count,
+    )
+    return LabResult(
+        success=False,
+        error=(
+            "[lifecycle-range-present] An APTL range already exists for this "
+            "deployment project. Run `aptl lab stop` and retry, or use "
+            "`aptl lab start --clean` for an explicit volume-reset boot."
+        ),
+    )
+
+
 def _configure_verified_appliance_launch(
     ctx: _LabStartContext,
 ) -> LabResult | None:
@@ -1082,10 +1186,7 @@ def _scenario_is_env_pack(ctx: _LabStartContext) -> bool:
     realization from the pack, not by the host-side lab-start steps.
     """
 
-    return (
-        ctx.config is not None
-        and ctx.config.scenario.source == "env-pack"
-    )
+    return ctx.config is not None and ctx.config.scenario.source == "env-pack"
 
 
 def _step_ensure_ssh_keys(ctx: _LabStartContext) -> LabResult | None:
@@ -1106,7 +1207,9 @@ def _step_ensure_ssh_keys(ctx: _LabStartContext) -> LabResult | None:
         # and authorized-key projections (generated + placed during realization);
         # only the control-plane key above is host-side. Generating the legacy
         # pivot/authorized-keys here would write dead files the pack never mounts.
-        log.info("Step 3: pivot/authorized keys come from the scenario pack; skipping host generation.")
+        log.info(
+            "Step 3: pivot/authorized keys come from the scenario pack; skipping host generation."
+        )
         return None
 
     return _generate_host_side_pivot_keys(keys_dir, pivot_dir)
@@ -2487,6 +2590,7 @@ def _step_sync_mcp_config(ctx: _LabStartContext) -> LabResult | None:
 _LAB_START_STEPS = (
     _step_load_env,
     _step_load_config,
+    _step_reject_preexisting_range,
     _step_resolve_host_ports,
     _step_ensure_ssh_keys,
     _step_check_sysreqs,
@@ -2510,6 +2614,7 @@ _LAB_START_STEPS = (
 _LAB_START_PROGRESS_MESSAGES = {
     "_step_load_env": "Preparing environment and credentials.",
     "_step_load_config": "Loading lab configuration.",
+    "_step_reject_preexisting_range": "Checking for an existing lab range.",
     "_step_resolve_host_ports": "Checking host port availability.",
     "_step_ensure_ssh_keys": "Preparing SSH keys.",
     "_step_check_sysreqs": "Checking host requirements.",
@@ -2541,6 +2646,30 @@ def _emit_progress(ctx: _LabStartContext, message: str) -> None:
 
 
 def orchestrate_lab_start(
+    project_dir: Path,
+    skip_seed: bool = False,
+    scenario_path: Path | None = None,
+    progress: ProgressCallback | None = None,
+    appliance: ApplianceStartOptions | None = None,
+) -> LabResult:
+    """Own and orchestrate the complete lab startup process."""
+
+    try:
+        with lifecycle_mutation_lock(project_dir) as project_root:
+            return _orchestrate_lab_start_owned(
+                project_root,
+                skip_seed=skip_seed,
+                scenario_path=scenario_path,
+                progress=progress,
+                appliance=appliance,
+            )
+    except LifecycleBusyError:
+        return _lifecycle_busy_result("start")
+    except LifecycleLockUnavailableError:
+        return _lifecycle_lock_unavailable_result()
+
+
+def _orchestrate_lab_start_owned(
     project_dir: Path,
     skip_seed: bool = False,
     scenario_path: Path | None = None,

--- a/src/aptl/core/lifecycle_enforce.py
+++ b/src/aptl/core/lifecycle_enforce.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, TextIO
+from typing import TYPE_CHECKING, Optional
 
 from aptl.core.config import (
     AptlConfig,
@@ -41,7 +40,10 @@ from aptl.core.lifecycle_policy import (
     decide,
     load_state,
     save_state,
-    state_path,
+)
+from aptl.core.lifecycle_guard import (
+    canonical_lifecycle_project_root,
+    lifecycle_mutation_lock,
 )
 from aptl.core.runstore import resolve_active_run_dir
 from aptl.utils.logging import get_logger
@@ -51,13 +53,6 @@ if TYPE_CHECKING:
     from aptl.core.deployment.backend import DeploymentBackend
 
 log = get_logger("lifecycle_enforce")
-
-try:
-    import fcntl
-except ModuleNotFoundError:
-    # Windows does not provide POSIX flock; lifecycle locks become in-process.
-    fcntl = None
-
 
 # ---------------------------------------------------------------------------
 # Activity signal + single-owner lock
@@ -102,41 +97,10 @@ def _latest_activity_at(project_dir: Path, state: LifecycleState) -> Optional[da
     return max(candidates) if candidates else None
 
 
-@contextmanager
-def _single_owner_lock(project_dir: Path) -> Iterator[None]:
-    """Hold an exclusive non-blocking flock for the duration of a tick/loop.
+def _single_owner_lock(project_dir: Path) -> Iterator[Path]:
+    """Return the shared project mutation guard for compatibility tests."""
 
-    Raises :class:`LifecycleBusyError` when another owner already holds it.
-    """
-    lock_path = state_path(project_dir).parent / ".lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    handle = lock_path.open("w")
-    try:
-        _try_lock_lifecycle(handle)
-        try:
-            yield
-        finally:
-            _unlock_lifecycle(handle)
-    finally:
-        handle.close()
-
-
-def _try_lock_lifecycle(handle: TextIO) -> None:
-    """Acquire the lifecycle owner lock on POSIX hosts."""
-    if fcntl is None:
-        return
-    try:
-        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError as exc:
-        raise LifecycleBusyError(
-            "another lifecycle owner is active (enforce/monitor lock held)"
-        ) from exc
-
-
-def _unlock_lifecycle(handle: TextIO) -> None:
-    """Release the lifecycle owner lock on POSIX hosts."""
-    if fcntl is not None:
-        fcntl.flock(handle, fcntl.LOCK_UN)
+    return lifecycle_mutation_lock(project_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +186,9 @@ def _apply_teardown(
     )
 
 
-def _resolve_schedule_scenario(project_dir: Path, scenario: Optional[str]) -> Optional[Path]:
+def _resolve_schedule_scenario(
+    project_dir: Path, scenario: Optional[str]
+) -> Optional[Path]:
     """Resolve an optional schedule scenario id to its SDL path."""
     if not scenario:
         return None
@@ -324,15 +290,16 @@ def enforce_once(
     owner holds the project lock.
     """
     now = datetime.now(timezone.utc) if now is None else _to_utc(now)
-    policy, failure = _policy_or_failure(project_dir)
+    project_root = canonical_lifecycle_project_root(project_dir)
+    policy, failure = _policy_or_failure(project_root)
     if failure is not None:
         return failure
     if policy is None:
         return LabResult(
             success=True, message="lifecycle: no policy configured; nothing to enforce"
         )
-    with _single_owner_lock(project_dir):
-        return _enforce_locked(project_dir, policy, now, backend, grace_minutes)
+    with _single_owner_lock(project_root) as locked_project_root:
+        return _enforce_locked(locked_project_root, policy, now, backend, grace_minutes)
 
 
 def run_monitor(
@@ -350,17 +317,18 @@ def run_monitor(
     one-shot ``enforce`` — cannot interleave. Each tick reloads the policy so
     edits to ``aptl.json`` take effect without a restart.
     """
-    policy, failure = _policy_or_failure(project_dir)
+    project_root = canonical_lifecycle_project_root(project_dir)
+    policy, failure = _policy_or_failure(project_root)
     if failure is not None:
         return [failure]
     if policy is None:
         log.info("No lifecycle_policy configured; monitor has nothing to do")
         return []
     results: list[LabResult] = []
-    with _single_owner_lock(project_dir):
+    with _single_owner_lock(project_root) as locked_project_root:
         tick = 0
         while max_ticks is None or tick < max_ticks:
-            policy, failure = _policy_or_failure(project_dir)
+            policy, failure = _policy_or_failure(locked_project_root)
             if failure is not None:
                 results.append(failure)
                 break
@@ -368,7 +336,9 @@ def run_monitor(
                 break
             now = datetime.now(timezone.utc)
             results.append(
-                _enforce_locked(project_dir, policy, now, backend, grace_minutes)
+                _enforce_locked(
+                    locked_project_root, policy, now, backend, grace_minutes
+                )
             )
             tick += 1
             if max_ticks is not None and tick >= max_ticks:

--- a/src/aptl/core/lifecycle_enforce.py
+++ b/src/aptl/core/lifecycle_enforce.py
@@ -32,7 +32,6 @@ from aptl.core.lab_types import (
     StartupOutcome,
 )
 from aptl.core.lifecycle_policy import (
-    LifecycleBusyError,
     LifecycleDecision,
     LifecycleState,
     _parse_iso,

--- a/src/aptl/core/lifecycle_guard.py
+++ b/src/aptl/core/lifecycle_guard.py
@@ -20,18 +20,35 @@ from aptl.core.config import find_config
 from aptl.core.lifecycle_policy import LifecycleBusyError
 from aptl.utils.pathsafe import PathContainmentError, open_dir_contained_nofollow
 
-try:  # pragma: no cover - platform-specific import
+# Platform-specific import.
+try:
     import fcntl
-except ModuleNotFoundError:  # pragma: no cover - Windows
+# Windows has no POSIX flock module.
+except ModuleNotFoundError:
     fcntl = None
 
-try:  # pragma: no cover - platform-specific import
+# Platform-specific import.
+try:
     import msvcrt
-except ModuleNotFoundError:  # pragma: no cover - POSIX
+# POSIX has no Microsoft C runtime module.
+except ModuleNotFoundError:
     msvcrt = None
 
 _LIFECYCLE_DIR = ".aptl/lifecycle"
 _LOCK_FILE = ".lock"
+_WIN_DIRECTORY_ACCESS = 0x00100187
+_WIN_FILE_ACCESS = 0x00100183
+_WIN_SHARE_ALL = 0x00000007
+_WIN_OPEN_EXISTING = 3
+_WIN_OPEN_IF = 3
+_WIN_ROOT_OPEN_FLAGS = 0x02200000
+_WIN_OBJECT_CASE_INSENSITIVE = 0x00000040
+_WIN_SYNC_OPEN_REPARSE = 0x00200020
+_WIN_DIRECTORY_OBJECT = 0x00000001
+_WIN_FILE_OBJECT = 0x00000040
+_WIN_FILE_ATTRIBUTE_NORMAL = 0x00000080
+_WIN_FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+_WIN_FILE_ATTRIBUTE_TAG_INFO = 9
 
 
 class LifecycleLockUnavailableError(RuntimeError):
@@ -40,6 +57,8 @@ class LifecycleLockUnavailableError(RuntimeError):
 
 @dataclass
 class _HeldLifecycleLock:
+    """One process-local reference to an owned operating-system lock."""
+
     fd: int
     depth: int
 
@@ -71,53 +90,73 @@ def lifecycle_mutation_lock(project_dir: Path) -> Iterator[Path]:
 
     root = canonical_lifecycle_project_root(project_dir)
     key = (str(root), threading.get_ident())
-    with _HELD_LOCKS_GUARD:
-        held = _HELD_LOCKS.get(key)
-        if held is not None:
-            held.depth += 1
-            reused = True
-        else:
-            reused = False
-
+    reused = _increment_reentrant_lock(key)
     if not reused:
-        fd: int | None = None
-        try:
-            fd = _open_lock_fd(root)
-            _try_lock(fd)
-        except LifecycleBusyError:
-            if fd is not None:
-                os.close(fd)
-            raise
-        except (PathContainmentError, OSError) as exc:
-            if fd is not None:
-                os.close(fd)
-            raise LifecycleLockUnavailableError(
-                "safe lifecycle ownership is unavailable"
-            ) from exc
-        except BaseException:
-            if fd is not None:
-                os.close(fd)
-            raise
-        assert fd is not None
+        fd = _acquire_lock_fd(root)
         with _HELD_LOCKS_GUARD:
             _HELD_LOCKS[key] = _HeldLifecycleLock(fd=fd, depth=1)
 
     try:
         yield root
     finally:
-        with _HELD_LOCKS_GUARD:
-            entry = _HELD_LOCKS[key]
-            entry.depth -= 1
-            if entry.depth == 0:
-                _unlock(entry.fd)
-                os.close(entry.fd)
-                del _HELD_LOCKS[key]
+        _release_lock(key)
+
+
+def _increment_reentrant_lock(key: tuple[str, int]) -> bool:
+    """Increment and report an existing same-thread ownership record."""
+
+    with _HELD_LOCKS_GUARD:
+        held = _HELD_LOCKS.get(key)
+        if held is not None:
+            held.depth += 1
+    return held is not None
+
+
+def _acquire_lock_fd(root: Path) -> int:
+    """Open and acquire a new OS lock, closing the descriptor on failure."""
+
+    fd: int | None = None
+    try:
+        fd = _open_lock_fd(root)
+        _try_lock(fd)
+    except LifecycleBusyError:
+        _close_if_open(fd)
+        raise
+    except (PathContainmentError, OSError) as exc:
+        _close_if_open(fd)
+        raise LifecycleLockUnavailableError(
+            "safe lifecycle ownership is unavailable"
+        ) from exc
+    except BaseException:
+        _close_if_open(fd)
+        raise
+    assert fd is not None
+    return fd
+
+
+def _close_if_open(fd: int | None) -> None:
+    """Close ``fd`` only when acquisition progressed far enough to open it."""
+
+    if fd is not None:
+        os.close(fd)
+
+
+def _release_lock(key: tuple[str, int]) -> None:
+    """Drop one reentrant depth and release the OS lock at depth zero."""
+
+    with _HELD_LOCKS_GUARD:
+        entry = _HELD_LOCKS[key]
+        entry.depth -= 1
+        if entry.depth == 0:
+            _unlock(entry.fd)
+            os.close(entry.fd)
+            del _HELD_LOCKS[key]
 
 
 def _open_lock_fd(project_dir: Path) -> int:
     """Open the fixed owner-only lock without following a POSIX symlink."""
 
-    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+    if os.name == "nt":
         return _open_windows_lock_fd(project_dir)
 
     lifecycle_fd = open_dir_contained_nofollow(project_dir, _LIFECYCLE_DIR, create=True)
@@ -158,7 +197,8 @@ def _open_windows_lock_fd(project_dir: Path) -> int:
         )
         _windows_reject_reparse_point(lock_handle)
         fd = _windows_handle_to_fd(lock_handle)
-        lock_handle = None  # the C runtime descriptor now owns the handle
+        # The C runtime descriptor now owns the handle.
+        lock_handle = None
     finally:
         if lock_handle is not None:
             _windows_close_handle(lock_handle)
@@ -192,11 +232,11 @@ def _windows_open_root_handle(project_dir: Path) -> int:
 
     handle = create_file(
         str(project_dir),
-        0x00100187,  # SYNCHRONIZE | read/write attributes | add/list children
-        0x00000007,  # FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
+        _WIN_DIRECTORY_ACCESS,
+        _WIN_SHARE_ALL,
         None,
-        3,  # OPEN_EXISTING
-        0x02200000,  # BACKUP_SEMANTICS | OPEN_REPARSE_POINT
+        _WIN_OPEN_EXISTING,
+        _WIN_ROOT_OPEN_FLAGS,
         None,
     )
     invalid_handle = ctypes.c_void_p(-1).value
@@ -214,6 +254,8 @@ def _windows_open_relative_handle(
     from ctypes import wintypes
 
     class UnicodeString(ctypes.Structure):
+        """Windows UNICODE_STRING used by descriptor-relative opens."""
+
         _fields_ = [
             ("Length", wintypes.USHORT),
             ("MaximumLength", wintypes.USHORT),
@@ -221,6 +263,8 @@ def _windows_open_relative_handle(
         ]
 
     class ObjectAttributes(ctypes.Structure):
+        """Windows OBJECT_ATTRIBUTES binding for a relative child name."""
+
         _fields_ = [
             ("Length", wintypes.ULONG),
             ("RootDirectory", wintypes.HANDLE),
@@ -231,9 +275,13 @@ def _windows_open_relative_handle(
         ]
 
     class IoStatusValue(ctypes.Union):
+        """Status-or-pointer union embedded in IO_STATUS_BLOCK."""
+
         _fields_ = [("Status", ctypes.c_long), ("Pointer", wintypes.LPVOID)]
 
     class IoStatusBlock(ctypes.Structure):
+        """Windows IO_STATUS_BLOCK returned by NtCreateFile."""
+
         _anonymous_ = ("value",)
         _fields_ = [("value", IoStatusValue), ("Information", ctypes.c_size_t)]
 
@@ -248,7 +296,7 @@ def _windows_open_relative_handle(
         Length=ctypes.sizeof(ObjectAttributes),
         RootDirectory=wintypes.HANDLE(parent_handle),
         ObjectName=ctypes.pointer(object_name),
-        Attributes=0x00000040,  # OBJ_CASE_INSENSITIVE
+        Attributes=_WIN_OBJECT_CASE_INSENSITIVE,
         SecurityDescriptor=None,
         SecurityQualityOfService=None,
     )
@@ -271,18 +319,19 @@ def _windows_open_relative_handle(
         wintypes.ULONG,
     )
     nt_create_file.restype = ctypes.c_long
-    options = 0x00200020 | (0x00000001 if directory else 0x00000040)
-    desired_access = 0x00100187 if directory else 0x00100183
+    object_type = _WIN_DIRECTORY_OBJECT if directory else _WIN_FILE_OBJECT
+    options = _WIN_SYNC_OPEN_REPARSE | object_type
+    desired_access = _WIN_DIRECTORY_ACCESS if directory else _WIN_FILE_ACCESS
     status = nt_create_file(
         ctypes.byref(handle),
         desired_access,
         ctypes.byref(attributes),
         ctypes.byref(io_status),
         None,
-        0x00000080,  # FILE_ATTRIBUTE_NORMAL
-        0x00000007,
-        3,  # FILE_OPEN_IF
-        options,  # synchronous, open-reparse, and expected object type
+        _WIN_FILE_ATTRIBUTE_NORMAL,
+        _WIN_SHARE_ALL,
+        _WIN_OPEN_IF,
+        options,
         None,
         0,
     )
@@ -301,6 +350,8 @@ def _windows_reject_reparse_point(handle: int) -> None:
     from ctypes import wintypes
 
     class FileAttributeTagInfo(ctypes.Structure):
+        """Windows FILE_ATTRIBUTE_TAG_INFO response structure."""
+
         _fields_ = [
             ("FileAttributes", wintypes.DWORD),
             ("ReparseTag", wintypes.DWORD),
@@ -318,19 +369,19 @@ def _windows_reject_reparse_point(handle: int) -> None:
     info = FileAttributeTagInfo()
     if not get_info(
         wintypes.HANDLE(handle),
-        9,  # FileAttributeTagInfo
+        _WIN_FILE_ATTRIBUTE_TAG_INFO,
         ctypes.byref(info),
         ctypes.sizeof(info),
     ):
         raise ctypes.WinError(ctypes.get_last_error())
-    if info.FileAttributes & 0x00000400:  # FILE_ATTRIBUTE_REPARSE_POINT
+    if info.FileAttributes & _WIN_FILE_ATTRIBUTE_REPARSE_POINT:
         raise OSError("lifecycle lock path contains a reparse point")
 
 
 def _windows_handle_to_fd(handle: int) -> int:
     """Transfer an owned Windows file handle to a Python descriptor."""
 
-    if msvcrt is None:  # pragma: no cover - guarded by the Windows call site
+    if msvcrt is None:
         raise OSError("Windows descriptor support is unavailable")
     flags = os.O_RDWR | getattr(os, "O_BINARY", 0)
     return msvcrt.open_osfhandle(handle, flags)
@@ -356,10 +407,12 @@ def _try_lock(fd: int) -> None:
     try:
         if fcntl is not None:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        elif msvcrt is not None:  # pragma: no cover - Windows
+        # Windows uses a one-byte Microsoft C runtime lock.
+        elif msvcrt is not None:
             os.lseek(fd, 0, os.SEEK_SET)
             msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-        else:  # pragma: no cover - unsupported runtime
+        # Fail closed on an unsupported Python runtime.
+        else:
             raise OSError("no cross-process file-lock implementation is available")
     except OSError as exc:
         if exc.errno not in (None, errno.EACCES, errno.EAGAIN):
@@ -374,6 +427,7 @@ def _unlock(fd: int) -> None:
 
     if fcntl is not None:
         fcntl.flock(fd, fcntl.LOCK_UN)
-    elif msvcrt is not None:  # pragma: no cover - Windows
+    # Windows uses a one-byte Microsoft C runtime lock.
+    elif msvcrt is not None:
         os.lseek(fd, 0, os.SEEK_SET)
         msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)

--- a/src/aptl/core/lifecycle_guard.py
+++ b/src/aptl/core/lifecycle_guard.py
@@ -1,0 +1,379 @@
+"""Shared project-wide ownership for mutating lab lifecycle operations.
+
+The fixed ``.aptl/lifecycle/.lock`` file is only a rendezvous point. Ownership
+comes from the operating system lock held on its descriptor, never from file
+existence or persisted PID metadata. Acquisitions are non-blocking so callers
+can return an actionable busy result instead of hanging behind a long startup.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+from aptl.core.config import find_config
+from aptl.core.lifecycle_policy import LifecycleBusyError
+from aptl.utils.pathsafe import PathContainmentError, open_dir_contained_nofollow
+
+try:  # pragma: no cover - platform-specific import
+    import fcntl
+except ModuleNotFoundError:  # pragma: no cover - Windows
+    fcntl = None
+
+try:  # pragma: no cover - platform-specific import
+    import msvcrt
+except ModuleNotFoundError:  # pragma: no cover - POSIX
+    msvcrt = None
+
+_LIFECYCLE_DIR = ".aptl/lifecycle"
+_LOCK_FILE = ".lock"
+
+
+class LifecycleLockUnavailableError(RuntimeError):
+    """Raised when the owner lock cannot be established safely."""
+
+
+@dataclass
+class _HeldLifecycleLock:
+    fd: int
+    depth: int
+
+
+_HELD_LOCKS: dict[tuple[str, int], _HeldLifecycleLock] = {}
+_HELD_LOCKS_GUARD = threading.Lock()
+
+
+def canonical_lifecycle_project_root(project_dir: Path) -> Path:
+    """Resolve the config-owning project root without mutating project state."""
+
+    candidate = Path(project_dir).resolve()
+    for directory in (candidate, *candidate.parents):
+        if find_config(directory) is not None:
+            return directory
+    return candidate
+
+
+@contextmanager
+def lifecycle_mutation_lock(project_dir: Path) -> Iterator[Path]:
+    """Hold the project lifecycle owner lock, reentrant in the current thread.
+
+    A different thread or process receives :class:`LifecycleBusyError`
+    immediately. The lock file is created below the trusted project directory
+    through descriptor-relative, no-follow path handling. POSIX locks are
+    forced to owner-only permissions; Windows creation inherits the project's
+    ACL while rejecting every reparse-point component by handle.
+    """
+
+    root = canonical_lifecycle_project_root(project_dir)
+    key = (str(root), threading.get_ident())
+    with _HELD_LOCKS_GUARD:
+        held = _HELD_LOCKS.get(key)
+        if held is not None:
+            held.depth += 1
+            reused = True
+        else:
+            reused = False
+
+    if not reused:
+        fd: int | None = None
+        try:
+            fd = _open_lock_fd(root)
+            _try_lock(fd)
+        except LifecycleBusyError:
+            if fd is not None:
+                os.close(fd)
+            raise
+        except (PathContainmentError, OSError) as exc:
+            if fd is not None:
+                os.close(fd)
+            raise LifecycleLockUnavailableError(
+                "safe lifecycle ownership is unavailable"
+            ) from exc
+        except BaseException:
+            if fd is not None:
+                os.close(fd)
+            raise
+        assert fd is not None
+        with _HELD_LOCKS_GUARD:
+            _HELD_LOCKS[key] = _HeldLifecycleLock(fd=fd, depth=1)
+
+    try:
+        yield root
+    finally:
+        with _HELD_LOCKS_GUARD:
+            entry = _HELD_LOCKS[key]
+            entry.depth -= 1
+            if entry.depth == 0:
+                _unlock(entry.fd)
+                os.close(entry.fd)
+                del _HELD_LOCKS[key]
+
+
+def _open_lock_fd(project_dir: Path) -> int:
+    """Open the fixed owner-only lock without following a POSIX symlink."""
+
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        return _open_windows_lock_fd(project_dir)
+
+    lifecycle_fd = open_dir_contained_nofollow(project_dir, _LIFECYCLE_DIR, create=True)
+    try:
+        fd = os.open(
+            _LOCK_FILE,
+            os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o600,
+            dir_fd=lifecycle_fd,
+        )
+    finally:
+        os.close(lifecycle_fd)
+    os.fchmod(fd, 0o600)
+    return fd
+
+
+def _open_windows_lock_fd(project_dir: Path) -> int:
+    """Open the Windows lock component-by-component without following reparses."""
+
+    open_handles: list[int] = []
+    lock_handle: int | None = None
+    try:
+        root_handle = _windows_open_root_handle(project_dir)
+        open_handles.append(root_handle)
+        _windows_reject_reparse_point(root_handle)
+
+        parent_handle = root_handle
+        for component in (".aptl", "lifecycle"):
+            child_handle = _windows_open_relative_handle(
+                parent_handle, component, directory=True
+            )
+            open_handles.append(child_handle)
+            _windows_reject_reparse_point(child_handle)
+            parent_handle = child_handle
+
+        lock_handle = _windows_open_relative_handle(
+            parent_handle, _LOCK_FILE, directory=False
+        )
+        _windows_reject_reparse_point(lock_handle)
+        fd = _windows_handle_to_fd(lock_handle)
+        lock_handle = None  # the C runtime descriptor now owns the handle
+    finally:
+        if lock_handle is not None:
+            _windows_close_handle(lock_handle)
+        for handle in reversed(open_handles):
+            _windows_close_handle(handle)
+
+    if os.fstat(fd).st_size == 0:
+        os.write(fd, b"\0")
+    os.lseek(fd, 0, os.SEEK_SET)
+    return fd
+
+
+def _windows_open_root_handle(project_dir: Path) -> int:
+    """Open the trusted project root itself, exposing any root reparse point."""
+
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+
+    handle = create_file(
+        str(project_dir),
+        0x00100187,  # SYNCHRONIZE | read/write attributes | add/list children
+        0x00000007,  # FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
+        None,
+        3,  # OPEN_EXISTING
+        0x02200000,  # BACKUP_SEMANTICS | OPEN_REPARSE_POINT
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if handle in (None, invalid_handle):
+        raise ctypes.WinError(ctypes.get_last_error())
+    return int(handle)
+
+
+def _windows_open_relative_handle(
+    parent_handle: int, component: str, *, directory: bool
+) -> int:
+    """Open or create one child relative to an already-validated directory."""
+
+    import ctypes
+    from ctypes import wintypes
+
+    class UnicodeString(ctypes.Structure):
+        _fields_ = [
+            ("Length", wintypes.USHORT),
+            ("MaximumLength", wintypes.USHORT),
+            ("Buffer", wintypes.LPWSTR),
+        ]
+
+    class ObjectAttributes(ctypes.Structure):
+        _fields_ = [
+            ("Length", wintypes.ULONG),
+            ("RootDirectory", wintypes.HANDLE),
+            ("ObjectName", ctypes.POINTER(UnicodeString)),
+            ("Attributes", wintypes.ULONG),
+            ("SecurityDescriptor", wintypes.LPVOID),
+            ("SecurityQualityOfService", wintypes.LPVOID),
+        ]
+
+    class IoStatusValue(ctypes.Union):
+        _fields_ = [("Status", ctypes.c_long), ("Pointer", wintypes.LPVOID)]
+
+    class IoStatusBlock(ctypes.Structure):
+        _anonymous_ = ("value",)
+        _fields_ = [("value", IoStatusValue), ("Information", ctypes.c_size_t)]
+
+    name_buffer = ctypes.create_unicode_buffer(component)
+    name_bytes = component.encode("utf-16-le")
+    object_name = UnicodeString(
+        Length=len(name_bytes),
+        MaximumLength=len(name_bytes) + 2,
+        Buffer=ctypes.cast(name_buffer, wintypes.LPWSTR),
+    )
+    attributes = ObjectAttributes(
+        Length=ctypes.sizeof(ObjectAttributes),
+        RootDirectory=wintypes.HANDLE(parent_handle),
+        ObjectName=ctypes.pointer(object_name),
+        Attributes=0x00000040,  # OBJ_CASE_INSENSITIVE
+        SecurityDescriptor=None,
+        SecurityQualityOfService=None,
+    )
+    io_status = IoStatusBlock()
+    handle = wintypes.HANDLE()
+
+    ntdll = ctypes.WinDLL("ntdll")
+    nt_create_file = ntdll.NtCreateFile
+    nt_create_file.argtypes = (
+        ctypes.POINTER(wintypes.HANDLE),
+        wintypes.DWORD,
+        ctypes.POINTER(ObjectAttributes),
+        ctypes.POINTER(IoStatusBlock),
+        wintypes.LPVOID,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.LPVOID,
+        wintypes.ULONG,
+    )
+    nt_create_file.restype = ctypes.c_long
+    options = 0x00200020 | (0x00000001 if directory else 0x00000040)
+    desired_access = 0x00100187 if directory else 0x00100183
+    status = nt_create_file(
+        ctypes.byref(handle),
+        desired_access,
+        ctypes.byref(attributes),
+        ctypes.byref(io_status),
+        None,
+        0x00000080,  # FILE_ATTRIBUTE_NORMAL
+        0x00000007,
+        3,  # FILE_OPEN_IF
+        options,  # synchronous, open-reparse, and expected object type
+        None,
+        0,
+    )
+    if status < 0:
+        rtl_status_to_error = ntdll.RtlNtStatusToDosError
+        rtl_status_to_error.argtypes = (ctypes.c_long,)
+        rtl_status_to_error.restype = wintypes.ULONG
+        raise ctypes.WinError(rtl_status_to_error(status))
+    return int(handle.value)
+
+
+def _windows_reject_reparse_point(handle: int) -> None:
+    """Reject symlinks, junctions, and every other Windows reparse object."""
+
+    import ctypes
+    from ctypes import wintypes
+
+    class FileAttributeTagInfo(ctypes.Structure):
+        _fields_ = [
+            ("FileAttributes", wintypes.DWORD),
+            ("ReparseTag", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_info = kernel32.GetFileInformationByHandleEx
+    get_info.argtypes = (
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    )
+    get_info.restype = wintypes.BOOL
+    info = FileAttributeTagInfo()
+    if not get_info(
+        wintypes.HANDLE(handle),
+        9,  # FileAttributeTagInfo
+        ctypes.byref(info),
+        ctypes.sizeof(info),
+    ):
+        raise ctypes.WinError(ctypes.get_last_error())
+    if info.FileAttributes & 0x00000400:  # FILE_ATTRIBUTE_REPARSE_POINT
+        raise OSError("lifecycle lock path contains a reparse point")
+
+
+def _windows_handle_to_fd(handle: int) -> int:
+    """Transfer an owned Windows file handle to a Python descriptor."""
+
+    if msvcrt is None:  # pragma: no cover - guarded by the Windows call site
+        raise OSError("Windows descriptor support is unavailable")
+    flags = os.O_RDWR | getattr(os, "O_BINARY", 0)
+    return msvcrt.open_osfhandle(handle, flags)
+
+
+def _windows_close_handle(handle: int) -> None:
+    """Close a raw Windows handle that was not transferred to a descriptor."""
+
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (wintypes.HANDLE,)
+    close_handle.restype = wintypes.BOOL
+    if not close_handle(wintypes.HANDLE(handle)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _try_lock(fd: int) -> None:
+    """Acquire the platform lock without waiting."""
+
+    try:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        elif msvcrt is not None:  # pragma: no cover - Windows
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:  # pragma: no cover - unsupported runtime
+            raise OSError("no cross-process file-lock implementation is available")
+    except OSError as exc:
+        if exc.errno not in (None, errno.EACCES, errno.EAGAIN):
+            raise
+        raise LifecycleBusyError(
+            "another lifecycle owner is active for this project"
+        ) from exc
+
+
+def _unlock(fd: int) -> None:
+    """Release the platform lock held on ``fd``."""
+
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    elif msvcrt is not None:  # pragma: no cover - Windows
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -12,6 +12,7 @@ from typer.testing import CliRunner
 
 from aptl.cli.main import app
 from aptl.core import lifecycle_enforce as le
+from aptl.core.lifecycle_policy import LifecycleBusyError
 from aptl.core.lab_types import LabResult, StartupOutcome
 
 
@@ -35,7 +36,8 @@ class TestEnforceCommand:
 
     def test_success_prints_message(self, runner, monkeypatch):
         monkeypatch.setattr(
-            le, "enforce_once",
+            le,
+            "enforce_once",
             lambda *a, **k: LabResult(success=True, message="lifecycle: no action (x)"),
         )
         result = runner.invoke(app, ["lab", "enforce"])
@@ -56,9 +58,12 @@ class TestEnforceCommand:
 
     def test_failure_exits_nonzero(self, runner, monkeypatch):
         monkeypatch.setattr(
-            le, "enforce_once",
+            le,
+            "enforce_once",
             lambda *a, **k: LabResult(
-                success=False, message="lifecycle: teardown (ttl_exceeded)", error="boom"
+                success=False,
+                message="lifecycle: teardown (ttl_exceeded)",
+                error="boom",
             ),
         )
         result = runner.invoke(app, ["lab", "enforce"])
@@ -66,7 +71,7 @@ class TestEnforceCommand:
 
     def test_busy_exits_nonzero(self, runner, monkeypatch):
         def raise_busy(*a, **k):
-            raise le.LifecycleBusyError("locked")
+            raise LifecycleBusyError("locked")
 
         monkeypatch.setattr(le, "enforce_once", raise_busy)
         result = runner.invoke(app, ["lab", "enforce"])

--- a/tests/test_compose_base_substrate.py
+++ b/tests/test_compose_base_substrate.py
@@ -276,16 +276,17 @@ def test_materialization_recreates_a_stopped_or_wrong_image_node(tmp_path):
     )
     # Present but not running -> must recreate.
     backend.container_inspect = MagicMock(
-        return_value={"State": {"Running": False}, "Config": {"Image": "debian:12-slim"}}
+        return_value={
+            "State": {"Running": False},
+            "Config": {"Image": "debian:12-slim"},
+        }
     )
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         backend.start_base_container(spec)
 
-    assert any(
-        call.args[0][:2] == ["docker", "rm"] for call in mock_run.call_args_list
-    )
+    assert any(call.args[0][:2] == ["docker", "rm"] for call in mock_run.call_args_list)
     assert any(
         call.args[0][:2] == ["docker", "run"] for call in mock_run.call_args_list
     )
@@ -463,7 +464,9 @@ class TestDynamicCompositionImmutableStart:
             for c in mock_run.call_args_list
         )
 
-    def test_fails_closed_when_availability_did_not_verify_the_substrate(self, tmp_path):
+    def test_fails_closed_when_availability_did_not_verify_the_substrate(
+        self, tmp_path
+    ):
         # No verified digest for this address (the substrate was unobtainable at
         # availability, or changed away since): refuse to resolve the tag and
         # start nothing -- ADR-051's "a changed substrate produces no container".
@@ -495,7 +498,8 @@ class TestDynamicCompositionImmutableStart:
             backend.start_base_container(spec)
 
         assert not any(
-            call.args[0][:2] in (["docker", "rm"], ["docker", "run"], ["docker", "create"])
+            call.args[0][:2]
+            in (["docker", "rm"], ["docker", "run"], ["docker", "create"])
             for call in mock_run.call_args_list
         )
 
@@ -573,7 +577,7 @@ class TestRemoveGenericMaterializerContainers:
         with patch("subprocess.run", side_effect=fake_run):
             failures = backend.remove_generic_materializer_containers()
 
-        assert failures and "container in use" in failures[0]
+        assert failures == ["failed to remove generic-materializer containers"]
 
     def test_docker_unavailable_is_reported_not_raised(self, tmp_path):
         # kill_compose_lab's own tests hit this exact path: every subprocess
@@ -583,4 +587,4 @@ class TestRemoveGenericMaterializerContainers:
         with patch("subprocess.run", side_effect=FileNotFoundError("docker not found")):
             failures = backend.remove_generic_materializer_containers()
 
-        assert failures and "docker not found" in failures[0]
+        assert failures == ["failed to remove generic-materializer containers"]

--- a/tests/test_deployment_backend.py
+++ b/tests/test_deployment_backend.py
@@ -147,6 +147,18 @@ class TestDeploymentConfig:
         with pytest.raises(ValueError, match="Unknown deployment provider"):
             DeploymentConfig(provider="kubernetes")
 
+    @pytest.mark.parametrize(
+        "project_name",
+        ["", "Uppercase", "with space", "../escape", "-leading", "x" * 64],
+    )
+    def test_rejects_unsafe_compose_project_name(self, project_name):
+        with pytest.raises(ValueError, match="project_name"):
+            DeploymentConfig(project_name=project_name)
+
+    @pytest.mark.parametrize("project_name", ["a", "aptl", "range-01", "range_01"])
+    def test_accepts_bounded_compose_project_name(self, project_name):
+        assert DeploymentConfig(project_name=project_name).project_name == project_name
+
     def test_ssh_fields_default_to_none(self):
         cfg = DeploymentConfig()
         assert cfg.ssh_host is None
@@ -224,6 +236,10 @@ class TestDockerComposeBackend:
 
     def _make_backend(self, tmp_path: Path) -> DockerComposeBackend:
         return DockerComposeBackend(project_dir=tmp_path, project_name="test")
+
+    def test_rejects_unsafe_direct_project_name(self, tmp_path):
+        with pytest.raises(ValueError, match="project_name"):
+            DockerComposeBackend(project_dir=tmp_path, project_name="../other")
 
     def test_start_calls_compose_up(self, tmp_path):
         backend = self._make_backend(tmp_path)
@@ -312,6 +328,48 @@ services:
 
         assert result.success is False
         assert "compose up failed" in result.error
+
+    def test_project_presence_counts_all_container_states_and_networks(self, tmp_path):
+        backend = self._make_backend(tmp_path)
+
+        def fake_run(cmd, **kwargs):
+            del kwargs
+            if cmd[:3] == ["docker", "ps", "-aq"]:
+                if "label=com.docker.compose.project=test" in cmd:
+                    return MagicMock(returncode=0, stdout="a\nb\nc\n", stderr="")
+                if "label=aptl.lifecycle.project=test" in cmd:
+                    return MagicMock(returncode=0, stdout="c\nd\n", stderr="")
+            if cmd[:3] == ["docker", "network", "ls"]:
+                return MagicMock(returncode=0, stdout="n\n", stderr="")
+            raise AssertionError(cmd)
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            presence = backend.observe_project_runtime()
+
+        assert presence.present is True
+        assert presence.container_count == 4
+        assert presence.network_count == 1
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        assert any("label=com.docker.compose.project=test" in cmd for cmd in commands)
+        assert any("label=aptl.lifecycle.project=test" in cmd for cmd in commands)
+        assert any(
+            cmd[:3] == ["docker", "network", "ls"]
+            and "label=com.docker.compose.project=test" in cmd
+            for cmd in commands
+        )
+
+    def test_project_presence_preserves_observation_failure(self, tmp_path):
+        backend = self._make_backend(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="raw daemon details"
+            )
+            presence = backend.observe_project_runtime()
+
+        assert presence.present is False
+        assert presence.error == "container observation failed"
+        assert "raw daemon details" not in presence.error
 
     def test_realize_reconciles_project_networks_after_start(self, tmp_path):
         backend = self._make_backend(tmp_path)
@@ -429,9 +487,7 @@ services:
             if cmd[:4] == ["docker", "compose", "-p", "test"]:
                 return MagicMock(returncode=0, stdout="", stderr="")
             if cmd[:3] == ["docker", "network", "ls"]:
-                return MagicMock(
-                    returncode=0, stdout="test_aptl-redteam\n", stderr=""
-                )
+                return MagicMock(returncode=0, stdout="test_aptl-redteam\n", stderr="")
             if cmd[:3] == ["docker", "network", "inspect"]:
                 return MagicMock(
                     returncode=0,
@@ -488,9 +544,7 @@ services:
             if cmd[:4] == ["docker", "compose", "-p", "test"]:
                 return MagicMock(returncode=0, stdout="", stderr="")
             if cmd[:3] == ["docker", "network", "ls"]:
-                return MagicMock(
-                    returncode=0, stdout="test_aptl-redteam\n", stderr=""
-                )
+                return MagicMock(returncode=0, stdout="test_aptl-redteam\n", stderr="")
             if cmd[:3] == ["docker", "network", "inspect"]:
                 return MagicMock(
                     returncode=0,
@@ -1175,7 +1229,7 @@ services:
 
         assert result.success is True
         commands = [call.args[0] for call in mock_run.call_args_list]
-        cmd = commands[0]
+        cmd = next(command for command in commands if "down" in command)
         assert cmd[2] == "-p"
         assert cmd[3] == "test"
         assert "down" in cmd
@@ -1216,9 +1270,7 @@ services:
         ls_cmd = next(cmd for cmd in commands if cmd[:3] == ["docker", "volume", "ls"])
         assert not any("--filter" in a or "label=" in a for a in ls_cmd)
 
-    def test_stop_with_volumes_removes_only_prefix_scoped_leftovers(
-        self, tmp_path
-    ):
+    def test_stop_with_volumes_removes_only_prefix_scoped_leftovers(self, tmp_path):
         backend = self._make_backend(tmp_path)
 
         def fake_run(cmd, **kwargs):
@@ -1244,16 +1296,12 @@ services:
         self, tmp_path
     ):
         backend = self._make_backend(tmp_path)
-        (tmp_path / "docker-compose.yml").write_text(
-            "volumes:\n  seeded_data:\n"
-        )
+        (tmp_path / "docker-compose.yml").write_text("volumes:\n  seeded_data:\n")
 
         def fake_run(cmd, **kwargs):
             del kwargs
             if cmd[:3] == ["docker", "volume", "ls"]:
-                return MagicMock(
-                    returncode=0, stdout="test_seeded_data\n", stderr=""
-                )
+                return MagicMock(returncode=0, stdout="test_seeded_data\n", stderr="")
             if cmd[:3] == ["docker", "volume", "rm"]:
                 return MagicMock(returncode=1, stdout="", stderr="still in use")
             return MagicMock(returncode=0, stdout="", stderr="")
@@ -1267,17 +1315,24 @@ services:
     def test_stop_removes_leftover_project_networks(self, tmp_path):
         backend = self._make_backend(tmp_path)
         network_ls_command = None
+        networks_present = True
 
         def fake_run(cmd, **kwargs):
-            nonlocal network_ls_command
+            nonlocal network_ls_command, networks_present
             del kwargs
             if cmd[:3] == ["docker", "network", "ls"]:
                 network_ls_command = cmd
                 return MagicMock(
                     returncode=0,
-                    stdout="test_aptl-dmz\ntest_aptl-isolated\n",
+                    stdout=(
+                        "test_aptl-dmz\ntest_aptl-isolated\n"
+                        if networks_present
+                        else ""
+                    ),
                     stderr="",
                 )
+            if cmd[:3] == ["docker", "network", "rm"]:
+                networks_present = False
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch("subprocess.run", side_effect=fake_run) as mock_run:
@@ -1285,7 +1340,8 @@ services:
 
         assert result.success is True
         assert network_ls_command is not None
-        assert "label=org.aptl.realization.network=true" in network_ls_command
+        assert "label=com.docker.compose.project=test" in network_ls_command
+        assert "label=org.aptl.realization.network=true" not in network_ls_command
         commands = [call.args[0] for call in mock_run.call_args_list]
         assert ["docker", "network", "rm", "test_aptl-dmz"] in commands
         assert ["docker", "network", "rm", "test_aptl-isolated"] in commands
@@ -1300,6 +1356,83 @@ services:
             result = backend.stop([])
 
         assert result.success is False
+
+    def test_stop_continues_project_cleanup_after_compose_down_error(self, tmp_path):
+        from aptl.core.deployment._compose_stop import stop_compose_lab
+        from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+
+        events: list[str] = []
+
+        class Backend:
+            project_dir = tmp_path
+            project_name = "test"
+
+            def _build_command(self, action, profiles, *, compose_files=None):
+                del profiles, compose_files
+                return ["docker", "compose", action]
+
+            def _run(self, cmd, *, timeout=None):
+                del timeout
+                events.append(cmd[-1])
+                return MagicMock(returncode=1, stdout="", stderr="raw compose error")
+
+            def remove_generic_materializer_containers(self):
+                events.append("generic")
+                return []
+
+            def remove_project_containers(self):
+                events.append("containers")
+                return []
+
+            def remove_project_networks(self):
+                events.append("networks")
+                return []
+
+            def observe_project_runtime(self):
+                events.append("verify")
+                return ProjectRuntimePresence()
+
+        result = stop_compose_lab(
+            Backend(), ["wazuh"], remove_volumes=False, timeout=30
+        )
+
+        assert result.success is True
+        assert events == ["generic", "down", "containers", "networks", "verify"]
+
+    def test_stop_fails_when_project_runtime_remains_after_cleanup(self, tmp_path):
+        from aptl.core.deployment._compose_stop import stop_compose_lab
+        from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+
+        class Backend:
+            project_dir = tmp_path
+            project_name = "test"
+
+            def _build_command(self, action, profiles, *, compose_files=None):
+                del profiles, compose_files
+                return ["docker", "compose", action]
+
+            def _run(self, cmd, *, timeout=None):
+                del cmd, timeout
+                return MagicMock(returncode=0, stdout="", stderr="")
+
+            def remove_generic_materializer_containers(self):
+                return []
+
+            def remove_project_containers(self):
+                return []
+
+            def remove_project_networks(self):
+                return []
+
+            def observe_project_runtime(self):
+                return ProjectRuntimePresence(container_count=1)
+
+        result = stop_compose_lab(
+            Backend(), ["wazuh"], remove_volumes=False, timeout=30
+        )
+
+        assert result.success is False
+        assert "runtime artifacts remain" in result.error
 
     def test_status_parses_json_array(self, tmp_path):
         backend = self._make_backend(tmp_path)
@@ -1393,6 +1526,7 @@ services:
 
         first_cmd = mock_run.call_args_list[0][0][0]
         assert "kill" in first_cmd
+        assert first_cmd[:4] == ["docker", "compose", "-p", "test"]
         second_cmd = mock_run.call_args_list[1][0][0]
         assert "down" in second_cmd
 
@@ -2124,6 +2258,20 @@ class TestSSHComposeBackend:
         env = mock_run.call_args[1]["env"]
         assert env["DOCKER_HOST"] == "ssh://admin@lab.example.com"
 
+    def test_project_presence_uses_ssh_backend_environment(self, tmp_path):
+        backend = self._make_backend(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            presence = backend.observe_project_runtime()
+
+        assert presence.present is False
+        assert presence.error == ""
+        assert len(mock_run.call_args_list) == 3
+        assert all(
+            call.kwargs["env"]["DOCKER_HOST"] == "ssh://admin@lab.example.com"
+            for call in mock_run.call_args_list
+        )
+
 
 # ---------------------------------------------------------------------------
 # Factory function tests
@@ -2273,22 +2421,22 @@ class TestKillBackwardCompat:
     """Verify kill_lab_containers still works without backend arg."""
 
     @patch("aptl.core.kill.subprocess.run")
-    def test_kill_without_backend(self, mock_run):
+    def test_kill_without_backend(self, mock_run, tmp_path):
         from aptl.core.kill import kill_lab_containers
 
-        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        success, error = kill_lab_containers(project_dir=Path("/tmp/aptl"))
+        success, error = kill_lab_containers(project_dir=tmp_path)
 
         assert success is True
 
-    def test_kill_with_backend(self):
+    def test_kill_with_backend(self, tmp_path):
         from aptl.core.kill import kill_lab_containers
 
         mock_backend = MagicMock()
         mock_backend.kill.return_value = (True, "")
 
-        success, error = kill_lab_containers(backend=mock_backend)
+        success, error = kill_lab_containers(project_dir=tmp_path, backend=mock_backend)
 
         assert success is True
         mock_backend.kill.assert_called_once()
@@ -2576,9 +2724,7 @@ class TestSeedNamedVolumes:
         # Exactly one container: the seed copy, no retire. (The label
         # inspect is a volume query, not a container.)
         container_runs = [
-            c[0][0]
-            for c in mock_run.call_args_list
-            if c[0][0][:2] == ["docker", "run"]
+            c[0][0] for c in mock_run.call_args_list if c[0][0][:2] == ["docker", "run"]
         ]
         assert len(container_runs) == 1
         assert "test_suricata_config_seed:/dest" in container_runs[0]
@@ -3055,9 +3201,7 @@ class TestObserveBindSourceType:
         with patch.object(backend, "_run") as run:
             assert backend.observe_bind_source_type(str(a_file)) == "file"
             assert backend.observe_bind_source_type(str(a_dir)) == "directory"
-            assert (
-                backend.observe_bind_source_type(str(tmp_path / "missing")) is None
-            )
+            assert backend.observe_bind_source_type(str(tmp_path / "missing")) is None
         # A local stat never spawns a probe container, so a missing source is
         # observed as nothing without ever creating it.
         run.assert_not_called()
@@ -3077,12 +3221,15 @@ class TestObserveBindSourceType:
     ):
         backend = DockerComposeBackend(project_dir=tmp_path, project_name="test")
         source = "/remote/.aptl/realization/content/otel-collector-config/config.yaml"
-        with patch.object(
-            type(backend),
-            "supports_local_artifacts",
-            new_callable=PropertyMock,
-            return_value=False,
-        ), patch.object(backend, "_run") as run:
+        with (
+            patch.object(
+                type(backend),
+                "supports_local_artifacts",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(backend, "_run") as run,
+        ):
             run.return_value = MagicMock(
                 returncode=returncode,
                 stdout="must-not-be-consumed",

--- a/tests/test_kill.py
+++ b/tests/test_kill.py
@@ -41,7 +41,9 @@ class TestFindMcpProcesses:
             if path == "/proc/100/cmdline":
                 m.__enter__ = lambda s: s
                 m.__exit__ = MagicMock(return_value=False)
-                m.read.return_value = b"node\x00/home/user/aptl/mcp/mcp-wazuh/build/index.js\x00"
+                m.read.return_value = (
+                    b"node\x00/home/user/aptl/mcp/mcp-wazuh/build/index.js\x00"
+                )
             elif path == "/proc/200/cmdline":
                 m.__enter__ = lambda s: s
                 m.__exit__ = MagicMock(return_value=False)
@@ -160,7 +162,9 @@ class TestFindMcpProcesses:
                 m.read.return_value = b"node\x00mcp/mcp-wazuh/build/index.js\x00"
             elif path == "/proc/999/cmdline":
                 # Own process cmdline might match if running aptl kill
-                m.read.return_value = b"python\x00aptl\x00kill\x00mcp-wazuh/build/index.js\x00"
+                m.read.return_value = (
+                    b"python\x00aptl\x00kill\x00mcp-wazuh/build/index.js\x00"
+                )
             else:
                 raise FileNotFoundError(path)
             return m
@@ -208,7 +212,11 @@ class TestKillMcpProcesses:
         from aptl.core.kill import kill_mcp_processes
 
         mock_find.return_value = [
-            {"pid": 100, "cmdline": "node mcp-wazuh/build/index.js", "name": "mcp-wazuh"},
+            {
+                "pid": 100,
+                "cmdline": "node mcp-wazuh/build/index.js",
+                "name": "mcp-wazuh",
+            },
         ]
         # Process exits after SIGTERM
         mock_alive.return_value = True
@@ -232,7 +240,11 @@ class TestKillMcpProcesses:
 
         mock_sys.platform = "linux"
         mock_find.return_value = [
-            {"pid": 100, "cmdline": "node mcp-wazuh/build/index.js", "name": "mcp-wazuh"},
+            {
+                "pid": 100,
+                "cmdline": "node mcp-wazuh/build/index.js",
+                "name": "mcp-wazuh",
+            },
         ]
         # Process stays alive throughout timeout (_process_exited returns False)
         mock_alive.return_value = False
@@ -265,7 +277,11 @@ class TestKillMcpProcesses:
 
         mock_sys.platform = "linux"
         mock_find.return_value = [
-            {"pid": 100, "cmdline": "node mcp-wazuh/build/index.js", "name": "mcp-wazuh"},
+            {
+                "pid": 100,
+                "cmdline": "node mcp-wazuh/build/index.js",
+                "name": "mcp-wazuh",
+            },
         ]
         mock_alive.return_value = False
         killed, errors = kill_mcp_processes(
@@ -285,7 +301,11 @@ class TestKillMcpProcesses:
         from aptl.core.kill import kill_mcp_processes
 
         mock_find.return_value = [
-            {"pid": 100, "cmdline": "node mcp-wazuh/build/index.js", "name": "mcp-wazuh"},
+            {
+                "pid": 100,
+                "cmdline": "node mcp-wazuh/build/index.js",
+                "name": "mcp-wazuh",
+            },
         ]
         mock_kill.side_effect = ProcessLookupError("No such process")
 
@@ -300,7 +320,11 @@ class TestKillMcpProcesses:
         from aptl.core.kill import kill_mcp_processes
 
         mock_find.return_value = [
-            {"pid": 100, "cmdline": "node mcp-wazuh/build/index.js", "name": "mcp-wazuh"},
+            {
+                "pid": 100,
+                "cmdline": "node mcp-wazuh/build/index.js",
+                "name": "mcp-wazuh",
+            },
         ]
         mock_kill.side_effect = PermissionError("Operation not permitted")
 
@@ -326,56 +350,55 @@ class TestKillLabContainers:
     """Tests for emergency container stop."""
 
     @patch("aptl.core.kill.subprocess.run")
-    def test_runs_docker_compose_kill_and_down(self, mock_run):
+    def test_runs_docker_compose_kill_and_down(self, mock_run, tmp_path):
         from aptl.core.kill import kill_lab_containers
 
-        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        success, error = kill_lab_containers(project_dir=Path("/tmp/aptl"))
+        success, error = kill_lab_containers(project_dir=tmp_path)
 
         assert success is True
         assert error == ""
-        assert mock_run.call_count == 2
+        assert mock_run.call_count >= 2
 
-        # First call: docker compose kill
-        first_cmd = mock_run.call_args_list[0][0][0]
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        first_cmd = next(command for command in commands if "kill" in command)
         assert "kill" in first_cmd
         assert "--profile" in first_cmd
 
-        # Second call: docker compose down
-        second_cmd = mock_run.call_args_list[1][0][0]
+        second_cmd = next(command for command in commands if "down" in command)
         assert "down" in second_cmd
 
     @patch("aptl.core.kill.subprocess.run")
-    def test_includes_all_profiles(self, mock_run):
+    def test_includes_all_profiles(self, mock_run, tmp_path):
         from aptl.core.kill import kill_lab_containers
         from aptl.core.lab import ALL_KNOWN_PROFILES
 
-        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        kill_lab_containers()
+        kill_lab_containers(project_dir=tmp_path)
 
         first_cmd = mock_run.call_args_list[0][0][0]
         for profile in ALL_KNOWN_PROFILES:
             assert profile in first_cmd
 
     @patch("aptl.core.kill.subprocess.run")
-    def test_handles_docker_failure(self, mock_run):
+    def test_handles_docker_failure(self, mock_run, tmp_path):
         from aptl.core.kill import kill_lab_containers
 
         mock_run.side_effect = FileNotFoundError("docker not found")
 
-        success, error = kill_lab_containers()
+        success, error = kill_lab_containers(project_dir=tmp_path)
 
         assert success is False
         assert "docker compose kill failed" in error
 
     @patch("aptl.core.kill.subprocess.run")
-    def test_uses_project_dir_as_cwd(self, mock_run):
+    def test_uses_project_dir_as_cwd(self, mock_run, tmp_path):
         from aptl.core.kill import kill_lab_containers
 
-        mock_run.return_value = MagicMock(returncode=0, stderr="")
-        project = Path("/my/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        project = tmp_path
 
         kill_lab_containers(project_dir=project)
 
@@ -383,44 +406,60 @@ class TestKillLabContainers:
             assert c[1]["cwd"] == project
 
     @patch("aptl.core.kill.subprocess.run")
-    def test_subprocess_calls_have_timeout(self, mock_run):
-        from aptl.core.kill import _DOCKER_TIMEOUT, kill_lab_containers
+    def test_subprocess_calls_have_timeout(self, mock_run, tmp_path):
+        from aptl.core.deployment.docker_compose import _DOCKER_TIMEOUT
+        from aptl.core.kill import kill_lab_containers
 
-        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        kill_lab_containers()
+        kill_lab_containers(project_dir=tmp_path)
 
-        for c in mock_run.call_args_list:
-            assert c[1]["timeout"] == _DOCKER_TIMEOUT
+        lifecycle_calls = [
+            call
+            for call in mock_run.call_args_list
+            if "kill" in call.args[0] or "down" in call.args[0]
+        ]
+        assert lifecycle_calls
+        assert all(
+            call.kwargs["timeout"] == _DOCKER_TIMEOUT for call in lifecycle_calls
+        )
+        assert all(call.kwargs["timeout"] > 0 for call in mock_run.call_args_list)
 
     @patch("aptl.core.kill.subprocess.run")
-    def test_handles_timeout_expired(self, mock_run):
+    def test_handles_timeout_expired(self, mock_run, tmp_path):
         from aptl.core.kill import kill_lab_containers
 
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=30)
 
-        success, error = kill_lab_containers()
+        success, error = kill_lab_containers(project_dir=tmp_path)
 
         assert success is False
 
     @patch("aptl.core.kill.subprocess.run")
-    def test_down_failure_is_non_fatal_when_kill_succeeded(self, mock_run):
+    def test_down_failure_is_non_fatal_when_kill_succeeded(self, mock_run, tmp_path):
         from aptl.core.kill import kill_lab_containers
 
         def run_side_effect(cmd, **kwargs):
+            del kwargs
             m = MagicMock()
             if "kill" in cmd:
                 m.returncode = 0
                 m.stderr = ""
-            else:
-                # docker compose down fails
+                m.stdout = ""
+            elif "down" in cmd:
                 m.returncode = 1
                 m.stderr = "network not found"
+                m.stdout = ""
+            else:
+                # Bounded project cleanup and final observation prove absence.
+                m.returncode = 0
+                m.stderr = ""
+                m.stdout = ""
             return m
 
         mock_run.side_effect = run_side_effect
 
-        success, error = kill_lab_containers()
+        success, error = kill_lab_containers(project_dir=tmp_path)
 
         # kill succeeded, down failure is just a warning
         assert success is True
@@ -436,11 +475,15 @@ class TestClearSession:
         state_dir = tmp_path / ".aptl"
         state_dir.mkdir()
         session_file = state_dir / "session.json"
-        session_file.write_text(json.dumps({
-            "scenario_id": "test-scenario",
-            "state": "active",
-            "started_at": "2026-03-22T00:00:00+00:00",
-        }))
+        session_file.write_text(
+            json.dumps(
+                {
+                    "scenario_id": "test-scenario",
+                    "state": "active",
+                    "started_at": "2026-03-22T00:00:00+00:00",
+                }
+            )
+        )
 
         result = clear_session(state_dir)
 
@@ -503,7 +546,7 @@ class TestExecuteKill:
     @patch("aptl.core.kill.clear_session")
     @patch("aptl.core.kill.clean_trace_context")
     def test_kills_mcp_only_by_default(
-        self, mock_trace, mock_session, mock_containers, mock_mcp
+        self, mock_trace, mock_session, mock_containers, mock_mcp, tmp_path
     ):
         from aptl.core.kill import execute_kill
 
@@ -511,7 +554,7 @@ class TestExecuteKill:
         mock_session.return_value = False
         mock_trace.return_value = False
 
-        result = execute_kill(containers=False)
+        result = execute_kill(containers=False, project_dir=tmp_path)
 
         assert result.success is True
         assert result.mcp_processes_killed == 3
@@ -523,7 +566,7 @@ class TestExecuteKill:
     @patch("aptl.core.kill.clear_session")
     @patch("aptl.core.kill.clean_trace_context")
     def test_kills_mcp_and_containers(
-        self, mock_trace, mock_session, mock_containers, mock_mcp
+        self, mock_trace, mock_session, mock_containers, mock_mcp, tmp_path
     ):
         from aptl.core.kill import execute_kill
 
@@ -532,7 +575,7 @@ class TestExecuteKill:
         mock_session.return_value = True
         mock_trace.return_value = True
 
-        result = execute_kill(containers=True)
+        result = execute_kill(containers=True, project_dir=tmp_path)
 
         assert result.success is True
         assert result.mcp_processes_killed == 2
@@ -546,7 +589,7 @@ class TestExecuteKill:
     @patch("aptl.core.kill.clear_session")
     @patch("aptl.core.kill.clean_trace_context")
     def test_continues_on_partial_failure(
-        self, mock_trace, mock_session, mock_containers, mock_mcp
+        self, mock_trace, mock_session, mock_containers, mock_mcp, tmp_path
     ):
         from aptl.core.kill import execute_kill
 
@@ -555,7 +598,7 @@ class TestExecuteKill:
         mock_session.return_value = True
         mock_trace.return_value = True
 
-        result = execute_kill(containers=True)
+        result = execute_kill(containers=True, project_dir=tmp_path)
 
         # MCP failed but containers + session + trace succeeded
         assert result.success is True
@@ -567,14 +610,14 @@ class TestExecuteKill:
     @patch("aptl.core.kill.kill_mcp_processes")
     @patch("aptl.core.kill.clear_session")
     @patch("aptl.core.kill.clean_trace_context")
-    def test_reports_all_errors(self, mock_trace, mock_session, mock_mcp):
+    def test_reports_all_errors(self, mock_trace, mock_session, mock_mcp, tmp_path):
         from aptl.core.kill import execute_kill
 
         mock_mcp.return_value = (0, ["perm denied pid=100"])
         mock_session.side_effect = RuntimeError("session broken")
         mock_trace.return_value = False
 
-        result = execute_kill(containers=False)
+        result = execute_kill(containers=False, project_dir=tmp_path)
 
         assert result.success is False
         assert len(result.errors) == 2
@@ -582,14 +625,16 @@ class TestExecuteKill:
     @patch("aptl.core.kill.kill_mcp_processes")
     @patch("aptl.core.kill.clear_session")
     @patch("aptl.core.kill.clean_trace_context")
-    def test_success_when_nothing_to_kill(self, mock_trace, mock_session, mock_mcp):
+    def test_success_when_nothing_to_kill(
+        self, mock_trace, mock_session, mock_mcp, tmp_path
+    ):
         from aptl.core.kill import execute_kill
 
         mock_mcp.return_value = (0, [])
         mock_session.return_value = False
         mock_trace.return_value = False
 
-        result = execute_kill(containers=False)
+        result = execute_kill(containers=False, project_dir=tmp_path)
 
         # No actions taken but no errors either = success
         assert result.success is True
@@ -598,14 +643,16 @@ class TestExecuteKill:
     @patch("aptl.core.kill.kill_mcp_processes")
     @patch("aptl.core.kill.clear_session")
     @patch("aptl.core.kill.clean_trace_context")
-    def test_cleans_session_and_trace_context(self, mock_trace, mock_session, mock_mcp):
+    def test_cleans_session_and_trace_context(
+        self, mock_trace, mock_session, mock_mcp, tmp_path
+    ):
         from aptl.core.kill import execute_kill
 
         mock_mcp.return_value = (0, [])
         mock_session.return_value = True
         mock_trace.return_value = True
 
-        result = execute_kill(containers=False)
+        result = execute_kill(containers=False, project_dir=tmp_path)
 
         assert result.session_cleared is True
         assert result.trace_context_cleaned is True

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -380,7 +380,8 @@ class TestPreexistingRangeAdmission:
 
         result = _step_reject_preexisting_range(ctx)
 
-        assert result is not None and result.success is False
+        assert result is not None
+        assert result.success is False
         assert "lifecycle-range-present" in result.error
         assert "aptl lab stop" in result.error
 
@@ -397,7 +398,8 @@ class TestPreexistingRangeAdmission:
 
         result = _step_reject_preexisting_range(ctx)
 
-        assert result is not None and "lifecycle-range-present" in result.error
+        assert result is not None
+        assert "lifecycle-range-present" in result.error
 
     def test_presence_observation_failure_blocks_start(self, tmp_path):
         from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
@@ -411,7 +413,8 @@ class TestPreexistingRangeAdmission:
 
         result = _step_reject_preexisting_range(ctx)
 
-        assert result is not None and result.success is False
+        assert result is not None
+        assert result.success is False
         assert "lifecycle-observation-failed" in result.error
         assert "docker stderr" not in result.error.lower()
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -245,30 +245,30 @@ class TestLabStop:
                 return cmd_args
         raise AssertionError("docker compose down was not called")
 
-    def test_stop_calls_compose_down(self, mock_subprocess):
+    def test_stop_calls_compose_down(self, mock_subprocess, tmp_path):
         """stop_lab should invoke docker compose down."""
         from aptl.core.lab import stop_lab
 
         mock_subprocess.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        result = stop_lab()
+        result = stop_lab(project_dir=tmp_path)
 
         assert result.success is True
         cmd_args = self._compose_down_args(mock_subprocess)
         assert "down" in cmd_args
 
-    def test_stop_with_volumes_flag(self, mock_subprocess):
+    def test_stop_with_volumes_flag(self, mock_subprocess, tmp_path):
         """stop_lab with remove_volumes=True should pass -v flag."""
         from aptl.core.lab import stop_lab
 
         mock_subprocess.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        stop_lab(remove_volumes=True)
+        stop_lab(remove_volumes=True, project_dir=tmp_path)
 
         cmd_args = self._compose_down_args(mock_subprocess)
         assert "-v" in cmd_args
 
-    def test_stop_returns_failure_on_error(self, mock_subprocess):
+    def test_stop_returns_failure_on_error(self, mock_subprocess, tmp_path):
         """If docker compose down fails, stop_lab returns failure."""
         from aptl.core.lab import stop_lab
 
@@ -276,7 +276,7 @@ class TestLabStop:
             returncode=1, stdout="", stderr="Cannot stop"
         )
 
-        result = stop_lab()
+        result = stop_lab(project_dir=tmp_path)
 
         assert result.success is False
 
@@ -318,6 +318,22 @@ class TestLabStop:
         assert "victim" in cmd_args
         assert "wazuh" in cmd_args
 
+    def test_stop_refuses_invalid_present_config_identity(
+        self, mock_subprocess, tmp_path
+    ):
+        """Teardown must not guess the default project when aptl.json is invalid."""
+        from aptl.core.lab import stop_lab
+
+        (tmp_path / "aptl.json").write_text(
+            '{"lab":{"name":"test"},"deployment":{"project_name":"../other"}}'
+        )
+
+        result = stop_lab(project_dir=tmp_path)
+
+        assert result.success is False
+        assert "invalid configuration" in result.error.lower()
+        mock_subprocess.assert_not_called()
+
     def test_stop_always_includes_otel_profile(self, mock_subprocess, tmp_path):
         """stop_lab must tear down every profile start_lab always brings up.
 
@@ -348,6 +364,66 @@ class TestLabStop:
         assert result.success is True
         cmd_args = self._compose_down_args(mock_subprocess)
         assert "otel" in cmd_args
+
+
+class TestPreexistingRangeAdmission:
+    def test_running_created_or_exited_container_blocks_start(self, tmp_path):
+        from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+        from aptl.core.lab import _LabStartContext, _step_reject_preexisting_range
+
+        backend = MagicMock()
+        backend.observe_project_runtime.return_value = ProjectRuntimePresence(
+            container_count=1,
+            network_count=0,
+        )
+        ctx = _LabStartContext(project_dir=tmp_path, skip_seed=False, backend=backend)
+
+        result = _step_reject_preexisting_range(ctx)
+
+        assert result is not None and result.success is False
+        assert "lifecycle-range-present" in result.error
+        assert "aptl lab stop" in result.error
+
+    def test_network_only_residue_blocks_start(self, tmp_path):
+        from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+        from aptl.core.lab import _LabStartContext, _step_reject_preexisting_range
+
+        backend = MagicMock()
+        backend.observe_project_runtime.return_value = ProjectRuntimePresence(
+            container_count=0,
+            network_count=1,
+        )
+        ctx = _LabStartContext(project_dir=tmp_path, skip_seed=False, backend=backend)
+
+        result = _step_reject_preexisting_range(ctx)
+
+        assert result is not None and "lifecycle-range-present" in result.error
+
+    def test_presence_observation_failure_blocks_start(self, tmp_path):
+        from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+        from aptl.core.lab import _LabStartContext, _step_reject_preexisting_range
+
+        backend = MagicMock()
+        backend.observe_project_runtime.return_value = ProjectRuntimePresence(
+            error="container observation failed"
+        )
+        ctx = _LabStartContext(project_dir=tmp_path, skip_seed=False, backend=backend)
+
+        result = _step_reject_preexisting_range(ctx)
+
+        assert result is not None and result.success is False
+        assert "lifecycle-observation-failed" in result.error
+        assert "docker stderr" not in result.error.lower()
+
+    def test_absent_project_allows_start_to_continue(self, tmp_path):
+        from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+        from aptl.core.lab import _LabStartContext, _step_reject_preexisting_range
+
+        backend = MagicMock()
+        backend.observe_project_runtime.return_value = ProjectRuntimePresence()
+        ctx = _LabStartContext(project_dir=tmp_path, skip_seed=False, backend=backend)
+
+        assert _step_reject_preexisting_range(ctx) is None
 
 
 class TestCleanBootLab:
@@ -1309,6 +1385,13 @@ class TestOrchestrateLabStart:
             "aptl.core.deployment.docker_compose."
             "DockerComposeBackend.seed_named_volumes",
         )
+        from aptl.core.deployment.backend_host_inventory import ProjectRuntimePresence
+
+        mocks["project_presence"] = mocker.patch(
+            "aptl.core.deployment.docker_compose."
+            "DockerComposeBackend.observe_project_runtime",
+            return_value=ProjectRuntimePresence(),
+        )
         # The seed step also runs the legacy source-ownership repair, which
         # now probes hostenv (docker info). Stub it so the orchestration
         # tests stay hermetic (#678).
@@ -1830,9 +1913,7 @@ class TestStatefulArtifactOwnership:
         assert result is None
         assert ctx.stateful_artifact_ownership == frozenset()
 
-    def test_admission_error_fails_before_legacy_mutation(
-        self, tmp_path, monkeypatch
-    ):
+    def test_admission_error_fails_before_legacy_mutation(self, tmp_path, monkeypatch):
         from aptl.core.config import AptlConfig
         from aptl.core.lab import _LabStartContext, _load_stateful_artifact_ownership
 
@@ -2032,9 +2113,7 @@ class TestSyncCredentialsStep:
         )
 
         ctx = self._ctx(mocker, tmp_path)
-        ctx.stateful_artifact_ownership = frozenset(
-            {_WAZUH_MANAGER_CONFIG_OWNERSHIP}
-        )
+        ctx.stateful_artifact_ownership = frozenset({_WAZUH_MANAGER_CONFIG_OWNERSHIP})
         dashboard = mocker.patch("aptl.core.lab.sync_dashboard_config")
         manager = mocker.patch("aptl.core.lab.sync_manager_config")
 
@@ -2241,9 +2320,7 @@ class TestResolveHostPortsStep:
             host_ip="127.0.0.1",
             remapped=True,
         )
-        mocker.patch(
-            "aptl.core.host_ports.resolve_host_ports", return_value=[remapped]
-        )
+        mocker.patch("aptl.core.host_ports.resolve_host_ports", return_value=[remapped])
         mocker.patch("aptl.core.host_ports.project_port_bindings", return_value={})
         progress = MagicMock()
 
@@ -2666,9 +2743,7 @@ class TestStartupClassificationWiring:
             "https://localhost:20015"
         )
 
-    def test_wait_for_services_falls_back_to_9200_when_no_remap(
-        self, tmp_path, mocker
-    ):
+    def test_wait_for_services_falls_back_to_9200_when_no_remap(self, tmp_path, mocker):
         """No entry for wazuh.indexer in `ctx.resolved_ports` (the common
         case where 9200 was free) keeps the historical URL."""
         from aptl.core.lab import _step_wait_for_services
@@ -2928,9 +3003,7 @@ class TestStartupClassificationWiring:
         wait_mock.assert_not_called()
         assert ctx.diagnostics == []
 
-    def test_test_ssh_skips_profile_alias_without_declared_ssh(
-        self, tmp_path, mocker
-    ):
+    def test_test_ssh_skips_profile_alias_without_declared_ssh(self, tmp_path, mocker):
         """An image-free Kali node need not inherit the appliance's sshd."""
         from aptl.core.lab import _step_test_ssh
 
@@ -3692,9 +3765,7 @@ class TestLabOrchestrationContracts:
         assert start_raes.call_args.kwargs["before_backend_retry"] is not None
         sleep.assert_called_once_with(60)
 
-    def test_start_containers_reuses_profiles_from_raes_outcome(
-        self, mocker, tmp_path
-    ):
+    def test_start_containers_reuses_profiles_from_raes_outcome(self, mocker, tmp_path):
         from raes_contracts.runtime_state import RuntimeSnapshot
 
         from aptl.backends.raes import AcesStartOutcome
@@ -3913,9 +3984,7 @@ class TestLabOrchestrationContracts:
         start_raes.assert_called_once()
         backend.container_restart.assert_not_called()
 
-    def test_start_containers_watchdog_swallows_exec_failures(
-        self, mocker, tmp_path
-    ):
+    def test_start_containers_watchdog_swallows_exec_failures(self, mocker, tmp_path):
         """A nonzero exec probe (or non-int stdout) blocks the restart —
         we do not know the process state, so refuse to restart rather
         than guess wrong."""
@@ -3940,9 +4009,7 @@ class TestLabOrchestrationContracts:
         start_raes.assert_called_once()
         backend.container_restart.assert_not_called()
 
-    def test_start_containers_watchdog_swallows_restart_failure(
-        self, mocker, tmp_path
-    ):
+    def test_start_containers_watchdog_swallows_restart_failure(self, mocker, tmp_path):
         """`container_restart` raising is logged and swallowed — the
         retry proceeds regardless."""
         from aptl.core.lab import _step_start_containers

--- a/tests/test_lifecycle_guard.py
+++ b/tests/test_lifecycle_guard.py
@@ -22,6 +22,15 @@ def _hold_lifecycle_lock_in_child(project_dir: str, ready_path: str) -> None:
         time.sleep(30)
 
 
+def _enter_lifecycle_lock(project_dir: Path) -> None:
+    """Acquire and immediately release the lifecycle lock for exception tests."""
+
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+
+    with lifecycle_mutation_lock(project_dir):
+        pass
+
+
 def test_lifecycle_mutation_lock_is_reentrant_per_thread(tmp_path: Path) -> None:
     from aptl.core.lifecycle_guard import lifecycle_mutation_lock
 
@@ -88,8 +97,7 @@ def test_lifecycle_mutation_lock_rejects_a_second_thread(tmp_path: Path) -> None
     assert acquired.wait(timeout=5)
     try:
         with pytest.raises(LifecycleBusyError, match="lifecycle owner"):
-            with lifecycle_mutation_lock(tmp_path):
-                pytest.fail("a second lifecycle owner must not enter")
+            _enter_lifecycle_lock(tmp_path)
     finally:
         release.set()
         holder.join(timeout=5)
@@ -114,8 +122,7 @@ def test_process_death_releases_lifecycle_ownership(tmp_path: Path) -> None:
             time.sleep(0.01)
         assert ready_path.exists()
         with pytest.raises(LifecycleBusyError, match="lifecycle owner"):
-            with lifecycle_mutation_lock(tmp_path):
-                pytest.fail("the live child process must retain lifecycle ownership")
+            _enter_lifecycle_lock(tmp_path)
         holder.terminate()
         holder.join(timeout=5)
         assert not holder.is_alive()
@@ -174,8 +181,7 @@ def test_windows_lock_rejects_a_junctioned_state_directory(tmp_path: Path) -> No
     )
 
     with pytest.raises(LifecycleLockUnavailableError):
-        with lifecycle_mutation_lock(tmp_path):
-            pytest.fail("a junctioned lifecycle root must not be followed")
+        _enter_lifecycle_lock(tmp_path)
     assert not (outside / "lifecycle").exists()
 
 
@@ -192,8 +198,7 @@ def test_lifecycle_mutation_lock_rejects_symlinked_state_directory(
     (tmp_path / ".aptl").symlink_to(outside, target_is_directory=True)
 
     with pytest.raises(LifecycleLockUnavailableError):
-        with lifecycle_mutation_lock(tmp_path):
-            pytest.fail("a symlinked lifecycle root must not be followed")
+        _enter_lifecycle_lock(tmp_path)
 
 
 def test_start_fails_busy_before_dotenv_hydration(tmp_path: Path) -> None:

--- a/tests/test_lifecycle_guard.py
+++ b/tests/test_lifecycle_guard.py
@@ -1,0 +1,306 @@
+"""Regression tests for project-wide lab lifecycle ownership (issue #905)."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import stat
+import subprocess
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _hold_lifecycle_lock_in_child(project_dir: str, ready_path: str) -> None:
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+
+    with lifecycle_mutation_lock(Path(project_dir)):
+        Path(ready_path).write_text("ready", encoding="utf-8")
+        time.sleep(30)
+
+
+def test_lifecycle_mutation_lock_is_reentrant_per_thread(tmp_path: Path) -> None:
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+
+    with lifecycle_mutation_lock(tmp_path):
+        with lifecycle_mutation_lock(tmp_path):
+            lock_path = tmp_path / ".aptl" / "lifecycle" / ".lock"
+            assert lock_path.is_file()
+            assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+
+def test_lifecycle_lock_anchors_a_descendant_to_the_config_owner(
+    tmp_path: Path,
+) -> None:
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+
+    (tmp_path / "aptl.json").write_text("{}", encoding="utf-8")
+    descendant = tmp_path / "nested" / "working-directory"
+    descendant.mkdir(parents=True)
+
+    with lifecycle_mutation_lock(descendant) as project_root:
+        assert project_root == tmp_path
+        assert (tmp_path / ".aptl" / "lifecycle" / ".lock").is_file()
+        assert not (descendant / ".aptl").exists()
+
+
+def test_start_from_a_descendant_passes_the_config_owner_to_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from aptl.core import lab
+    from aptl.core.lab_types import LabResult
+
+    (tmp_path / "aptl.json").write_text("{}", encoding="utf-8")
+    descendant = tmp_path / "nested"
+    descendant.mkdir()
+    observed: list[Path] = []
+
+    def start_owned(project_dir: Path, **kwargs: object) -> LabResult:
+        del kwargs
+        observed.append(project_dir)
+        return LabResult(success=True)
+
+    monkeypatch.setattr(lab, "_orchestrate_lab_start_owned", start_owned)
+
+    result = lab.orchestrate_lab_start(descendant)
+
+    assert result.success is True
+    assert observed == [tmp_path]
+
+
+def test_lifecycle_mutation_lock_rejects_a_second_thread(tmp_path: Path) -> None:
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+    from aptl.core.lifecycle_policy import LifecycleBusyError
+
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        with lifecycle_mutation_lock(tmp_path):
+            acquired.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert acquired.wait(timeout=5)
+    try:
+        with pytest.raises(LifecycleBusyError, match="lifecycle owner"):
+            with lifecycle_mutation_lock(tmp_path):
+                pytest.fail("a second lifecycle owner must not enter")
+    finally:
+        release.set()
+        holder.join(timeout=5)
+    with lifecycle_mutation_lock(tmp_path):
+        pass
+
+
+def test_process_death_releases_lifecycle_ownership(tmp_path: Path) -> None:
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+    from aptl.core.lifecycle_policy import LifecycleBusyError
+
+    context = multiprocessing.get_context("spawn")
+    ready_path = tmp_path / "child-ready"
+    holder = context.Process(
+        target=_hold_lifecycle_lock_in_child,
+        args=(str(tmp_path), str(ready_path)),
+    )
+    holder.start()
+    try:
+        deadline = time.monotonic() + 5
+        while not ready_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready_path.exists()
+        with pytest.raises(LifecycleBusyError, match="lifecycle owner"):
+            with lifecycle_mutation_lock(tmp_path):
+                pytest.fail("the live child process must retain lifecycle ownership")
+        holder.terminate()
+        holder.join(timeout=5)
+        assert not holder.is_alive()
+        with lifecycle_mutation_lock(tmp_path):
+            pass
+    finally:
+        if holder.is_alive():
+            holder.terminate()
+            holder.join(timeout=5)
+
+
+def test_windows_lock_walk_rejects_a_reparse_directory_by_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import aptl.core.lifecycle_guard as guard
+
+    opened: list[tuple[int, str, bool]] = []
+    closed: list[int] = []
+
+    monkeypatch.setattr(guard, "_windows_open_root_handle", lambda project_dir: 10)
+
+    def open_relative(parent: int, component: str, *, directory: bool) -> int:
+        opened.append((parent, component, directory))
+        return 11
+
+    def reject_reparse(handle: int) -> None:
+        if handle == 11:
+            raise OSError("reparse")
+
+    monkeypatch.setattr(guard, "_windows_open_relative_handle", open_relative)
+    monkeypatch.setattr(guard, "_windows_reject_reparse_point", reject_reparse)
+    monkeypatch.setattr(guard, "_windows_close_handle", closed.append)
+
+    with pytest.raises(OSError, match="reparse"):
+        guard._open_windows_lock_fd(tmp_path)
+
+    assert opened == [(10, ".aptl", True)]
+    assert closed == [11, 10]
+    assert not (tmp_path / ".aptl").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires Windows junction semantics")
+def test_windows_lock_rejects_a_junctioned_state_directory(tmp_path: Path) -> None:
+    from aptl.core.lifecycle_guard import (
+        LifecycleLockUnavailableError,
+        lifecycle_mutation_lock,
+    )
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(tmp_path / ".aptl"), str(outside)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with pytest.raises(LifecycleLockUnavailableError):
+        with lifecycle_mutation_lock(tmp_path):
+            pytest.fail("a junctioned lifecycle root must not be followed")
+    assert not (outside / "lifecycle").exists()
+
+
+def test_lifecycle_mutation_lock_rejects_symlinked_state_directory(
+    tmp_path: Path,
+) -> None:
+    from aptl.core.lifecycle_guard import (
+        LifecycleLockUnavailableError,
+        lifecycle_mutation_lock,
+    )
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / ".aptl").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(LifecycleLockUnavailableError):
+        with lifecycle_mutation_lock(tmp_path):
+            pytest.fail("a symlinked lifecycle root must not be followed")
+
+
+def test_start_fails_busy_before_dotenv_hydration(tmp_path: Path) -> None:
+    from aptl.core.lab import orchestrate_lab_start
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        with lifecycle_mutation_lock(tmp_path):
+            acquired.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert acquired.wait(timeout=5)
+    try:
+        result = orchestrate_lab_start(tmp_path)
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert result.success is False
+    assert "lifecycle-owner-busy" in result.error
+    assert "wait" in result.error.lower()
+    assert not (tmp_path / ".env").exists()
+
+
+def test_start_normalizes_an_unavailable_lock_path(tmp_path: Path) -> None:
+    from aptl.core.lab import orchestrate_lab_start
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / ".aptl").symlink_to(outside, target_is_directory=True)
+
+    result = orchestrate_lab_start(tmp_path)
+
+    assert result.success is False
+    assert "lifecycle-lock-unavailable" in result.error
+    assert str(outside) not in result.error
+
+
+@pytest.mark.parametrize("operation", ["stop", "kill"])
+def test_destructive_operation_does_not_mutate_while_start_owner_is_alive(
+    tmp_path: Path, operation: str
+) -> None:
+    from aptl.core.kill import kill_lab_containers
+    from aptl.core.lab import stop_lab
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+
+    acquired = threading.Event()
+    release = threading.Event()
+    backend = MagicMock()
+
+    def hold_lock() -> None:
+        with lifecycle_mutation_lock(tmp_path):
+            acquired.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert acquired.wait(timeout=5)
+    try:
+        if operation == "stop":
+            result = stop_lab(project_dir=tmp_path, backend=backend)
+            assert result.success is False
+            assert "lifecycle-owner-busy" in result.error
+            backend.stop.assert_not_called()
+        else:
+            success, error = kill_lab_containers(project_dir=tmp_path, backend=backend)
+            assert success is False
+            assert "lifecycle-owner-busy" in error
+            backend.kill.assert_not_called()
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+
+def test_full_kill_switch_does_not_clear_state_while_start_owner_is_alive(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from aptl.core import kill
+    from aptl.core.lifecycle_guard import lifecycle_mutation_lock
+
+    acquired = threading.Event()
+    release = threading.Event()
+    kill_processes = MagicMock()
+    clear_session = MagicMock()
+    monkeypatch.setattr(kill, "kill_mcp_processes", kill_processes)
+    monkeypatch.setattr(kill, "clear_session", clear_session)
+
+    def hold_lock() -> None:
+        with lifecycle_mutation_lock(tmp_path):
+            acquired.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert acquired.wait(timeout=5)
+    try:
+        result = kill.execute_kill(project_dir=tmp_path)
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert result.success is False
+    assert any("lifecycle-owner-busy" in error for error in result.errors)
+    kill_processes.assert_not_called()
+    clear_session.assert_not_called()

--- a/tests/test_lifecycle_policy.py
+++ b/tests/test_lifecycle_policy.py
@@ -108,9 +108,10 @@ class TestEvaluateTtl:
         provisioned = _now(hour=12)
         assert lp.evaluate_ttl(policy, provisioned, _now(hour=13)) is True
         # boundary: exactly ttl minutes elapsed
-        assert lp.evaluate_ttl(
-            policy, provisioned, provisioned + timedelta(minutes=60)
-        ) is True
+        assert (
+            lp.evaluate_ttl(policy, provisioned, provisioned + timedelta(minutes=60))
+            is True
+        )
 
     def test_not_expired_within_ttl(self):
         policy = LabLifecyclePolicyConfig(ttl_minutes=60)
@@ -190,7 +191,9 @@ class TestDecide:
     def test_running_within_policy_is_noop(self):
         policy = LabLifecyclePolicyConfig(ttl_minutes=240, idle_timeout_minutes=60)
         state = lp.LifecycleState(provisioned_at=_now(hour=11, minute=30).isoformat())
-        decision = lp.decide(policy, state, _now(hour=12), True, _now(hour=11, minute=45), 60)
+        decision = lp.decide(
+            policy, state, _now(hour=12), True, _now(hour=11, minute=45), 60
+        )
         assert decision.action == "none"
 
     def test_running_ttl_exceeded_tears_down(self):
@@ -216,7 +219,9 @@ class TestDecide:
     def test_not_running_due_schedule_provisions(self):
         entry = LifecycleScheduleEntry(at="08:00", scenario="techvault")
         policy = LabLifecyclePolicyConfig(schedule=[entry])
-        decision = lp.decide(policy, lp.LifecycleState(), _now(hour=8, minute=5), False, None, 60)
+        decision = lp.decide(
+            policy, lp.LifecycleState(), _now(hour=8, minute=5), False, None, 60
+        )
         assert decision.action == "provision"
         assert decision.scenario == "techvault"
 
@@ -287,11 +292,33 @@ class TestEnforceOnce:
         result = le.enforce_once(tmp_path)
         assert result.success is True
 
+    def test_descendant_invocation_uses_the_config_owning_project(
+        self, tmp_path, monkeypatch
+    ):
+        _write_policy_config(tmp_path, {"ttl_minutes": 60})
+        descendant = tmp_path / "nested"
+        descendant.mkdir()
+        observed = []
+
+        def status(**kwargs):
+            observed.append(kwargs["project_dir"])
+            return LabStatus(running=False)
+
+        monkeypatch.setattr(le, "lab_status", status)
+
+        result = le.enforce_once(descendant, now=_now())
+
+        assert result.success is True
+        assert observed == [tmp_path]
+        assert not (descendant / ".aptl").exists()
+
     def test_running_within_policy_takes_no_action(self, tmp_path, monkeypatch):
         _write_policy_config(tmp_path, {"ttl_minutes": 240})
         monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=True))
         calls = []
-        monkeypatch.setattr(le, "stop_lab", lambda **k: calls.append("stop") or LabResult(success=True))
+        monkeypatch.setattr(
+            le, "stop_lab", lambda **k: calls.append("stop") or LabResult(success=True)
+        )
         result = le.enforce_once(tmp_path, now=_now())
         assert calls == []
         assert result.success is True
@@ -299,14 +326,20 @@ class TestEnforceOnce:
         assert lp.load_state(tmp_path).provisioned_at is not None
 
     def test_ttl_expired_calls_stop_lab(self, tmp_path, monkeypatch):
-        _write_policy_config(tmp_path, {"ttl_minutes": 60, "teardown_remove_volumes": True})
+        _write_policy_config(
+            tmp_path, {"ttl_minutes": 60, "teardown_remove_volumes": True}
+        )
         # seed state with an old provisioned_at so TTL is already exceeded
-        lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=10).isoformat()))
+        lp.save_state(
+            tmp_path, lp.LifecycleState(provisioned_at=_now(hour=10).isoformat())
+        )
         monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=True))
         seen = {}
+
         def fake_stop(**kwargs):
             seen.update(kwargs)
             return LabResult(success=True)
+
         monkeypatch.setattr(le, "stop_lab", fake_stop)
         result = le.enforce_once(tmp_path, now=_now(hour=12))
         assert seen.get("remove_volumes") is True
@@ -317,10 +350,14 @@ class TestEnforceOnce:
 
     def test_idle_expired_calls_stop_lab(self, tmp_path, monkeypatch):
         _write_policy_config(tmp_path, {"idle_timeout_minutes": 30})
-        lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=10).isoformat()))
+        lp.save_state(
+            tmp_path, lp.LifecycleState(provisioned_at=_now(hour=10).isoformat())
+        )
         monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=True))
         called = []
-        monkeypatch.setattr(le, "stop_lab", lambda **k: called.append(True) or LabResult(success=True))
+        monkeypatch.setattr(
+            le, "stop_lab", lambda **k: called.append(True) or LabResult(success=True)
+        )
         result = le.enforce_once(tmp_path, now=_now(hour=12))
         assert called == [True]
         assert result.success is True
@@ -333,8 +370,12 @@ class TestEnforceOnce:
         monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
         booted = []
         monkeypatch.setattr(
-            le, "clean_boot_lab",
-            lambda *a, **k: booted.append(True) or LabResult(success=True, outcome=StartupOutcome.READY),
+            le,
+            "clean_boot_lab",
+            lambda *a, **k: (
+                booted.append(True)
+                or LabResult(success=True, outcome=StartupOutcome.READY)
+            ),
         )
         result = le.enforce_once(tmp_path, now=_now(hour=8, minute=5))
         assert booted == [True]
@@ -345,13 +386,16 @@ class TestEnforceOnce:
         # fired-today guard recorded
         assert state.fired_schedules
 
-    def test_failed_scheduled_provision_is_not_marked_fired(self, tmp_path, monkeypatch):
+    def test_failed_scheduled_provision_is_not_marked_fired(
+        self, tmp_path, monkeypatch
+    ):
         # A failed provision must NOT consume the day's fire marker, so a
         # later tick inside the grace window retries it.
         _write_policy_config(tmp_path, {"schedule": [{"at": "08:00"}]})
         monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
         monkeypatch.setattr(
-            le, "clean_boot_lab",
+            le,
+            "clean_boot_lab",
             lambda *a, **k: LabResult(
                 success=False, error="boom", outcome=StartupOutcome.FAILED
             ),
@@ -366,7 +410,9 @@ class TestEnforceOnce:
         # A malformed lifecycle policy must surface as a FAILED tick, not a
         # silent no-op that hides a broken unattended timer.
         (tmp_path / "aptl.json").write_text(
-            json.dumps({"lab": {"name": "aptl"}, "lifecycle_policy": {"ttl_minutes": 0}})
+            json.dumps(
+                {"lab": {"name": "aptl"}, "lifecycle_policy": {"ttl_minutes": 0}}
+            )
         )
         result = le.enforce_once(tmp_path, now=_now())
         assert result.success is False
@@ -375,9 +421,13 @@ class TestEnforceOnce:
     def test_not_running_no_schedule_is_noop(self, tmp_path, monkeypatch):
         _write_policy_config(tmp_path, {"ttl_minutes": 60})
         # Seed a stale provisioned_at from a range that has since gone down.
-        lp.save_state(tmp_path, lp.LifecycleState(provisioned_at=_now(hour=1).isoformat()))
+        lp.save_state(
+            tmp_path, lp.LifecycleState(provisioned_at=_now(hour=1).isoformat())
+        )
         monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
-        monkeypatch.setattr(le, "clean_boot_lab", lambda *a, **k: pytest.fail("should not boot"))
+        monkeypatch.setattr(
+            le, "clean_boot_lab", lambda *a, **k: pytest.fail("should not boot")
+        )
         result = le.enforce_once(tmp_path, now=_now())
         assert result.success is True
         # stale provisioned_at is cleared when the lab is observed down
@@ -409,6 +459,7 @@ class TestLatestActivity:
         marker.write_text("{}")
         recent = _now(hour=12).timestamp()
         import os
+
         os.utime(marker, (recent, recent))
         monkeypatch.setattr(le, "resolve_active_run_dir", lambda state_dir: active)
         state = lp.LifecycleState(provisioned_at=_now(hour=1).isoformat())
@@ -418,7 +469,9 @@ class TestLatestActivity:
 
 
 class TestRunMonitor:
-    def test_runs_bounded_ticks_without_sleeping_after_last(self, tmp_path, monkeypatch):
+    def test_runs_bounded_ticks_without_sleeping_after_last(
+        self, tmp_path, monkeypatch
+    ):
         _write_policy_config(tmp_path, {"ttl_minutes": 60})
         monkeypatch.setattr(le, "lab_status", lambda **k: LabStatus(running=False))
         sleeps = []
@@ -435,7 +488,9 @@ class TestRunMonitor:
 
     def test_invalid_config_yields_failed_result(self, tmp_path):
         (tmp_path / "aptl.json").write_text(
-            json.dumps({"lab": {"name": "aptl"}, "lifecycle_policy": {"ttl_minutes": 0}})
+            json.dumps(
+                {"lab": {"name": "aptl"}, "lifecycle_policy": {"ttl_minutes": 0}}
+            )
         )
         results = le.run_monitor(tmp_path, interval_seconds=1, max_ticks=3)
         assert len(results) == 1


### PR DESCRIPTION
## Summary

Harden lab lifecycle ownership and recovery so overlapping operations fail clearly, abandoned project runtime is detected before startup mutation, and teardown reliably removes and verifies project-scoped residue.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #905

## ADR Impact

- ADR-021
- ADR-045
- ADR-046

## Changes

- Add a canonical, reentrant cross-process lifecycle guard shared by start, stop, clean boot, kill, and policy enforcement.
- Detect Compose and directly materialized project runtime before startup, with bounded actionable failures for presence and observation errors.
- Make stop and kill continue project-scoped cleanup, remove residual containers and networks, and verify runtime absence while preserving volumes by default.
- Validate destructive Compose project identities and document operator recovery without weakening authoritative readiness checks.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Configured completion, policy, and pre-commit gates passed. Targeted lifecycle, deployment-backend, CLI, and API regression suites also passed.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: Issue #905 ← src/aptl/core/lifecycle_guard.py, Issue #905 ← src/aptl/core/lab.py, Issue #905 ← src/aptl/core/kill.py, Issue #905 ← src/aptl/core/deployment
- TESTS: Issue #905 ← tests/test_lifecycle_guard.py, Issue #905 ← tests/test_lifecycle_policy.py, Issue #905 ← tests/test_deployment_backend.py, Issue #905 ← tests/test_lab.py and tests/test_kill.py

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.