### PR TITLE
fix(ci): allow exact dev promotion titles

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -8,12 +8,12 @@ name: PR Title Lint
 # Runs on PRs targeting BOTH `main` and `dev` (issue #852). `main` was previously
 # exempt on the grounds that a `dev`->`main` promotion PR "carries a
 # non-conventional (merge/promotion) title and would always fail this check".
-# That was never a necessity: `make devmain` opens the promotion with
-# `chore(main): promote dev`, which this guard accepts and which release-please
-# treats as a no-release type. Every title that reaches `main` is now checked —
-# the promotion, and release-please's own `chore(main): release X.Y.Z`.
-# `tests/test_promotion_workflow.py` pins both halves so the exemption cannot
-# quietly return.
+# `make devmain` remains the preferred path and opens the promotion with
+# `chore(main): promote dev`, which release-please treats as a no-release type.
+# The checker also accepts GitHub's default `Dev` title only when trusted event
+# fields identify the exact same-repository `dev` -> `main` branch pair. Every
+# other title targeting `main` or `dev` still follows the normal policy.
+# `tests/test_pr_title_guard.py` pins the exact exception and its near-misses.
 #
 # Note the merge-commit subject GitHub writes for a merged promotion
 # (`Merge pull request #N from ...`) is NOT a PR title and is not checked here;

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,10 @@ policy:
 
 # Open the dev -> main promotion PR with the standardized title (issue #852).
 #
