### PR TITLE
docs: clarify scenario-pack ownership terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Scenarios are [Reproducible Agentic Environments SDL](docs/sdl/index.md) documen
 
 The SDL language and the reusable environment-pack format live in the RAES companion repositories—[OpenRAE/rae](https://github.com/OpenRAE/rae) (SDL and semantics) and [OpenRAE/env-packs](https://github.com/OpenRAE/env-packs) (pack definitions, templates, schemas, and authoring support). APTL consumes those definitions and realizes them as a running Docker lab; the lab lifecycle and runtime stay APTL-owned.
 
-The catalog ships the operational default plus four curated slices:
+The APTL startup catalog ships the operational default plus four curated slices:
 
 | Scenario id | Boots | Omits |
 |---|---|---|

--- a/docs/adrs/adr-054-lilrae-core-and-experience-ownership.md
+++ b/docs/adrs/adr-054-lilrae-core-and-experience-ownership.md
@@ -35,8 +35,10 @@ pack. Remaining work removes residual coupling and qualifies pack consumption.
 Keep one backend execution path. LilRAE owns local admission, host diagnostics,
 realization, readiness, native observation, evidence capture, recovery, reset,
 and teardown. RAES remains the authority for portable meaning, processing,
-runtime/control contracts, diagnostics, and conformance. Catalogs and env-packs
-own scenario content and pack acquisition contracts.
+runtime/control contracts, diagnostics, and conformance. `OpenRAE/env-packs`
+owns the environment-pack format, validation, tooling, and released pack bytes.
+Downstream scenario authors own authored scenario content. LilRAE owns the APTL
+startup catalog, pack admission and acquisition, and runtime realization.
 
 Here, LilRAE names the same product after the rename. It does not name a new
 host for APTL code or a parallel runtime.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -157,6 +157,7 @@ The victim and kali containers publish no host ports; use
 ## Preflights
 
 - [Issue #934 APTL-To-LilRAE Rename Boundary](issue-934-rename-boundary-preflight.md)
+- [Issue #592 Scenario-Pack Terminology](issue-592-scenario-pack-terminology-preflight.md)
 - [Issue #951 Fresh Env-Pack Start](issue-951-fresh-env-pack-start-preflight.md)
 - [Issue #913 Shuffle Post-Realization Mutation](issue-913-shuffle-post-realization-mutation-preflight.md)
 - [Issue #905 Lab Lifecycle Robustness](issue-905-lab-lifecycle-robustness-preflight.md)

--- a/docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md
+++ b/docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md
@@ -1,7 +1,7 @@
 # Issue #589 RAES Scenario-Pack Capture Workflow Ownership Preflight
 
 This note records the APTL-side boundary for RAES scenario packs. RAES is the
-renamed RAES project; existing `raes_*` package, module, and CLI names remain
+current project name; existing `raes_*` package, module, and CLI names remain
 technical compatibility identifiers. This is guidance, not an implementation
 plan. No new ADR is needed: ADR-035 establishes RAES as the scenario authoring
 surface, ADR-046 removes APTL's capture-inventory and parity-inventory surfaces,

--- a/docs/architecture/issue-592-scenario-pack-terminology-preflight.md
+++ b/docs/architecture/issue-592-scenario-pack-terminology-preflight.md
@@ -1,0 +1,115 @@
+# Issue #592 Scenario-Pack Terminology Preflight
+
+This note fixes the terminology boundary for issue #592. It does not rename a
+runtime identifier, migrate an asset, or change pack acquisition. The issue
+predates the ACES-to-RAES project rename and the companion repository's current
+`OpenRAE/env-packs` identity. Its architectural intent remains current: APTL
+documentation must use the portable system's current vocabulary and must not
+present an APTL-private catalog concept as a companion contract.
+
+No new ADR is required. ADR-035 assigns portable scenario meaning to RAES,
+ADR-053 owns pack/backend interaction, issue #589 records the four-way capture
+and pack-ownership boundary, and issue #934 governs current versus historical
+identity wording.
+
+## Terminology decision
+
+| Meaning | Canonical wording | Boundary |
+| --- | --- | --- |
+| Portable authored meaning | RAES scenario, RAES SDL, or RAES runtime contract | `OpenRAE/rae` owns the schemas, parser, semantic validation, compilation, planning, diagnostics, and controlled vocabulary. |
+| Reusable packaged scenario material | RAES environment pack or environment pack | `OpenRAE/env-packs` owns the pack format, schemas, validation, tooling, and released pack bytes. Use *scenario pack* only as the broader domain category, in an issue or historical title, or when distinguishing TechVault as pack-specific rather than product-owned. |
+| APTL operator selection index | APTL startup catalog or curated scenario catalog | `scenarios/catalog.json` and `aptl.core.scenario_catalog.ScenarioCatalog` are an APTL-owned alias and card-metadata index. They are not a portable RAES schema, a pack registry, or the companion repository. |
+| One admitted source | scenario source, `ScenarioBundle`, and, when present, validated pack identity/version/digest | APTL stages and admits a selected source. Do not call an arbitrary URL, directory, package index, or repository a catalog entry accepted by the runtime. |
+| Exact compatibility identity | The literal identifier, for example `env-pack`, `raes-env-packs`, `raes_env_packs`, `ScenarioSourceKind.ENV_PACK`, `scenario_catalog`, or `scenarios/catalog.json` | Code, config, package, CLI, telemetry, and persisted identifiers are contracts rather than prose. Issue #592 does not rename them. |
+| Historical evidence | The name recorded at the time, including ACES and `Brad-Edwards/aces-scenario-packs` | Accepted ADRs, requirements, issue titles, changelog entries, and sealed evidence retain historical identity. Current guidance may explain the successor name; it must not rewrite history. |
+
+The unqualified statement that "catalogs" own scenario content is too broad.
+Current prose must name the actual owner: RAES owns portable meaning;
+`OpenRAE/env-packs` owns the environment-pack contract and released pack bytes;
+the scenario author owns the authored scenario; and APTL owns its local startup
+catalog and runtime realization. APTL's catalog must not be generalized into a
+cross-repository catalog abstraction.
+
+## Repository documentation inventory
+
+The repository-scoped terminology inventory at this preflight has these
+surfaces. Generated dependency files and source/test identifiers are excluded
+from the documentation inventory, but their contracts are named below because
+prose must not accidentally rename them.
+
+| Surface | Files | Disposition |
+| --- | --- | --- |
+| Current user and authoring guidance | `README.md`, `docs/index.md`, `docs/sdl/index.md` | Treat `docs/sdl/index.md` as the exemplar: companion authoring and format links are separate from the APTL-owned operator catalog and runtime section. Qualify nearby catalog prose as APTL startup selection when context is not explicit. |
+| Accepted realization and pack-boundary decisions | `docs/adrs/adr-035-raes-sdl-adoption.md`, `docs/adrs/adr-046-dynamic-raes-scenario-realization.md`, `docs/adrs/adr-053-pack-backend-deployment-serving-interaction-seam.md` | Preserve decision history. Add current clarification around historical names instead of mechanically rewriting accepted records. |
+| Proposed product and release decisions | `docs/adrs/adr-054-lilrae-core-and-experience-ownership.md`, `docs/adrs/adr-058-adoption-and-security-release-gates.md` | Keep TechVault pack-specific and APTL runtime-specific concerns distinct. Replace ambiguous ownership by unnamed "catalogs" only when editing current prose. |
+| Current architecture guidance | `docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md`, `issue-866-techvault-realization-contract-preflight.md`, `issue-875-scenario-content-declaration-preflight.md`, `issue-878-scenario-verification-plugin-seam-preflight.md`, `issue-913-shuffle-post-realization-mutation-preflight.md`, `issue-934-rename-boundary-preflight.md`, `issue-949-orborus-control-authority-preflight.md`, `issue-951-fresh-env-pack-start-preflight.md` | Reuse their ownership, admission, realization, validation, and historical-identity decisions. Do not create a second terminology or pack-ownership model. |
+| Extension documentation | `plugins/aptl-techvault-pack-interaction/README.md`, `plugins/aptl-techvault-verifier/README.md` | A plugin may be compatible with an exact pack binding; it is neither the pack, RAES, an APTL startup-catalog entry, nor a new catalog authority. |
+| Historical requirements and review evidence | `docs/requirements/SCN-010/requirement.md`, `docs/reviews/962-lilrae-readiness/` | Preserve historical names and exact recorded links. The review's backlog and identity dispositions provide current interpretation without changing the underlying evidence. |
+| Terminology record and navigation labels | `docs/architecture/issue-592-scenario-pack-terminology-preflight.md`, `docs/architecture/index.md`, `mkdocs.yml` | Titles may preserve an issue's or file's historical locator. Descriptive labels for current contracts use the terminology above. |
+
+The inventory identified three current-prose hazards for issue #592 to resolve:
+the tautological rename sentence at the start of the issue #589 preflight, the
+unqualified "Catalogs and env-packs" owner in ADR-054, and README wording in
+which "The catalog ships" immediately follows the companion-repository
+paragraph. The implementation clarifies the current project name, names each
+content and runtime owner, and qualifies the catalog as APTL's startup catalog.
+None justifies changing a code or persisted identifier.
+
+## Required incumbent boundaries
+
+This is a documentation-only change. It adds no security, configuration,
+network, persistence, or OS exposure. Companion hyperlinks are references for
+humans; they are not runtime source URLs, trust roots, resolver inputs, or
+authorization grants.
+
+Any implementation that expands beyond prose is outside issue #592 and must
+reuse, rather than duplicate, these incumbents:
+
+| Cross-cutting layer | Canonical incumbent and required passage |
+| --- | --- |
+| Local selection shape | `ScenarioCatalog`, `ScenarioCatalogEntry`, and `ScenarioCatalogMetadata` in `aptl.core.scenario_catalog`, including strict Pydantic shapes, unique IDs, project containment, and RAES parsing. Do not mirror this schema in docs, the API, or a pack model. |
+| Pack ingress and validation | `ScenarioSourceConfig`, `resolve_scenario_bundle()`, `ScenarioBundle`, `env_pack_bundle()`, env-packs `validate_pack()` / `validate_pack_content_manifest()`, and `aptl.utils.pathsafe`. An external documentation link never bypasses installed-package acquisition, exact identity/digest validation, contained immutable staging, or no-follow path checks. |
+| Portable semantic validation | RAES public SDL models, `parse_sdl_file`, compiler/planner diagnostics, `RuntimeModel`, and `ExecutionPlan`. APTL does not create a scenario-pack DTO, vocabulary, parser, or validation fork. |
+| Capability and lifecycle handoff | `create_aptl_manifest()`, `create_aptl_runtime_target()`, `start_raes_scenario()`, `DeploymentBackend`, and the existing lab lifecycle. Do not dispatch on a repository name, catalog label, pack display name, or nearby file. |
+| API and error envelope | The existing authenticated `/api/scenarios` router, narrow response DTOs, `ScenarioNotFoundError` / `ScenarioValidationError`, generic HTTP details, and redacted projection errors remain the only catalog API surface. Do not expose catalog paths, raw RAES objects, parser errors, or pack bytes. |
+| Auth, secrets, and configuration | `verify_token`, `WebAuthSettings`, BFF host/CSRF/session protections, strict `AptlConfig`, `EnvVars`, placeholder validation, and generated-config owners remain unchanged. Pack or catalog prose never selects credentials, environment keys, host paths, providers, commands, or policy. |
+| Logging and observability | `get_logger`, `redact`, bounded RAES diagnostics, and `LabResult` remain authoritative. No raw source content, internal path, credential, parser payload, backend stderr, URL token, or plugin metadata is added to logs or error envelopes. |
+| Persistence | Existing snapshot/run-store and content-addressed evidence boundaries remain unchanged. Terminology is not a schema migration and must not rewrite persisted source kinds, pack identities, historical evidence, or archive readers. |
+| OS/process exposure | None for this issue. No repository link or pack/catalog field may flow to shell text, process argv, Docker/Compose commands, SSH, `curl`, import strings, or unrestricted filesystem access. |
+
+The extensibility seam remains `(pack identity, version, digest, scenario entry
+point)` admitted through `ScenarioBundle`, with APTL startup aliases as a
+separate optional projection. A future pack source varies behind the authorized
+resolver and trust-root policy; it does not add another catalog schema or make
+the source kind, repository name, or pack identity a dispatch branch.
+
+## Guardrails and anti-patterns
+
+- Do not globally replace ACES with RAES or rewrite immutable historical
+  records, links, schema keys, import roots, issue titles, or changelog entries.
+- Do not call `OpenRAE/env-packs` a private catalog, make APTL's startup catalog
+  a portable pack contract, or imply that catalog listing proves acquisition,
+  admission, realization, readiness, qualification, or semantic verification.
+- Do not collapse a RAES scenario, an environment pack, an APTL catalog alias,
+  a `ScenarioBundle`, a verifier plugin, and a running lab into one concept.
+- Do not introduce a pack/catalog DTO, validator, exception hierarchy, logger,
+  resolver, workflow engine, persistence record, API route, or compatibility
+  alias for a terminology-only issue.
+- Do not move product-specific container, Compose, credential, host path, MCP,
+  readiness, evidence, or lifecycle language into RAES or environment-pack
+  authoring sections. Keep it in explicitly APTL-owned sections.
+- Do not turn documentation hyperlinks into package acquisition or runtime
+  trust configuration.
+
+## Non-goals and implementation boundary
+
+- No scenario, environment-pack, capture, inventory, plugin, or evidence asset
+  migration.
+- No change to RAES or env-packs contracts, dependencies, package coordinates,
+  schemas, validation, controlled vocabularies, or repository ownership.
+- No rename of source, config, CLI, API, telemetry, persistence, or error
+  identifiers, and no compatibility layer for old prose.
+- No change to APTL scenario selection, pack acquisition, lab realization,
+  authentication, secret handling, logging, observability, or persistence.
+- No claim that the historical companion repository remains a current runtime
+  source. Current documentation links and runtime trust are separate concerns.

--- a/docs/requirements/SCN-010/requirement.md
+++ b/docs/requirements/SCN-010/requirement.md
@@ -108,6 +108,7 @@ APTL and ACES are co-developed inside a single research agenda. ACES's core rese
 - IMPLEMENTS → GITHUB_ISSUE `#580` (Backend manifest truth-up + conformance re-verification)
 - IMPLEMENTS → PULL_REQUEST `792` (fix(aces): truth up backend manifest)
 - IMPLEMENTS → DOCUMENTATION `docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md` (RAES environment-pack ownership decision)
+- IMPLEMENTS → DOCUMENTATION `docs/architecture/issue-592-scenario-pack-terminology-preflight.md` (RAES scenario-pack terminology and ownership boundary)
 - TESTS → TEST `tests/test_scenario_pack_ownership_contract.py` (Scenario-pack ownership contract test)
 - IMPLEMENTS → GITHUB_ISSUE `589` (Review APTL ownership for scenario-pack capture workflows)
 - IMPLEMENTS → CODE_FILE `src/aptl/backends/raes_realization.py`

--- a/docs/reviews/962-lilrae-readiness/tracked-file-inventory.tsv
+++ b/docs/reviews/962-lilrae-readiness/tracked-file-inventory.tsv
@@ -258,6 +258,7 @@ docs/architecture/index.md	docs-follow-owner	Separate current user guidance from
 docs/architecture/issue-550-soc-selected-profile-preflight.md	docs-follow-owner	Separate current user guidance from historical evidence and scenario-pack-specific docs
 docs/architecture/issue-557-participant-implementation-binding-preflight.md	docs-follow-owner	Separate current user guidance from historical evidence and scenario-pack-specific docs
 docs/architecture/issue-589-scenario-pack-capture-ownership-preflight.md	docs-follow-owner	Separate current user guidance from historical evidence and scenario-pack-specific docs
+docs/architecture/issue-592-scenario-pack-terminology-preflight.md	docs-follow-owner	Separate current user guidance from historical evidence and scenario-pack-specific docs
 docs/architecture/issue-677-cert-producer-ownership-preflight.md	docs-follow-owner	Separate current user guidance from historical evidence and scenario-pack-specific docs
 docs/architecture/issue-790-ssh-module-split-preflight.md	docs-follow-owner	Separate current user guidance from historical evidence and scenario-pack-specific docs
 docs/architecture/issue-820-resource-bounded-participant-profile-preflight.md	docs-follow-owner	Separate current user guidance from historical evidence and scenario-pack-specific docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - "Issue #823 Versioned Disposable Lab Appliance Preflight": architecture/issue-823-versioned-disposable-appliance-preflight.md
     - "Issue #845 RAES Hard-Rename Preflight": architecture/issue-845-raes-hard-rename-preflight.md
     - "Issue #934 APTL-To-LilRAE Rename Boundary Preflight": architecture/issue-934-rename-boundary-preflight.md
+    - "Issue #592 Scenario-Pack Terminology Preflight": architecture/issue-592-scenario-pack-terminology-preflight.md
     - "Issue #866 TechVault Component Realization Preflight": architecture/issue-866-techvault-realization-contract-preflight.md
     - "Issue #874 Scenario-Bundle Realization Roots Preflight": architecture/issue-874-scenario-bundle-realization-roots-preflight.md
     - "Issue #878 Scenario Verification Plugin Seam Preflight": architecture/issue-878-scenario-verification-plugin-seam-preflight.md

--- a/tests/test_scenario_pack_ownership_contract.py
+++ b/tests/test_scenario_pack_ownership_contract.py
@@ -1,5 +1,7 @@
-"""Structural contract for the scenario-pack ownership decision."""
+"""Structural contracts for scenario-pack ownership and terminology."""
 
+import re
+from collections import Counter
 from pathlib import Path
 
 
@@ -9,8 +11,13 @@ _OWNERSHIP_NOTE = (
 )
 _README = _REPO_ROOT / "README.md"
 _SDL_BOUNDARY = _REPO_ROOT / "docs/sdl/index.md"
+_TERMINOLOGY_NOTE = (
+    _REPO_ROOT / "docs/architecture/issue-592-scenario-pack-terminology-preflight.md"
+)
+_IDENTITY_ADR = _REPO_ROOT / "docs/adrs/adr-054-lilrae-core-and-experience-ownership.md"
 
 _ENV_PACKS_REPO = "https://github.com/OpenRAE/env-packs"
+_PACK_TERM = re.compile(r"\b(?:scenario|environment|env)[ -]packs?\b", re.IGNORECASE)
 
 
 def _decision_rows(note: str) -> dict[str, str]:
@@ -26,6 +33,51 @@ def _decision_rows(note: str) -> dict[str, str]:
         for line in rows
         if len(cells := line.split("|")) >= 4
     }
+
+
+def _terminology_rows(note: str) -> dict[str, str]:
+    decision = (
+        note.split("## Terminology decision\n", maxsplit=1)[1]
+        .split("## ", maxsplit=1)[0]
+        .strip()
+    )
+    table = next(
+        block.splitlines()
+        for block in decision.split("\n\n")
+        if block.startswith("| Meaning | Canonical wording | Boundary |")
+    )
+    rows = [line for line in table if line.startswith("|")][2:]
+    return {
+        cells[1].strip(): f"{cells[2]} {cells[3]}"
+        for line in rows
+        if len(cells := line.split("|")) >= 4
+    }
+
+
+def _current_pack_docs() -> set[str]:
+    candidates = [_README, *_REPO_ROOT.joinpath("docs").rglob("*.md")]
+    candidates.extend(_REPO_ROOT.joinpath("plugins").rglob("README.md"))
+    discovered: set[str] = set()
+    for path in candidates:
+        relative = path.relative_to(_REPO_ROOT).as_posix()
+        if relative.startswith(("docs/requirements/", "docs/reviews/")):
+            continue
+        if _PACK_TERM.search(path.read_text(encoding="utf-8")):
+            discovered.add(relative)
+    return discovered
+
+
+def _uninventoried_paths(paths: set[str], inventory: str) -> list[str]:
+    basename_counts = Counter(Path(path).name for path in paths)
+    return sorted(
+        path
+        for path in paths
+        if f"`{path}`" not in inventory
+        and not (
+            basename_counts[Path(path).name] == 1
+            and f"`{Path(path).name}`" in inventory
+        )
+    )
 
 
 def test_scenario_pack_ownership_remains_four_way_and_current() -> None:
@@ -74,3 +126,75 @@ def test_user_docs_cross_reference_env_pack_companion_repo() -> None:
     # The stale org name must not appear in either user-facing surface.
     assert "RAESystem" not in readme
     assert "RAESystem" not in boundary
+
+
+def test_scenario_pack_terminology_inventory_covers_current_docs() -> None:
+    note = _TERMINOLOGY_NOTE.read_text(encoding="utf-8")
+    inventory = note.split("## Repository documentation inventory\n", maxsplit=1)[
+        1
+    ].split("## ", maxsplit=1)[0]
+
+    missing = _uninventoried_paths(_current_pack_docs(), inventory)
+
+    assert not missing, f"scenario-pack documentation is not inventoried: {missing}"
+
+
+def test_inventory_matching_does_not_alias_duplicate_readmes() -> None:
+    paths = {
+        "README.md",
+        "plugins/example-a/README.md",
+        "plugins/example-b/README.md",
+    }
+
+    assert _uninventoried_paths(paths, "`README.md`") == [
+        "plugins/example-a/README.md",
+        "plugins/example-b/README.md",
+    ]
+
+
+def test_current_scenario_pack_owners_use_raes_native_terms() -> None:
+    terminology = _TERMINOLOGY_NOTE.read_text(encoding="utf-8")
+    ownership = _OWNERSHIP_NOTE.read_text(encoding="utf-8")
+    identity_adr = _IDENTITY_ADR.read_text(encoding="utf-8")
+    rows = _terminology_rows(terminology)
+
+    assert "RAES scenario" in rows["Portable authored meaning"]
+    assert "OpenRAE/env-packs" in rows["Reusable packaged scenario material"]
+    assert "APTL startup catalog" in rows["APTL operator selection index"]
+    assert not re.search(
+        r"\b(?P<name>RAES)\s+is\s+the\s+renamed\s+(?P=name)\s+project\b",
+        ownership,
+    )
+
+    proposed_decision = identity_adr.split("## Proposed decision\n", maxsplit=1)[
+        1
+    ].split("## ", maxsplit=1)[0]
+    assert re.search(
+        r"OpenRAE/env-packs.*owns the environment-pack format",
+        proposed_decision,
+        flags=re.DOTALL,
+    )
+    assert re.search(
+        r"scenario authors own authored scenario content", proposed_decision
+    )
+    assert re.search(
+        r"LilRAE owns.*startup catalog", proposed_decision, flags=re.DOTALL
+    )
+
+
+def test_aptl_catalog_language_stays_product_owned() -> None:
+    readme = _README.read_text(encoding="utf-8")
+    boundary = _SDL_BOUNDARY.read_text(encoding="utf-8")
+    scenario_section = readme.split("## Scenarios\n", maxsplit=1)[1].split(
+        "## ", maxsplit=1
+    )[0]
+    unqualified_catalog_sentences = [
+        sentence.strip()
+        for sentence in re.split(r"(?<=[.!?])\s+", scenario_section)
+        if re.search(r"\bcatalog\b", sentence, re.IGNORECASE)
+        and "aptl" not in sentence.lower()
+    ]
+
+    assert not unqualified_catalog_sentences
+    assert "APTL-owned" in boundary
+    assert "Compose topology" in boundary


### PR DESCRIPTION
## Summary

Inventory APTL scenario-pack documentation and make current ownership terminology explicit across RAES, OpenRAE/env-packs, scenario authors, and the APTL startup/runtime boundary.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #592

## ADR Impact

- ADR-021
- ADR-054 (clarified)

## Changes

- Add the issue #592 terminology decision and repository-wide documentation inventory.
- Clarify current README, ownership-note, and proposed ADR wording without renaming historical or compatibility identifiers.
- Extend the SCN-010 structural contract tests with dynamic inventory and duplicate-basename regression coverage.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Focused scenario-pack and rename-boundary tests pass (11 tests). The full completion suite, policy gate, mandatory pre-commit suite, and test-quality review also pass.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: SCN-010 ← docs/architecture/issue-592-scenario-pack-terminology-preflight.md
- TESTS: SCN-010 ← tests/test_scenario_pack_ownership_contract.py

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.