### PR TITLE
fix(quality): resolve SonarCloud new-code findings blocking the dev gate

### DIFF
--- a/src/aptl/utils/_pathsafe_core.py
+++ b/src/aptl/utils/_pathsafe_core.py
@@ -1,0 +1,228 @@
+"""Shared no-follow containment primitives for :mod:`aptl.utils.pathsafe`.
+
+This is the leaf of the pathsafe trio: the untrusted-path validation
+(:func:`_split_components`), the ``REASON_*`` codes and
+:class:`PathContainmentError`, the trusted base-fd opener, and the
+component-by-component walkers used by both the read side
+(:mod:`aptl.utils._pathsafe_read`) and the write side
+(:mod:`aptl.utils.pathsafe`). It imports neither, so there is no cycle.
+
+The public surface is re-exported from :mod:`aptl.utils.pathsafe`; import from
+there, not from this private module.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import stat
+from collections.abc import Callable
+from pathlib import Path
+
+REASON_NOT_RELATIVE = "not_relative"
+REASON_NUL_BYTE = "nul_byte"
+REASON_EMPTY_COMPONENT = "empty_component"
+REASON_DOT_COMPONENT = "dot_component"
+REASON_TRAVERSAL = "traversal"
+REASON_SYMLINK = "symlink"
+REASON_NOT_FOUND = "not_found"
+REASON_NOT_REGULAR_FILE = "not_regular_file"
+REASON_BASE_DIR_UNAVAILABLE = "base_dir_unavailable"
+REASON_OPEN_FAILED = "open_failed"
+
+
+class PathContainmentError(Exception):
+    """Raised when ``relative_path`` cannot be safely opened under ``base_dir``.
+
+    ``reason`` is a short, stable, machine-checkable code (one of this
+    module's ``REASON_*`` constants) so callers can translate this single
+    typed error into their own domain-specific message without parsing
+    prose out of ``str(exc)``.
+    """
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def _split_components(relative_path: str | Path) -> list[str]:
+    """Validate and split ``relative_path`` into literal ``/``-separated
+    components, rejecting anything that could escape or be ambiguous.
+
+    Splits on literal ``/`` rather than going through ``pathlib`` so a
+    double slash or trailing slash surfaces as the empty component it
+    lexically is, instead of being silently collapsed away.
+    """
+    text = str(relative_path)
+    if "\x00" in text:
+        raise PathContainmentError(REASON_NUL_BYTE, "path must not contain NUL bytes")
+    if not text:
+        raise PathContainmentError(REASON_EMPTY_COMPONENT, "path must not be empty")
+    if text.startswith("/"):
+        raise PathContainmentError(REASON_NOT_RELATIVE, f"path must be relative: {text!r}")
+    components = text.split("/")
+    for component in components:
+        if component == "":
+            raise PathContainmentError(
+                REASON_EMPTY_COMPONENT, f"path contains an empty component: {text!r}"
+            )
+        if component == "..":
+            raise PathContainmentError(
+                REASON_TRAVERSAL, f"path contains a '..' component: {text!r}"
+            )
+        if component == ".":
+            raise PathContainmentError(
+                REASON_DOT_COMPONENT, f"path contains a '.' component: {text!r}"
+            )
+    return components
+
+
+def _reason_for(exc: OSError, component: str, parent_fd: int) -> str:
+    """Classify a failed component open into a stable ``REASON_*`` code.
+
+    ``ELOOP`` is the unambiguous no-follow-hit-a-symlink signal for a leaf
+    open (no ``O_DIRECTORY``). For an intermediate directory open, Linux's
+    ``O_DIRECTORY | O_NOFOLLOW`` combination surfaces a symlinked component
+    as ``ENOTDIR`` instead of ``ELOOP`` (empirically verified), which is
+    indistinguishable from an ordinary "not a directory" without a further
+    check. Since the access has *already been rejected* either way by the
+    failed ``os.open()``, a no-follow ``fstatat`` purely to choose the more
+    honest reason code is safe — it cannot reopen, follow, or grant access
+    to anything; it only makes the error message accurate.
+    """
+    if exc.errno == errno.ELOOP:
+        return REASON_SYMLINK
+    if exc.errno not in (errno.ENOENT, errno.ENOTDIR):
+        return REASON_OPEN_FAILED
+    return _reason_for_missing_component(component, parent_fd)
+
+
+def _reason_for_missing_component(component: str, parent_fd: int) -> str:
+    """Distinguish a genuinely missing path component from an existing symlink at that path.
+
+    Called only for the ``ENOENT``/``ENOTDIR`` case, where a symlinked
+    intermediate component surfaces as ``ENOTDIR`` rather than ``ELOOP``
+    (see :func:`_reason_for`).
+    """
+    try:
+        st = os.stat(component, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return REASON_NOT_FOUND
+    return REASON_SYMLINK if stat.S_ISLNK(st.st_mode) else REASON_NOT_FOUND
+
+
+def _open_base_fd(base_dir: Path | str) -> int:
+    """Open base_dir as a read-only directory file descriptor, the trusted root every walk starts from."""
+    try:
+        return os.open(base_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    except OSError as exc:
+        raise PathContainmentError(
+            REASON_BASE_DIR_UNAVAILABLE, f"base directory unavailable: {exc}"
+        ) from exc
+
+
+def _walk(
+    components: list[str],
+    base_fd: int,
+    *,
+    open_dir: Callable[[str, int], int],
+    open_leaf: Callable[[str, int], int],
+) -> int:
+    """Walk ``components`` under ``base_fd``, closing intermediate fds.
+
+    Every fd opened along the way except the final leaf is closed before
+    returning or raising, so only the caller-owned leaf descriptor (on
+    success) survives. ``base_fd`` is never closed here — that remains the
+    caller's responsibility.
+    """
+    current_fd = base_fd
+    try:
+        for index, component in enumerate(components):
+            is_leaf = index == len(components) - 1
+            opener = open_leaf if is_leaf else open_dir
+            next_fd = opener(component, current_fd)
+            if current_fd != base_fd:
+                os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except BaseException:
+        if current_fd != base_fd:
+            os.close(current_fd)
+        raise
+
+
+def _walk_to_parent(
+    dir_components: list[str],
+    base_fd: int,
+    *,
+    open_dir: Callable[[str, int], int],
+) -> int:
+    """Walk the directory components under ``base_fd``, returning the leaf's parent fd.
+
+    Like :func:`_walk` but stops at the parent directory of the leaf and returns
+    that descriptor OPEN (creating intermediate dirs when ``open_dir`` does),
+    closing every earlier intermediate. When ``dir_components`` is empty the leaf
+    lives directly under ``base_dir``, so ``base_fd`` itself is the parent and is
+    returned unchanged — the caller must never close it here. Any non-``base_fd``
+    parent it returns is caller-owned and must be closed by the caller.
+    """
+    current_fd = base_fd
+    try:
+        for component in dir_components:
+            next_fd = open_dir(component, current_fd)
+            if current_fd != base_fd:
+                os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except BaseException:
+        if current_fd != base_fd:
+            os.close(current_fd)
+        raise
+
+
+def _open_dir_nofollow(component: str, parent_fd: int) -> int:
+    """Open component as a directory under parent_fd, no-follow; raise PathContainmentError on any failure."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        return os.open(component, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc
+
+
+def _open_dir_nofollow_or_create(component: str, parent_fd: int) -> int:
+    """Open ``component`` no-follow, creating it as a real directory if
+    (and only if) it does not already exist. A pre-existing symlink or
+    non-directory at this path is rejected exactly like
+    :func:`_open_dir_nofollow` — creation never overwrites or follows an
+    existing entry.
+    """
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        return os.open(component, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc
+    try:
+        os.mkdir(component, 0o700, dir_fd=parent_fd)
+    except FileExistsError:
+        # lost a create race with another writer; fall through to open
+        pass
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"cannot create directory {component!r}: {exc}",
+        ) from exc
+    try:
+        return os.open(component, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc

--- a/src/aptl/utils/_pathsafe_read.py
+++ b/src/aptl/utils/_pathsafe_read.py
@@ -1,0 +1,153 @@
+"""No-follow read/list operations for :mod:`aptl.utils.pathsafe`.
+
+The read half of the pathsafe trio: open a contained regular file, read its
+bytes, list a contained directory, or open a contained directory descriptor —
+each walking every path component ``O_NOFOLLOW`` (openat-style) so a symlinked
+component anywhere on the path is rejected rather than followed. Built on the
+shared primitives in :mod:`aptl.utils._pathsafe_core`.
+
+The public surface is re-exported from :mod:`aptl.utils.pathsafe`; import from
+there, not from this private module.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import BinaryIO
+
+from aptl.utils._pathsafe_core import (
+    REASON_NOT_REGULAR_FILE,
+    PathContainmentError,
+    _open_base_fd,
+    _open_dir_nofollow,
+    _open_dir_nofollow_or_create,
+    _reason_for,
+    _split_components,
+    _walk,
+)
+
+
+def _open_leaf_read_nofollow(component: str, parent_fd: int) -> int:
+    """Open component read-only under parent_fd, no-follow, rejecting a non-regular-file target."""
+    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        fd = os.open(component, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        os.close(fd)
+        raise PathContainmentError(REASON_NOT_REGULAR_FILE, "target is not a regular file")
+    return fd
+
+
+def open_contained_nofollow(base_dir: Path | str, relative_path: str | Path) -> BinaryIO:
+    """Open ``relative_path`` under ``base_dir`` with one-open, no-follow semantics.
+
+    Walks each path component with ``os.open(..., O_NOFOLLOW, dir_fd=parent)``
+    so a symlinked directory component or leaf is rejected rather than
+    silently followed, and opens the final regular file exactly once.
+    Returns a binary file object bound to that single open handle — read or
+    hash directly from it; never reopen the original path afterward (that
+    would reintroduce the TOCTOU race this function exists to close).
+
+    Raises :class:`PathContainmentError` for: an absolute ``relative_path``;
+    a NUL byte; an empty, ``.``, or ``..`` path component; any symlinked
+    component (including the leaf); a missing component; or a leaf that is
+    not a regular file. Every intermediate directory descriptor is closed;
+    only the leaf descriptor is returned (open) on success.
+    """
+    components = _split_components(relative_path)
+    base_fd = _open_base_fd(base_dir)
+    try:
+        leaf_fd = _walk(
+            components, base_fd, open_dir=_open_dir_nofollow, open_leaf=_open_leaf_read_nofollow
+        )
+    finally:
+        os.close(base_fd)
+    return os.fdopen(leaf_fd, "rb")
+
+
+def read_contained_nofollow(base_dir: Path | str, relative_path: str | Path) -> bytes:
+    """Return the exact bytes of ``relative_path`` under ``base_dir``.
+
+    One-open convenience over :func:`open_contained_nofollow`: reads from
+    the very handle that was opened no-follow, so nothing can be swapped
+    between validation and read (TOCTOU-proof by construction).
+    """
+    with open_contained_nofollow(base_dir, relative_path) as handle:
+        return handle.read()
+
+
+def _open_leaf_dir_nofollow(component: str, parent_fd: int) -> int:
+    """Open ``component`` as a directory under ``parent_fd``, no-follow.
+
+    The listing companion to :func:`_open_leaf_read_nofollow`: the leaf must be
+    a real directory, and a symlink at the leaf is rejected exactly like any
+    other symlinked component.
+    """
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        return os.open(component, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise PathContainmentError(
+            _reason_for(exc, component, parent_fd),
+            f"rejected path component {component!r}: {exc}",
+        ) from exc
+
+
+def listdir_contained_nofollow(base_dir: Path | str, relative_path: str | Path) -> list[str]:
+    """Return the sorted entry names of ``relative_path`` under ``base_dir``.
+
+    Walks each path component no-follow (openat-style) exactly like
+    :func:`open_contained_nofollow`, then lists the leaf directory through the
+    descriptor that was opened — never by re-resolving the path — so a symlinked
+    component anywhere on the path (including the leaf directory itself) raises
+    :class:`PathContainmentError` instead of enumerating an attacker-chosen
+    directory. Names are sorted for deterministic iteration.
+
+    Raises :class:`PathContainmentError` for an absolute, empty, ``.``, or
+    ``..`` component; a symlinked component; a missing component; or a leaf that
+    is not a directory (surfaced as its ``os.open`` failure reason).
+    """
+    components = _split_components(relative_path)
+    base_fd = _open_base_fd(base_dir)
+    try:
+        dir_fd = _walk(
+            components, base_fd, open_dir=_open_dir_nofollow, open_leaf=_open_leaf_dir_nofollow
+        )
+    finally:
+        os.close(base_fd)
+    try:
+        return sorted(os.listdir(dir_fd))
+    finally:
+        os.close(dir_fd)
+
+
+def open_dir_contained_nofollow(
+    base_dir: Path | str, relative_dir: str | Path, *, create: bool = False
+) -> int:
+    """Return a descriptor for ``relative_dir`` under ``base_dir``, walked no-follow.
+
+    Every component (including the leaf directory) is opened with
+    ``O_DIRECTORY | O_NOFOLLOW`` under its parent's descriptor, so a symlinked
+    intermediate — the classic ``index -> /elsewhere`` swap — is rejected rather
+    than followed. With ``create=True`` missing directory components are created
+    as real directories (never replacing an existing symlink). The caller owns
+    the returned descriptor and must close it.
+
+    Raises :class:`PathContainmentError` for an absolute/``.``/``..``/empty/NUL
+    component, a symlinked component, or (when ``create`` is false) a missing one.
+    """
+    components = _split_components(relative_dir)
+    opener = _open_dir_nofollow_or_create if create else _open_dir_nofollow
+    base_fd = _open_base_fd(base_dir)
+    try:
+        return _walk(components, base_fd, open_dir=opener, open_leaf=opener)
+    finally:
+        os.close(base_fd)

--- a/src/aptl/utils/pathsafe.py
+++ b/src/aptl/utils/pathsafe.py
@@ -25,6 +25,13 @@ This is the ONE shared containment helper (ADR-047 "Scenario containment
 precedent" / "Persistence" security layers): ``scenario_catalog`` and the
 run store's create-once persistence both reuse it rather than each
 maintaining their own lexical path checker.
+
+The implementation is split across three modules to stay within the
+per-file size budget while keeping one public import surface: the shared
+validation/walk primitives live in :mod:`aptl.utils._pathsafe_core`, the
+read/list operations in :mod:`aptl.utils._pathsafe_read`, and the
+create-once write path below. All public names are re-exported here — always
+import from ``aptl.utils.pathsafe``, never from the private sibling modules.
 """
 
 from __future__ import annotations
@@ -32,323 +39,56 @@ from __future__ import annotations
 import errno
 import itertools
 import os
-import stat
-from collections.abc import Callable
 from pathlib import Path
-from typing import BinaryIO
+
+from aptl.utils._pathsafe_core import (
+    REASON_BASE_DIR_UNAVAILABLE,
+    REASON_DOT_COMPONENT,
+    REASON_EMPTY_COMPONENT,
+    REASON_NOT_FOUND,
+    REASON_NOT_REGULAR_FILE,
+    REASON_NOT_RELATIVE,
+    REASON_NUL_BYTE,
+    REASON_OPEN_FAILED,
+    REASON_SYMLINK,
+    REASON_TRAVERSAL,
+    PathContainmentError,
+    _open_base_fd,
+    _open_dir_nofollow_or_create,
+    _split_components,
+    _walk_to_parent,
+)
+from aptl.utils._pathsafe_read import (
+    listdir_contained_nofollow,
+    open_contained_nofollow,
+    open_dir_contained_nofollow,
+    read_contained_nofollow,
+)
+
+__all__ = [
+    "REASON_BASE_DIR_UNAVAILABLE",
+    "REASON_DOT_COMPONENT",
+    "REASON_EMPTY_COMPONENT",
+    "REASON_NOT_FOUND",
+    "REASON_NOT_REGULAR_FILE",
+    "REASON_NOT_RELATIVE",
+    "REASON_NUL_BYTE",
+    "REASON_OPEN_FAILED",
+    "REASON_SYMLINK",
+    "REASON_TRAVERSAL",
+    "PathContainmentError",
+    "create_exclusive_nofollow",
+    "listdir_contained_nofollow",
+    "open_contained_nofollow",
+    "open_dir_contained_nofollow",
+    "read_contained_nofollow",
+    "write_all",
+]
 
 #: Per-process monotonic counter for unique temporary publish names. Combined
 #: with the PID it makes create-once temp inodes collision-free without needing
 #: a wall clock or randomness.
 _TMP_COUNTER = itertools.count()
-
-REASON_NOT_RELATIVE = "not_relative"
-REASON_NUL_BYTE = "nul_byte"
-REASON_EMPTY_COMPONENT = "empty_component"
-REASON_DOT_COMPONENT = "dot_component"
-REASON_TRAVERSAL = "traversal"
-REASON_SYMLINK = "symlink"
-REASON_NOT_FOUND = "not_found"
-REASON_NOT_REGULAR_FILE = "not_regular_file"
-REASON_BASE_DIR_UNAVAILABLE = "base_dir_unavailable"
-REASON_OPEN_FAILED = "open_failed"
-
-
-class PathContainmentError(Exception):
-    """Raised when ``relative_path`` cannot be safely opened under ``base_dir``.
-
-    ``reason`` is a short, stable, machine-checkable code (one of this
-    module's ``REASON_*`` constants) so callers can translate this single
-    typed error into their own domain-specific message without parsing
-    prose out of ``str(exc)``.
-    """
-
-    def __init__(self, reason: str, message: str) -> None:
-        super().__init__(message)
-        self.reason = reason
-
-
-def _split_components(relative_path: str | Path) -> list[str]:
-    """Validate and split ``relative_path`` into literal ``/``-separated
-    components, rejecting anything that could escape or be ambiguous.
-
-    Splits on literal ``/`` rather than going through ``pathlib`` so a
-    double slash or trailing slash surfaces as the empty component it
-    lexically is, instead of being silently collapsed away.
-    """
-    text = str(relative_path)
-    if "\x00" in text:
-        raise PathContainmentError(REASON_NUL_BYTE, "path must not contain NUL bytes")
-    if not text:
-        raise PathContainmentError(REASON_EMPTY_COMPONENT, "path must not be empty")
-    if text.startswith("/"):
-        raise PathContainmentError(REASON_NOT_RELATIVE, f"path must be relative: {text!r}")
-    components = text.split("/")
-    for component in components:
-        if component == "":
-            raise PathContainmentError(
-                REASON_EMPTY_COMPONENT, f"path contains an empty component: {text!r}"
-            )
-        if component == "..":
-            raise PathContainmentError(
-                REASON_TRAVERSAL, f"path contains a '..' component: {text!r}"
-            )
-        if component == ".":
-            raise PathContainmentError(
-                REASON_DOT_COMPONENT, f"path contains a '.' component: {text!r}"
-            )
-    return components
-
-
-def _reason_for(exc: OSError, component: str, parent_fd: int) -> str:
-    """Classify a failed component open into a stable ``REASON_*`` code.
-
-    ``ELOOP`` is the unambiguous no-follow-hit-a-symlink signal for a leaf
-    open (no ``O_DIRECTORY``). For an intermediate directory open, Linux's
-    ``O_DIRECTORY | O_NOFOLLOW`` combination surfaces a symlinked component
-    as ``ENOTDIR`` instead of ``ELOOP`` (empirically verified), which is
-    indistinguishable from an ordinary "not a directory" without a further
-    check. Since the access has *already been rejected* either way by the
-    failed ``os.open()``, a no-follow ``fstatat`` purely to choose the more
-    honest reason code is safe — it cannot reopen, follow, or grant access
-    to anything; it only makes the error message accurate.
-    """
-    if exc.errno == errno.ELOOP:
-        return REASON_SYMLINK
-    if exc.errno not in (errno.ENOENT, errno.ENOTDIR):
-        return REASON_OPEN_FAILED
-    return _reason_for_missing_component(component, parent_fd)
-
-
-def _reason_for_missing_component(component: str, parent_fd: int) -> str:
-    """Distinguish a genuinely missing path component from an existing symlink at that path.
-
-    Called only for the ``ENOENT``/``ENOTDIR`` case, where a symlinked
-    intermediate component surfaces as ``ENOTDIR`` rather than ``ELOOP``
-    (see :func:`_reason_for`).
-    """
-    try:
-        st = os.stat(component, dir_fd=parent_fd, follow_symlinks=False)
-    except OSError:
-        return REASON_NOT_FOUND
-    return REASON_SYMLINK if stat.S_ISLNK(st.st_mode) else REASON_NOT_FOUND
-
-
-def _open_base_fd(base_dir: Path | str) -> int:
-    """Open base_dir as a read-only directory file descriptor, the trusted root every walk starts from."""
-    try:
-        return os.open(base_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
-    except OSError as exc:
-        raise PathContainmentError(
-            REASON_BASE_DIR_UNAVAILABLE, f"base directory unavailable: {exc}"
-        ) from exc
-
-
-def _walk(
-    components: list[str],
-    base_fd: int,
-    *,
-    open_dir: Callable[[str, int], int],
-    open_leaf: Callable[[str, int], int],
-) -> int:
-    """Walk ``components`` under ``base_fd``, closing intermediate fds.
-
-    Every fd opened along the way except the final leaf is closed before
-    returning or raising, so only the caller-owned leaf descriptor (on
-    success) survives. ``base_fd`` is never closed here — that remains the
-    caller's responsibility.
-    """
-    current_fd = base_fd
-    try:
-        for index, component in enumerate(components):
-            is_leaf = index == len(components) - 1
-            opener = open_leaf if is_leaf else open_dir
-            next_fd = opener(component, current_fd)
-            if current_fd != base_fd:
-                os.close(current_fd)
-            current_fd = next_fd
-        return current_fd
-    except BaseException:
-        if current_fd != base_fd:
-            os.close(current_fd)
-        raise
-
-
-def _open_dir_nofollow(component: str, parent_fd: int) -> int:
-    """Open component as a directory under parent_fd, no-follow; raise PathContainmentError on any failure."""
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
-    try:
-        return os.open(component, flags, dir_fd=parent_fd)
-    except OSError as exc:
-        raise PathContainmentError(
-            _reason_for(exc, component, parent_fd),
-            f"rejected path component {component!r}: {exc}",
-        ) from exc
-
-
-def _open_leaf_read_nofollow(component: str, parent_fd: int) -> int:
-    """Open component read-only under parent_fd, no-follow, rejecting a non-regular-file target."""
-    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC
-    try:
-        fd = os.open(component, flags, dir_fd=parent_fd)
-    except OSError as exc:
-        raise PathContainmentError(
-            _reason_for(exc, component, parent_fd),
-            f"rejected path component {component!r}: {exc}",
-        ) from exc
-    st = os.fstat(fd)
-    if not stat.S_ISREG(st.st_mode):
-        os.close(fd)
-        raise PathContainmentError(REASON_NOT_REGULAR_FILE, "target is not a regular file")
-    return fd
-
-
-def open_contained_nofollow(base_dir: Path | str, relative_path: str | Path) -> BinaryIO:
-    """Open ``relative_path`` under ``base_dir`` with one-open, no-follow semantics.
-
-    Walks each path component with ``os.open(..., O_NOFOLLOW, dir_fd=parent)``
-    so a symlinked directory component or leaf is rejected rather than
-    silently followed, and opens the final regular file exactly once.
-    Returns a binary file object bound to that single open handle — read or
-    hash directly from it; never reopen the original path afterward (that
-    would reintroduce the TOCTOU race this function exists to close).
-
-    Raises :class:`PathContainmentError` for: an absolute ``relative_path``;
-    a NUL byte; an empty, ``.``, or ``..`` path component; any symlinked
-    component (including the leaf); a missing component; or a leaf that is
-    not a regular file. Every intermediate directory descriptor is closed;
-    only the leaf descriptor is returned (open) on success.
-    """
-    components = _split_components(relative_path)
-    base_fd = _open_base_fd(base_dir)
-    try:
-        leaf_fd = _walk(
-            components, base_fd, open_dir=_open_dir_nofollow, open_leaf=_open_leaf_read_nofollow
-        )
-    finally:
-        os.close(base_fd)
-    return os.fdopen(leaf_fd, "rb")
-
-
-def read_contained_nofollow(base_dir: Path | str, relative_path: str | Path) -> bytes:
-    """Return the exact bytes of ``relative_path`` under ``base_dir``.
-
-    One-open convenience over :func:`open_contained_nofollow`: reads from
-    the very handle that was opened no-follow, so nothing can be swapped
-    between validation and read (TOCTOU-proof by construction).
-    """
-    with open_contained_nofollow(base_dir, relative_path) as handle:
-        return handle.read()
-
-
-def _open_leaf_dir_nofollow(component: str, parent_fd: int) -> int:
-    """Open ``component`` as a directory under ``parent_fd``, no-follow.
-
-    The listing companion to :func:`_open_leaf_read_nofollow`: the leaf must be
-    a real directory, and a symlink at the leaf is rejected exactly like any
-    other symlinked component.
-    """
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
-    try:
-        return os.open(component, flags, dir_fd=parent_fd)
-    except OSError as exc:
-        raise PathContainmentError(
-            _reason_for(exc, component, parent_fd),
-            f"rejected path component {component!r}: {exc}",
-        ) from exc
-
-
-def listdir_contained_nofollow(base_dir: Path | str, relative_path: str | Path) -> list[str]:
-    """Return the sorted entry names of ``relative_path`` under ``base_dir``.
-
-    Walks each path component no-follow (openat-style) exactly like
-    :func:`open_contained_nofollow`, then lists the leaf directory through the
-    descriptor that was opened — never by re-resolving the path — so a symlinked
-    component anywhere on the path (including the leaf directory itself) raises
-    :class:`PathContainmentError` instead of enumerating an attacker-chosen
-    directory. Names are sorted for deterministic iteration.
-
-    Raises :class:`PathContainmentError` for an absolute, empty, ``.``, or
-    ``..`` component; a symlinked component; a missing component; or a leaf that
-    is not a directory (surfaced as its ``os.open`` failure reason).
-    """
-    components = _split_components(relative_path)
-    base_fd = _open_base_fd(base_dir)
-    try:
-        dir_fd = _walk(
-            components, base_fd, open_dir=_open_dir_nofollow, open_leaf=_open_leaf_dir_nofollow
-        )
-    finally:
-        os.close(base_fd)
-    try:
-        return sorted(os.listdir(dir_fd))
-    finally:
-        os.close(dir_fd)
-
-
-def _open_dir_nofollow_or_create(component: str, parent_fd: int) -> int:
-    """Open ``component`` no-follow, creating it as a real directory if
-    (and only if) it does not already exist. A pre-existing symlink or
-    non-directory at this path is rejected exactly like
-    :func:`_open_dir_nofollow` — creation never overwrites or follows an
-    existing entry.
-    """
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
-    try:
-        return os.open(component, flags, dir_fd=parent_fd)
-    except FileNotFoundError:
-        pass
-    except OSError as exc:
-        raise PathContainmentError(
-            _reason_for(exc, component, parent_fd),
-            f"rejected path component {component!r}: {exc}",
-        ) from exc
-    try:
-        os.mkdir(component, 0o700, dir_fd=parent_fd)
-    except FileExistsError:
-        # lost a create race with another writer; fall through to open
-        pass
-    except OSError as exc:
-        raise PathContainmentError(
-            _reason_for(exc, component, parent_fd),
-            f"cannot create directory {component!r}: {exc}",
-        ) from exc
-    try:
-        return os.open(component, flags, dir_fd=parent_fd)
-    except OSError as exc:
-        raise PathContainmentError(
-            _reason_for(exc, component, parent_fd),
-            f"rejected path component {component!r}: {exc}",
-        ) from exc
-
-
-def _walk_to_parent(
-    dir_components: list[str],
-    base_fd: int,
-    *,
-    open_dir: Callable[[str, int], int],
-) -> int:
-    """Walk the directory components under ``base_fd``, returning the leaf's parent fd.
-
-    Like :func:`_walk` but stops at the parent directory of the leaf and returns
-    that descriptor OPEN (creating intermediate dirs when ``open_dir`` does),
-    closing every earlier intermediate. When ``dir_components`` is empty the leaf
-    lives directly under ``base_dir``, so ``base_fd`` itself is the parent and is
-    returned unchanged — the caller must never close it here. Any non-``base_fd``
-    parent it returns is caller-owned and must be closed by the caller.
-    """
-    current_fd = base_fd
-    try:
-        for component in dir_components:
-            next_fd = open_dir(component, current_fd)
-            if current_fd != base_fd:
-                os.close(current_fd)
-            current_fd = next_fd
-        return current_fd
-    except BaseException:
-        if current_fd != base_fd:
-            os.close(current_fd)
-        raise
 
 
 def write_all(fd: int, data: bytes) -> None:
@@ -367,24 +107,6 @@ def write_all(fd: int, data: bytes) -> None:
         if written <= 0:
             raise OSError(errno.EIO, "short write while sealing archive file")
         total += written
-
-
-def _open_leaf_create_exclusive_nofollow(component: str, parent_fd: int) -> int:
-    """Create-exclusive-open component under parent_fd, no-follow, for the create-once write path."""
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
-    try:
-        return os.open(component, flags, 0o600, dir_fd=parent_fd)
-    except FileExistsError:
-        # A distinct, un-wrapped signal: the leaf already exists (whether a
-        # regular file, a directory, or a symlink — O_EXCL fires before
-        # O_NOFOLLOW is even consulted for an existing path per open(2)).
-        # Callers decide the idempotency policy from here.
-        raise
-    except OSError as exc:
-        raise PathContainmentError(
-            _reason_for(exc, component, parent_fd),
-            f"rejected leaf component {component!r}: {exc}",
-        ) from exc
 
 
 def create_exclusive_nofollow(
@@ -491,27 +213,3 @@ def _create_temp_leaf(tmp_name: str, parent_fd: int) -> int:
         raise PathContainmentError(
             REASON_OPEN_FAILED, f"cannot create temporary publish inode: {exc}"
         ) from exc
-
-
-def open_dir_contained_nofollow(
-    base_dir: Path | str, relative_dir: str | Path, *, create: bool = False
-) -> int:
-    """Return a descriptor for ``relative_dir`` under ``base_dir``, walked no-follow.
-
-    Every component (including the leaf directory) is opened with
-    ``O_DIRECTORY | O_NOFOLLOW`` under its parent's descriptor, so a symlinked
-    intermediate — the classic ``index -> /elsewhere`` swap — is rejected rather
-    than followed. With ``create=True`` missing directory components are created
-    as real directories (never replacing an existing symlink). The caller owns
-    the returned descriptor and must close it.
-
-    Raises :class:`PathContainmentError` for an absolute/``.``/``..``/empty/NUL
-    component, a symlinked component, or (when ``create`` is false) a missing one.
-    """
-    components = _split_components(relative_dir)
-    opener = _open_dir_nofollow_or_create if create else _open_dir_nofollow
-    base_fd = _open_base_fd(base_dir)
-    try:
-        return _walk(components, base_fd, open_dir=opener, open_leaf=opener)
-    finally:
-        os.close(base_fd)

--- a/src/aptl/validation/_live_gate_probes.py
+++ b/src/aptl/validation/_live_gate_probes.py
@@ -86,7 +86,7 @@ def _find_container(
 
 def _compute_realization(
     scenario: Scenario, project_dir: Path, config: "AptlConfig"
-) -> tuple["AptlRealization | None", list[str]]:
+) -> tuple[AptlRealization | None, list[str]]:
     """Interpret the scenario's provisioning plan, returning (realization, diags)."""
     try:
         backend = get_backend(config, project_dir)

--- a/tests/test_appliance_egress_proxy.py
+++ b/tests/test_appliance_egress_proxy.py
@@ -16,7 +16,8 @@ PROXY = Path(__file__).parents[1] / "containers" / "appliance-egress-proxy" / "p
 @pytest.fixture(scope="module")
 def proxy():
     spec = importlib.util.spec_from_file_location("appliance_egress_proxy", PROXY)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tests/test_capture_registry.py
+++ b/tests/test_capture_registry.py
@@ -277,7 +277,8 @@ class TestMatchIsDeterministic:
         forward = CollectorRegistry((first, second)).match(spec, requirement)
         reverse = CollectorRegistry((second, first)).match(spec, requirement)
 
-        assert forward is not None and reverse is not None
+        assert forward is not None
+        assert reverse is not None
         # Both cover; ID-sorted selection picks "aaa" regardless of insertion order.
         assert forward.registration_id == reverse.registration_id == "aptl.collector.aaa"
 
@@ -404,5 +405,6 @@ class TestProjectionIsOrderCanonical:
         registration = _covering_registration(media_types=frozenset({"application/json", "text/plain"}))
         forward = _bind_reference(registration, expected_media_types=["application/json", "text/plain"])
         reverse = _bind_reference(registration, expected_media_types=["text/plain", "application/json"])
-        assert forward is not None and reverse is not None
+        assert forward is not None
+        assert reverse is not None
         assert forward.binding_projection() == reverse.binding_projection()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1075,7 +1075,8 @@ class TestLabContinuityAuditCommand:
 
         assert result.exit_code == 0
         parsed = json_mod.loads(result.stdout)
-        assert isinstance(parsed, list) and len(parsed) == 1
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
         assert parsed[0]["target"] == "aptl-victim"
         assert parsed[0]["action"] == "REVERTED"
 

--- a/tests/test_compose_base_substrate.py
+++ b/tests/test_compose_base_substrate.py
@@ -112,7 +112,8 @@ class TestEnsureGenericBaseImage:
                 "aptl/generic-systemd-base-debian:latest"
             )
 
-        assert failures and "aptl/generic-systemd-base-debian:latest" in failures[0]
+        assert failures
+        assert "aptl/generic-systemd-base-debian:latest" in failures[0]
 
 
 def test_start_base_container_carries_the_compose_project_ownership_label(tmp_path):

--- a/tests/test_compose_platform_boundary.py
+++ b/tests/test_compose_platform_boundary.py
@@ -182,7 +182,8 @@ def test_ambiguous_platform_anchor_fails_before_mutation(tmp_path) -> None:
 
     result = backend._realize_platform_boundary()
 
-    assert result is not None and result.success is False
+    assert result is not None
+    assert result.success is False
     backend.realize_boundary.assert_not_called()
 
 

--- a/tests/test_compose_service_health.py
+++ b/tests/test_compose_service_health.py
@@ -97,9 +97,12 @@ def test_unhealthy_container_reasons_enumerates_each_failure():
     reasons = unhealthy_container_reasons(backend, ["aptl-a", "aptl-b", "aptl-c", "aptl-d"])
     joined = " ".join(reasons)
     assert "aptl-a" not in joined
-    assert "not running" in joined and "aptl-b" in joined
-    assert "unhealthy" in joined and "aptl-c" in joined
-    assert "was never created" in joined and "aptl-d" in joined
+    assert "not running" in joined
+    assert "aptl-b" in joined
+    assert "unhealthy" in joined
+    assert "aptl-c" in joined
+    assert "was never created" in joined
+    assert "aptl-d" in joined
 
 
 def test_wait_returns_empty_when_no_containers():

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -262,7 +262,8 @@ class TestKaliContainerLifecycle:
         in issue #293, now a property of image selection, not a Compose
         `init: true` flag)."""
         kali = self._kali_node(techvault_sdl)
-        assert kali.runtime is not None and kali.runtime.service_manager_units, (
+        assert kali.runtime is not None
+        assert kali.runtime.service_manager_units, (
             "kali must declare at least one service_manager_units entry "
             "(ADR-033 §2 / issue #293): with none, the materializer selects "
             "the non-service base image, which has no PID-1 reaper."

--- a/tests/test_continuity.py
+++ b/tests/test_continuity.py
@@ -726,7 +726,8 @@ class TestAuditAndRevert:
         first = audit_and_revert(backend, ["victim"], kali_ips=kali_ips)
         second = audit_and_revert(backend, ["victim"], kali_ips=kali_ips)
 
-        assert first.events == [] and second.events == []
+        assert first.events == []
+        assert second.events == []
         # Each invocation does exactly one audit call per target; no
         # phantom delete attempts.
         assert all(c.cmd[:2] == ["iptables", "-S"] for c in backend.calls)
@@ -1001,7 +1002,8 @@ class TestDefaultTargets:
             node = scenario.nodes.get(node_name)
             if node is not None and node.runtime is not None:
                 caps = node.runtime.linux_capabilities
-                assert caps is not None and "CAP_NET_ADMIN" in caps.add, (
+                assert caps is not None
+                assert "CAP_NET_ADMIN" in caps.add, (
                     f"{target}'s SDL node must declare "
                     "runtime.linux_capabilities.add: [CAP_NET_ADMIN]; iptables "
                     "audit will fail there otherwise. Either add the "
@@ -1152,4 +1154,5 @@ class TestContinuityIntegration:
         first = audit_and_revert(backend, [_LIVE_TARGET], kali_ips=kali_ips)
         second = audit_and_revert(backend, [_LIVE_TARGET], kali_ips=kali_ips)
 
-        assert first.events == [] and second.events == []
+        assert first.events == []
+        assert second.events == []

--- a/tests/test_correlation_builder.py
+++ b/tests/test_correlation_builder.py
@@ -903,8 +903,10 @@ class TestRunRecordSchemaCompatibility:
     def test_v1_and_v2_records_produce_identical_projections(self):
         v1_manifest, orchestration = _minimal_run(schema_version="aptl.run-record/v1")
         v2_manifest, _ = _minimal_run(schema_version="aptl.run-record/v2")
-        assert "aces" in v1_manifest and "raes" not in v1_manifest
-        assert "raes" in v2_manifest and "aces" not in v2_manifest
+        assert "aces" in v1_manifest
+        assert "raes" not in v1_manifest
+        assert "raes" in v2_manifest
+        assert "aces" not in v2_manifest
 
         v1_projection = _build(v1_manifest, orchestration)
         v2_projection = _build(v2_manifest, orchestration)

--- a/tests/test_correlation_persistence.py
+++ b/tests/test_correlation_persistence.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import tarfile
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -330,16 +331,19 @@ from hypothesis import strategies as st  # noqa: E402
 class TestFuzzPersistenceDeterminism:
     @given(run_suffix=st.integers(min_value=0, max_value=10_000))
     @settings(max_examples=15, deadline=None)
-    def test_repeated_persist_of_the_same_archive_is_byte_identical(self, tmp_path_factory, run_suffix):
-        tmp_path = tmp_path_factory.mktemp(f"persist-fuzz-{run_suffix}")
-        store = LocalRunStore(tmp_path / "runs")
-        run_id = f"run-fuzz-{run_suffix}"
-        _write_run_archive(store, run_id)
+    def test_repeated_persist_of_the_same_archive_is_byte_identical(self, run_suffix):
+        # hypothesis runs many examples in one function call, so a fresh store
+        # per example comes from a context manager rather than a function-scoped
+        # tmp_path fixture (which hypothesis rejects) or a session-scoped factory.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            store = LocalRunStore(Path(tmp_dir) / "runs")
+            run_id = f"run-fuzz-{run_suffix}"
+            _write_run_archive(store, run_id)
 
-        first = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
-        second = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
+            first = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
+            second = build_and_persist_correlation(run_id=run_id, run_store=store, clock_provider=_FIXED_CLOCK)
 
-        assert first.canonical_bytes == second.canonical_bytes
+            assert first.canonical_bytes == second.canonical_bytes
 
 
 class TestPersistRunCorrelationBestEffort:

--- a/tests/test_evidence_bundle_archive.py
+++ b/tests/test_evidence_bundle_archive.py
@@ -77,9 +77,11 @@ class TestDeterminism:
             infos = tar.getmembers()
         assert [i.name for i in infos] == sorted(i.name for i in infos)
         for info in infos:
-            assert info.uid == 0 and info.gid == 0
+            assert info.uid == 0
+            assert info.gid == 0
             assert info.mtime == 0
-            assert info.uname == "root" and info.gname == "root"
+            assert info.uname == "root"
+            assert info.gname == "root"
 
 
 class TestSourceIntegrity:

--- a/tests/test_evidence_bundle_projections.py
+++ b/tests/test_evidence_bundle_projections.py
@@ -136,7 +136,8 @@ class TestParquetTypeFidelity:
         table = _read_parquet(member.content)
         assert str(table.schema.field("retained_content_bytes").type) == "int64"
         values = table.column("retained_content_bytes").to_pylist()
-        assert big in values and None in values
+        assert big in values
+        assert None in values
 
     def test_out_of_int64_uses_exact_decimal_string(self, tmp_path: Path) -> None:
         records = _records()
@@ -222,7 +223,8 @@ class TestParquetDeterminismAndEvolution:
     ) -> None:
         run = run_projections(["parquet"], _ctx(tmp_path))
         descriptor = run.descriptors[0]
-        assert descriptor.mapping_id and descriptor.mapping_version
+        assert descriptor.mapping_id
+        assert descriptor.mapping_version
         assert descriptor.target_schema_version == "aptl-evidence-bundle-parquet/v1"
         assert descriptor.field_maps
 

--- a/tests/test_experiment_admission.py
+++ b/tests/test_experiment_admission.py
@@ -30,6 +30,8 @@ import dataclasses
 import hashlib
 import json
 import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 import yaml
@@ -837,7 +839,8 @@ class TestAdmitExperimentDeterminism:
             ),
         )
 
-        assert first.admitted and second.admitted
+        assert first.admitted
+        assert second.admitted
         assert first.plan.source_set_digest != second.plan.source_set_digest
         assert first.plan.plan_id != second.plan.plan_id
 
@@ -849,38 +852,42 @@ class TestFuzzAdmitExperimentDeterminism:
 
     @given(target_run_count=st.integers(min_value=1, max_value=30))
     @settings(max_examples=20, deadline=None)
-    def test_repeated_admission_is_deterministic_across_random_flat_counts(self, tmp_path_factory, target_run_count):
+    def test_repeated_admission_is_deterministic_across_random_flat_counts(self, target_run_count):
         bundle, backend, processor = _capability_only_bundle(
             spec_id=f"spec-fuzz-{target_run_count}", target_run_count=target_run_count
         )
-        store = LocalRunStore(tmp_path_factory.mktemp("store"))
+        # hypothesis runs many examples in one function call, so a fresh store
+        # per example comes from a context manager rather than a function-scoped
+        # tmp_path fixture (which hypothesis rejects) or a session-scoped factory.
+        with tempfile.TemporaryDirectory() as store_dir:
+            store = LocalRunStore(Path(store_dir))
 
-        first = admit_experiment(
-            experiment_root=bundle.experiment_root,
-            artifact_source=bundle.artifact_source,
-            run_store=store,
-            policy=default_admission_policy(),
-            environment=AdmissionEnvironment(
-                backend_manifest=backend,
-                processor_manifest=processor,
-            ),
-        )
-        second = admit_experiment(
-            experiment_root=bundle.experiment_root,
-            artifact_source=bundle.artifact_source,
-            run_store=store,
-            policy=default_admission_policy(),
-            environment=AdmissionEnvironment(
-                backend_manifest=backend,
-                processor_manifest=processor,
-            ),
-        )
+            first = admit_experiment(
+                experiment_root=bundle.experiment_root,
+                artifact_source=bundle.artifact_source,
+                run_store=store,
+                policy=default_admission_policy(),
+                environment=AdmissionEnvironment(
+                    backend_manifest=backend,
+                    processor_manifest=processor,
+                ),
+            )
+            second = admit_experiment(
+                experiment_root=bundle.experiment_root,
+                artifact_source=bundle.artifact_source,
+                run_store=store,
+                policy=default_admission_policy(),
+                environment=AdmissionEnvironment(
+                    backend_manifest=backend,
+                    processor_manifest=processor,
+                ),
+            )
 
-        assert first.admitted is True
-        assert second.admitted is True
-        assert first.plan_digest == second.plan_digest
-        assert len(first.trial_ids) == target_run_count
-        assert len(set(first.trial_ids)) == target_run_count
+            assert first.admitted is True
+            assert second.admitted is True
+            assert first.plan_digest == second.plan_digest
+            assert len(first.trial_ids) == target_run_count
+            assert len(set(first.trial_ids)) == target_run_count
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -4201,16 +4201,15 @@ class TestLabOrchestrationContracts:
         from aptl.core.lab import _step_sync_credentials
 
         ctx = self._ctx(tmp_path)  # env stays None
-        try:
+        with pytest.raises(icontract.ViolationError) as exc_info:
             _step_sync_credentials(ctx)
-            pytest.fail("expected ViolationError")
-        except icontract.ViolationError as exc:
-            text = str(exc)
-            # The label must be a narrow, attributable string the CLI can
-            # grep for; raw `EnvVars(...)` repr must not appear.
-            assert "EnvVars(" not in text
-            assert "api_password" not in text
-            assert "INDEXER_PASSWORD" not in text
+
+        text = str(exc_info.value)
+        # The label must be a narrow, attributable string the CLI can
+        # grep for; raw `EnvVars(...)` repr must not appear.
+        assert "EnvVars(" not in text
+        assert "api_password" not in text
+        assert "INDEXER_PASSWORD" not in text
 
     def test_violation_with_secret_bearing_ctx_stays_narrow(self, tmp_path):
         """Tougher property (codex cycle 2 finding #1): when a contract
@@ -4243,21 +4242,20 @@ class TestLabOrchestrationContracts:
             # ssh_key_path stays None — triggers the contract.
         )
 
-        try:
+        with pytest.raises(icontract.ViolationError) as exc_info:
             _step_test_ssh(ctx)
-            pytest.fail("expected ViolationError")
-        except icontract.ViolationError as exc:
-            text = str(exc)
-            # Narrow description survives.
-            assert "ssh_key_is_ready" in text
-            # None of the secret-shaped env values leak.
-            assert "indexer-secret-do-not-leak" not in text
-            assert "api-secret-do-not-leak" not in text
-            assert "cluster-key-do-not-leak" not in text
-            # Nor does any context repr framing.
-            assert "_LabStartContext(" not in text
-            assert "EnvVars(" not in text
-            assert "ctx was" not in text
+
+        text = str(exc_info.value)
+        # Narrow description survives.
+        assert "ssh_key_is_ready" in text
+        # None of the secret-shaped env values leak.
+        assert "indexer-secret-do-not-leak" not in text
+        assert "api-secret-do-not-leak" not in text
+        assert "cluster-key-do-not-leak" not in text
+        # Nor does any context repr framing.
+        assert "_LabStartContext(" not in text
+        assert "EnvVars(" not in text
+        assert "ctx was" not in text
 
 
 class TestOrchestrateLabStartContractMapping:

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -2331,7 +2331,8 @@ class TestResolveHostPortsStep:
 
         notes = " ".join(c.args[0] for c in progress.call_args_list)
         assert "wazuh.dashboard" in notes
-        assert "443" in notes and "20009" in notes
+        assert "443" in notes
+        assert "20009" in notes
 
 
 class TestSeedSuricataVolumesStep:
@@ -4202,7 +4203,7 @@ class TestLabOrchestrationContracts:
         ctx = self._ctx(tmp_path)  # env stays None
         try:
             _step_sync_credentials(ctx)
-            assert False, "expected ViolationError"
+            pytest.fail("expected ViolationError")
         except icontract.ViolationError as exc:
             text = str(exc)
             # The label must be a narrow, attributable string the CLI can
@@ -4244,7 +4245,7 @@ class TestLabOrchestrationContracts:
 
         try:
             _step_test_ssh(ctx)
-            assert False, "expected ViolationError"
+            pytest.fail("expected ViolationError")
         except icontract.ViolationError as exc:
             text = str(exc)
             # Narrow description survives.

--- a/tests/test_network_boundary_helper.py
+++ b/tests/test_network_boundary_helper.py
@@ -14,7 +14,8 @@ HELPER = (
 @pytest.fixture(scope="module")
 def helper():
     spec = importlib.util.spec_from_file_location("network_boundary_helper", HELPER)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tests/test_raes_docker_materializer.py
+++ b/tests/test_raes_docker_materializer.py
@@ -70,7 +70,9 @@ class TestPackages:
         _executor(fake).install_packages("techvault.wazuh-manager", "apt", ("wazuh-manager",))
         container, argv = fake.calls[-1]
         assert container == "aptl-wazuh-manager"
-        assert "apt-get" in argv and "install" in argv and "wazuh-manager" in argv
+        assert "apt-get" in argv
+        assert "install" in argv
+        assert "wazuh-manager" in argv
 
     def test_install_nonzero_raises_translatable_command_error(self):
         fake = _FakeExec(lambda c, a: (100, "E: Unable to locate package"))
@@ -146,8 +148,11 @@ class TestIdentity:
         fake = _FakeExec()
         _executor(fake).ensure_group("n.node", "wazuh", 1000)
         argv = fake.calls[-1][1]
-        assert argv[0] == "groupadd" and "-f" in argv and argv[-1] == "wazuh"
-        assert "-g" in argv and "1000" in argv
+        assert argv[0] == "groupadd"
+        assert "-f" in argv
+        assert argv[-1] == "wazuh"
+        assert "-g" in argv
+        assert "1000" in argv
 
     def test_ensure_user_skips_creation_when_user_exists(self):
         # id -u returns 0 -> user already present -> no useradd.
@@ -163,7 +168,8 @@ class TestIdentity:
         )
         useradd = next(argv for argv in fake.argvs() if argv[0] == "useradd")
         assert useradd[-1] == "wazuh"
-        assert "/bin/bash" in useradd and "wazuh" in useradd  # shell + group
+        assert "/bin/bash" in useradd
+        assert "wazuh" in useradd  # shell + group
 
     def test_observe_local_user_and_group_from_returncode(self):
         present = _executor(_FakeExec(lambda c, a: (0, "")))

--- a/tests/test_raes_materializer.py
+++ b/tests/test_raes_materializer.py
@@ -40,7 +40,8 @@ from aptl.backends.raes_materializer import (
 class TestBaseImageForOs:
     def test_linux_resolves_to_a_fixed_generic_base(self):
         image = base_image_for_os("linux", "")
-        assert isinstance(image, str) and image
+        assert isinstance(image, str)
+        assert image
         # The same os/version always maps to the same base (deterministic).
         assert base_image_for_os("linux", "") == image
 
@@ -241,7 +242,8 @@ class TestPackageFamilyBaseSelection:
         deb = base_image_for_os("linux", "", runs_services=True, family="debian")
         rhel = base_image_for_os("linux", "", runs_services=True, family="rhel")
         assert deb != rhel
-        assert "debian" in deb and "debian" not in rhel
+        assert "debian" in deb
+        assert "debian" not in rhel
 
     def test_unknown_family_fails_closed(self):
         with pytest.raises(UnsupportedOsFamilyError):

--- a/tests/test_raes_materializer_engine.py
+++ b/tests/test_raes_materializer_engine.py
@@ -134,7 +134,8 @@ class TestMaterializeNode:
                 pass  # runs but materializes nothing; observation stays empty
 
         result = materialize_node("techvault.wazuh-manager", ops, _SilentInstall())
-        assert result is not None and result.success is False
+        assert result is not None
+        assert result.success is False
         assert "techvault.wazuh-manager" in (result.error or "")
         assert "wazuh-manager" in (result.error or "")
 
@@ -146,7 +147,8 @@ class TestMaterializeNode:
                 pass  # never becomes active
 
         result = materialize_node("techvault.wazuh-manager", ops, _SilentStart())
-        assert result is not None and result.success is False
+        assert result is not None
+        assert result.success is False
         assert "wazuh-manager.service" in (result.error or "")
 
     def test_backend_error_translates_to_labresult_not_exception(self):
@@ -158,7 +160,8 @@ class TestMaterializeNode:
 
         # No exception escapes; a fail-closed LabResult naming the node is returned.
         result = materialize_node("techvault.wazuh-manager", ops, _Broken())
-        assert result is not None and result.success is False
+        assert result is not None
+        assert result.success is False
         assert "techvault.wazuh-manager" in (result.error or "")
         # The raw internal detail is not echoed verbatim into the envelope.
         assert "hunter2" not in (result.error or "")
@@ -200,7 +203,8 @@ class TestMaterializeNode:
                 pass  # runs but materializes nothing
 
         result = materialize_node("techvault.dns", ops, _SilentDirectory())
-        assert result is not None and result.success is False
+        assert result is not None
+        assert result.success is False
         assert "/var/log/named" in (result.error or "")
 
     def test_dependency_manifest_is_materialized_and_verified(self):
@@ -232,7 +236,8 @@ class TestMaterializeNode:
                 pass  # runs but materializes nothing
 
         result = materialize_node("techvault.sync", ops, _SilentInstall())
-        assert result is not None and result.success is False
+        assert result is not None
+        assert result.success is False
         assert "/app/pyproject.toml" in (result.error or "")
 
     def test_empty_runtime_only_needs_base_substrate(self):

--- a/tests/test_raes_node_desired_state.py
+++ b/tests/test_raes_node_desired_state.py
@@ -20,7 +20,8 @@ class TestExtraction:
         node_spec = {"os": "linux", "os_version": "debian12"}
         assert _node_os(node_spec) == "linux"
         assert _node_os_version(node_spec) == "debian12"
-        assert _node_os(None) == "" and _node_os_version(None) == ""
+        assert _node_os(None) == ""
+        assert _node_os_version(None) == ""
 
     def test_runtime_reconstructed_as_typed_model(self):
         node_spec = {

--- a/tests/test_raes_node_materialization.py
+++ b/tests/test_raes_node_materialization.py
@@ -99,7 +99,8 @@ def test_realize_node_fails_closed_when_state_unverifiable():
             return super().container_exec(name, cmd, timeout=timeout)
 
     result = realize_node(_node(), _SilentBackend())
-    assert result is not None and result.success is False
+    assert result is not None
+    assert result.success is False
     assert "curl" in (result.error or "")
 
 
@@ -130,7 +131,8 @@ def test_realize_nodes_fails_closed_on_first_failure():
             raise RuntimeError("cannot start base")
 
     result = realize_nodes([_node()], _BrokenBackend())
-    assert result is not None and result.success is False
+    assert result is not None
+    assert result.success is False
     assert "techvault.analyst-box" in (result.error or "")
 
 

--- a/tests/test_runstore.py
+++ b/tests/test_runstore.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from aptl.core.runstore import LocalRunStore, RunStoreConflictError
 
 
@@ -445,22 +447,20 @@ class TestSessionScopedHelpers:
 
     def test_session_id_validation_rejects_path_traversal(self, tmp_path):
         store = LocalRunStore(tmp_path / "runs")
-        import pytest as _pytest
 
         for bad in ["../escape", "sess/with/slash", "sess..", ".."]:
-            with _pytest.raises(ValueError):
+            with pytest.raises(ValueError):
                 store.kali_side_session_dir("run-A", bad)
-            with _pytest.raises(ValueError):
+            with pytest.raises(ValueError):
                 store.mcp_session_jsonl("run-A", bad)
 
     def test_run_id_validation_rejects_path_traversal(self, tmp_path):
         store = LocalRunStore(tmp_path / "runs")
-        import pytest as _pytest
 
         for bad in ["../escape", "run/with/slash", ".."]:
-            with _pytest.raises(ValueError):
+            with pytest.raises(ValueError):
                 store.mcp_side_dir(bad)
-            with _pytest.raises(ValueError):
+            with pytest.raises(ValueError):
                 store.kali_side_session_dir(bad, "sess-1")
 
 

--- a/tests/test_techvault_curated_variants.py
+++ b/tests/test_techvault_curated_variants.py
@@ -189,7 +189,8 @@ def test_variant_selection_is_content_driven_not_name_driven(variant: _Variant):
         scenario=renamed, project_dir=PROJECT_ROOT, config=variant.config
     )
 
-    assert original_check.passed and renamed_check.passed
+    assert original_check.passed
+    assert renamed_check.passed
     assert original_details.get("profiles") == renamed_details.get("profiles")
     assert frozenset(original_details.get("profiles", [])) == variant.expected_profiles
 

--- a/tests/test_techvault_live_gate.py
+++ b/tests/test_techvault_live_gate.py
@@ -198,7 +198,9 @@ def test_live_gate_report_passed_failures_categories_and_render():
     assert report.failures() == (bad,)
     assert report.failure_categories() == (CATEGORY_KALI_REACHABILITY,)
     text = report.render()
-    assert "FAIL" in text and "unreachable" in text and "failing layers" in text
+    assert "FAIL" in text
+    assert "unreachable" in text
+    assert "failing layers" in text
     assert LiveGateReport("s", "p", "r", (ok,)).passed is True
 
 
@@ -351,7 +353,8 @@ def test_check_static_prerequisite_passes_and_parses(monkeypatch):
         SCENARIO, project_dir=PROJECT_ROOT, config=_config(), options=LiveGateOptions()
     )
     assert scenario == "SCENARIO-OBJ"
-    assert check.passed and check.category == CATEGORY_RAES_SPECIFICATION
+    assert check.passed
+    assert check.category == CATEGORY_RAES_SPECIFICATION
 
 
 def test_check_static_prerequisite_blocks_on_static_failure(monkeypatch):
@@ -361,7 +364,8 @@ def test_check_static_prerequisite_blocks_on_static_failure(monkeypatch):
     scenario, check = lgc.check_static_prerequisite(
         SCENARIO, project_dir=PROJECT_ROOT, config=_config(), options=LiveGateOptions()
     )
-    assert scenario is None and not check.passed
+    assert scenario is None
+    assert not check.passed
     assert any("static gate failed" in d for d in check.diagnostics)
 
 
@@ -380,7 +384,8 @@ def test_check_raes_driven_boot_happy_populates_state(monkeypatch):
         options=LiveGateOptions(),
         state=state,
     )
-    assert check.passed and check.category == CATEGORY_BACKEND_INSTANTIATION
+    assert check.passed
+    assert check.category == CATEGORY_BACKEND_INSTANTIATION
     assert state.realization_details["nodes"]
     assert state.selected_profiles == ["dmz", "soc"]
     assert state.snapshot["containers"]
@@ -399,7 +404,8 @@ def test_check_raes_driven_boot_fails_on_interpretation_error(monkeypatch):
         options=LiveGateOptions(),
         state=state,
     )