-# The title matters: `chore(main): promote dev` satisfies tools/check_pr_title.py,
-# which is why `pr-title-lint.yml` can gate `main` instead of exempting it, and
-# `chore` is a no-release type so the promotion never computes a bump of its own.
+# The title matters: `chore(main): promote dev` is the preferred explicit title,
+# and `chore` is a no-release type so the promotion never computes a bump of its
+# own. The guard also recognizes GitHub's default branch title for the exact
+# same-repository branch pair, so web-created promotions are not fragile.
 #
 # The merge method matters more. Release Please derives the version and
 # CHANGELOG.md from the Conventional Commit subjects on `main`; squashing the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,9 +27,14 @@ make devmain
 ```
 
 That creates a `dev` → `main` PR titled `chore(main): promote dev`. The title is
-fixed rather than free-form for two reasons: it satisfies the PR-title guard (so
-`main` needs no exemption from it), and `chore` is a no-release type, so the
-promotion never computes a version bump of its own.
+fixed rather than free-form because it is unambiguous and `chore` is a
+no-release type, so the promotion never computes a version bump of its own.
+
+GitHub's web and API flows can instead generate the branch title `Dev`. The
+PR-title guard accepts that fallback only when the event identifies the exact
+same-repository `dev` → `main` branch pair. Forks, differently named heads,
+other base branches, and arbitrary titles remain subject to the normal
+Conventional Commit policy.
 
 **Merge the promotion with a merge commit. Do not squash it.** This is the one
 place in the workflow where squashing is wrong. release-please computes the

--- a/tests/test_pr_title_guard.py
+++ b/tests/test_pr_title_guard.py
@@ -6,6 +6,7 @@ run it stdlib-only; these tests exercise its policy as a first-class contract.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -19,6 +20,29 @@ sys.path.insert(0, str(_REPO_ROOT / "tools"))
 import check_pr_title  # noqa: E402
 
 validate_pr_title = check_pr_title.validate_pr_title
+
+
+def _pull_request_event(
+    *,
+    title: str = "Dev",
+    base_repo: str = "Brad-Edwards/aptl",
+    head_repo: str = "Brad-Edwards/aptl",
+    base_ref: str = "main",
+    head_ref: str = "dev",
+) -> dict[str, object]:
+    return {
+        "pull_request": {
+            "title": title,
+            "base": {"ref": base_ref, "repo": {"full_name": base_repo}},
+            "head": {"ref": head_ref, "repo": {"full_name": head_repo}},
+        }
+    }
+
+
+def _run_with_event(tmp_path: Path, event: dict[str, object]) -> int:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+    return check_pr_title.main(["--event-path", str(event_path)])
 
 
 @pytest.mark.parametrize(
@@ -95,3 +119,27 @@ def test_accepts_every_title_the_release_path_emits(title: str, origin: str) -> 
     release path, and it should break here first.
     """
     assert validate_pr_title(title) == [], f"would block {origin}"
+
+
+def test_accepts_platform_title_for_exact_same_repo_promotion(tmp_path: Path) -> None:
+    assert _run_with_event(tmp_path, _pull_request_event()) == 0
+
+
+@pytest.mark.parametrize(
+    ("override", "value"),
+    [
+        ("base_repo", "someone/aptl"),
+        ("head_repo", "someone/aptl"),
+        ("base_ref", "dev"),
+        ("head_ref", "dev-copy"),
+    ],
+)
+def test_rejects_platform_title_for_promotion_near_misses(
+    tmp_path: Path, override: str, value: str
+) -> None:
+    assert _run_with_event(tmp_path, _pull_request_event(**{override: value})) == 1
+
+
+def test_exact_promotion_does_not_exempt_an_arbitrary_title(tmp_path: Path) -> None:
+    event = _pull_request_event(title="ship whatever")
+    assert _run_with_event(tmp_path, event) == 1

--- a/tests/test_promotion_workflow.py
+++ b/tests/test_promotion_workflow.py
@@ -2,17 +2,17 @@
 
 Two halves of one contract:
 
-* `make devmain` opens the promotion PR with a title the PR-title guard accepts.
-* `pr-title-lint.yml` actually runs on `main`, not just `dev`.
+* `make devmain` opens the preferred promotion PR with a conventional title.
+* `pr-title-lint.yml` runs on `main` and recognizes only the exact branch-pair
+  fallback pinned in `test_pr_title_guard.py`.
+* the substantive checks workflow continues to run for promotions.
 
 They are tested together because each is what justifies the other. The workflow
-previously exempted `main` on the stated grounds that "a `dev`->`main` promotion
-PR carries a non-conventional (merge/promotion) title and would always fail this
-check". Standardizing the title through the Make target removes that premise; if
-the target's title ever drifts away from the guard's policy, the exemption's
-reasoning quietly becomes true again and `main` PRs start failing. So the title
-the target emits is asserted against the *real* validator rather than against a
-copy of its regex.
+previously exempted `main` on the stated grounds that a promotion would carry a
+non-conventional title. The Make target avoids that failure by construction,
+while the event-aware fallback covers other creation paths without exempting
+ordinary PRs. The target's title is asserted against the *real* validator rather
+than against a copy of its regex.
 
 Note what this does NOT claim: a workflow trigger makes the check run, not merge.
 Whether `PR title lint` blocks a merge is live branch-protection configuration,
@@ -30,6 +30,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr-title-lint.yml"
+CHECKS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "checks.yml"
 MAKEFILE = REPO_ROOT / "Makefile"
 
 # Reuse the repository's single title validator rather than reimplementing its
@@ -142,3 +143,26 @@ def test_pr_title_lint_reads_the_title_without_shell_interpolation() -> None:
         "the title must reach the checker via $GITHUB_EVENT_PATH, never a "
         "workflow expression interpolated into a shell command"
     )
+
+
+def test_substantive_checks_stay_enabled_for_promotions() -> None:
+    """Promotion title handling must not bypass the repository's real gates."""
+    workflow = yaml.safe_load(CHECKS_WORKFLOW.read_text(encoding="utf-8"))
+    branches = workflow[True]["pull_request"]["branches"]
+    assert set(branches) == {"main", "dev"}
+
+    expected_jobs = {
+        "pre-commit",
+        "docs",
+        "python-tests",
+        "python-cross-platform",
+        "mcp-tests",
+        "web-tests",
+        "dependency-audit",
+        "trivy-fs",
+        "trivy-iac",
+        "trivy-image",
+        "osv-scanner",
+        "sonarcloud",
+    }
+    assert expected_jobs <= set(workflow["jobs"])

--- a/tools/check_pr_title.py
+++ b/tools/check_pr_title.py
@@ -13,6 +13,8 @@ Policy:
   * Reject agent/tool advertising bracketed prefixes such as ``[codex] ...``,
     ``[claude] ...``, ``[openai] ...``, ``[chatgpt] ...`` (case-insensitive),
     on every target branch including ``dev``.
+  * Accept GitHub's default ``Dev`` title only for an exact same-repository
+    ``dev`` -> ``main`` promotion identified from trusted event fields.
   * Enforce the conventional title shape ``<type>(<optional-scope>): <subject>``
     with a single allowed type.
   * Require the subject to start lowercase (``^[a-z].*$``).
@@ -62,6 +64,11 @@ RULE_AGENT_BRAND = "pr-title-agent-brand"
 RULE_CONVENTIONAL = "pr-title-conventional"
 RULE_SUBJECT_LOWERCASE = "pr-title-subject-lowercase"
 RULE_EMPTY = "pr-title-empty"
+
+PROMOTION_REPOSITORY = "Brad-Edwards/aptl"
+PROMOTION_BASE_REF = "main"
+PROMOTION_HEAD_REF = "dev"
+PROMOTION_PLATFORM_TITLE = "Dev"
 
 
 @dataclass(frozen=True)
@@ -156,14 +163,44 @@ def validate_pr_title(
     return violations
 
 
-def _resolve_title(args: argparse.Namespace) -> str | None:
-    """Resolve the PR title without ever shell-interpolating untrusted data.
+def is_platform_titled_promotion(event: object) -> bool:
+    """Return whether trusted event fields identify the narrow title exception."""
+    if not isinstance(event, dict):
+        return False
+
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return False
+
+    base = pull_request.get("base")
+    head = pull_request.get("head")
+    if not isinstance(base, dict) or not isinstance(head, dict):
+        return False
+
+    base_repo = base.get("repo")
+    head_repo = head.get("repo")
+    if not isinstance(base_repo, dict) or not isinstance(head_repo, dict):
+        return False
+
+    return (
+        pull_request.get("title") == PROMOTION_PLATFORM_TITLE
+        and base_repo.get("full_name") == PROMOTION_REPOSITORY
+        and head_repo.get("full_name") == PROMOTION_REPOSITORY
+        and base.get("ref") == PROMOTION_BASE_REF
+        and head.get("ref") == PROMOTION_HEAD_REF
+    )
+
+
+def _resolve_title(
+    args: argparse.Namespace,
+) -> tuple[str | None, dict[str, object] | None]:
+    """Resolve title and event without shell-interpolating untrusted data.
 
     Priority: explicit ``--title`` (local/testing) -> ``$GITHUB_EVENT_PATH``
     JSON (the CI path) -> ``PR_TITLE`` env var.
     """
     if args.title is not None:
-        return args.title
+        return args.title, None
 
     event_path = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
     if event_path:
@@ -175,16 +212,24 @@ def _resolve_title(args: argparse.Namespace) -> str | None:
                 f"pr-title-guard: could not read event JSON from {event_path}: {exc}",
                 file=sys.stderr,
             )
-            return None
-        title = (event.get("pull_request") or {}).get("title")
-        if title is None:
+            return None, None
+        if not isinstance(event, dict):
+            print(
+                "pr-title-guard: event JSON root must be an object.",
+                file=sys.stderr,
+            )
+            return None, None
+        pull_request = event.get("pull_request")
+        title = pull_request.get("title") if isinstance(pull_request, dict) else None
+        if not isinstance(title, str):
             print(
                 "pr-title-guard: no pull_request.title in event payload.",
                 file=sys.stderr,
             )
-        return title
+            return None, event
+        return title, event
 
-    return os.environ.get("PR_TITLE")
+    return os.environ.get("PR_TITLE"), None
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -203,7 +248,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    title = _resolve_title(args)
+    title, event = _resolve_title(args)
     if title is None:
         # Fail closed: a pull_request event should always carry a title.
         print(
@@ -212,7 +257,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 2
 
-    violations = validate_pr_title(title)
+    violations = [] if is_platform_titled_promotion(event) else validate_pr_title(title)
     if violations:
         print(f"pr-title-guard: rejected PR title: {title!r}", file=sys.stderr)
         for violation in violations:


### PR DESCRIPTION
## Summary

Allow GitHub-generated promotion titles only for the trusted same-repository dev-to-main branch pair while retaining normal title policy everywhere else.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #940

## ADR Impact

- ADR-021

## Changes

- Classify the exact Brad-Edwards/aptl dev-to-main event before applying the Conventional Commit title rules.
- Cover the accepted platform title, rejected repository and branch near-misses, and continued substantive promotion checks.
- Document make devmain as the preferred path and the branch-pair-aware web/API fallback.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Focused policy tests and the configured repository completion, policy, and pre-commit gates pass.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.