### PR TITLE
fix: derive lab-start pre-flight from the admitted realization

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -172,6 +172,82 @@ jobs:
         # measurement is not a concern.
         run: python -m pytest tests/test_techvault_static_gate.py -q -m integration -n auto
 
+  fresh-start-preflight:
+    name: Fresh-install lab-start pre-flight (issue #951)
+    runs-on: ubuntu-latest
+    # Blocking, and deliberately separate from `python-tests`: admitting the
+    # bundled env-pack needs Docker and takes minutes, which does not belong in
+    # the fast coverage run. It is the unit-level counterpart to
+    # `clean-install-lab-boot` — same regression, checked from a materialized
+    # project directory without booting containers.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - run: |
+          pip install --require-hashes -r requirements/dev.txt
+          pip install -e . --no-deps --no-build-isolation
+          pip install -e ./plugins/aptl-techvault-pack-interaction --no-deps --no-build-isolation
+      - run: python -m pytest tests/test_lab_fresh_start.py -q -m integration
+
+  clean-install-lab-boot:
+    name: Clean-install lab boot and teardown (DEP-008)
+    runs-on: ubuntu-latest
+    # DEP-008 promises `pipx install aptl-labs && aptl lab init && aptl lab start`
+    # produces a working lab with no git clone. Nothing proved it: every other
+    # job installs the project editable from the checkout, and a developer
+    # checkout carries gitignored generated state (config/soc_certs/, .aptl/)
+    # that hides a fresh-install failure entirely. Issue #951 shipped exactly
+    # that failure to PyPI in 5.2.0 — the quick start failed in nine seconds for
+    # every scenario. This boots the smallest curated scenario from the built
+    # wheel in a clean environment so the released artifact is what gets tested.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Build the wheel with the locked, no-isolation toolchain
+        run: |
+          pip install --require-hashes -r requirements/ci.txt
+          python -m build --wheel --no-isolation --outdir dist/
+      - name: Install the wheel into a clean virtual environment
+        # Deliberately NOT `pip install -e .`, not the checkout's CLI, and not
+        # the local pack-interaction plugin: any of those would test something
+        # other than the artifact users install. `--no-deps` after the locked
+        # runtime set keeps the dependency closure pinned and hash-verified.
+        run: |
+          python -m venv "$RUNNER_TEMP/clean-venv"
+          "$RUNNER_TEMP/clean-venv/bin/pip" install --require-hashes -r requirements/runtime.txt
+          "$RUNNER_TEMP/clean-venv/bin/pip" install --no-deps dist/*.whl
+      - name: Materialize a lab project from the installed package
+        # Run from an empty directory so nothing in the checkout can satisfy an
+        # asset the wheel forgot to ship.
+        run: |
+          mkdir -p "$RUNNER_TEMP/clean-install"
+          cd "$RUNNER_TEMP/clean-install"
+          "$RUNNER_TEMP/clean-venv/bin/aptl" lab init ci-lab
+          test ! -e ci-lab/config/soc_certs
+          test ! -e ci-lab/.aptl
+      - name: Start the smallest curated scenario
+        # `aptl lab start` enforces the documented vm.max_map_count prerequisite
+        # on a native Linux Docker Engine, so the runner satisfies it the same
+        # way docs/getting-started/prerequisites.md tells an operator to.
+        run: |
+          sudo sysctl -w vm.max_map_count=262144
+          cd "$RUNNER_TEMP/clean-install/ci-lab"
+          "$RUNNER_TEMP/clean-venv/bin/aptl" lab start --scenario techvault-observability-core
+      - name: Stop the lab and remove its volumes
+        if: always()
+        run: |
+          cd "$RUNNER_TEMP/clean-install/ci-lab"
+          "$RUNNER_TEMP/clean-venv/bin/aptl" lab stop --volumes --yes
+      - name: Assert no project containers, networks, or volumes remain
+        if: always()
+        run: |
+          "$RUNNER_TEMP/clean-venv/bin/python" scripts/ci/assert_project_teardown.py \
+            "$RUNNER_TEMP/clean-install/ci-lab"
+
   mcp-tests:
     name: MCP TypeScript tests + coverage
     runs-on: ubuntu-latest

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,6 +156,7 @@ The victim and kali containers publish no host ports; use
 
 ## Preflights
 
+- [Issue #951 Fresh Env-Pack Start](issue-951-fresh-env-pack-start-preflight.md)
 - [Issue #913 Shuffle Post-Realization Mutation](issue-913-shuffle-post-realization-mutation-preflight.md)
 - [Issue #905 Lab Lifecycle Robustness](issue-905-lab-lifecycle-robustness-preflight.md)
 - [Issue #874 Scenario-Bundle Realization Roots](issue-874-scenario-bundle-realization-roots-preflight.md)

--- a/docs/architecture/issue-951-fresh-env-pack-start-preflight.md
+++ b/docs/architecture/issue-951-fresh-env-pack-start-preflight.md
@@ -1,0 +1,201 @@
+# Issue #951 Fresh Env-Pack Start Preflight
+
+This note fixes the architecture boundary for the clean-install startup
+regression in issue #951. It is design guidance, not an implementation plan.
+No new ADR is needed: the accepted authorities are already
+[the scenario-bundle root boundary](issue-874-scenario-bundle-realization-roots-preflight.md),
+[the env-pack admission boundary](issue-875-scenario-content-declaration-preflight.md),
+[the certificate producer boundary](issue-677-cert-producer-ownership-preflight.md),
+and [the lifecycle cleanup boundary](issue-905-lab-lifecycle-robustness-preflight.md).
+
+## Architecture Decisions
+
+### Resolve and admit the selected bundle once
+
+Scenario selection has one precedence rule: an explicit catalog/path selection
+is a project-tree bundle; otherwise `ScenarioSourceConfig` selects the configured
+env-pack or project-tree source. `config.scenario.source` therefore does not, by
+itself, describe the source of the scenario being started. Code that skips a
+legacy producer because the config default says `env-pack` is wrong when the
+operator supplied a catalog or explicit path.
+
+The public start must reuse `resolve_scenario_bundle()`. A missing default
+project-tree filename must not be substituted before that resolver runs, and a
+missing file must not silently mean “no ownership.” In particular,
+`DEFAULT_RAES_SCENARIO` is not the default env-pack's location and must not be
+used by lab-start preflight when `scenario_path is None`.
+
+Resolve the `ScenarioBundle`, parse it, create the `RuntimeTarget`, and produce
+the RAES `ExecutionPlan` once. The same target, plan, and
+`AptlProvisioner.realize_plan()` result must drive pre-mutation decisions and
+the later `RuntimeManager.apply()`. Reuse the provisioner's existing cached
+`AptlRealization`; do not create a second ownership DTO, reparse/replan in
+`_load_stateful_artifact_ownership()`, or stage the same env-pack twice.
+Request-scoped orchestration may carry these existing objects through
+`_LabStartContext`; they are not a new persisted or public schema.
+
+### Validate the model that will actually be applied
+
+The bind-source preflight has one narrow purpose: stop Docker from fabricating
+a missing host source as a root-owned directory. It is not an alternate
+authority for scenario membership, generated-artifact consumers, or mount
+destinations.
+
+For a project-tree bundle, the static `docker-compose.yml` remains the model and
+its bind check is a compatibility guard. It must be limited to the profiles
+selected by the admitted realization, not the broader `AptlConfig.containers`
+ceiling. This is what keeps a reduced catalog scenario from validating SOC
+services it does not start.
+
+For an env-pack bundle, the project directory's `docker-compose.yml` is not an
+input to realization. The backend generates the base model and its stateful and
+content overrides from `DeploymentRealizationSpec`. Lab orchestration must not
+scan the unrelated static file. Bind-source existence belongs in the existing
+fully merged, `--no-interpolate` effective-model validation after generated
+artifacts and content have been materialized and before `compose up`.
+`effective_stateful_model_errors()`, provider output checks, and content
+placement/readback remain the semantic validators; do not reproduce them in
+`core.lab`.
+
+Mount targets are still checked against the admitted consumer contract in the
+backend's effective-model validation. Do not compare a target from the static
+Compose compatibility model with a target from the env-pack realization. If a
+narrow compatibility exemption is retained during migration, its existence
+claim may match only the exact admitted service plus canonical generated source
+under `DeploymentBackend.realization_root`; destination matching remains the
+effective model's job. No scenario name, service allowlist, TechVault path, or
+certificate filename may select the exemption.
+
+Generated output paths for an env-pack are rooted at the backend's writable
+`realization_root` (`project_dir` for local Compose), not the pristine staged
+`ScenarioBundle.root`. The pack root remains the authority for immutable input
+bytes. Confusing these roots recreates the same defect with a different path.
+
+### Prove the distributed artifact and cleanup contract
+
+The regression gate must exercise the product users install, not an editable
+checkout. Build the wheel with the existing locked, no-isolation toolchain;
+install locked runtime dependencies plus that wheel into a clean virtual
+environment; do not install the project editable or copy ignored generated
+state. Run the public `aptl lab init`, start
+`techvault-observability-core`, and run `aptl lab stop -v --yes`.
+
+Teardown verification is project-scoped. Reuse the identities and query rules
+from `observe_project_runtime()` and `_compose_volume_cleanup`: both Compose and
+direct-materializer container labels, the Compose project network label, and
+the validated `<project_name>_` volume namespace. Assert zero containers,
+networks, and volumes. Never use names such as `aptl-*` as the sole authority,
+and never use a daemon-wide prune. Cleanup must run on failure as well as
+success, while a failed start or failed cleanup still fails the job.
+
+The `5.2.1` version and changelog are release-please outputs. The fix PR needs a
+`fix:` Conventional Commit title; implementation must not hand-edit
+`pyproject.toml`, `src/aptl/__init__.py`, `CHANGELOG.md`, or the release manifest
+to publish the patch.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical owner and required reuse |
+| --- | --- |
+| Scenario selection and source | `ScenarioCatalog`, `resolve_scenario_selection()`, `ScenarioSourceConfig`, `resolve_scenario_bundle()`, `ScenarioBundle`, and `ScenarioSourceKind`. Explicit selection precedence stays in the resolver. |
+| Pack ingress | `env_pack_bundle()`, `validate_pack()`, `validate_pack_content_manifest()`, per-invocation contained staging, and `aptl.utils.pathsafe`. No local pack schema or fallback search. |
+| Admission and interpretation | `_plan_scenario()`, RAES parser/compiler/planner diagnostics, `RuntimeTarget`, `ExecutionPlan`, `AptlProvisioner.realize_plan()`, `AptlRealization`, and `DeploymentRealizationSpec`. One admitted execution, not a query plan plus an apply plan. |
+| Generated artifacts | `raes_stateful_realization.py`, `artifact_source_path()`, `ComposeStatefulRealizationMixin`, `stateful_realization_errors()`, provider-specific output validation, and `DeploymentBackend.realization_root`. |
+| Compose model | `base_compose_file()`, `_realization_compose_files()`, `_validate_realization_compose_model()`, `effective_stateful_model_errors()`, and `_build_command()`. Validate the merged model with no interpolation; do not add another Compose parser. |
+| Config and secrets | Strict `AptlConfig` models, `hydrate_dotenv()`, `load_dotenv()`, `EnvVars`, placeholder rejection, owner-only generated files, ADR-029 redaction, and explicit `project_dir/.env` Compose binding. |
+| Results and observability | RAES `Diagnostic`, `render_raes_diagnostics()`, `LabResult`, `StartupOutcome`, `StartupDiagnostic`, `get_logger()`, and `redact()`. No new exception hierarchy or API envelope. |
+| Distribution | `_asset_manifest.py`, `hatch_build.py`, `assets.materialize()`, `.gitignore`, wheel-content tests, locked requirements, and the existing release workflow. Generated certs, keys, `.env`, and `.aptl/` remain absent from artifacts. |
+| Lifecycle cleanup | `lifecycle_mutation_lock()`, `stop_lab()`, `stop_compose_lab()`, `observe_project_runtime()`, project-label cleanup, and `project_scoped_volume_names()`. |
+
+## Security And Cross-Cutting Passage
+
+| Layer | Required behavior |
+| --- | --- |
+| Auth surface | This issue adds no endpoint or authorization decision. Existing API token, Host, CSRF, session, and CLI boundaries remain unchanged; the CI job uses only the local CLI. |
+| Config shape | `aptl.json` continues through Pydantic models with `extra="forbid"`; scenario identity/source and validated `deployment.project_name` remain the only durable selectors. Add no bind-preflight toggle, service list, or path map. |
+| Catalog/path gate | Catalog entries and explicit paths pass the existing id schema, no-follow project containment, and RAES parse validation. An explicit path is never reclassified from the config default. |
+| Pack shape and bytes | Env-pack acquisition passes both public env-packs validators, exact inventory/digest checks, no-symlink/hardlink/special-file rules, and contained immutable staging. A missing/rejected pack fails closed as `EnvPackError`; it never falls back to a deleted project path. |
+| RAES shape and policy | Generated outputs, consumers, service bindings, access modes, sensitivity, dependencies, and destinations pass RAES validation and APTL's existing typed lowering/stateful graph checks before mutation. |
+| Filesystem and secret handling | Immutable pack input uses `ScenarioBundle.root`; generated output uses `realization_root`; operator secrets use `project_dir/.env`. Preserve canonical contained paths, no-follow checks, atomic writes, restrictive modes, declared-output completeness, and package exclusions. No PEM, private-key, token, or env bytes enter mount metadata or evidence. |
+| Compose/effective model | Use the existing argv-list runner, explicit project directory/env file, bounded timeouts, `--no-interpolate`, and normalized effective model. Do not serialize, log, or persist the rendered model because it can carry sensitive configuration. |
+| OS/process exposure | Only non-secret paths and fixed Docker/Compose options may appear in argv. Do not add `shell=True`, command strings, credential-bearing URLs, env dumps, or raw Docker output. Local/SSH visibility continues through `supports_local_artifacts` and the existing remote-artifact refusal/probe boundaries. |
+| Error envelope | Pack/parser/planner errors become bounded, redacted diagnostics; producer/backend failures stay unsuccessful `LabResult`/RAES apply results. Do not expose raw YAML parser context, absolute staging roots, full commands, Compose stderr, tracebacks, or environment mappings. |
+| Logging/persistence | Log bounded phase, source kind, stable diagnostic code, service/address, and counts through `get_logger()`/`redact()`. `ScenarioBundle.details()` continues to omit roots; run records retain identities/digests and outcomes, never generated bytes or operational paths. |
+| CI authority | Keep workflow permissions read-only, pin actions by SHA, use hashed dependency exports, install the wheel with `--no-deps` after the locked runtime set, and scope every Docker assertion to the validated Compose project identity. |
+
+## Extensibility Seam
+
+The seam is the already-selected, request-scoped `ScenarioBundle` plus the one
+admitted `ExecutionPlan` and cached `AptlRealization`. The next pack identity,
+catalog scenario, or immutable acquisition mechanism changes the resolver input;
+it does not add branches to lab steps or teach the static Compose checker about
+new services.
+
+The bind-validation parameter is the actual model source (`project-tree` static
+model or generated effective model) and its backend `realization_root`. A future
+remote-materialization implementation can change how that backend proves source
+existence without changing RAES, the catalog, or lab orchestration. The CI
+scenario id and project name are explicit inputs; resource assertions derive
+from the project identity rather than copied container/network lists.
+
+## Whole-Repository Surface In Scope
+
+- Selection/admission: `src/aptl/core/{config,scenario_catalog,scenario_bundle,lab}.py`
+  and `src/aptl/backends/{raes,_raes_scenario_resolution,_raes_scenario_queries,raes_provisioner,raes_realization}.py`.
+- Realization: `src/aptl/core/deployment/{backend,docker_compose,realization,`
+  `_compose_realization,_compose_model_realization,_compose_stateful_*,`
+  `_compose_content_mounts}.py`.
+- Secrets/errors: `src/aptl/core/{env,credentials,soc_ca,lab_types}.py`,
+  `src/aptl/utils/{pathsafe,redaction,logging}.py`, and CLI/API result projections.
+- Distribution/workflow: `src/aptl/_asset_manifest.py`, `hatch_build.py`,
+  `pyproject.toml`, locked requirements, `.gitignore`, `.github/workflows/checks.yml`,
+  `.github/workflows/release-please.yml`, and `docs/releasing.md`.
+- Cleanup: lifecycle lock/orchestration plus `_compose_stop`,
+  `_compose_runtime_inventory`, `_compose_project_cleanup`, and
+  `_compose_volume_cleanup`.
+- Verification: lab, scenario-bundle/catalog, env-pack, stateful/effective-model,
+  asset/wheel, lifecycle/cleanup, and current-catalog scenario tests. The public
+  catalog is data; coverage must not copy a fixed count of four entries now that
+  the repository contains another catalog scenario.
+
+## Gotchas And Anti-Patterns
+
+- Do not infer actual source kind from `config.scenario.source` after an
+  explicit scenario path has won selection.
+- Do not replace `None` with `DEFAULT_RAES_SCENARIO` before env-pack resolution,
+  and do not silently return when that deleted file is absent.
+- Do not resolve/stage the bundle once for display, again for ownership, and a
+  third time for apply. Distinct staging paths are not proof of one admitted
+  execution.
+- Do not compare static-Compose destinations with generated-model destinations
+  or weaken destination validation globally to make two unrelated models agree.
+- Do not compute generated source paths from the pristine pack root when the
+  backend writes them under its realization root.
+- Do not key behavior on `techvault`, `misp`, `thehive`, `shuffle`, `cortex`, a
+  certificate filename, or `/opt/aptl/soc-certs`.
+- Do not add another tuple/DTO mirroring generated artifacts, another YAML or
+  Compose schema, another validation pass, or another exception hierarchy.
+- Do not treat a developer's ignored generated state as a fixture. Start tests
+  from `assets.materialize()`/the public init path and assert the relevant
+  generated roots are initially absent.
+- Do not let the wheel CI use `pip install -e .`, the source checkout's CLI,
+  or a separately installed local integration plugin; those bypass the released
+  artifact contract under test.
+- Do not make teardown best-effort in CI, assert only running containers, or use
+  broad name prefixes/global prune. Include stopped containers, networks, and
+  volumes, and fail when absence cannot be proved.
+- Do not hand-edit release versions or changelog entries for `5.2.1`.
+
+## Non-Goals And Boundaries
+
+This issue does not redesign RAES or env-packs schemas, change scenario content,
+add a pack-specific provider, migrate all legacy project-tree producers, add a
+deployment backend, weaken TLS/credential policy, alter participant behavior or
+readiness, or make remote Docker consume controller-local generated files.
+
+It does not make `docker compose up` a supported replacement for `aptl lab
+start`, ship generated credentials/certificates in the wheel, rename services,
+or revise the intended topology. The implementation boundary is correct
+scenario selection, one admitted realization, validation of the model actually
+applied, clean wheel-installed startup, project-scoped teardown proof, and the
+normal automated patch-release workflow.

--- a/docs/requirements/DEP-008/requirement.md
+++ b/docs/requirements/DEP-008/requirement.md
@@ -6,7 +6,7 @@ type: FUNCTIONAL
 priority: SHOULD
 wave: 2
 created_at: 2026-07-06T08:00:25.969813Z
-updated_at: 2026-07-06T18:33:10.977695Z
+updated_at: 2026-09-04T00:00:00.000000Z
 ---
 
 # DEP-008: Self-Contained Distribution of Lab Assets from Installed Package
@@ -29,3 +29,6 @@ PyPI publication (#651, #656) installs the `aptl` CLI but not the lab assets, so
 - TESTS → TEST `tests/test_assets.py` (Asset resolution + materialization + secret-exclusion tests)
 - TESTS → TEST `tests/test_hatch_build_hook.py` (Build-hook selection + wheel-content regression tests)
 - TESTS → TEST `tests/test_lab_init_cli.py` (aptl lab init CLI end-to-end tests)
+- TESTS → TEST `tests/test_lab_fresh_start.py` (Lab-start pre-flight from a freshly materialized project, no generated state)
+- TESTS → TEST `scripts/ci/assert_project_teardown.py` (Project-scoped teardown proof for the clean-install boot gate)
+- IMPLEMENTS → CONFIG `.github/workflows/checks.yml` (clean-install-lab-boot and fresh-start-preflight CI gates: build the wheel, install it clean, init, boot, tear down)

--- a/docs/requirements/DSL-008/requirement.md
+++ b/docs/requirements/DSL-008/requirement.md
@@ -6,7 +6,7 @@ type: FUNCTIONAL
 priority: MUST
 wave: 1
 created_at: 2026-03-24T02:44:23.438740Z
-updated_at: 2026-06-25T01:41:02.775104Z
+updated_at: 2026-09-04T00:00:00.000000Z
 ---
 
 # DSL-008: APTL Realization of ACES Infrastructure Topology
@@ -32,3 +32,7 @@ After ADR-035 and SCN-010, ACES SDL owns scenario authoring and topology declara
 - IMPLEMENTS → CODE_FILE `src/aptl/backends/raes.py`
 - IMPLEMENTS → CODE_FILE `src/aptl/backends/raes_realization_model.py`
 - IMPLEMENTS → CODE_FILE `src/aptl/backends/raes_diagnostics.py`
+- IMPLEMENTS → CODE_FILE `src/aptl/backends/_raes_scenario_queries.py` (Admit one scenario execution; project the pre-start facts lab start reads)
+- IMPLEMENTS → CODE_FILE `src/aptl/backends/raes_runtime_observation.py` (Trusted observation of declared runtime concerns on the realized range)
+- IMPLEMENTS → CODE_FILE `src/aptl/backends/_runtime_concern_excess.py` (Excess/scope detection and the runtime baselines subtracted before rejection)
+- TESTS → TEST `tests/test_raes_runtime_observation.py` (Realization-observation gate tests, including the runtime-baseline carve-outs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - "Issue #874 Scenario-Bundle Realization Roots Preflight": architecture/issue-874-scenario-bundle-realization-roots-preflight.md
     - "Issue #878 Scenario Verification Plugin Seam Preflight": architecture/issue-878-scenario-verification-plugin-seam-preflight.md
     - "Issue #905 Lab Lifecycle Robustness Preflight": architecture/issue-905-lab-lifecycle-robustness-preflight.md
+    - "Issue #951 Fresh Env-Pack Start Preflight": architecture/issue-951-fresh-env-pack-start-preflight.md
   - Deployment: deployment.md
   - Components:
     - Wazuh SIEM: components/wazuh-siem.md

--- a/scripts/ci/assert_project_teardown.py
+++ b/scripts/ci/assert_project_teardown.py
@@ -1,0 +1,74 @@
+"""Prove a stopped lab left no project-scoped Docker resources behind.
+
+The clean-install regression gate (issue #951) boots a lab from the built wheel
+and tears it down; this asserts the teardown actually removed everything. It
+runs against the *installed* package, so it reuses the same identities and query
+rules production teardown uses rather than restating them:
+
+- containers and networks through ``DeploymentBackend.observe_project_runtime``,
+  which counts stopped containers and both admitted project labels;
+- volumes through ``project_scoped_volume_names``, whose ``<project>_`` prefix
+  catches ADR-043 seeded volumes that carry no Compose label at all.
+
+Both are scoped to the validated Compose project identity from the lab's own
+``aptl.json``. A name prefix such as ``aptl-*`` is never the authority, and
+nothing here prunes daemon-wide state.
+
+Absence that cannot be *proved* is a failure: a Docker query that errors exits
+non-zero rather than reporting a clean lab.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from aptl.core.config import find_config, load_config
+from aptl.core.deployment import get_backend
+from aptl.core.deployment._compose_volume_cleanup import project_scoped_volume_names
+
+_VOLUME_QUERY_TIMEOUT = 60
+
+
+def main(argv: list[str]) -> int:
+    """Return 0 only when the project owns no containers, networks, or volumes."""
+
+    project_dir = Path(argv[1] if len(argv) > 1 else ".").resolve()
+    config_path = find_config(project_dir)
+    if config_path is None:
+        print(f"No aptl.json found in {project_dir}", file=sys.stderr)
+        return 2
+    config = load_config(config_path)
+    backend = get_backend(config, project_dir)
+    project_name = config.deployment.project_name
+
+    failures: list[str] = []
+    presence = backend.observe_project_runtime()
+    if presence.error:
+        failures.append(f"runtime presence could not be observed: {presence.error}")
+    if presence.container_count:
+        failures.append(f"{presence.container_count} project container(s) remain")
+    if presence.network_count:
+        failures.append(f"{presence.network_count} project network(s) remain")
+
+    # `_compose_stop` calls this helper with the backend's own runner; reuse the
+    # same pairing so the gate and teardown ask Docker the identical question.
+    volumes, volume_error = project_scoped_volume_names(
+        project_name, backend._run, timeout=_VOLUME_QUERY_TIMEOUT
+    )
+    if volume_error:
+        failures.append(f"project volumes could not be listed: {volume_error}")
+    if volumes:
+        failures.append(f"project volume(s) remain: {', '.join(sorted(volumes))}")
+
+    if failures:
+        print(f"Teardown left project '{project_name}' dirty:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print(f"Project '{project_name}': no containers, networks, or volumes remain.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/aptl/backends/_raes_scenario_queries.py
+++ b/src/aptl/backends/_raes_scenario_queries.py
@@ -3,92 +3,127 @@
 Split out of :mod:`aptl.backends.raes` so that module keeps the start/apply flow
 while this one carries the read-only queries the CLI and lab lifecycle ask
 before (and instead of) a start: which Compose profiles a scenario selects, and
-which stateful artifact mounts the admitted graph owns. Both plan through the
-same RAES runtime manager the start path uses, so an answer here and a start
-cannot disagree; neither applies the plan.
+which stateful artifact mounts the admitted graph owns. Both project the same
+admission the start path applies, so an answer here and a start cannot disagree;
+neither applies the plan.
 
-The planning seams (``create_aptl_runtime_target``, ``parse_sdl_file``,
-``RuntimeManager``, ``artifact_availability_for_scenario``) are resolved from
-``aptl.backends.raes`` at call time rather than bound at import: that module
-stays the single composition surface for them, so substituting one there governs
-every path that plans a scenario, this one included.
+``aptl.backends.raes.admit_raes_scenario`` is resolved at call time rather than
+bound at import: that module stays the single composition surface for the
+planning seams, so substituting one there governs every path that plans a
+scenario, this one included.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from aptl.backends.raes_diagnostics import render_raes_diagnostics
 from aptl.backends.raes_profiles import select_backend_profiles
-from aptl.backends.raes_realization import interpret_provisioning_plan
 from aptl.core.config import AptlConfig
 from aptl.core.deployment._compose_stateful_model import artifact_source_path
+from aptl.core.scenario_bundle import ScenarioSourceKind
 
 if TYPE_CHECKING:
-    from raes_processor.models import ExecutionPlan
-
+    from aptl.backends.raes_start_model import AdmittedScenarioStart
     from aptl.core.deployment.backend import DeploymentBackend
-    from aptl.core.scenario_bundle import ScenarioBundle
 
 
-def _plan_without_applying(
+@dataclass(frozen=True)
+class AdmittedStartSurface:
+    """The pre-mutation facts one admitted scenario execution settles.
+
+    Lab start reads every scenario-dependent decision off this instead of
+    guessing from the operator's configuration ceiling or a hardcoded default
+    path (issue #951):
+
+    - ``bundle_root`` is where the Compose model the run actually uses lives. A
+      project-tree bundle ships a static ``docker-compose.yml`` there; an
+      env-pack ships none and the backend generates the base model from the
+      realization, so there is no static model to inspect.
+    - ``source_kind`` is the *resolved* source. An explicit scenario selection
+      is project-tree even when the configured default names an env-pack, so
+      legacy host-side producers must key off this, never ``config.scenario``.
+    - ``selected_profiles`` is the realized runtime surface — the profiles
+      ``docker compose --profile`` receives — not ``containers.enabled_profiles()``.
+    - ``stateful_artifact_ownership`` is the exact admitted consumer set.
+    """
+
+    bundle_root: Path
+    source_kind: ScenarioSourceKind
+    selected_profiles: tuple[str, ...]
+    stateful_artifact_ownership: frozenset[tuple[str, str, str, str, str]]
+
+
+def admit_start_surface(
     project_dir: Path,
     config: AptlConfig,
     backend: "DeploymentBackend",
-    scenario_path: Path | None,
-) -> tuple[ScenarioBundle, ExecutionPlan]:
-    """Resolve, parse and plan a scenario, returning its bundle and plan."""
+    scenario_path: Path | None = None,
+) -> tuple["AdmittedScenarioStart", AdmittedStartSurface]:
+    """Admit the scenario once and project the pre-start facts off it.
 
-    from aptl.backends.raes import (
-        RuntimeManager,
-        artifact_availability_for_scenario,
-        create_aptl_runtime_target,
-        parse_sdl_file,
-        resolve_scenario_bundle,
-    )
+    Returns the admission itself alongside the surface so the caller can hand
+    the same admission to the apply path rather than planning a second time.
+    """
 
-    bundle = resolve_scenario_bundle(project_dir, scenario_path, config)
-    scenario = parse_sdl_file(bundle.sdl_path)
-    target = create_aptl_runtime_target(
-        project_dir=project_dir, config=config, backend=backend, bundle=bundle
+    from aptl.backends.raes import admit_raes_scenario
+
+    admitted = admit_raes_scenario(
+        project_dir, config, backend, scenario_path=scenario_path
     )
-    execution_plan = RuntimeManager(target).plan(
-        scenario,
-        artifact_availability=artifact_availability_for_scenario(
-            scenario,
-            backend,
-            scenario_root=bundle.root,
-            component_root=project_dir,
+    return admitted, start_surface_of(admitted, config)
+
+
+def start_surface_of(
+    admitted: "AdmittedScenarioStart",
+    config: AptlConfig,
+) -> AdmittedStartSurface:
+    """Project one admitted execution onto the facts pre-start steps need."""
+
+    realization = _admitted_realization(admitted)
+    return AdmittedStartSurface(
+        bundle_root=admitted.bundle.root,
+        source_kind=admitted.bundle.source_kind,
+        selected_profiles=tuple(
+            select_backend_profiles(config, realization.profiles)
+        ),
+        stateful_artifact_ownership=_artifact_ownership(
+            admitted.bundle.root, realization
         ),
     )
-    return bundle, execution_plan
 
 
-def selected_profiles_for_scenario(
-    project_dir: Path,
-    config: AptlConfig,
-    backend: "DeploymentBackend",
-    scenario_path: Path | None = None,
-) -> list[str]:
-    """Return the Compose profiles selected by a scenario without side effects."""
-    bundle, execution_plan = _plan_without_applying(
-        project_dir, config, backend, scenario_path
-    )
-    realization = interpret_provisioning_plan(
-        plan=execution_plan.provisioning,
-        config=config,
-        bundle=bundle,
-        component_root=project_dir,
-    )
-    return select_backend_profiles(config, realization.profiles)
+def _admitted_realization(admitted: "AdmittedScenarioStart"):
+    """Return the admitted realization, refusing a blocking-diagnostic plan.
+
+    A plan or realization that carries an error diagnostic never becomes a
+    pre-start answer: the caller must fail closed before any legacy mutation
+    rather than proceed on a partial interpretation.
+    """
+
+    blocking = [
+        diagnostic
+        for diagnostic in admitted.execution_plan.diagnostics
+        if diagnostic.is_error
+    ]
+    if blocking:
+        raise ValueError(render_raes_diagnostics(blocking))
+    realization = admitted.realization
+    if realization is None:
+        raise ValueError("Admitted scenario produced no APTL realization.")
+    blocking = [
+        diagnostic for diagnostic in realization.diagnostics if diagnostic.is_error
+    ]
+    if blocking:
+        raise ValueError(render_raes_diagnostics(blocking))
+    return realization
 
 
-def admitted_stateful_artifact_ownership(
-    project_dir: Path,
-    config: AptlConfig,
-    backend: "DeploymentBackend",
-    scenario_path: Path | None = None,
+def _artifact_ownership(
+    root: Path,
+    realization,
 ) -> frozenset[tuple[str, str, str, str, str]]:
     """Return exact addressed artifact consumers from the admitted graph.
 
@@ -99,35 +134,38 @@ def admitted_stateful_artifact_ownership(
     beneath an owned directory is not owned by the artifact (issue #677).
     """
 
-    bundle, execution_plan = _plan_without_applying(
-        project_dir, config, backend, scenario_path
-    )
-    blocking = [
-        diagnostic for diagnostic in execution_plan.diagnostics if diagnostic.is_error
-    ]
-    if blocking:
-        raise ValueError(render_raes_diagnostics(blocking))
-    realization = interpret_provisioning_plan(
-        plan=execution_plan.provisioning,
-        config=config,
-        bundle=bundle,
-        component_root=project_dir,
-    )
-    blocking = [
-        diagnostic for diagnostic in realization.diagnostics if diagnostic.is_error
-    ]
-    if blocking:
-        raise ValueError(render_raes_diagnostics(blocking))
     return frozenset(
         (
             artifact.address,
             artifact.generator,
             consumer.service_name,
             consumer.mount_destination,
-            artifact_source_path(bundle.root, artifact)
-            .relative_to(bundle.root)
-            .as_posix(),
+            artifact_source_path(root, artifact).relative_to(root).as_posix(),
         )
         for artifact in realization.generated_artifacts
         for consumer in artifact.consumers
     )
+
+
+def selected_profiles_for_scenario(
+    project_dir: Path,
+    config: AptlConfig,
+    backend: "DeploymentBackend",
+    scenario_path: Path | None = None,
+) -> list[str]:
+    """Return the Compose profiles selected by a scenario without side effects."""
+
+    _, surface = admit_start_surface(project_dir, config, backend, scenario_path)
+    return list(surface.selected_profiles)
+
+
+def admitted_stateful_artifact_ownership(
+    project_dir: Path,
+    config: AptlConfig,
+    backend: "DeploymentBackend",
+    scenario_path: Path | None = None,
+) -> frozenset[tuple[str, str, str, str, str]]:
+    """Return exact addressed artifact consumers from the admitted graph."""
+
+    _, surface = admit_start_surface(project_dir, config, backend, scenario_path)
+    return surface.stateful_artifact_ownership

--- a/src/aptl/backends/_raes_scenario_queries.py
+++ b/src/aptl/backends/_raes_scenario_queries.py
@@ -26,6 +26,7 @@ from aptl.core.deployment._compose_stateful_model import artifact_source_path
 from aptl.core.scenario_bundle import ScenarioSourceKind
 
 if TYPE_CHECKING:
+    from aptl.backends.raes_realization_model import AptlRealization
     from aptl.backends.raes_start_model import AdmittedScenarioStart
     from aptl.core.deployment.backend import DeploymentBackend
 
@@ -95,7 +96,7 @@ def start_surface_of(
     )
 
 
-def _admitted_realization(admitted: "AdmittedScenarioStart"):
+def _admitted_realization(admitted: "AdmittedScenarioStart") -> "AptlRealization":
     """Return the admitted realization, refusing a blocking-diagnostic plan.
 
     A plan or realization that carries an error diagnostic never becomes a
@@ -123,7 +124,7 @@ def _admitted_realization(admitted: "AdmittedScenarioStart"):
 
 def _artifact_ownership(
     root: Path,
-    realization,
+    realization: "AptlRealization",
 ) -> frozenset[tuple[str, str, str, str, str]]:
     """Return exact addressed artifact consumers from the admitted graph.
 

--- a/src/aptl/backends/_runtime_concern_excess.py
+++ b/src/aptl/backends/_runtime_concern_excess.py
@@ -43,6 +43,20 @@ _INIT_CAPABILITY_BASELINE = frozenset(
 )
 _INIT_BIND_MOUNT_TARGETS = frozenset({"/sys/fs/cgroup"})
 
+# The listener half of that same baseline. Docker attaches its embedded DNS
+# resolver to every container on a user-defined network, listening on this
+# reserved address inside the container's own network namespace, on a tcp and a
+# udp port the daemon picks at attach time.
+#
+# Those two sockets are not workload exposure and cannot be declared: no SDL
+# author can name a port Docker chooses per attachment. Counting them as
+# undeclared exposure made the excess check reject *every* node that declares a
+# service listener, so the SEM-218 realization gate failed the whole lab start
+# (issue #951) — the check's own reason for existing (a leftover or hostile
+# listener) was never in play. Same carve-out the unix-socket exemption below
+# already makes for an init's internal sockets.
+_EMBEDDED_DNS_RESOLVER_ADDRESS = "127.0.0.11"
+
 
 def _sensitivity(value: object) -> str:
     """Return a protocol/sensitivity enum's canonical string value."""
@@ -172,7 +186,12 @@ def _has_undeclared_network_listeners(
     sockets: tuple[tuple[str, str, int], ...],
     declared: Sequence[object],
 ) -> bool:
-    """Return whether the container serves a tcp/udp listener no declaration covers."""
+    """Return whether the container serves a tcp/udp listener no declaration covers.
+
+    Docker's own embedded DNS resolver sockets are subtracted first, as runtime
+    baseline rather than realized workload state — see
+    :func:`_embedded_dns_resolver_sockets`.
+    """
 
     declared_keys = {
         (_sensitivity(getattr(listener, "protocol", "")), int(getattr(listener, "port")))
@@ -180,4 +199,35 @@ def _has_undeclared_network_listeners(
         if _sensitivity(getattr(listener, "protocol", "")) != "unix"
         and getattr(listener, "port", None) is not None
     }
-    return any((protocol, port) not in declared_keys for protocol, _address, port in sockets)
+    baseline = _embedded_dns_resolver_sockets(sockets)
+    realized = (socket for socket in sockets if socket not in baseline)
+    return any(
+        (protocol, port) not in declared_keys for protocol, _address, port in realized
+    )
+
+
+def _embedded_dns_resolver_sockets(
+    sockets: tuple[tuple[str, str, int], ...],
+) -> frozenset[tuple[str, str, int]]:
+    """Return the sockets attributable to Docker's embedded DNS resolver.
+
+    The resolver opens exactly one tcp and one udp socket on
+    :data:`_EMBEDDED_DNS_RESOLVER_ADDRESS`. Nothing in the kernel's socket table
+    distinguishes those from a workload's own bind, and Linux lets a workload
+    bind an unused port on that address too — so exempting the address wholesale
+    would let a container hide a backdoor listener behind the baseline.
+
+    Attribution is therefore only safe while the address carries a single socket
+    of a protocol. A second one means neither can be attributed, so both stay
+    subject to excess detection and the gate rejects: fail closed rather than
+    subtract a socket that might be the workload's.
+    """
+
+    by_protocol: dict[str, list[tuple[str, str, int]]] = {}
+    for socket in sockets:
+        protocol, address, _port = socket
+        if address == _EMBEDDED_DNS_RESOLVER_ADDRESS:
+            by_protocol.setdefault(protocol, []).append(socket)
+    return frozenset(
+        candidates[0] for candidates in by_protocol.values() if len(candidates) == 1
+    )

--- a/src/aptl/backends/raes.py
+++ b/src/aptl/backends/raes.py
@@ -44,6 +44,7 @@ from aptl.backends.raes_start_model import (
     DEFAULT_RAES_SCENARIO as DEFAULT_RAES_SCENARIO,
     AcesRunTarget,
     AcesStartOutcome,
+    AdmittedScenarioStart,
 )
 from aptl.core.config import AptlConfig
 from aptl.core.scenario_bundle import (
@@ -127,6 +128,7 @@ def start_raes_scenario(
     run_target: AcesRunTarget | None = None,
     parameters: Mapping[str, object] | None = None,
     before_backend_retry: Callable[[], None] | None = None,
+    admitted: AdmittedScenarioStart | None = None,
 ) -> AcesStartOutcome:
     """Start an APTL lab by compiling and applying a RAES SDL scenario.
 
@@ -135,23 +137,29 @@ def start_raes_scenario(
     persist under the same run directory the reproducibility record is written
     to. ``parameters`` is the explicit per-run RAES binding mapping; only the
     planner sees it, and APTL neither logs nor persists it.
+
+    ``admitted`` is the scenario execution the caller already admitted through
+    :func:`admit_raes_scenario`. Lab start admits once, before it mutates
+    anything, and hands that same admission back here; re-planning would stage
+    the env-pack a second time and let a pre-start decision diverge from the
+    deployment it precedes (issue #951). ``None`` admits here, which keeps
+    every other caller unchanged.
     """
 
     resolved_scenario = _resolve_scenario_path(project_dir, scenario_path, config)
     try:
-        resolved_scenario = resolve_scenario_bundle(
-            project_dir, scenario_path, config
-        ).sdl_path
-        target, execution_plan = _plan_scenario(
-            project_dir,
-            config,
-            backend,
-            scenario_path,
-            parameters,
-        )
+        if admitted is None:
+            admitted = admit_raes_scenario(
+                project_dir,
+                config,
+                backend,
+                scenario_path=scenario_path,
+                parameters=parameters,
+            )
+        resolved_scenario = admitted.bundle.sdl_path
         return _apply_with_backend_retry(
-            target,
-            execution_plan,
+            admitted.target,
+            admitted.execution_plan,
             resolved_scenario,
             run_target,
             before_backend_retry,
@@ -194,14 +202,22 @@ def _start_failure_outcome(
     )
 
 
-def _plan_scenario(
+def admit_raes_scenario(
     project_dir: Path,
     config: AptlConfig,
     backend: "DeploymentBackend",
-    scenario_path: Path | None,
-    parameters: Mapping[str, object] | None,
-) -> tuple[RuntimeTarget, "ExecutionPlan"]:
-    """Build one RAES plan and the target that consumes its concrete model."""
+    *,
+    scenario_path: Path | None = None,
+    parameters: Mapping[str, object] | None = None,
+) -> AdmittedScenarioStart:
+    """Admit one scenario execution: resolve, parse, plan, and interpret it once.
+
+    This is the single admission every caller shares. Pre-mutation questions
+    (which profiles the run selects, which generated artifacts own which mounts,
+    which bundle root holds the Compose model) are answered from the returned
+    admission rather than by planning again, and the same admission is applied
+    by :func:`start_raes_scenario`. Nothing here mutates the deployment.
+    """
 
     # Resolve the scenario bundle once, here, where the scenario is resolved: an
     # explicit path (or in-tree config) yields the project tree; the configured
@@ -255,7 +271,12 @@ def _plan_scenario(
             execution_plan,
             bundle.sdl_path,
         )
-    return target, execution_plan
+    return AdmittedScenarioStart(
+        bundle=bundle,
+        target=target,
+        execution_plan=execution_plan,
+        realization=realization,
+    )
 
 
 def _apply_with_backend_retry(

--- a/src/aptl/backends/raes.py
+++ b/src/aptl/backends/raes.py
@@ -64,7 +64,10 @@ if TYPE_CHECKING:
 
 log = get_logger("raes-backend")
 
-_INSTANTIATION_FAILURE_MESSAGE = (
+# Fixed disclosure for a rejected variable binding: the rejected value can be an
+# operator secret, so no admission failure — here or in lab start's pre-mutation
+# admission — may echo it back (issue #951 moved that second call site).
+INSTANTIATION_FAILURE_MESSAGE = (
     "RAES runtime variable binding failed before deployment. Provide every "
     "required variable using its declared type and allowed values."
 )
@@ -126,7 +129,6 @@ def start_raes_scenario(
     scenario_path: Path | None = None,
     *,
     run_target: AcesRunTarget | None = None,
-    parameters: Mapping[str, object] | None = None,
     before_backend_retry: Callable[[], None] | None = None,
     admitted: AdmittedScenarioStart | None = None,
 ) -> AcesStartOutcome:
@@ -135,8 +137,8 @@ def start_raes_scenario(
     ``run_target`` (resolved once for the whole lab-start run, REP-001 / GAP 4)
     is threaded into orchestration so workflow result and history artifacts
     persist under the same run directory the reproducibility record is written
-    to. ``parameters`` is the explicit per-run RAES binding mapping; only the
-    planner sees it, and APTL neither logs nor persists it.
+    to. Per-run RAES variable bindings are an *admission* input: supply them to
+    :func:`admit_raes_scenario` and pass the resulting admission here.
 
     ``admitted`` is the scenario execution the caller already admitted through
     :func:`admit_raes_scenario`. Lab start admits once, before it mutates
@@ -154,7 +156,6 @@ def start_raes_scenario(
                 config,
                 backend,
                 scenario_path=scenario_path,
-                parameters=parameters,
             )
         resolved_scenario = admitted.bundle.sdl_path
         return _apply_with_backend_retry(
@@ -189,7 +190,7 @@ def _start_failure_outcome(
     if isinstance(exc, EnvPackError):
         error = redact(f"RAES scenario pack acquisition failed: {exc}")
     elif isinstance(exc, SDLInstantiationError):
-        error = _INSTANTIATION_FAILURE_MESSAGE
+        error = INSTANTIATION_FAILURE_MESSAGE
     else:
         error = redact(f"RAES runtime handoff failed: {exc}")
     return AcesStartOutcome(

--- a/src/aptl/backends/raes_start_model.py
+++ b/src/aptl/backends/raes_start_model.py
@@ -11,9 +11,32 @@ from raes_contracts.runtime_state import RuntimeSnapshot
 from aptl.core.lab_types import LabResult
 
 if TYPE_CHECKING:
+    from raes_processor.models import ExecutionPlan
+    from raes_runtime.registry import RuntimeTarget
+
+    from aptl.backends.raes_realization_model import AptlRealization
     from aptl.core.runstore import RunStorageBackend
+    from aptl.core.scenario_bundle import ScenarioBundle
 
 DEFAULT_RAES_SCENARIO = Path("scenarios") / "techvault-operational.sdl.yaml"
+
+
+@dataclass(frozen=True)
+class AdmittedScenarioStart:
+    """One admitted scenario execution, shared by pre-mutation steps and apply.
+
+    Resolving the bundle, parsing it, building the runtime target, planning, and
+    interpreting the provisioning plan are one admission. Lab start caches this
+    before it mutates anything and hands the *same* object back to apply, so a
+    pre-start decision and the deployment it precedes cannot disagree — and a
+    staged env-pack is acquired and validated once per run rather than once per
+    question asked about it (issue #951).
+    """
+
+    bundle: ScenarioBundle
+    target: RuntimeTarget
+    execution_plan: ExecutionPlan
+    realization: AptlRealization | None
 
 
 @dataclass(frozen=True)

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -14,7 +14,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import icontract
 import yaml
@@ -94,8 +94,9 @@ from aptl.utils.redaction import redact
 if TYPE_CHECKING:
     from docker.client import DockerClient
 
+    from aptl.backends._raes_scenario_queries import AdmittedStartSurface
     from aptl.backends.raes import AcesStartOutcome
-    from aptl.backends.raes_start_model import AcesRunTarget
+    from aptl.backends.raes_start_model import AcesRunTarget, AdmittedScenarioStart
     from aptl.core.deployment.backend import DeploymentBackend
 
 log = get_logger("lab")
@@ -147,6 +148,7 @@ def start_raes_scenario(
     run_target: AcesRunTarget | None = None,
     parameters: Mapping[str, object] | None = None,
     before_backend_retry: Callable[[], None] | None = None,
+    admitted: "AdmittedScenarioStart | None" = None,
 ) -> AcesStartOutcome | LabResult:
     """Lazy RAES handoff import for the public lab-start path.
 
@@ -155,6 +157,8 @@ def start_raes_scenario(
     under the same run directory the run record is written to.
     ``before_backend_retry`` lets the lifecycle prepare SOC dependencies while
     the backend retains and reapplies the already admitted execution plan.
+    ``admitted`` is the execution `_step_load_config` already admitted, so the
+    handoff applies it instead of planning the scenario a second time (#951).
     """
     try:
         from aptl.backends.raes import start_raes_scenario as _start_raes_scenario
@@ -171,6 +175,7 @@ def start_raes_scenario(
         run_target=run_target,
         parameters=parameters,
         before_backend_retry=before_backend_retry,
+        admitted=admitted,
     )
 
 
@@ -254,7 +259,7 @@ def admitted_stateful_artifact_ownership(
     config: AptlConfig,
     backend: "DeploymentBackend",
     scenario_path: Path | None = None,
-) -> frozenset[tuple[str, str, str, str]]:
+) -> frozenset[tuple[str, str, str, str, str]]:
     """Lazy RAES import for exact pre-mutation artifact ownership."""
 
     from aptl.backends._raes_scenario_queries import (
@@ -262,6 +267,21 @@ def admitted_stateful_artifact_ownership(
     )
 
     return _load(project_dir, config, backend, scenario_path=scenario_path)
+
+
+def admit_start_surface(
+    project_dir: Path,
+    config: AptlConfig,
+    backend: "DeploymentBackend",
+    scenario_path: Path | None = None,
+) -> tuple["AdmittedScenarioStart", "AdmittedStartSurface"]:
+    """Lazy RAES import for the one admitted execution lab start reuses."""
+
+    from aptl.backends._raes_scenario_queries import (
+        admit_start_surface as _admit,
+    )
+
+    return _admit(project_dir, config, backend, scenario_path=scenario_path)
 
 
 WAZUH_IMAGE_VERSION = "4.12.0"
@@ -821,6 +841,13 @@ class _LabStartContext(object):
     run_store: object = None
     run_id: str | None = None
     stateful_artifact_ownership: frozenset[tuple[str, str, str, str, str]] = frozenset()
+    # The one admitted scenario execution (issue #951). `_step_load_config`
+    # admits it before any legacy mutation; `_step_start_containers` applies
+    # this exact object rather than planning (and re-staging the env-pack) a
+    # second time. `object` mirrors `raes_outcome`/`snapshot` above: typed at
+    # use sites to keep the RAES import lazy.
+    admitted_start: object = None
+    admitted_surface: "AdmittedStartSurface | None" = None
 
 
 # Ownership tuples are (address, generator, service_name, mount_destination,
@@ -1045,7 +1072,7 @@ def _step_load_config(ctx: _LabStartContext) -> LabResult | None:
             )
             result = _configure_verified_appliance_launch(ctx)
         if result is None:
-            result = _load_stateful_artifact_ownership(ctx)
+            result = _load_admitted_start_surface(ctx)
     return result
 
 
@@ -1160,27 +1187,35 @@ def _read_appliance_boot_id() -> str:
     return Path("/proc/sys/kernel/random/boot_id").read_text().strip()
 
 
-def _load_stateful_artifact_ownership(
+def _load_admitted_start_surface(
     ctx: _LabStartContext,
 ) -> LabResult | None:
-    """Cache exact admitted artifact consumers before legacy mutation."""
+    """Admit the selected scenario once and cache what pre-start steps need.
 
-    from aptl.backends.raes_start_model import DEFAULT_RAES_SCENARIO
+    ``ctx.scenario_path`` is handed to the resolver unchanged. Substituting a
+    default filename here is wrong twice over: ``DEFAULT_RAES_SCENARIO`` names
+    an in-tree document that no longer exists, and it is not where the default
+    env-pack lives, so the substitution made every fresh install admit nothing
+    and then fail the bind-mount pre-flight (issue #951). ``scenario_path=None``
+    means "resolve the configured selection", which is exactly what
+    ``resolve_scenario_bundle`` does — including staging and validating the
+    bundled env-pack.
 
-    scenario_path = ctx.scenario_path or DEFAULT_RAES_SCENARIO
-    if not scenario_path.is_absolute():
-        scenario_path = ctx.project_dir / scenario_path
-    if not scenario_path.is_file():
-        return None
+    Admission failure is fatal: continuing with no admitted facts is what
+    produced the regression, and every later step would be guessing.
+    """
+
+    from aptl.core.scenario_bundle import EnvPackError
+
+    assert ctx.config is not None and ctx.backend is not None
     try:
-        assert ctx.config is not None and ctx.backend is not None
-        ctx.stateful_artifact_ownership = admitted_stateful_artifact_ownership(
+        admitted, surface = admit_start_surface(
             ctx.project_dir,
             ctx.config,
             ctx.backend,
-            scenario_path=scenario_path,
+            scenario_path=ctx.scenario_path,
         )
-    except (OSError, TypeError, ValueError) as exc:
+    except (EnvPackError, OSError, TypeError, ValueError) as exc:
         return LabResult(
             success=False,
             error=(
@@ -1188,6 +1223,9 @@ def _load_stateful_artifact_ownership(
                 f"{redact(str(exc))}"
             ),
         )
+    ctx.admitted_start = admitted
+    ctx.admitted_surface = surface
+    ctx.stateful_artifact_ownership = surface.stateful_artifact_ownership
     return None
 
 
@@ -1206,9 +1244,18 @@ def _scenario_is_env_pack(ctx: _LabStartContext) -> bool:
     When it does, standup material the pack declares as generated artifacts
     (SSH pivot keys, authorized-key projections, the SOC CA) is produced during
     realization from the pack, not by the host-side lab-start steps.
+
+    The answer comes from the *resolved* bundle, not ``config.scenario.source``.
+    An explicit catalog id or scenario path wins selection and resolves to a
+    project-tree bundle even while the configured default names an env-pack, so
+    reading the config flag skipped the host-side producers a curated scenario
+    still depends on (issue #951).
     """
 
-    return ctx.config is not None and ctx.config.scenario.source == "env-pack"
+    from aptl.core.scenario_bundle import ScenarioSourceKind
+
+    surface = ctx.admitted_surface
+    return surface is not None and surface.source_kind is ScenarioSourceKind.ENV_PACK
 
 
 def _step_ensure_ssh_keys(ctx: _LabStartContext) -> LabResult | None:
@@ -1579,11 +1626,26 @@ def _step_generate_soc_certs(ctx: _LabStartContext) -> LabResult | None:
 
 
 def _step_check_bind_mounts(ctx: _LabStartContext) -> LabResult | None:
-    """Validate active Compose bind-mount sources before Docker runs."""
+    """Validate the bind-mount sources of the model this run actually applies.
+
+    The Compose model is a scenario-declared input, so it is read from the
+    admitted bundle root, never the engine checkout. A project-tree bundle ships
+    a static ``docker-compose.yml`` there and this stays its compatibility
+    guard; an env-pack ships none, the backend generates the base model from the
+    realization, and ``_check_bind_mounts`` finds no file to inspect. Scanning
+    the project's unrelated static file instead is what failed every fresh
+    install (issue #951).
+
+    Services are filtered by the profiles the *admitted realization* selected —
+    the surface ``docker compose --profile`` receives — not by
+    ``containers.enabled_profiles()``, which is the operator's capability
+    ceiling. A reduced catalog scenario must not be judged against SOC services
+    it never starts (issue #550's rule, applied here).
+    """
     log.info("Step 6b: Checking bind-mount sources...")
-    enabled = (
-        ctx.config.containers.enabled_profiles() if ctx.config is not None else None
-    )
+    surface = ctx.admitted_surface
+    project_root = surface.bundle_root if surface is not None else ctx.project_dir
+    enabled = list(surface.selected_profiles) if surface is not None else None
     stateful_owned = frozenset(
         (service_name, mount_destination, source_relpath)
         for _address, _generator, service_name, mount_destination, source_relpath in (
@@ -1591,7 +1653,7 @@ def _step_check_bind_mounts(ctx: _LabStartContext) -> LabResult | None:
         )
     )
     mount_errors = _check_bind_mounts(
-        ctx.project_dir,
+        project_root,
         enabled_profiles=enabled,
         stateful_owned_mounts=stateful_owned,
     )
@@ -1749,6 +1811,10 @@ def _step_start_containers(ctx: _LabStartContext) -> LabResult | None:
         ctx.config,
         ctx.backend,
         scenario_path=ctx.scenario_path,
+        # Apply the execution admitted at `_step_load_config`. Re-planning here
+        # would stage the env-pack a second time and let the pre-start
+        # decisions taken since then describe a different admission (#951).
+        admitted=cast("AdmittedScenarioStart | None", ctx.admitted_start),
         run_target=AcesRunTarget(run_store=ctx.run_store, run_id=ctx.run_id),
         # The RAES handoff invokes this only for a retryable backend-start
         # failure whose admitted plan actually selected SOC. Keeping that gate

--- a/src/aptl/core/lab.py
+++ b/src/aptl/core/lab.py
@@ -146,7 +146,6 @@ def start_raes_scenario(
     scenario_path: Path | None = None,
     *,
     run_target: AcesRunTarget | None = None,
-    parameters: Mapping[str, object] | None = None,
     before_backend_retry: Callable[[], None] | None = None,
     admitted: "AdmittedScenarioStart | None" = None,
 ) -> AcesStartOutcome | LabResult:
@@ -173,7 +172,6 @@ def start_raes_scenario(
         backend,
         scenario_path=scenario_path,
         run_target=run_target,
-        parameters=parameters,
         before_backend_retry=before_backend_retry,
         admitted=admitted,
     )
@@ -1202,9 +1200,16 @@ def _load_admitted_start_surface(
     bundled env-pack.
 
     Admission failure is fatal: continuing with no admitted facts is what
-    produced the regression, and every later step would be guessing.
+    produced the regression, and every later step would be guessing. Admission
+    parses and instantiates the scenario, so this catches the RAES parse and
+    binding errors too — and a rejected variable binding discloses only the
+    fixed message, never the value, exactly as the in-handoff failure path
+    always did. Moving admission here must not move that boundary.
     """
 
+    from raes import SDLError, SDLInstantiationError
+
+    from aptl.backends.raes import INSTANTIATION_FAILURE_MESSAGE
     from aptl.core.scenario_bundle import EnvPackError
 
     assert ctx.config is not None and ctx.backend is not None
@@ -1215,7 +1220,9 @@ def _load_admitted_start_surface(
             ctx.backend,
             scenario_path=ctx.scenario_path,
         )
-    except (EnvPackError, OSError, TypeError, ValueError) as exc:
+    except SDLInstantiationError:
+        return LabResult(success=False, error=INSTANTIATION_FAILURE_MESSAGE)
+    except (EnvPackError, SDLError, OSError, TypeError, ValueError) as exc:
         return LabResult(
             success=False,
             error=(

--- a/src/aptl/validation/_live_gate_probes.py
+++ b/src/aptl/validation/_live_gate_probes.py
@@ -99,7 +99,7 @@ def _compute_realization(
             project_dir=project_dir, config=config, backend=backend, bundle=bundle
         )
         # Gather artifact availability at the backend trust boundary before
-        # planning, exactly as `aptl lab start` does (`_plan_scenario`): the image
+        # planning, exactly as `aptl lab start` does (`admit_raes_scenario`): the image
         # policy trusts a node's source image only against verified availability,
         # so a real-backend plan without it rejects every imaged node as
         # ``untrusted-image``.

--- a/src/aptl/validation/participant_agency_qualification.py
+++ b/src/aptl/validation/participant_agency_qualification.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from aptl.backends.raes import _plan_scenario
+from aptl.backends.raes import admit_raes_scenario
 from aptl.backends.raes_participant_provider import (
     ParticipantDecisionSolicitation,
 )
@@ -109,13 +109,13 @@ def validate_participant_agency_qualification(
     selected_run_id = run_id or f"participant-qualification-{uuid4().hex}"
     run_store.create_run(selected_run_id)
     deployment = backend or get_backend(config, project_dir)
-    target, plan = _plan_scenario(
+    admitted = admit_raes_scenario(
         project_dir,
         config,
         deployment,
-        project_dir / SCENARIO_RELATIVE_PATH,
-        None,
+        scenario_path=project_dir / SCENARIO_RELATIVE_PATH,
     )
+    target, plan = admitted.target, admitted.execution_plan
     authority = target.participant_runtime.plan_authority
     if authority is None:
         raise ValueError("participant plan authority is unavailable")

--- a/src/aptl/validation/participant_agency_readiness.py
+++ b/src/aptl/validation/participant_agency_readiness.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 from raes_contracts.participant_episode import ParticipantEpisodeTerminalReason
 from raes_contracts.runtime_state import OperationState
 
-from aptl.backends.raes import _plan_scenario
+from aptl.backends.raes import admit_raes_scenario
 from aptl.backends.raes_participant_apparatus import build_participant_apparatus
 from aptl.backends.raes_participant_driver import (
     AptlParticipantControlPlane,
@@ -183,13 +183,13 @@ def _prepare_readiness_context(
 
     deployment = request.backend or get_backend(request.config, request.project_dir)
     scenario_path = request.project_dir / SCENARIO_RELATIVE_PATH
-    target, execution_plan = _plan_scenario(
+    admitted = admit_raes_scenario(
         request.project_dir,
         request.config,
         deployment,
-        scenario_path,
-        None,
+        scenario_path=scenario_path,
     )
+    target, execution_plan = admitted.target, admitted.execution_plan
     if any(diagnostic.is_error for diagnostic in execution_plan.diagnostics):
         raise _ReadinessFailure("bounded participant scenario planning failed")
     bundle = project_tree_bundle(request.project_dir, scenario_path)

--- a/src/aptl/validation/participant_qualification_boundary_environment.py
+++ b/src/aptl/validation/participant_qualification_boundary_environment.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from raes_contracts.runtime_state import OperationState
 
-from aptl.backends.raes import _plan_scenario
+from aptl.backends.raes import admit_raes_scenario
 from aptl.backends.raes_participant_apparatus import build_participant_apparatus
 from aptl.backends.raes_participant_driver import AptlParticipantControlPlane
 from aptl.backends.raes_participant_fixture import participant_episode_state_dir
@@ -50,13 +50,13 @@ def prepare_challenge_context(
 
     run_store.create_run(run_id)
     scenario_path = project_dir / SCENARIO_RELATIVE_PATH
-    target, plan = _plan_scenario(
+    admitted = admit_raes_scenario(
         project_dir,
         config,
         backend,
-        scenario_path,
-        None,
+        scenario_path=scenario_path,
     )
+    target, plan = admitted.target, admitted.execution_plan
     if any(diagnostic.is_error for diagnostic in plan.diagnostics):
         raise ValueError("boundary challenge scenario planning failed")
     bundle = project_tree_bundle(project_dir, scenario_path)

--- a/tests/test_bounded_participant_agency_scenario.py
+++ b/tests/test_bounded_participant_agency_scenario.py
@@ -16,7 +16,7 @@ from raes_processor.compiler import compile_runtime_model
 from raes_contracts.runtime_state import OperationState
 from raes_runtime.control_plane import RuntimeControlPlane
 
-from aptl.backends.raes import _plan_scenario, create_aptl_runtime_target
+from aptl.backends.raes import admit_raes_scenario, create_aptl_runtime_target
 from aptl.backends.raes_realization import interpret_provisioning_plan
 from aptl.backends.raes_participant_actions import PARTICIPANT_ACTION_ADDRESS
 from aptl.backends.raes_runtime_model_artifact import compiled_runtime_model_bytes
@@ -82,13 +82,12 @@ def test_compiled_model_artifact_rejects_lossy_string_coercion() -> None:
 
 def test_selected_scenario_has_no_blocking_backend_diagnostics() -> None:
     config = AptlConfig(lab={"name": "test"})
-    _, plan = _plan_scenario(
+    plan = admit_raes_scenario(
         PROJECT_ROOT,
         config,
         MagicMock(),
-        SCENARIO,
-        None,
-    )
+        scenario_path=SCENARIO,
+    ).execution_plan
 
     assert [diagnostic for diagnostic in plan.diagnostics if diagnostic.is_error] == []
     realization = interpret_provisioning_plan(
@@ -189,13 +188,13 @@ def test_participant_realization_readiness_fails_closed_on_missing_handler() -> 
 
 
 def test_final_runtime_target_retains_the_exact_admitted_plan_and_model() -> None:
-    target, plan = _plan_scenario(
+    admitted = admit_raes_scenario(
         PROJECT_ROOT,
         AptlConfig(lab={"name": "test"}),
         MagicMock(),
-        SCENARIO,
-        None,
+        scenario_path=SCENARIO,
     )
+    target, plan = admitted.target, admitted.execution_plan
 
     authority = target.participant_runtime.plan_authority
     assert authority is not None
@@ -210,13 +209,12 @@ def test_privileged_realization_rejects_same_name_with_unapproved_source(
 ) -> None:
     modified = tmp_path / SCENARIO.name
     modified.write_bytes(SCENARIO.read_bytes() + b"\n")
-    target, _ = _plan_scenario(
+    target = admit_raes_scenario(
         PROJECT_ROOT,
         AptlConfig(lab={"name": "test"}),
         MagicMock(),
-        modified,
-        None,
-    )
+        scenario_path=modified,
+    ).target
     authority = target.participant_runtime.plan_authority
     assert authority is not None
     assert authority.is_bounded_participant_agency is True

--- a/tests/test_bounded_participant_runtime.py
+++ b/tests/test_bounded_participant_runtime.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 from raes_contracts.runtime_state import OperationState
 
-from aptl.backends.raes import _plan_scenario
+from aptl.backends.raes import admit_raes_scenario
 from aptl.backends.raes_participant_apparatus import (
     build_participant_apparatus,
     project_participant_turn,
@@ -248,13 +248,13 @@ def _runtime(
     LocalRunStore,
 ]:
     backend = _StatefulBackend()
-    target, plan = _plan_scenario(
+    admitted = admit_raes_scenario(
         PROJECT_ROOT,
         AptlConfig(lab={"name": "test"}),
         backend,
-        SCENARIO,
-        None,
+        scenario_path=SCENARIO,
     )
+    target, plan = admitted.target, admitted.execution_plan
     store = LocalRunStore(tmp_path / "runs")
     store.create_run("readiness-run")
     target.participant_runtime.plan_authority.bind_runtime_context(

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -2088,6 +2088,60 @@ class TestAdmittedStartSurface:
         assert ctx.stateful_artifact_ownership == frozenset()
         assert ctx.admitted_start is None
 
+    def test_rejected_variable_binding_never_discloses_the_value(
+        self, mocker, tmp_path
+    ):
+        """Admission moved earlier; the binding-disclosure boundary did not.
+
+        A rejected RAES variable binding can carry an operator secret. The
+        in-handoff failure path always projected a fixed message instead of the
+        exception; moving admission into `_step_load_config` (#951) must keep
+        that, not fall through to the generic redacted-exception branch.
+        """
+        from raes import SDLInstantiationError
+
+        from aptl.backends.raes import INSTANTIATION_FAILURE_MESSAGE
+        from aptl.core.lab import _load_admitted_start_surface
+
+        secret = "operator-supplied-tier-value"
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.admit_start_surface",
+            side_effect=SDLInstantiationError(
+                f"variable 'deployment_tier' rejected value {secret}"
+            ),
+        )
+
+        result = _load_admitted_start_surface(ctx)
+
+        assert result is not None
+        assert result.success is False
+        assert secret not in result.error
+        assert result.error == INSTANTIATION_FAILURE_MESSAGE
+
+    def test_sdl_parse_failure_fails_closed(self, mocker, tmp_path):
+        """Admission parses the scenario, so RAES parse errors must be caught.
+
+        `SDLError` is not an `OSError`/`ValueError`, so without an explicit
+        branch it would escape `_step_load_config` as an unhandled exception
+        instead of a `LabResult`.
+        """
+        from raes import SDLError
+
+        from aptl.core.lab import _load_admitted_start_surface
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.admit_start_surface",
+            side_effect=SDLError("fixture parse failure"),
+        )
+
+        result = _load_admitted_start_surface(ctx)
+
+        assert result is not None
+        assert result.success is False
+        assert "admission failed" in result.error
+
     def test_missing_env_pack_fails_closed(self, mocker, tmp_path):
         """A missing or rejected pack fails closed rather than resolving nothing."""
         from aptl.core.lab import _load_admitted_start_surface

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -45,6 +45,32 @@ def _raes_outcome(
     )
 
 
+def _admitted_surface(
+    bundle_root: Path,
+    *,
+    env_pack: bool = True,
+    selected_profiles: tuple[str, ...] = (),
+    ownership: frozenset[tuple[str, str, str, str, str]] = frozenset(),
+):
+    """Build the pre-start facts `_step_load_config` admits (issue #951).
+
+    Admission is a RAES boundary, so orchestration tests stub it exactly as they
+    stub the start handoff: planning a real scenario here would make every lab
+    orchestration test stage and admit the bundled env-pack.
+    """
+    from aptl.backends._raes_scenario_queries import AdmittedStartSurface
+    from aptl.core.scenario_bundle import ScenarioSourceKind
+
+    return AdmittedStartSurface(
+        bundle_root=bundle_root,
+        source_kind=(
+            ScenarioSourceKind.ENV_PACK if env_pack else ScenarioSourceKind.PROJECT_TREE
+        ),
+        selected_profiles=selected_profiles,
+        stateful_artifact_ownership=ownership,
+    )
+
+
 def _raes_start_after_backend_retry(
     *_args,
     before_backend_retry=None,
@@ -896,6 +922,90 @@ class TestCheckBindMounts:
 
         assert _step_check_bind_mounts(ctx) is None
 
+    def test_step_reads_the_compose_model_from_the_admitted_bundle_root(
+        self, tmp_path
+    ):
+        """The Compose model is scenario input, read from the admitted bundle.
+
+        An env-pack bundle ships no ``docker-compose.yml``; the backend
+        generates the base model from the realization. Scanning the project
+        directory's unrelated static file instead is what failed every fresh
+        install for every scenario (issue #951).
+        """
+        from aptl.core.lab import _LabStartContext, _step_check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  misp:\n"
+            "    profiles: [soc]\n"
+            "    volumes:\n"
+            "      - ./config/soc_certs/misp/server.pem"
+            ":/etc/nginx/certs/cert.pem:ro\n"
+        )
+        pack_root = tmp_path / ".aptl" / "staged-packs" / "fixture"
+        pack_root.mkdir(parents=True)
+        ctx = _LabStartContext(project_dir=tmp_path, skip_seed=False)
+        ctx.admitted_surface = _admitted_surface(
+            pack_root, selected_profiles=("soc",)
+        )
+
+        assert _step_check_bind_mounts(ctx) is None
+
+    def test_step_filters_by_admitted_profiles_not_the_config_ceiling(
+        self, tmp_path
+    ):
+        """A reduced scenario is not judged against services it never starts.
+
+        ``containers.enabled_profiles()`` is the operator's capability ceiling;
+        the admitted realization names the surface ``docker compose --profile``
+        actually receives (issue #550's rule, issue #951's failure).
+        """
+        from aptl.core.config import AptlConfig
+        from aptl.core.lab import _LabStartContext, _step_check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  misp:\n"
+            "    profiles: [soc]\n"
+            "    volumes:\n"
+            "      - ./config/soc_certs/misp/server.pem"
+            ":/etc/nginx/certs/cert.pem:ro\n"
+        )
+        ctx = _LabStartContext(
+            project_dir=tmp_path, skip_seed=False, config=AptlConfig()
+        )
+        ctx.admitted_surface = _admitted_surface(
+            tmp_path, env_pack=False, selected_profiles=("otel",)
+        )
+
+        assert "soc" in ctx.config.containers.enabled_profiles()
+        assert _step_check_bind_mounts(ctx) is None
+
+    def test_step_still_fails_an_admitted_service_with_a_missing_source(
+        self, tmp_path
+    ):
+        """The compatibility guard still protects the project-tree model."""
+        from aptl.core.lab import _LabStartContext, _step_check_bind_mounts
+
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  misp:\n"
+            "    profiles: [soc]\n"
+            "    volumes:\n"
+            "      - ./config/soc_certs/misp/server.pem"
+            ":/etc/nginx/certs/cert.pem:ro\n"
+        )
+        ctx = _LabStartContext(project_dir=tmp_path, skip_seed=False)
+        ctx.admitted_surface = _admitted_surface(
+            tmp_path, env_pack=False, selected_profiles=("soc",)
+        )
+
+        result = _step_check_bind_mounts(ctx)
+
+        assert result is not None
+        assert result.success is False
+        assert "soc_certs" in result.error
+
 
 class TestStartupClassificationTypes:
     """Tests for the StartupOutcome / DiagnosticImpact / StartupDiagnostic types.
@@ -1413,6 +1523,21 @@ class TestOrchestrateLabStart:
             return_value=CertResult(success=True, generated=False, certs_dir=certs_dir),
         )
 
+        # Mock the single scenario admission (#951). The default config selects
+        # the bundled env-pack, so without this every orchestration test would
+        # stage and plan the real pack. The staged pack root carries no
+        # docker-compose.yml, which is what makes the bind-mount pre-flight a
+        # no-op on that path.
+        pack_root = tmp_path / ".aptl" / "staged-packs" / "fixture"
+        pack_root.mkdir(parents=True)
+        mocks["admitted_surface"] = _admitted_surface(
+            pack_root, selected_profiles=("wazuh", "victim", "kali", "otel")
+        )
+        mocks["admit"] = mocker.patch(
+            "aptl.core.lab.admit_start_surface",
+            return_value=(object(), mocks["admitted_surface"]),
+        )
+
         # Mock RAES runtime handoff start. The planned profile set is part of
         # the outcome so the lifecycle does not re-plan the authored scenario.
         mocks["start"] = mocker.patch(
@@ -1863,85 +1988,166 @@ class TestOrchestrateLabStart:
         assert len(pull_calls) >= 1
 
 
-class TestStatefulArtifactOwnership:
-    def test_real_scenario_populates_exact_admitted_ownership(self, tmp_path):
-        from aptl.core.config import load_config
-        from aptl.core.lab import (
-            _LabStartContext,
-            _WAZUH_CERTIFICATE_OWNERSHIP,
-            _WAZUH_MANAGER_CONFIG_OWNERSHIP,
-            _load_stateful_artifact_ownership,
-        )
+class TestAdmittedStartSurface:
+    """`_step_load_config` admits the selected scenario exactly once (#951)."""
 
-        project_root = Path(__file__).resolve().parents[1]
-        backend = MagicMock()
-        # The real contract returns a sha256 identity for a materialized
-        # component image; a bare MagicMock would be treated as no digest and
-        # the scenario would fail admission before artifact preparation.
-        backend.materialize_component_image.return_value = "sha256:" + "e" * 64
-        # The default TechVault scenario now ships as the bundled env-pack
-        # (#875). Stage it and admit ownership from the staged SDL; anchoring to
-        # the project tree keeps the compose service-name mapping the exact
-        # admitted ownership below is expressed against.
-        from tests.helpers import techvault_scenario_path
-
-        ctx = _LabStartContext(
-            project_dir=project_root,
-            skip_seed=False,
-            scenario_path=techvault_scenario_path(tmp_path),
-            config=load_config(project_root / "aptl.json"),
-            backend=backend,
-        )
-
-        result = _load_stateful_artifact_ownership(ctx)
-
-        assert result is None
-        assert _WAZUH_CERTIFICATE_OWNERSHIP <= ctx.stateful_artifact_ownership
-        assert _WAZUH_MANAGER_CONFIG_OWNERSHIP in ctx.stateful_artifact_ownership
-
-    def test_missing_scenario_leaves_legacy_ownership(self, tmp_path):
+    def _ctx(self, tmp_path, scenario_path=None):
         from aptl.core.config import AptlConfig
-        from aptl.core.lab import _LabStartContext, _load_stateful_artifact_ownership
+        from aptl.core.lab import _LabStartContext
 
-        ctx = _LabStartContext(
+        return _LabStartContext(
             project_dir=tmp_path,
             skip_seed=False,
-            scenario_path=tmp_path / "missing.sdl.yaml",
+            scenario_path=scenario_path,
             config=AptlConfig(),
             backend=MagicMock(),
         )
 
-        result = _load_stateful_artifact_ownership(ctx)
+    def test_default_selection_resolves_without_substituting_a_default_path(
+        self, mocker, tmp_path
+    ):
+        """`scenario_path=None` reaches the resolver unchanged.
 
-        assert result is None
-        assert ctx.stateful_artifact_ownership == frozenset()
+        Substituting `DEFAULT_RAES_SCENARIO` named a document deleted in #908
+        that was never the env-pack's location, so the admission silently
+        resolved nothing and every fresh install failed the bind-mount
+        pre-flight (issue #951).
+        """
+        from aptl.core.lab import _load_admitted_start_surface
 
-    def test_admission_error_fails_before_legacy_mutation(self, tmp_path, monkeypatch):
-        from aptl.core.config import AptlConfig
-        from aptl.core.lab import _LabStartContext, _load_stateful_artifact_ownership
-
-        scenario = tmp_path / "scenario.sdl.yaml"
-        scenario.write_text("schema_version: 1.0.0\nname: fixture\n")
-        ctx = _LabStartContext(
-            project_dir=tmp_path,
-            skip_seed=False,
-            scenario_path=scenario,
-            config=AptlConfig(),
-            backend=MagicMock(),
-        )
-        monkeypatch.setattr(
-            "aptl.core.lab.admitted_stateful_artifact_ownership",
-            lambda *args, **kwargs: (_ for _ in ()).throw(
-                ValueError("fixture admission failure")
-            ),
+        ctx = self._ctx(tmp_path)
+        admit = mocker.patch(
+            "aptl.core.lab.admit_start_surface",
+            return_value=(object(), _admitted_surface(tmp_path / "pack")),
         )
 
-        result = _load_stateful_artifact_ownership(ctx)
+        assert _load_admitted_start_surface(ctx) is None
+
+        assert admit.call_args.kwargs["scenario_path"] is None
+
+    def test_explicit_selection_reaches_the_resolver_unchanged(
+        self, mocker, tmp_path
+    ):
+        """An operator-selected scenario path is not rewritten before resolution."""
+        from aptl.core.lab import _load_admitted_start_surface
+
+        selected = tmp_path / "scenarios" / "custom.sdl.yaml"
+        ctx = self._ctx(tmp_path, scenario_path=selected)
+        admit = mocker.patch(
+            "aptl.core.lab.admit_start_surface",
+            return_value=(object(), _admitted_surface(tmp_path, env_pack=False)),
+        )
+
+        assert _load_admitted_start_surface(ctx) is None
+
+        assert admit.call_args.kwargs["scenario_path"] == selected
+
+    def test_admitted_facts_are_cached_for_the_later_steps(self, mocker, tmp_path):
+        """Ownership, the admission itself, and the surface all land on ctx."""
+        from aptl.core.lab import _load_admitted_start_surface
+
+        ctx = self._ctx(tmp_path)
+        admitted = object()
+        surface = _admitted_surface(
+            tmp_path / "pack",
+            selected_profiles=("otel",),
+            ownership=frozenset({("a", "certificate_bundle", "svc", "/d", "src")}),
+        )
+        mocker.patch(
+            "aptl.core.lab.admit_start_surface", return_value=(admitted, surface)
+        )
+
+        assert _load_admitted_start_surface(ctx) is None
+
+        assert ctx.admitted_start is admitted
+        assert ctx.admitted_surface is surface
+        assert ctx.stateful_artifact_ownership == surface.stateful_artifact_ownership
+
+    def test_admission_failure_fails_closed_before_legacy_mutation(
+        self, mocker, tmp_path
+    ):
+        """A scenario that cannot be admitted stops the start; it never degrades.
+
+        Continuing with no admitted facts is exactly what #951 did: every later
+        step then guessed, and the run failed further downstream with an error
+        that named the wrong cause.
+        """
+        from aptl.core.lab import _load_admitted_start_surface
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.admit_start_surface",
+            side_effect=ValueError("fixture admission failure"),
+        )
+
+        result = _load_admitted_start_surface(ctx)
 
         assert result is not None
         assert result.success is False
         assert "admission failed" in result.error
         assert ctx.stateful_artifact_ownership == frozenset()
+        assert ctx.admitted_start is None
+
+    def test_missing_env_pack_fails_closed(self, mocker, tmp_path):
+        """A missing or rejected pack fails closed rather than resolving nothing."""
+        from aptl.core.lab import _load_admitted_start_surface
+        from aptl.core.scenario_bundle import EnvPackError
+
+        ctx = self._ctx(tmp_path)
+        mocker.patch(
+            "aptl.core.lab.admit_start_surface",
+            side_effect=EnvPackError("env-pack source not found"),
+        )
+
+        result = _load_admitted_start_surface(ctx)
+
+        assert result is not None
+        assert result.success is False
+        assert ctx.admitted_surface is None
+
+
+class TestScenarioSourceKindIsResolved:
+    """`_scenario_is_env_pack` reads the resolved bundle, not the config flag."""
+
+    def _ctx(self, tmp_path, surface):
+        from aptl.core.config import AptlConfig
+        from aptl.core.lab import _LabStartContext
+
+        ctx = _LabStartContext(
+            project_dir=tmp_path,
+            skip_seed=False,
+            # The configured default names the env-pack in both cases; only the
+            # resolved bundle distinguishes them.
+            config=AptlConfig(),
+        )
+        ctx.admitted_surface = surface
+        return ctx
+
+    def test_explicit_project_tree_selection_is_not_an_env_pack_run(self, tmp_path):
+        """A catalog id resolves to a project-tree bundle even under the default.
+
+        Reading `config.scenario.source` made a curated scenario skip the
+        host-side SOC CA it still depends on (issue #951).
+        """
+        from aptl.core.lab import _scenario_is_env_pack
+
+        ctx = self._ctx(tmp_path, _admitted_surface(tmp_path, env_pack=False))
+
+        assert ctx.config.scenario.source == "env-pack"
+        assert _scenario_is_env_pack(ctx) is False
+
+    def test_configured_env_pack_selection_is_an_env_pack_run(self, tmp_path):
+        from aptl.core.lab import _scenario_is_env_pack
+
+        ctx = self._ctx(tmp_path, _admitted_surface(tmp_path / "pack"))
+
+        assert _scenario_is_env_pack(ctx) is True
+
+    def test_unadmitted_context_is_not_an_env_pack_run(self, tmp_path):
+        """Without an admission the legacy host-side producers stay enabled."""
+        from aptl.core.lab import _scenario_is_env_pack
+
+        assert _scenario_is_env_pack(self._ctx(tmp_path, None)) is False
 
 
 class TestSyncCredentialsStep:
@@ -3717,6 +3923,7 @@ class TestLabOrchestrationContracts:
         ctx = self._ctx(tmp_path)
         ctx.config = self._full_config()
         ctx.backend = MagicMock()
+        ctx.admitted_start = object()
         start_raes = mocker.patch(
             "aptl.core.lab.start_raes_scenario",
             return_value=_raes_outcome(success=True),
@@ -3729,11 +3936,14 @@ class TestLabOrchestrationContracts:
 
         # GAP 4: the handoff is invoked with the single run target resolved
         # once on ctx, so orchestration and the run record share a run_id.
+        # #951: it is also handed the admission `_step_load_config` already
+        # made, so the apply path never plans (or re-stages the pack) again.
         start_raes.assert_called_once_with(
             tmp_path,
             ctx.config,
             ctx.backend,
             scenario_path=None,
+            admitted=ctx.admitted_start,
             run_target=AcesRunTarget(run_store=ctx.run_store, run_id=ctx.run_id),
             before_backend_retry=ANY,
         )

--- a/tests/test_lab_fresh_start.py
+++ b/tests/test_lab_fresh_start.py
@@ -9,16 +9,19 @@ every existing test. Two things hid it:
   ``config/soc_certs/`` and ``.aptl/`` trees, so the bind-mount pre-flight found
   the sources it wanted and passed for the wrong reason.
 
-So this test starts from a directory materialized by the public ``aptl lab
-init`` path and asserts those generated roots are absent before it runs
-anything. It then drives the real ordered lab-start steps that produced the
-failure — load the environment, admit the configured scenario, prepare SOC TLS
-material, check bind mounts — against the bundled env-pack default, with no
-stubs on the admission seam.
+So these tests start from a directory materialized by the public ``aptl lab
+init`` path and assert those generated roots are absent before anything runs.
+They then drive the real ordered lab-start steps that produced the failure —
+load the environment, admit the configured scenario, prepare SOC TLS material,
+check bind mounts — against the bundled env-pack default, with no stubs on the
+admission seam.
 
 Integration-marked and integration-named: admitting the default scenario stages
 the bundled pack and asks the deployment backend for component-image
-availability, so it needs Docker and does not belong in the fast suite.
+availability, so it needs Docker and does not belong in the fast suite. That
+admission is also expensive enough that the module admits **once** and both
+tests assert against the same result — admitting per test built the component
+image set twice per CI job.
 """
 
 from __future__ import annotations
@@ -28,17 +31,35 @@ from pathlib import Path
 import pytest
 
 
-def _materialize_lab(target: Path) -> Path:
-    """Materialize a lab project the way ``aptl lab init`` does."""
+@pytest.fixture(scope="module")
+def admitted_fresh_lab(tmp_path_factory):
+    """Materialize a lab the way ``aptl lab init`` does, then admit it once.
 
+    Returns the startup context after the real `_step_load_env` and
+    `_step_load_config` have run, so the assertions below read one admission.
+    """
     from aptl.core.assets import materialize
+    from aptl.core.lab import _LabStartContext, _step_load_config, _step_load_env
 
-    materialize(target)
-    return target
+    project_dir = tmp_path_factory.mktemp("fresh") / "fresh-lab"
+    materialize(project_dir)
+
+    # No pre-existing generated state: a developer's ignored trees are exactly
+    # what masked this failure, so they must not be a fixture here.
+    assert not (project_dir / "config" / "soc_certs").exists()
+    assert not (project_dir / ".aptl").exists()
+
+    ctx = _LabStartContext(project_dir=project_dir, skip_seed=True)
+    assert _step_load_env(ctx) is None
+    load_config_result = _step_load_config(ctx)
+    assert load_config_result is None, load_config_result
+    return ctx
 
 
 @pytest.mark.integration
-def test_fresh_init_directory_passes_bind_mount_preflight_integration(tmp_path):
+def test_fresh_init_directory_passes_bind_mount_preflight_integration(
+    admitted_fresh_lab,
+):
     """A clean install reaches the end of the bind-mount pre-flight.
 
     Before the fix this failed with eight missing ``config/soc_certs/`` sources
@@ -47,25 +68,9 @@ def test_fresh_init_directory_passes_bind_mount_preflight_integration(tmp_path):
     those paths, described by a static ``docker-compose.yml`` the run does not
     use.
     """
-    from aptl.core.lab import (
-        _LabStartContext,
-        _step_check_bind_mounts,
-        _step_generate_soc_certs,
-        _step_load_config,
-        _step_load_env,
-    )
+    from aptl.core.lab import _step_check_bind_mounts, _step_generate_soc_certs
 
-    project_dir = _materialize_lab(tmp_path / "fresh-lab")
-
-    # No pre-existing generated state: a developer's ignored trees are exactly
-    # what masked this failure, so they must not be a fixture here.
-    assert not (project_dir / "config" / "soc_certs").exists()
-    assert not (project_dir / ".aptl").exists()
-
-    ctx = _LabStartContext(project_dir=project_dir, skip_seed=True)
-
-    assert _step_load_env(ctx) is None
-    assert _step_load_config(ctx) is None
+    ctx = admitted_fresh_lab
     # The configured default is the bundled env-pack, and admission must have
     # resolved it rather than substituting a scenario path deleted in #908.
     assert ctx.admitted_surface is not None
@@ -76,7 +81,9 @@ def test_fresh_init_directory_passes_bind_mount_preflight_integration(tmp_path):
 
 
 @pytest.mark.integration
-def test_fresh_init_admits_the_compose_model_the_run_applies_integration(tmp_path):
+def test_fresh_init_admits_the_compose_model_the_run_applies_integration(
+    admitted_fresh_lab,
+):
     """The admitted bundle root, not the project directory, holds the model.
 
     The env-pack ships no ``docker-compose.yml``; the backend generates the base
@@ -84,18 +91,12 @@ def test_fresh_init_admits_the_compose_model_the_run_applies_integration(tmp_pat
     ship one, so a pre-flight that reads the project directory is reading a file
     with no bearing on the run.
     """
-    from aptl.core.lab import _LabStartContext, _step_load_config, _step_load_env
     from aptl.core.scenario_bundle import ScenarioSourceKind
 
-    project_dir = _materialize_lab(tmp_path / "fresh-lab")
-    ctx = _LabStartContext(project_dir=project_dir, skip_seed=True)
-
-    assert _step_load_env(ctx) is None
-    assert _step_load_config(ctx) is None
-
+    ctx = admitted_fresh_lab
     surface = ctx.admitted_surface
     assert surface is not None
     assert surface.source_kind is ScenarioSourceKind.ENV_PACK
-    assert (project_dir / "docker-compose.yml").is_file()
-    assert surface.bundle_root != project_dir
+    assert (Path(ctx.project_dir) / "docker-compose.yml").is_file()
+    assert surface.bundle_root != ctx.project_dir
     assert not (surface.bundle_root / "docker-compose.yml").exists()

--- a/tests/test_lab_fresh_start.py
+++ b/tests/test_lab_fresh_start.py
@@ -1,0 +1,101 @@
+"""Issue #951: lab start's pre-flight must pass on a freshly installed lab.
+
+The regression this file guards shipped to PyPI in 5.2.0 and was invisible to
+every existing test. Two things hid it:
+
+- the unit suite asserted the *old* behaviour directly — a scenario path that
+  resolves to nothing left ownership empty and returned success;
+- every developer checkout that has ever booted a lab carries the gitignored
+  ``config/soc_certs/`` and ``.aptl/`` trees, so the bind-mount pre-flight found
+  the sources it wanted and passed for the wrong reason.
+
+So this test starts from a directory materialized by the public ``aptl lab
+init`` path and asserts those generated roots are absent before it runs
+anything. It then drives the real ordered lab-start steps that produced the
+failure — load the environment, admit the configured scenario, prepare SOC TLS
+material, check bind mounts — against the bundled env-pack default, with no
+stubs on the admission seam.
+
+Integration-marked and integration-named: admitting the default scenario stages
+the bundled pack and asks the deployment backend for component-image
+availability, so it needs Docker and does not belong in the fast suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _materialize_lab(target: Path) -> Path:
+    """Materialize a lab project the way ``aptl lab init`` does."""
+
+    from aptl.core.assets import materialize
+
+    materialize(target)
+    return target
+
+
+@pytest.mark.integration
+def test_fresh_init_directory_passes_bind_mount_preflight_integration(tmp_path):
+    """A clean install reaches the end of the bind-mount pre-flight.
+
+    Before the fix this failed with eight missing ``config/soc_certs/`` sources
+    for `misp`, `thehive`, `shuffle-frontend`, and `cortex` — services the
+    env-pack realization starts from a *generated* Compose base that never binds
+    those paths, described by a static ``docker-compose.yml`` the run does not
+    use.
+    """
+    from aptl.core.lab import (
+        _LabStartContext,
+        _step_check_bind_mounts,
+        _step_generate_soc_certs,
+        _step_load_config,
+        _step_load_env,
+    )
+
+    project_dir = _materialize_lab(tmp_path / "fresh-lab")
+
+    # No pre-existing generated state: a developer's ignored trees are exactly
+    # what masked this failure, so they must not be a fixture here.
+    assert not (project_dir / "config" / "soc_certs").exists()
+    assert not (project_dir / ".aptl").exists()
+
+    ctx = _LabStartContext(project_dir=project_dir, skip_seed=True)
+
+    assert _step_load_env(ctx) is None
+    assert _step_load_config(ctx) is None
+    # The configured default is the bundled env-pack, and admission must have
+    # resolved it rather than substituting a scenario path deleted in #908.
+    assert ctx.admitted_surface is not None
+    assert ctx.stateful_artifact_ownership
+
+    assert _step_generate_soc_certs(ctx) is None
+    assert _step_check_bind_mounts(ctx) is None
+
+
+@pytest.mark.integration
+def test_fresh_init_admits_the_compose_model_the_run_applies_integration(tmp_path):
+    """The admitted bundle root, not the project directory, holds the model.
+
+    The env-pack ships no ``docker-compose.yml``; the backend generates the base
+    Compose model from the realization. The materialized project directory does
+    ship one, so a pre-flight that reads the project directory is reading a file
+    with no bearing on the run.
+    """
+    from aptl.core.lab import _LabStartContext, _step_load_config, _step_load_env
+    from aptl.core.scenario_bundle import ScenarioSourceKind
+
+    project_dir = _materialize_lab(tmp_path / "fresh-lab")
+    ctx = _LabStartContext(project_dir=project_dir, skip_seed=True)
+
+    assert _step_load_env(ctx) is None
+    assert _step_load_config(ctx) is None
+
+    surface = ctx.admitted_surface
+    assert surface is not None
+    assert surface.source_kind is ScenarioSourceKind.ENV_PACK
+    assert (project_dir / "docker-compose.yml").is_file()
+    assert surface.bundle_root != project_dir
+    assert not (surface.bundle_root / "docker-compose.yml").exists()

--- a/tests/test_raes_backend.py
+++ b/tests/test_raes_backend.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, MagicMock
 
 import pytest
 
+from raes import SDLInstantiationError
 from raes_contracts.planning import (
     ChangeAction,
     EvaluationPlan,
@@ -1748,7 +1749,9 @@ def test_start_raes_scenario_passes_runtime_parameters_to_raes_planner(
         tmp_path,
         config,
         backend,
-        parameters=parameters,
+        admitted=raes.admit_raes_scenario(
+            tmp_path, config, backend, parameters=parameters
+        ),
     )
 
     assert result.lab_result.success is True
@@ -1865,12 +1868,22 @@ def test_start_raes_scenario_projects_instantiation_failure_without_values(
     backend = MagicMock()
     before_retry = MagicMock()
 
+    config = AptlConfig(lab={"name": "test"})
+    with pytest.raises(SDLInstantiationError):
+        raes.admit_raes_scenario(
+            tmp_path,
+            config,
+            backend,
+            scenario_path=scenario_path,
+            parameters={"deployment_tier": supplied_value},
+        )
+    # The handoff projects that same failure through its fixed message when it
+    # admits internally, so the rejected binding is never disclosed.
     result = raes.start_raes_scenario(
         tmp_path,
-        AptlConfig(lab={"name": "test"}),
+        config,
         backend,
         scenario_path=scenario_path,
-        parameters={"deployment_tier": supplied_value},
         before_backend_retry=before_retry,
     )
 
@@ -1919,7 +1932,18 @@ def test_start_raes_scenario_retries_soc_apply_without_replanning(mocker, tmp_pa
             ),
         ),
         backend,
-        parameters={"victim_os": "linux"},
+        admitted=raes.admit_raes_scenario(
+            tmp_path,
+            AptlConfig(
+                lab={"name": "test"},
+                containers={"soc": True},
+                scenario=ScenarioSourceConfig(
+                    source="project-tree", identity="techvault-operational"
+                ),
+            ),
+            backend,
+            parameters={"victim_os": "linux"},
+        ),
         before_backend_retry=before_retry,
     )
 

--- a/tests/test_raes_backend.py
+++ b/tests/test_raes_backend.py
@@ -1929,6 +1929,80 @@ def test_start_raes_scenario_retries_soc_apply_without_replanning(mocker, tmp_pa
     before_retry.assert_called_once_with()
 
 
+def _raes_started_outcome():
+    """Build the successful apply outcome the handoff returns."""
+    from aptl.backends.raes_start_model import AcesStartOutcome
+
+    return AcesStartOutcome(
+        lab_result=LabResult(success=True, message="ok"),
+        final_snapshot=RuntimeSnapshot(),
+        realization_details={},
+        selected_profiles=[],
+        scenario_path=None,
+    )
+
+
+def test_start_raes_scenario_applies_a_supplied_admission_without_replanning(
+    mocker, tmp_path
+):
+    """A caller-supplied admission is applied as-is, not planned again.
+
+    Lab start admits the scenario before it mutates anything and hands that
+    admission here. Re-planning would stage the env-pack a second time and let
+    the pre-start decisions already taken describe a different admission
+    (issue #951).
+    """
+    from types import SimpleNamespace
+
+    from aptl.backends import raes
+
+    _write_compose(tmp_path, {"aptl-soc": ["soc"]})
+    admit = mocker.patch("aptl.backends.raes.admit_raes_scenario")
+    apply_plan = mocker.patch(
+        "aptl.backends.raes._apply_with_backend_retry",
+        return_value=_raes_started_outcome(),
+    )
+    bundle = project_tree_bundle(tmp_path, tmp_path / "scenarios" / "x.sdl.yaml")
+    admitted = SimpleNamespace(
+        bundle=bundle, target=object(), execution_plan=object(), realization=None
+    )
+
+    result = raes.start_raes_scenario(
+        tmp_path,
+        AptlConfig(lab={"name": "test"}),
+        MagicMock(),
+        admitted=admitted,
+    )
+
+    assert result.lab_result.success is True
+    admit.assert_not_called()
+    assert apply_plan.call_args.args[0] is admitted.target
+    assert apply_plan.call_args.args[1] is admitted.execution_plan
+    assert apply_plan.call_args.args[2] == bundle.sdl_path
+
+
+def test_lab_start_handoff_forwards_the_admission_to_the_backend(mocker, tmp_path):
+    """`core.lab`'s lazy wrapper must forward the admission it is given.
+
+    The orchestration tests stub this wrapper, so a parameter dropped between it
+    and the backend handoff is invisible to them and only surfaces on a real
+    `aptl lab start`.
+    """
+    from aptl.core import lab
+
+    handoff = mocker.patch(
+        "aptl.backends.raes.start_raes_scenario",
+        return_value=_raes_started_outcome(),
+    )
+    admitted = object()
+
+    lab.start_raes_scenario(
+        tmp_path, AptlConfig(lab={"name": "test"}), MagicMock(), admitted=admitted
+    )
+
+    assert handoff.call_args.kwargs["admitted"] is admitted
+
+
 def test_start_raes_scenario_does_not_retry_non_soc_apply(mocker, tmp_path):
     """A retryable apply is not enough; the admitted plan must select SOC."""
     from aptl.backends import raes

--- a/tests/test_raes_runtime_observation.py
+++ b/tests/test_raes_runtime_observation.py
@@ -785,6 +785,108 @@ def test_undeclared_network_listener_is_rejected():
     assert _GATE_REJECT in codes
 
 
+def test_docker_embedded_dns_resolver_is_baseline_not_excess():
+    """Docker's own resolver sockets must not count as undeclared exposure.
+
+    Docker attaches an embedded DNS resolver to every container on a
+    user-defined network, on 127.0.0.11 with daemon-chosen ports. Counting those
+    as excess rejected every node that declares a service listener and failed
+    the whole lab start at the SEM-218 gate (issue #951): the observed sockets
+    for `aptl-shuffle-backend` were tcp 127.0.0.11:44277, tcp :::5001, and udp
+    127.0.0.11:39146 against a single declared tcp 5001.
+    """
+    runtime = _listener_runtime()  # declares only tcp 8080
+    backend = _Backend(
+        {_CONTAINER: _inspect()},
+        listeners=_listeners(
+            sockets=[
+                ("tcp", "127.0.0.11", 44277),
+                ("udp", "127.0.0.11", 39146),
+                ("tcp", "::", 8080),
+            ]
+        ),
+    )
+    codes, _provenance, observations = _gate(runtime, backend, "service-listeners")
+    assert codes == []
+    assert _LISTENERS_PATH in observations[_ADDRESS].concerns
+
+
+def test_extra_socket_on_the_resolver_address_defeats_attribution():
+    """A workload cannot hide a listener behind the resolver's address.
+
+    Linux lets a container bind an unused port on 127.0.0.11, and the socket
+    table cannot distinguish that from Docker's own resolver socket. A second
+    socket of the same protocol makes neither attributable, so both stay subject
+    to excess detection and the gate rejects.
+    """
+    runtime = _listener_runtime()  # declares only tcp 8080
+    backend = _Backend(
+        {_CONTAINER: _inspect()},
+        listeners=_listeners(
+            sockets=[
+                ("tcp", "127.0.0.11", 44277),
+                ("tcp", "127.0.0.11", 31337),
+                ("udp", "127.0.0.11", 39146),
+                ("tcp", "::", 8080),
+            ]
+        ),
+    )
+    codes, _provenance, observations = _gate(runtime, backend, "service-listeners")
+    assert _LISTENERS_PATH not in observations[_ADDRESS].concerns
+    assert _GATE_REJECT in codes
+
+
+def test_resolver_attribution_is_per_protocol():
+    """One tcp plus one udp is the resolver's shape and stays attributable."""
+    runtime = _listener_runtime()  # declares only tcp 8080
+    backend = _Backend(
+        {_CONTAINER: _inspect()},
+        listeners=_listeners(
+            sockets=[
+                ("tcp", "127.0.0.11", 44277),
+                ("udp", "127.0.0.11", 39146),
+                ("udp", "127.0.0.11", 39147),
+                ("tcp", "::", 8080),
+            ]
+        ),
+    )
+    # The duplicated udp pair is unattributable and undeclared, so the gate
+    # rejects even though the tcp resolver socket alone would have been baseline.
+    codes, _provenance, observations = _gate(runtime, backend, "service-listeners")
+    assert _LISTENERS_PATH not in observations[_ADDRESS].concerns
+    assert _GATE_REJECT in codes
+
+
+def test_undeclared_listener_on_ordinary_loopback_is_still_rejected():
+    """The carve-out is the resolver address alone, not loopback in general.
+
+    A workload port on 127.0.0.1 is a real undeclared listener; exempting all of
+    loopback would hide it.
+    """
+    runtime = _listener_runtime()  # declares only tcp 8080
+    backend = _Backend(
+        {_CONTAINER: _inspect()},
+        listeners=_listeners(
+            sockets=[("tcp", "0.0.0.0", 8080), ("tcp", "127.0.0.1", 9000)]
+        ),
+    )
+    codes, _provenance, observations = _gate(runtime, backend, "service-listeners")
+    assert _LISTENERS_PATH not in observations[_ADDRESS].concerns
+    assert _GATE_REJECT in codes
+
+
+def test_declared_listener_on_the_resolver_address_is_still_corroborated():
+    """Exemption applies to excess detection only, never to presence matching."""
+    runtime = _listener_runtime()  # declares tcp 0.0.0.0:8080
+    backend = _Backend(
+        {_CONTAINER: _inspect()},
+        listeners=_listeners(sockets=[("tcp", "127.0.0.11", 8080)]),
+    )
+    codes, _provenance, observations = _gate(runtime, backend, "service-listeners")
+    assert _LISTENERS_PATH not in observations[_ADDRESS].concerns
+    assert _GATE_REJECT in codes
+
+
 def test_wildcard_declared_listener_realized_on_loopback_is_rejected():
     # A listener declared on all interfaces but realized only on loopback is
     # under-exposed and must not corroborate the authored wildcard.

--- a/tests/test_scenario_bundle_wiring.py
+++ b/tests/test_scenario_bundle_wiring.py
@@ -84,7 +84,7 @@ def test_realization_receives_the_bundle_not_just_the_project(monkeypatch):
 
 
 def test_the_public_start_path_resolves_a_bundle(monkeypatch, tmp_path):
-    """`_plan_scenario` must resolve a bundle and thread it into the target.
+    """`admit_raes_scenario` must resolve a bundle and thread it into the target.
 
     Behavioral, not a source grep: it executes the planning step and asserts the
     bundle actually handed to ``create_aptl_runtime_target`` is rooted where the
@@ -113,7 +113,7 @@ def test_the_public_start_path_resolves_a_bundle(monkeypatch, tmp_path):
     config = AptlConfig()
     mock = MagicMock()
     with pytest.raises(RuntimeError):
-        raes._plan_scenario(project_dir, config, mock, scenario_path, None)
+        raes.admit_raes_scenario(project_dir, config, mock, scenario_path=scenario_path)
 
     assert seen["bundle"] is not None
     assert seen["bundle"].root == project_tree_bundle(project_dir, scenario_path).root


### PR DESCRIPTION
## Summary

A fresh `pipx install aptl-labs && aptl lab init && aptl lab start` failed the bind-mount pre-flight in about nine seconds, for the default scenario and every catalog scenario, on 5.2.0 and on `dev`. Three lab-start steps guessed scenario facts from the config ceiling or a hardcoded path instead of reading the admitted realization: ownership loading substituted `DEFAULT_RAES_SCENARIO` (deleted in #908) then returned silently; the bind-mount check validated `project_dir/docker-compose.yml`, a file an env-pack run never uses because the backend generates its base Compose model from the realization; and `_scenario_is_env_pack` read `config.scenario.source`, so an explicit `--scenario` run skipped host-side SOC certs it needed. Lab start now admits the scenario exactly once and derives the bundle root, source kind, selected profiles, and artifact ownership from that one admission, which apply also consumes. Fixing this exposed a second defect unreachable behind the nine-second failure: the SEM-218 excess-listener check counted Docker's embedded DNS resolver sockets as undeclared exposure. Both are fixed, and CI now boots and tears down a lab from the built wheel.

## Requirement UIDs

- `DEP-008`
- `DSL-008`

## Related Issues

Refs #951

## ADR Impact

- ADR-046
- ADR-048
- ADR-051
- ADR-030

## Changes

- `admit_raes_scenario` is the single admission seam: resolve the bundle, parse, plan, and interpret once. `start_raes_scenario(admitted=...)` applies that same admission instead of planning again, so the env-pack is staged once per run rather than once per question asked about it (measured at 92s per admission).
- `_load_admitted_start_surface` passes `ctx.scenario_path` to the resolver unchanged — no `DEFAULT_RAES_SCENARIO` substitution, no silent return — and fails closed on `EnvPackError`/`OSError`/`ValueError`/`TypeError`.
- `_step_check_bind_mounts` reads the Compose model from the admitted bundle root and filters by the admitted selected profiles. An env-pack bundle ships no `docker-compose.yml`, so the check is a logged no-op there and source existence stays with the backend's post-realization effective-model validation; a project-tree bundle keeps the static compatibility guard. `_stateful_realization_owns_mount` is untouched — #677's both-sides match still holds.
- `_scenario_is_env_pack` reads the resolved bundle's `ScenarioSourceKind`, so an explicit catalog id or path is project-tree even when the configured default names the pack.
- SEM-218 excess-listener check: Docker's embedded DNS resolver sockets on 127.0.0.11 are subtracted as runtime baseline, attributed only while the address carries a single socket of a protocol. A second socket of that protocol makes neither attributable and the gate rejects, so a workload cannot hide a listener behind the baseline; an undeclared port on 127.0.0.1 or any other address is still refused.
- New blocking CI job `clean-install-lab-boot`: build the wheel with the locked no-isolation toolchain, install it `--no-deps` into a clean venv (never editable, never the checkout CLI or the local plugin), `aptl lab init`, boot `techvault-observability-core`, `aptl lab stop -v --yes`, then assert zero project containers, networks, and volumes using the same identities as `observe_project_runtime()` and `_compose_volume_cleanup`.
- New blocking CI job `fresh-start-preflight` runs the integration-marked step-sequence regression from a materialized project directory with no pre-existing generated state.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Validated on a real local Docker lab, not only in tests, because CI has never booted one. From a fresh `aptl lab init` directory with no `config/soc_certs/` and no `.aptl/`: the default env-pack scenario now passes the pre-flight, starts (exit 0, 32 containers), and `aptl lab stop -v --yes` leaves zero project containers, networks, and volumes; `techvault-observability-core` runs the same init → start → stop → zero-residue sequence cleanly, which is exactly what the new CI job does. Before the fix all three catalog scenarios and the default reproduced the same 8 bind-mount errors. The SEM-218 fix was confirmed independent of the admit-once change by re-running the default scenario with the old planning timing: identical failure, so it was pre-existing and merely unreachable. The full stack still reports one `degraded_unusable` readiness diagnostic (SSH to kali not ready in 303s) on this box under 32-container load; that is ADR-030 classification working, not a start failure, and is unrelated to this change. Repository gates: `uv run pytest -n auto -k "not integration"` (4504 passed), the TechVault static integration gate, `make policy`, and `pre-commit run --all-files` all pass.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: src/aptl/backends/raes.py, src/aptl/backends/raes_start_model.py, src/aptl/backends/_raes_scenario_queries.py, src/aptl/backends/_runtime_concern_excess.py, src/aptl/core/lab.py, .github/workflows/checks.yml, scripts/ci/assert_project_teardown.py
- TESTS: tests/test_lab.py, tests/test_lab_fresh_start.py, tests/test_raes_backend.py, tests/test_raes_runtime_observation.py

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.

https://claude.ai/code/session_01M71qqYVNMqw6rutmcp1KiL