-    assert not check.passed and check.category == CATEGORY_BACKEND_INTERPRETATION
+    assert not check.passed
+    assert check.category == CATEGORY_BACKEND_INTERPRETATION
 
 
 def test_check_raes_driven_boot_fails_on_empty_realization(monkeypatch):
@@ -426,7 +432,8 @@ def test_check_raes_driven_boot_fails_on_boot_failed(monkeypatch):
         options=LiveGateOptions(),
         state=state,
     )
-    assert not check.passed and check.category == CATEGORY_BACKEND_INSTANTIATION
+    assert not check.passed
+    assert check.category == CATEGORY_BACKEND_INSTANTIATION
     assert any("public lab start failed" in d for d in check.diagnostics)
 
 
@@ -451,7 +458,8 @@ def test_check_raes_driven_boot_skips_cleanup_and_reboot_when_requested(monkeypa
     # Non-destructive: no clean boot (cleanup+reboot), but the running lab is
     # still snapshotted and the realization matrix is still computed.
     assert boots == []
-    assert check.passed and state.snapshot["containers"]
+    assert check.passed
+    assert state.snapshot["containers"]
 
 
 def test_check_raes_driven_boot_fails_when_clean_boot_fails(monkeypatch):
@@ -474,7 +482,8 @@ def test_check_raes_driven_boot_fails_when_clean_boot_fails(monkeypatch):
         options=LiveGateOptions(),
         state=state,
     )
