### PR TITLE
fix(workbench): escalate group teardown unconditionally and stop reading EPERM as presence

### DIFF
--- a/src/aptl/validation/participant_qualification_boundary_environment.py
+++ b/src/aptl/validation/participant_qualification_boundary_environment.py
@@ -160,21 +160,42 @@ def persist_boundary_check(
     )
 
 
-def wait_until_process_absent(pid: int) -> bool:
-    """Wait briefly for the timed-out provider's child process to disappear."""
+# The reap that follows a kill is not instantaneous, and a process whose
+# parent died is reparented before it is reaped -- to init on Linux, to
+# launchd on Darwin -- so the wait has to outlast whatever that takes. No
+# measurement of Darwin's reparent-and-reap latency under CI load was
+# available when this was set, so it is deliberately generous: the wait costs
+# nothing when teardown worked, because the probe returns as soon as the pid
+# is gone.
+_PROCESS_ABSENT_TIMEOUT_SECONDS = 10.0
 
-    deadline = time.monotonic() + 2
-    absent = False
-    while time.monotonic() < deadline and not absent:
+
+def wait_until_process_absent(pid: int) -> bool:
+    """Wait for the timed-out provider's child process to disappear.
+
+    ``kill(pid, 0)`` answers ESRCH once a pid is gone, but a process that has
+    exited and has not yet been reaped is reported differently across
+    platforms: Linux keeps answering 0 for the zombie, while Darwin answers
+    EPERM once the zombie's credentials are cleared. EPERM is therefore
+    inconclusive rather than proof of presence, and abandoning the wait on it
+    reported "still present" for a process that had already exited. Keep
+    polling to the deadline and let the reap turn the answer into ESRCH.
+
+    A pid that stays unsignalable to the deadline returns ``False``. That is
+    the fail-closed answer, and the right one: this backs a containment
+    boundary, so an unproven teardown must not read as a proven one.
+    """
+
+    deadline = time.monotonic() + _PROCESS_ABSENT_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
         try:
             os.kill(pid, 0)
         except ProcessLookupError:
-            absent = True
+            return True
         except PermissionError:
-            break
-        if not absent:
-            time.sleep(0.02)
-    return absent
+            pass
+        time.sleep(0.02)
+    return False
 
 
 def _behavior_name(behavior_address: str) -> str:

--- a/src/aptl/workbench/process.py
+++ b/src/aptl/workbench/process.py
@@ -152,36 +152,48 @@ def _wait_for_process(
     return None
 
 
-def _signal_group(process: subprocess.Popen[bytes], number: int) -> bool:
-    """Signal the child's group; ``False`` when there was nothing left to kill.
+def _signal_group(pid: int, number: int) -> None:
+    """Signal a whole process group, best effort.
 
-    Platforms disagree on how ``killpg`` reports a group with no member it can
-    signal. Linux raises ``ProcessLookupError`` (ESRCH); Darwin raises
-    ``PermissionError`` (EPERM) once the group holds only the exited child.
-    Both mean the same thing here, so both are tolerated -- but EPERM only
-    after ``poll()`` confirms the child really has exited, because an EPERM
-    against a live child is a genuine permission failure and must still
-    propagate rather than leave the group running behind a swallowed error.
+    Neither error this can raise is actionable, and neither is evidence about
+    what survived. ``ProcessLookupError`` (ESRCH) means the group had no
+    member left to signal. ``PermissionError`` (EPERM) means the platform
+    could not signal any member: Darwin answers EPERM where Linux answers
+    ESRCH once a group holds only unreaped zombies, because a zombie's
+    credentials are already cleared. Reading either errno as "the group is
+    gone" is what made teardown stop early. Escalation below runs on a fixed
+    schedule instead, so both are swallowed here.
     """
 
     try:
-        os.killpg(process.pid, number)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        if process.poll() is None:
-            raise
-        return False
-    return True
+        os.killpg(pid, number)
+    except (ProcessLookupError, PermissionError):
+        pass
 
 
 def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
-    """Terminate the entire child process group, escalating when necessary."""
-    if not _signal_group(process, signal.SIGTERM):
-        process.wait()
-        return
+    """Terminate the entire child process group, escalating unconditionally.
+
+    SIGTERM, then a bounded grace period for the direct child, then SIGKILL to
+    the whole group whether or not the direct child has already gone.
+
+    Escalating only when the *direct child* outlived the grace period was the
+    defect: a descendant that ignores or outlives SIGTERM stayed alive
+    whenever its parent died promptly, because nothing ever escalated to the
+    group again. The runner's contract is that a bounded run leaves nothing
+    behind, so the escalation cannot be conditional on the one process the
+    runner happens to hold a handle for.
+
+    The SIGKILL is sent before the child is reaped. While any member remains,
+    the group id stays allocated and cannot name a stranger's group; once the
+    group is empty the signal is a no-op that raises ESRCH or EPERM, both
+    swallowed above.
+    """
+
+    _signal_group(process.pid, signal.SIGTERM)
     try:
         process.wait(timeout=1)
     except subprocess.TimeoutExpired:
-        _signal_group(process, signal.SIGKILL)
-        process.wait()
+        pass
+    _signal_group(process.pid, signal.SIGKILL)
+    process.wait()

--- a/tests/test_participant_qualification.py
+++ b/tests/test_participant_qualification.py
@@ -623,3 +623,53 @@ def test_mcp_artifact_bytes_must_match_asset_lock(tmp_path: Path) -> None:
             project,
             project / "participant-profiles" / "guided-purple-v1" / "profile.json",
         )
+
+
+def test_process_absence_keeps_polling_through_an_inconclusive_eperm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """EPERM is inconclusive, not proof the process is still present.
+
+    Darwin answers EPERM for an unreaped zombie where Linux answers 0. The
+    probe used to abandon the wait on it and report the process as present,
+    which failed BC-09 for a process group that had in fact been torn down.
+    """
+
+    from aptl.validation import participant_qualification_boundary_environment as env
+
+    answers = iter(
+        [
+            PermissionError(1, "Operation not permitted"),
+            PermissionError(1, "Operation not permitted"),
+            ProcessLookupError(3, "No such process"),
+        ]
+    )
+
+    def _probe(pid: int, signal_number: int) -> None:
+        del pid, signal_number
+        raise next(answers)
+
+    monkeypatch.setattr(env.os, "kill", _probe)
+
+    assert env.wait_until_process_absent(4321) is True
+
+
+def test_process_absence_fails_closed_when_the_pid_stays_unsignalable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pid that never resolves reads as present, never as absent.
+
+    This backs a containment boundary, so an unproven teardown must not be
+    reported as a proven one.
+    """
+
+    from aptl.validation import participant_qualification_boundary_environment as env
+
+    def _probe(pid: int, signal_number: int) -> None:
+        del pid, signal_number
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(env.os, "kill", _probe)
+    monkeypatch.setattr(env, "_PROCESS_ABSENT_TIMEOUT_SECONDS", 0.2)
+
+    assert env.wait_until_process_absent(4321) is False

--- a/tests/test_participant_workbench_adapter.py
+++ b/tests/test_participant_workbench_adapter.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
+import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -745,13 +749,78 @@ def test_bounded_runner_terminates_output_overflow_and_timeout(
         )
 
 
-def test_bounded_runner_tolerates_eperm_for_an_already_exited_child() -> None:
-    """Darwin reports an empty group as EPERM where Linux reports ESRCH.
+def _poll_until_absent(pid: int, timeout: float = 30.0) -> bool:
+    """Whether ``pid`` disappears within ``timeout`` seconds.
 
-    The runner terminates the group after it has already decided the run
-    failed, and by then a child that overflowed its budget has usually
-    exited. Treating that platform-specific EPERM as a real error turned an
-    "output exceeded" verdict into an unhandled PermissionError on macOS.
+    EPERM is inconclusive, not proof of presence: Darwin answers it for an
+    unreaped zombie where Linux answers 0. Keep polling on it.
+    """
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            pass
+        time.sleep(0.02)
+    return False
+
+
+def test_bounded_runner_kills_a_descendant_that_outlives_sigterm(
+    tmp_path: Path,
+) -> None:
+    """Escalation to SIGKILL cannot be conditional on the direct child.
+
+    The regression: teardown escalated only when the process it holds a
+    handle for outlived the grace period. A descendant that ignores SIGTERM
+    therefore survived whenever its parent died promptly — which is exactly
+    the residue a bounded run promises not to leave behind.
+    """
+
+    from aptl.workbench.process import _terminate_process_group
+
+    pid_path = tmp_path / "grandchild.pid"
+    grandchild_program = (
+        "import signal,time;"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+        "time.sleep(120)"
+    )
+    program = (
+        "import pathlib,subprocess,sys;"
+        f"child=subprocess.Popen([sys.executable,'-c',{grandchild_program!r}]);"
+        f"pathlib.Path({str(pid_path)!r}).write_text(str(child.pid));"
+        "sys.exit(0)"
+    )
+    process = subprocess.Popen(
+        (sys.executable, "-c", program),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline and not pid_path.exists():
+        time.sleep(0.02)
+    assert pid_path.exists(), "fixture never recorded the grandchild pid"
+    grandchild = int(pid_path.read_text(encoding="utf-8"))
+
+    try:
+        _terminate_process_group(process)
+        assert _poll_until_absent(grandchild), (
+            "the descendant outlived teardown"
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            os.kill(grandchild, signal.SIGKILL)
+
+
+def test_bounded_runner_tolerates_eperm_from_the_group_signal() -> None:
+    """Neither errno killpg can raise is treated as an error.
+
+    Darwin answers EPERM where Linux answers ESRCH once a group holds only
+    unreaped zombies. Treating that platform-specific EPERM as a real failure
+    turned an "output exceeded" verdict into an unhandled PermissionError.
     """
 
     from aptl.workbench.process import _terminate_process_group
@@ -773,29 +842,26 @@ def test_bounded_runner_tolerates_eperm_for_an_already_exited_child() -> None:
     assert process.returncode == 0
 
 
-def test_bounded_runner_propagates_eperm_for_a_live_child() -> None:
-    """An EPERM against a child still running is a real permission failure."""
+def test_bounded_runner_escalates_even_when_the_child_exits_promptly() -> None:
+    """SIGKILL reaches the group whether or not the handle process lingers."""
 
     from aptl.workbench.process import _terminate_process_group
 
     process = subprocess.Popen(
-        (sys.executable, "-c", "import time; time.sleep(30)"),
+        (sys.executable, "-c", "pass"),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         start_new_session=True,
     )
-    try:
-        with (
-            mock.patch(
-                "aptl.workbench.process.os.killpg",
-                side_effect=PermissionError(1, "Operation not permitted"),
-            ),
-            pytest.raises(PermissionError),
-        ):
-            _terminate_process_group(process)
-    finally:
-        process.kill()
-        process.wait()
+    process.wait()
+
+    with mock.patch("aptl.workbench.process.os.killpg") as killpg:
+        _terminate_process_group(process)
+
+    assert [call.args[1] for call in killpg.call_args_list] == [
+        signal.SIGTERM,
+        signal.SIGKILL,
+    ]
 
 
 def test_appliance_factory_wires_the_production_workbench_without_operator_routes(


### PR DESCRIPTION
## Summary

`Python cross-platform smoke (macos-latest)` was failing `test_bounded_participant_runtime.py`'s **BC-09** boundary check ("timed-out provider process group was removed before realization") — twice in three runs, against seven consecutive green runs before. It blocked #994.

Two sites inferred process state from errno, and both are wrong on Darwin.

### Teardown escalated only when the direct child outlived the grace period

This is the real defect, and the earlier EPERM fix (`103388af`) exposed it rather than introduced it. A descendant that ignores or outlives SIGTERM survives whenever its parent dies promptly, because nothing escalates to the group again. BC-09 exists precisely to catch a bounded run leaving a live process behind, so it is the check that noticed.

`_terminate_process_group` now sends SIGTERM, waits out the grace period, and sends SIGKILL to the group either way. The SIGKILL goes out **before** the child is reaped: while any member remains, the group id stays allocated and cannot name a stranger's group; once the group is empty the signal is a no-op.

With escalation on a fixed schedule, `_signal_group` no longer interprets the errno at all — it swallows both `ProcessLookupError` and `PermissionError`, since neither is evidence about what survived. That drops the narrowing `103388af` accepted, where EPERM with an already-exited child was read as "nothing left to kill" and skipped the escalation.

### `wait_until_process_absent` treated EPERM as proof of presence

Same divergence, opposite direction. Linux keeps answering `0` for a zombie; Darwin answers EPERM once its credentials are cleared. The probe abandoned the wait on EPERM and reported "still present" for a process that had already exited. It now polls to the deadline and lets the reap turn the answer into ESRCH. A pid that never resolves still returns `False` — the fail-closed answer this containment boundary needs.

The deadline moves 2s → 10s. A process whose parent died is reparented before it is reaped, and no measurement of that latency under CI load was available. The wait costs nothing when teardown worked, because the probe returns as soon as the pid is gone.

## Evidence

Runner image was ruled out as the cause: holding it constant at `macos-26-arm64/20260831.0337`, BC-09 passed twice before `103388af` and failed twice after.

`test_bounded_runner_kills_a_descendant_that_outlives_sigterm` and `test_bounded_runner_escalates_even_when_the_child_exits_promptly` both fail against the previous escalation and pass against this one — verified locally by reverting the escalation and re-running.

## Audit

`os.kill` sites in `appliance/seat/vm.py` and `core/kill.py` were reviewed and deliberately left alone: they probe processes the caller may not own, where treating EPERM as "not actionable" is intentional and documented in place.

## Verification

- Full suite: 4749 passed, 189 skipped, 0 failed
- `tests/test_bounded_participant_runtime.py`: 45 passed
- ruff clean, pre-commit all-files clean

Closes #995
Closes #996