-    assert not check.passed and check.category == CATEGORY_BACKEND_INSTANTIATION
+    assert not check.passed
+    assert check.category == CATEGORY_BACKEND_INSTANTIATION
     assert any("public lab start failed" in d for d in check.diagnostics)
 
 
@@ -514,7 +523,8 @@ def test_boot_inputs_pass_for_default_scenario_and_profile():
     check = lgc.check_boot_inputs_match_public_path(
         SCENARIO, project_dir=PROJECT_ROOT, options=LiveGateOptions()
     )
-    assert check.passed and check.category == CATEGORY_BACKEND_INSTANTIATION
+    assert check.passed
+    assert check.category == CATEGORY_BACKEND_INSTANTIATION
 
 
 def test_boot_inputs_pass_for_custom_scenario_when_profile_matches():
@@ -869,7 +879,8 @@ def test_run_archive_roundtrips_to_local_store(tmp_path):
     assert check.passed
     manifest_path = tmp_path / "rid" / "live-gate" / "manifest.json"
     written = manifest_path.read_text()
-    assert "raes_provenance" in written and "realization" in written
+    assert "raes_provenance" in written
+    assert "realization" in written
     # Regression guard: the validation outcome key must survive the run-archive
     # redaction boundary (a `passed` key would be masked as [REDACTED]).
     reloaded = json.loads(written)

--- a/tests/test_wazuh_active_response.py
+++ b/tests/test_wazuh_active_response.py
@@ -719,7 +719,8 @@ class TestWazuhActiveResponseSource:
             f"Wrapper failed to short-circuit on whitelisted 172.20.4.30; "
             f"rc={result.returncode}, stderr={result.stderr[:200]}"
         )
-        assert log.exists() and "SKIPPED for whitelisted 172.20.4.30" in log.read_text(), (
+        assert log.exists()
+        assert "SKIPPED for whitelisted 172.20.4.30" in log.read_text(), (
             f"Log file missing or no SKIPPED entry; contents: "
             f"{log.read_text() if log.exists() else '<no file>'}"
         )


### PR DESCRIPTION
## What

Clears the **SonarCloud new-issue gate** on `dev`, which failed PR #937 with
`SonarCloud new-issue gate failed for branch dev: 56 issue(s)`. All 56 are
pre-existing code smells that count as new code in the `dev` → `main` diff.

## Findings fixed

| Rule | Count | Fix |
|------|-------|-----|
| `python:S9073` | 48 | Split composite `assert A and B` into one assertion per condition (messages preserved; 3-way asserts fully split). |
| `python:S104` | 1 | `src/aptl/utils/pathsafe.py` (518 > 500 lines) split into `_pathsafe_core` (validation + walk primitives), `_pathsafe_read` (open/read/listdir), and `pathsafe` (create-once write path). |
| `python:S1128` | 1 | Unquoted the `AptlRealization` return annotation in `_live_gate_probes.py` so it isn't seen as an unused import. |
| `python:S9084` | 2 | Dropped `import pytest as _pytest` aliases in `test_runstore.py`. |
| `python:S9077` | 2 | `assert False, msg` → `pytest.fail(msg)` in `test_lab.py`. |
| `python:S9002` | 2 | Two hypothesis fuzz tests → `tempfile.TemporaryDirectory` (see note). |

## Notes / judgement calls

- **`pathsafe.py` split keeps the public API identical** — all consumers still
  `from aptl.utils.pathsafe import ...`; names are re-exported via `__all__`.
  The write path stays co-located with `write_all` so the `test_pathsafe`
  monkeypatch (`monkeypatch.setattr(pathsafe, "write_all", ...)`) still
  resolves. The dead, never-referenced `_open_leaf_create_exclusive_nofollow`
  helper was removed as part of the split.
- **S9002 was a false positive**, verified: switching these `@given` fuzz tests
  to a function-scoped `tmp_path` raises `hypothesis FailedHealthCheck`
  (function-scoped fixtures are shared across generated examples). Instead of
  suppressing, they now use a `tempfile.TemporaryDirectory` context manager —
  the replacement hypothesis itself recommends — which mints a fresh store per
  example and removes the flagged `tmp_path_factory` fixture.

## Verification

- `763 passed` across all 24 changed test modules; `test_pathsafe.py` 31/31
  including the two monkeypatch tests; both fuzz tests pass under `-m fuzz`.
- Ruff C901 complexity gate passes; all `pathsafe` importers load.

https://claude.ai/code/session_01L7HuB8gprjeudCz4hPti7n
